### PR TITLE
feat: initial monorepo scaffold (core + agent-claude + cli)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      # No `cache: pnpm` yet — lockfile lands after first successful install.
+      # Swap to `pnpm install --frozen-lockfile` + cache once pnpm-lock.yaml is committed.
+      - run: pnpm install
+      - run: pnpm typecheck
+      - run: pnpm build
+      - run: pnpm test

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,229 @@
+# Ai-Conclave Architecture
+
+**Status:** architecture finalized 2026-04-19. Decisions 1–34 are locked; do
+not re-litigate without explicit reopen. This document is the source of
+truth for scaffolding.
+
+## Product
+
+- **Brand**: Ai-Conclave (hero display may be stylized `Con{claude}ve`)
+- **npm scope**: `@ai-conclave` (fallbacks: `conclaveai`, `ai-conclave-io`)
+- **CLI binary**: `conclave`
+- **Positioning (α)**: *"AI drafted. Council refined."*
+- **Tagline**: *A multi-agent council reviews your AI-generated code and
+  design, debates issues, auto-fixes blockers, and learns your preferences
+  over time. Built for solo makers who ship with AI.*
+- **Target persona**: users of Cursor / Claude Code / Windsurf / v0 /
+  Lovable / Bolt whose AI-generated output is mediocre, off-style, or
+  needs human polish. Not seasoned engineers polishing their own code.
+
+## 7-Layer Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Layer 1 — USER SURFACE (equal weight, any subset)          │
+│  CLI · Web · VSCode · Telegram · Discord · Slack · Email    │
+└───────────────────────────┬─────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│  Layer 2 — EFFICIENCY GATE (every LLM call routes through)  │
+│  cache · triage · budget · compact · route · metrics        │
+└───────────────────────────┬─────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│  Layer 3 — DECISION CORE                                    │
+│  Council (Mastra graph, N pluggable agents)                 │
+│  Tool-use loops (Claude Agent SDK + OpenAI Agents SDK)      │
+│  Structured I/O (Zod schemas, MCP protocol)                 │
+│  Scoring (Build 40% / Review 30% / Time 20% / Rework 10%)   │
+└────────┬────────────────────────────────┬───────────────────┘
+         ↕                                ↕
+┌────────────────────────┐  ┌────────────────────────────────┐
+│  Layer 4 — AGENTS      │  │  Layer 5 — INFRASTRUCTURE      │
+│  @ai-conclave/agent-*  │  │  scm / platform / integration  │
+│  (pluggable npm pkgs)  │  │  packages                      │
+│  claude, openai,       │  │  GitHub/Vercel/Netlify/...     │
+│  gemini, grok,         │  │  Telegram/Discord/Slack/Email  │
+│  deepseek, qwen,       │  │                                │
+│  bedrock, vertex,      │  │                                │
+│  cheetah (Triton),     │  │                                │
+│  ollama (local),       │  │                                │
+│  custom user-authored  │  │                                │
+└────────────────────────┘  └────────────────────────────────┘
+         ↕                                ↕
+┌────────────────────────┐  ┌────────────────────────────────┐
+│  Layer 6 —             │  │  Layer 7 — OBSERVABILITY       │
+│  SELF-EVOLVE           │  │  Langfuse self-hosted          │
+│  (정답지 + 오답지)     │  │  per-PR trace                  │
+│  episodic (90d)        │  │  cache hit rate                │
+│  answer-keys (∞)       │  │  cost + tokens per call        │
+│  failure-catalog (∞)   │  │  precision/recall per category │
+│  semantic rules        │  │  agent scores over time        │
+│  procedural playbooks  │  │  budget compliance             │
+│  federated baseline    │  │                                │
+│  (hash+cat, DP)        │  │                                │
+└────────────────────────┘  └────────────────────────────────┘
+```
+
+## Self-Evolve Substrate (정답지/오답지 duality — the moat)
+
+```
+packages/core/src/memory/
+├── episodic/                      # raw event log, 90d TTL
+│   └── YYYY-MM-DD/pr-{n}.json
+├── answer-keys/ (정답지)          # ★ SUCCESS PATTERNS
+│   ├── code/{by-pattern,by-user,by-repo}/
+│   └── design/{by-pattern,by-component}/
+├── failure-catalog/ (오답지)      # ★ FAILURE PATTERNS
+│   ├── code/by-category/{type-errors,missing-tests,regression,security,...}
+│   └── design/{accessibility-fails,contrast-fails,...}
+├── semantic/rules.json            # extracted rules (nightly Haiku compression)
+├── procedural/playbooks.md        # promoted how-to (weekly)
+└── federated-sync/                # cross-user (hash+category ONLY)
+    ├── answer-keys-baseline/
+    └── failure-baseline/
+```
+
+**Training loop:**
+- Merge → write to answer-keys (positive)
+- Reject → write to failure-catalog (negative)
+- Rework → failure (1st version) + answer-key (final accepted)
+- Every review READS: top-K answer-keys + top-K failures + procedural
+  rules + federated baseline signal (RAG into system prompt)
+- Nightly: episodic → classify into catalogs (Haiku, cheap)
+- Weekly: catalog → semantic rules
+- Monthly: semantic → procedural + federated sync
+
+## Efficiency Gate (day-1 requirement)
+
+```
+packages/core/src/efficiency/
+├── cache.ts        # Anthropic prompt-cache 5-min TTL aware scheduling
+├── compact.ts      # Round-to-round context compression (Haiku summary)
+├── triage.ts       # Small/simple PR → lite path (single agent)
+│                   # Complex PR → full council (3-round)
+├── budget.ts       # Hard cost caps: per-PR default $0.50
+├── relevance.ts    # Selective context (diff + import graph)
+├── router.ts       # Model by input size (Haiku / Sonnet / Gemini 2.5 Pro)
+└── metrics.ts      # Per-call cost/tokens/latency → Langfuse
+```
+
+**All LLM calls route through efficiency gate. Direct SDK calls forbidden.**
+
+Expected (compounded): $0.50 default PR budget → $0.08–0.15 actual average.
+
+## Scoring (ported from solo-cto-agent)
+
+Rolling weighted score per agent:
+- Build pass rate: 40%
+- Review approval rate: 30%
+- Time to resolution: 20%
+- Rework frequency: 10%
+
+Plus new metrics:
+- Precision / recall per blocker category (per agent)
+- Cache hit rate (efficiency)
+- Cost per PR (budget compliance)
+
+## Tech Stack (locked)
+
+| Purpose | Tech |
+|---|---|
+| Language | TypeScript (strict) |
+| Monorepo | pnpm workspaces + turbo |
+| Orchestration | **Mastra** (TS-native multi-agent) |
+| Claude agent loop | `@anthropic-ai/claude-agent-sdk` (official TS) |
+| OpenAI agent loop | `@openai/agents` v0.8.x (official TS) |
+| Gemini | `@google/genai` with 2.5 Pro (long-context slot) |
+| Structured output | Zod → JSON Schema + per-provider adapter |
+| Tool protocol | MCP (filesystem, Figma Dev Mode, GitHub, custom) |
+| Observability | **Langfuse self-hosted** |
+| Workflow engine | GitHub Actions (Trigger.dev v3 fallback only if 6h hit) |
+| Visual diff | `odiff` + Playwright + vision-model semantic judge |
+| Plugin loading | `cosmiconfig` + dynamic `import()` |
+
+## Monorepo Layout
+
+```
+ai-conclave/
+├── package.json                  # pnpm workspace root
+├── pnpm-workspace.yaml
+├── turbo.json
+├── tsconfig.base.json
+├── README.md
+├── ARCHITECTURE.md               # this doc
+├── LICENSE
+├── packages/
+│   ├── core/                     # @ai-conclave/core
+│   │   └── src/
+│   │       ├── agent.ts          # Agent interface
+│   │       ├── council.ts        # Mastra-based N-agent graph
+│   │       ├── schema/           # Zod schemas
+│   │       ├── memory/           # self-evolve 정답지/오답지
+│   │       ├── efficiency/       # cache/triage/budget/compact/route
+│   │       ├── scoring/          # ported from solo-cto-agent
+│   │       ├── guards.ts         # anti-loop + circuit breaker
+│   │       └── registry.ts       # plugin registration
+│   ├── agent-claude/             # wraps @anthropic-ai/claude-agent-sdk
+│   ├── agent-openai/             # wraps @openai/agents          (v2.1)
+│   ├── agent-gemini/             # (v2.1)
+│   ├── agent-{grok,deepseek,qwen,bedrock,vertex,cheetah,ollama}/ (v2.1)
+│   ├── scm-github/               # v2.0
+│   ├── scm-{gitlab,bitbucket,gitea}/                              (v2.1)
+│   ├── platform-{vercel,netlify,railway,cloudflare,fly,render,
+│   │              replit,vertex-deploy,docker-local,
+│   │              deployment-status}/
+│   ├── integration-{telegram,discord,slack,email}/
+│   ├── cli/                      # @ai-conclave/cli, binary `conclave`
+│   └── orchestrator-template/    # GitHub Actions YAML templates
+├── apps/
+│   ├── web-dashboard/            # v2.1 — cost/trace viz
+│   └── vscode-extension/
+└── docs/
+```
+
+## End-to-End Pipeline
+
+1. **Intent Capture** — CLI / Telegram / Discord / Web / IDE → raw NL
+2. **Intent Parse** — router agent (Haiku) → structured Intent (Zod)
+3. **Work Dispatch** — SCM labeled issue OR direct dispatch
+4. **Worker Execution** — tool-use loop → PR with commits (reads
+   answer-keys + procedural memory for style)
+5. **Council Consensus** — 3-round debate (or early-exit). Each agent
+   reads answer-keys + failure-catalog + federated baseline as RAG
+6. **Rework Loop** — on blocker: rework agent → commits → re-review
+   (bounded by maxRounds + circuit breaker)
+7. **Visual Verify** — resolve preview URL (any platform) → Playwright +
+   odiff → vision-model semantic judgment → attach to PR + notifications
+8. **Delivery** — consolidated message to configured channels, action
+   buttons
+9. **Merge + Final Notify** — GitHub auto-merge on CI green
+10. **Learning** — outcome writes to episodic → nightly classify → weekly
+    extract rules → monthly federate
+
+## Migration From solo-cto-agent
+
+Port directly (no redesign):
+- `failure-catalog.json` (ERR-001~) → seed `failure-catalog/code/`
+- Agent scoring weights → `scoring/` package
+- Anti-loop 7-layer guards → `guards.ts` middleware
+- Circuit breaker → `guards.ts`
+- `diff-guard.js` secret detection → new `secret-guard/` package
+- Orchestrator workflow templates → `orchestrator-template/`
+
+solo-cto-agent 1.4.x stays on npm in maintenance (security fixes only).
+`conclave migrate` CLI at v2.0 RC.
+
+## Novelty Self-Assessment (locked)
+
+- Individual features: 4.5/10 (prior art exists)
+- Architectural sophistication: **8.5/10**
+- Self-evolve as moat (정답지/오답지 duality + federated): **9/10**
+- Overall product thesis: **8.5/10**
+- Execution risk pulls shipped value: TBD
+
+**Differentiators (priority order):**
+1. 정답지 + 오답지 dual catalog as RLHF-like substrate without fine-tuning
+2. Efficiency gate built in from day 1 (most multi-agent systems die from cost)
+3. Architectural coherence (all 7 layers woven, not bolted-on)
+4. Pluggable agents including self-hosted Triton-based + local Ollama

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+### Added
+- Monorepo skeleton (pnpm workspaces + turbo).
+- `@ai-conclave/core`: `Agent` / `Council` interfaces + Zod schemas.
+- `@ai-conclave/agent-claude`: Claude agent skeleton implementing `Agent`.
+- `@ai-conclave/cli`: `conclave` binary with `init` and `review` commands (skeleton).
+- `ARCHITECTURE.md`: locked 7-layer design for the council, efficiency gate,
+  self-evolve substrate (정답지 + 오답지), and migration path from solo-cto-agent.
+- GitHub Actions CI: typecheck + build + test on push/PR.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "ai-conclave",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Ai-Conclave monorepo — AI drafted. Council refined.",
+  "license": "MIT",
+  "author": "Seunghun Bae",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/seunghunbae-3svs/ai-conclave.git"
+  },
+  "homepage": "https://github.com/seunghunbae-3svs/ai-conclave#readme",
+  "packageManager": "pnpm@9.15.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "test": "turbo run test",
+    "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
+    "clean": "turbo run clean && rm -rf node_modules"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "turbo": "^2.3.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/agent-claude/README.md
+++ b/packages/agent-claude/README.md
@@ -1,0 +1,25 @@
+# @ai-conclave/agent-claude
+
+Claude agent for Ai-Conclave council review. Implements the `Agent`
+interface from `@ai-conclave/core`.
+
+Skeleton status: interface correct, review stub returns `approve`. Real
+tool-use loop (via `@anthropic-ai/claude-agent-sdk`) with RAG over
+answer-keys + failure-catalog and efficiency-gate cost metering lands in
+a later PR.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/agent-claude @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { ClaudeAgent } from "@ai-conclave/agent-claude";
+import { Council } from "@ai-conclave/core";
+
+const agent = new ClaudeAgent({ apiKey: process.env.ANTHROPIC_API_KEY });
+const council = new Council({ agents: [agent] });
+```

--- a/packages/agent-claude/package.json
+++ b/packages/agent-claude/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ai-conclave/agent-claude",
+  "version": "0.0.0",
+  "description": "Ai-Conclave Claude agent — wraps @anthropic-ai/claude-agent-sdk.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@ai-conclave/core": "workspace:*",
+    "@anthropic-ai/sdk": "^0.65.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/agent-claude/src/claude-agent.ts
+++ b/packages/agent-claude/src/claude-agent.ts
@@ -1,0 +1,54 @@
+import type { Agent, ReviewContext, ReviewResult } from "@ai-conclave/core";
+
+export interface ClaudeAgentOptions {
+  apiKey?: string;
+  model?: string;
+  maxTokens?: number;
+}
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+const DEFAULT_MAX_TOKENS = 4096;
+
+/**
+ * ClaudeAgent — wraps Anthropic's Claude SDK for council review.
+ *
+ * Skeleton status: interface correct, implementation returns a stub
+ * "approve" verdict. The real tool-use loop with
+ * @anthropic-ai/claude-agent-sdk (official TS, bundles MCP + tool_use +
+ * compaction) lands in a subsequent PR together with the efficiency
+ * gate and RAG-over-answer-keys.
+ */
+export class ClaudeAgent implements Agent {
+  readonly id = "claude";
+  readonly displayName = "Claude";
+
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+
+  constructor(opts: ClaudeAgentOptions = {}) {
+    const key = opts.apiKey ?? process.env["ANTHROPIC_API_KEY"] ?? "";
+    if (!key) {
+      throw new Error("ClaudeAgent: ANTHROPIC_API_KEY not set (pass opts.apiKey or env var)");
+    }
+    this.apiKey = key;
+    this.model = opts.model ?? DEFAULT_MODEL;
+    this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+  }
+
+  async review(ctx: ReviewContext): Promise<ReviewResult> {
+    // Skeleton — real implementation will call the SDK with a tool-use
+    // loop, RAG context from answer-keys + failure-catalog, and cost
+    // metering through the efficiency gate.
+    void ctx;
+    void this.apiKey;
+    void this.model;
+    void this.maxTokens;
+    return {
+      agent: this.id,
+      verdict: "approve",
+      blockers: [],
+      summary: "ClaudeAgent skeleton — real review logic pending.",
+    };
+  }
+}

--- a/packages/agent-claude/src/index.ts
+++ b/packages/agent-claude/src/index.ts
@@ -1,0 +1,2 @@
+export { ClaudeAgent } from "./claude-agent.js";
+export type { ClaudeAgentOptions } from "./claude-agent.js";

--- a/packages/agent-claude/test/smoke.test.mjs
+++ b/packages/agent-claude/test/smoke.test.mjs
@@ -1,0 +1,7 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ClaudeAgent } from "../dist/index.js";
+
+test("agent-claude: ClaudeAgent is exported", () => {
+  assert.equal(typeof ClaudeAgent, "function");
+});

--- a/packages/agent-claude/tsconfig.json
+++ b/packages/agent-claude/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,24 @@
+# @ai-conclave/cli
+
+The `conclave` command-line interface for Ai-Conclave.
+
+Skeleton status: `init` and `review` wired end-to-end through the core
+skeleton. Real PR discovery, efficiency gate, memory write-back, and
+notification dispatch land in later PRs.
+
+## Install
+
+```bash
+pnpm add -g @ai-conclave/cli
+# or
+npm install -g @ai-conclave/cli
+```
+
+## Commands
+
+```
+conclave init                Write .conclaverc.json in the current repo
+conclave review [--pr N]     Run a council review (skeleton)
+conclave --help              Show help
+conclave --version           Show version
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@ai-conclave/cli",
+  "version": "0.0.0",
+  "description": "Ai-Conclave CLI — the `conclave` binary.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "conclave": "./dist/bin/conclave.js"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@ai-conclave/agent-claude": "workspace:*",
+    "@ai-conclave/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cli/src/bin/conclave.ts
+++ b/packages/cli/src/bin/conclave.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { run } from "../index.js";
+
+run(process.argv.slice(2)).catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`conclave: ${msg}\n`);
+  process.exit(1);
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,32 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const CONFIG_FILENAME = ".conclaverc.json";
+
+const DEFAULT_CONFIG = {
+  version: 1,
+  agents: ["claude"],
+  budget: { perPrUsd: 0.5 },
+  efficiency: { cacheEnabled: true, compactEnabled: true },
+  memory: { answerKeysDir: ".conclave/answer-keys", failureCatalogDir: ".conclave/failure-catalog" },
+};
+
+export async function init(_argv: string[]): Promise<void> {
+  const cwd = process.cwd();
+  const target = path.join(cwd, CONFIG_FILENAME);
+
+  try {
+    await fs.access(target);
+    process.stderr.write(`conclave: ${CONFIG_FILENAME} already exists at ${cwd}. Aborting.\n`);
+    process.exit(1);
+    return;
+  } catch {
+    // does not exist, proceed
+  }
+
+  await fs.writeFile(target, JSON.stringify(DEFAULT_CONFIG, null, 2) + "\n", "utf8");
+  process.stdout.write(
+    `conclave: wrote ${CONFIG_FILENAME}\n` +
+      `Next: set ANTHROPIC_API_KEY, then run \`conclave review\`.\n`,
+  );
+}

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -1,0 +1,52 @@
+import { Council } from "@ai-conclave/core";
+import { ClaudeAgent } from "@ai-conclave/agent-claude";
+
+/**
+ * `conclave review` — skeleton command.
+ *
+ * Real implementation will:
+ *   1. Discover the current PR (git + gh CLI)
+ *   2. Load the diff + repo context
+ *   3. Route through the efficiency gate (cache / triage / budget)
+ *   4. Run the council deliberation across N agents
+ *   5. Post consensus back to the PR (GitHub comment + optional Telegram)
+ *   6. Write outcome to episodic memory (nightly classifies into
+ *      answer-keys / failure-catalog)
+ *
+ * Current scaffold: spins up a single-Claude council with an empty diff so
+ * we can validate the wiring end-to-end.
+ */
+export async function review(argv: string[]): Promise<void> {
+  const prFlag = argv.findIndex((a) => a === "--pr");
+  const prNumber = prFlag >= 0 && argv[prFlag + 1] ? Number.parseInt(argv[prFlag + 1]!, 10) : 0;
+
+  if (!process.env["ANTHROPIC_API_KEY"]) {
+    process.stderr.write(
+      "conclave review: ANTHROPIC_API_KEY not set. Export the key and retry.\n",
+    );
+    process.exit(1);
+    return;
+  }
+
+  const council = new Council({ agents: [new ClaudeAgent()] });
+
+  process.stdout.write(
+    `conclave review (skeleton):\n` +
+      `  agents: ${council.agentCount}\n` +
+      `  rounds: ${council.roundLimit}\n` +
+      `  pr: ${prNumber || "(none — dry run)"}\n`,
+  );
+
+  const outcome = await council.deliberate({
+    diff: "",
+    repo: "local/dry-run",
+    pullNumber: prNumber || 0,
+    newSha: "HEAD",
+  });
+
+  process.stdout.write(
+    `  verdict: ${outcome.verdict}\n` +
+      `  consensus: ${outcome.consensusReached}\n` +
+      `  results: ${outcome.results.length}\n`,
+  );
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,44 @@
+import { init } from "./commands/init.js";
+import { review } from "./commands/review.js";
+
+const HELP = `conclave — Ai-Conclave CLI (skeleton)
+
+Usage:
+  conclave <command> [options]
+
+Commands:
+  init                  Set up conclave in the current repo (config + skeleton)
+  review                Run a council review on the current branch
+  --help, -h            Show this
+  --version, -v         Show version
+
+Examples:
+  conclave init
+  conclave review --pr 42
+`;
+
+export async function run(argv: string[]): Promise<void> {
+  const [cmd, ...rest] = argv;
+
+  if (!cmd || cmd === "--help" || cmd === "-h" || cmd === "help") {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  if (cmd === "--version" || cmd === "-v") {
+    process.stdout.write("0.0.0\n");
+    return;
+  }
+
+  switch (cmd) {
+    case "init":
+      await init(rest);
+      return;
+    case "review":
+      await review(rest);
+      return;
+    default:
+      process.stderr.write(`Unknown command: ${cmd}\n\n${HELP}`);
+      process.exit(2);
+  }
+}

--- a/packages/cli/test/smoke.test.mjs
+++ b/packages/cli/test/smoke.test.mjs
@@ -1,0 +1,22 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { run } from "../dist/index.js";
+
+test("cli: run is exported", () => {
+  assert.equal(typeof run, "function");
+});
+
+test("cli: --version prints 0.0.0 to stdout", async () => {
+  const chunks = [];
+  const origWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (c) => {
+    chunks.push(String(c));
+    return true;
+  };
+  try {
+    await run(["--version"]);
+  } finally {
+    process.stdout.write = origWrite;
+  }
+  assert.match(chunks.join(""), /0\.0\.0/);
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../agent-claude" }
+  ]
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,28 @@
+# @ai-conclave/core
+
+Agent interface, council orchestration, self-evolve substrate, and
+efficiency gate for Ai-Conclave.
+
+Skeleton status: `Agent` / `Council` interfaces + Zod schemas only. Mastra
+graph, memory substrate, and efficiency gate land in subsequent PRs.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { Council, type Agent, type ReviewContext } from "@ai-conclave/core";
+
+const council = new Council({ agents: [claudeAgent, openaiAgent] });
+const ctx: ReviewContext = {
+  diff: "...",
+  repo: "acme/my-app",
+  pullNumber: 42,
+  newSha: "abc123",
+};
+const outcome = await council.deliberate(ctx);
+```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ai-conclave/core",
+  "version": "0.0.0",
+  "description": "Ai-Conclave core — Agent interface, council orchestration, self-evolve substrate, efficiency gate.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -1,0 +1,34 @@
+export type Severity = "blocker" | "major" | "minor" | "nit";
+
+export interface Blocker {
+  severity: Severity;
+  category: string;
+  message: string;
+  file?: string;
+  line?: number;
+}
+
+export interface ReviewContext {
+  diff: string;
+  repo: string;
+  pullNumber: number;
+  prevSha?: string;
+  newSha: string;
+  answerKeys?: string[];
+  failureCatalog?: string[];
+}
+
+export interface ReviewResult {
+  agent: string;
+  verdict: "approve" | "rework" | "reject";
+  blockers: Blocker[];
+  summary: string;
+  tokensUsed?: number;
+  costUsd?: number;
+}
+
+export interface Agent {
+  readonly id: string;
+  readonly displayName: string;
+  review(ctx: ReviewContext): Promise<ReviewResult>;
+}

--- a/packages/core/src/council.ts
+++ b/packages/core/src/council.ts
@@ -1,0 +1,60 @@
+import type { Agent, ReviewContext, ReviewResult } from "./agent.js";
+
+export interface CouncilOptions {
+  agents: Agent[];
+  maxRounds?: number;
+}
+
+export interface CouncilOutcome {
+  verdict: "approve" | "rework" | "reject";
+  rounds: number;
+  results: ReviewResult[];
+  consensusReached: boolean;
+}
+
+/**
+ * Council — orchestrates N agents across up to `maxRounds` of review.
+ *
+ * This is a skeleton. The real Mastra-graph implementation (3-round A/B/C
+ * debate with early-exit on agreement, rework dispatch, efficiency-gate
+ * routing) lands in a subsequent PR. For now, Council runs a single round
+ * and returns each agent's individual verdict.
+ */
+export class Council {
+  private readonly agents: Agent[];
+  private readonly maxRounds: number;
+
+  constructor(opts: CouncilOptions) {
+    if (opts.agents.length === 0) {
+      throw new Error("Council requires at least one agent");
+    }
+    this.agents = opts.agents;
+    this.maxRounds = opts.maxRounds ?? 3;
+  }
+
+  async deliberate(ctx: ReviewContext): Promise<CouncilOutcome> {
+    const results = await Promise.all(this.agents.map((a) => a.review(ctx)));
+    const verdicts = results.map((r) => r.verdict);
+    const allApprove = verdicts.every((v) => v === "approve");
+    const anyReject = verdicts.some((v) => v === "reject");
+    const verdict: CouncilOutcome["verdict"] = anyReject
+      ? "reject"
+      : allApprove
+      ? "approve"
+      : "rework";
+    return {
+      verdict,
+      rounds: 1,
+      results,
+      consensusReached: allApprove || anyReject,
+    };
+  }
+
+  get agentCount(): number {
+    return this.agents.length;
+  }
+
+  get roundLimit(): number {
+    return this.maxRounds;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,3 @@
+export type { Agent, ReviewContext, ReviewResult, Blocker, Severity } from "./agent.js";
+export { Council } from "./council.js";
+export { ReviewResultSchema, BlockerSchema } from "./schema.js";

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const SeveritySchema = z.enum(["blocker", "major", "minor", "nit"]);
+
+export const BlockerSchema = z.object({
+  severity: SeveritySchema,
+  category: z.string().min(1),
+  message: z.string().min(1),
+  file: z.string().optional(),
+  line: z.number().int().positive().optional(),
+});
+
+export const ReviewResultSchema = z.object({
+  agent: z.string().min(1),
+  verdict: z.enum(["approve", "rework", "reject"]),
+  blockers: z.array(BlockerSchema),
+  summary: z.string(),
+  tokensUsed: z.number().int().nonnegative().optional(),
+  costUsd: z.number().nonnegative().optional(),
+});
+
+export type BlockerInput = z.input<typeof BlockerSchema>;
+export type ReviewResultInput = z.input<typeof ReviewResultSchema>;

--- a/packages/core/test/smoke.test.mjs
+++ b/packages/core/test/smoke.test.mjs
@@ -1,0 +1,11 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Council } from "../dist/index.js";
+
+test("core: Council is exported from @ai-conclave/core", () => {
+  assert.equal(typeof Council, "function");
+});
+
+test("core: Council empty agents throws", () => {
+  assert.throws(() => new Council({ agents: [] }), /at least one agent/);
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "packages/*"
+  - "apps/*"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "incremental": true
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "ui": "stream",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "*.tsbuildinfo"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

First PR on ai-conclave — lands the minimal end-to-end skeleton per `ARCHITECTURE.md`. Follows the 34 locked decisions from 2026-04-19.

## What's included

| Package | State |
|---|---|
| `@ai-conclave/core` | `Agent` / `Council` interfaces + Zod schemas for Blocker / ReviewResult. Single-round Council stub so a single-agent review wires end-to-end. |
| `@ai-conclave/agent-claude` | `ClaudeAgent` class implements `Agent`. Skeleton returns `approve` + empty blockers; real tool-use loop + RAG over answer-keys lands in a follow-up. |
| `@ai-conclave/cli` | `conclave` binary with `init` (writes `.conclaverc.json`) and `review --pr N` (spins up single-Claude council for E2E wiring). |
| Root | pnpm workspaces + turbo + TS strict (ES2022, NodeNext, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`). GitHub Actions CI for typecheck / build / test. |
| Docs | README (positioning, pipeline summary), ARCHITECTURE.md (full 7-layer design), CHANGELOG (Unreleased). |

## Out of scope (by design — lands in follow-ups)

- Mastra graph + 3-round debate
- Efficiency gate (cache / triage / budget / compact / route / metrics)
- Self-evolve memory substrate (정답지 / 오답지 / federated)
- Additional agents (openai / gemini / grok / deepseek / qwen / bedrock / vertex / cheetah / ollama)
- SCM + platform + integration packages
- Observability (Langfuse self-hosted)
- `conclave migrate` command

## Verification

- [ ] `pnpm install` completes (CI will verify; lockfile generation intentionally left to first `pnpm install` since no deps are installed locally)
- [ ] `pnpm typecheck` passes (strict mode, noUncheckedIndexedAccess, exactOptionalPropertyTypes)
- [ ] `pnpm build` emits `dist/` for all 3 packages
- [ ] `node packages/cli/dist/bin/conclave.js --help` prints help
- [ ] `node packages/cli/dist/bin/conclave.js --version` prints `0.0.0`
- [ ] `conclave init` (after build + link) writes `.conclaverc.json` and refuses to overwrite
- [ ] `ANTHROPIC_API_KEY=... conclave review` prints skeleton output (`verdict: approve`)

## Notes

- Repo currently lives under `seunghunbae-3svs/ai-conclave`. Per decisions #1-2, the `ai-conclave` GitHub org and `@ai-conclave` npm scope are the intended final home; GitHub does not expose org creation via API, so the transfer is a one-click `gh repo transfer` after Bae creates the org at https://github.com/account/organizations/new.
- npm scope `@ai-conclave` will be reserved once the first real release happens. Fallbacks (`conclaveai`, `ai-conclave-io`) are documented in locked decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)