### PR TITLE
feat(core): efficiency gate — cache, budget, triage, routing, compact, relevance, metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,24 @@
 - `ARCHITECTURE.md`: locked 7-layer design for the council, efficiency gate,
   self-evolve substrate (정답지 + 오답지), and migration path from solo-cto-agent.
 - GitHub Actions CI: typecheck + build + test on push/PR.
+- **Efficiency Gate** (`@ai-conclave/core/efficiency`) per decision #22 —
+  first-class from day 1. Every LLM call must route through
+  `EfficiencyGate.run(...)`; direct SDK calls are forbidden by contract.
+  - `PromptCache` — Anthropic 5-min TTL aware scheduler (sha256-keyed, LRU-evicted).
+  - `BudgetTracker` — $0.50 default per-PR cap (decision #20), throws
+    `BudgetExceededError` on reserve-beyond-cap, warning handler at 80% default.
+  - `triageReview` — lite (single agent) vs full (3-round council) classification.
+    Risky paths (schema / migrations / auth / payments / `.sql` / prisma) always
+    force full regardless of size.
+  - `selectModel` — input-size routing: Haiku ≤ 8k tokens → Sonnet ≤ 50k →
+    Gemini 2.5 Pro for long-context slot (override-able).
+  - `compact` — round-to-round context compression (summarizer injected;
+    pinned-message preservation; newest-first fit under budget).
+  - `buildRelevanceContext` — diff + test-file + direct-import graph walk
+    under a token budget (safe defaults when `readFile` / `importsOf` omitted).
+  - `MetricsRecorder` — per-call cost / tokens / latency / cache-hit with
+    per-agent + per-model aggregation; pluggable external sink for Langfuse.
+  - `EfficiencyGate.run(...)` — orchestrates reserve → route → cache-check →
+    execute → mark → commit → record in a single call.
+- Test coverage (`node --test`): 9 files, 45+ test cases across all
+  efficiency modules and Council outcome logic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,24 @@
     execute → mark → commit → record in a single call.
 - Test coverage (`node --test`): 9 files, 45+ test cases across all
   efficiency modules and Council outcome logic.
+- **Real Claude review loop** in `@ai-conclave/agent-claude`:
+  - `ClaudeAgent.review(ctx)` now issues a real `messages.create` call via
+    the injected (or lazy-loaded) `@anthropic-ai/sdk` client.
+  - Single-tool pattern (`tool_choice: { type: "tool", name: "submit_review" }`)
+    forces structured output — no free-form parsing.
+  - System prompt + RAG prefix sent as a cache-controlled ephemeral block
+    so repeat calls within 5 minutes hit Anthropic's prompt cache (~90%
+    input-cost savings on the prefix).
+  - All SDK calls route through `EfficiencyGate.run(...)`: pre-flight budget
+    reserve (throws before the network call), cache-liveness tracking,
+    actual-cost metering via `actualCost(model, usage)`, per-call metrics.
+  - `PRICING` table covers Sonnet 4.6 / Haiku 4.5 / Opus 4.7 with standard,
+    cache-write, and cache-read rates. `estimateCallCost` is pessimistic
+    (no cache assumed) for safe pre-flight reservation.
+  - Parser tolerates malformed blockers (drops invalid entries instead of
+    failing the whole review), throws on missing `submit_review` tool_use
+    block or invalid verdict.
+  - Agent-claude tests (16 cases): happy verdicts (approve / rework with
+    blockers), invalid response shapes, budget enforcement, cache_control
+    wire-format, tool_choice wire-format, missing-key constructor guard,
+    metrics aggregation on shared gate.

--- a/packages/agent-claude/package.json
+++ b/packages/agent-claude/package.json
@@ -21,6 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/agent-claude/src/claude-agent.ts
+++ b/packages/agent-claude/src/claude-agent.ts
@@ -1,22 +1,77 @@
-import type { Agent, ReviewContext, ReviewResult } from "@ai-conclave/core";
+import type { Agent, ReviewContext, ReviewResult, Blocker } from "@ai-conclave/core";
+import { EfficiencyGate, estimateTokens } from "@ai-conclave/core";
+import { REVIEW_TOOL_NAME, REVIEW_TOOL_DESCRIPTION, REVIEW_TOOL_INPUT_SCHEMA } from "./review-tool.js";
+import { buildReviewPrompt, buildCacheablePrefix, SYSTEM_PROMPT } from "./prompts.js";
+import { actualCost, estimateCallCost } from "./pricing.js";
+
+/**
+ * Minimal shape of the Anthropic SDK client that ClaudeAgent needs.
+ * We type against this instead of the full SDK to keep tests cheap to mock
+ * and to tolerate SDK minor version churn.
+ */
+export interface AnthropicLike {
+  messages: {
+    create(params: AnthropicCreateParams): Promise<AnthropicResponse>;
+  };
+}
+
+export interface AnthropicCreateParams {
+  model: string;
+  max_tokens: number;
+  system?: string | ReadonlyArray<{ type: "text"; text: string; cache_control?: { type: "ephemeral" } }>;
+  messages: ReadonlyArray<{ role: "user" | "assistant"; content: string }>;
+  tools?: ReadonlyArray<{
+    name: string;
+    description: string;
+    input_schema: unknown;
+  }>;
+  tool_choice?: { type: "tool"; name: string } | { type: "auto" } | { type: "any" };
+}
+
+export interface AnthropicResponse {
+  id: string;
+  model: string;
+  content: ReadonlyArray<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; id: string; name: string; input: unknown }
+  >;
+  stop_reason?: string;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}
 
 export interface ClaudeAgentOptions {
   apiKey?: string;
+  /** Defaults to claude-sonnet-4-6. Gate router may force a different model per call. */
   model?: string;
   maxTokens?: number;
+  /** Shared gate (recommended). If omitted, the agent creates its own. */
+  gate?: EfficiencyGate;
+  /** For tests or alternate providers — inject a Messages-compatible client. */
+  client?: AnthropicLike;
+  /** Factory used when `client` is not supplied. Defaults to lazy-loading @anthropic-ai/sdk. */
+  clientFactory?: (apiKey: string) => Promise<AnthropicLike>;
 }
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
-const DEFAULT_MAX_TOKENS = 4096;
+const DEFAULT_MAX_TOKENS = 2_048;
+
+async function defaultClientFactory(apiKey: string): Promise<AnthropicLike> {
+  // Dynamic import so tests that inject a client never pay the SDK load cost.
+  const mod = (await import("@anthropic-ai/sdk")) as unknown as {
+    default: new (opts: { apiKey: string }) => AnthropicLike;
+  };
+  const Ctor = mod.default;
+  return new Ctor({ apiKey });
+}
 
 /**
- * ClaudeAgent — wraps Anthropic's Claude SDK for council review.
- *
- * Skeleton status: interface correct, implementation returns a stub
- * "approve" verdict. The real tool-use loop with
- * @anthropic-ai/claude-agent-sdk (official TS, bundles MCP + tool_use +
- * compaction) lands in a subsequent PR together with the efficiency
- * gate and RAG-over-answer-keys.
+ * ClaudeAgent — routes a real Claude tool-use review call through the
+ * efficiency gate. Returns a parsed ReviewResult.
  */
 export class ClaudeAgent implements Agent {
   readonly id = "claude";
@@ -25,30 +80,134 @@ export class ClaudeAgent implements Agent {
   private readonly apiKey: string;
   private readonly model: string;
   private readonly maxTokens: number;
+  private readonly gate: EfficiencyGate;
+  private readonly clientFactory: (apiKey: string) => Promise<AnthropicLike>;
+  private clientPromise: Promise<AnthropicLike> | null;
 
   constructor(opts: ClaudeAgentOptions = {}) {
     const key = opts.apiKey ?? process.env["ANTHROPIC_API_KEY"] ?? "";
-    if (!key) {
-      throw new Error("ClaudeAgent: ANTHROPIC_API_KEY not set (pass opts.apiKey or env var)");
+    if (!key && !opts.client) {
+      throw new Error("ClaudeAgent: ANTHROPIC_API_KEY not set (pass opts.apiKey, opts.client, or the env var)");
     }
     this.apiKey = key;
     this.model = opts.model ?? DEFAULT_MODEL;
     this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.gate = opts.gate ?? new EfficiencyGate();
+    this.clientFactory = opts.clientFactory ?? defaultClientFactory;
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+  }
+
+  private async getClient(): Promise<AnthropicLike> {
+    if (!this.clientPromise) {
+      this.clientPromise = this.clientFactory(this.apiKey);
+    }
+    return this.clientPromise;
   }
 
   async review(ctx: ReviewContext): Promise<ReviewResult> {
-    // Skeleton — real implementation will call the SDK with a tool-use
-    // loop, RAG context from answer-keys + failure-catalog, and cost
-    // metering through the efficiency gate.
-    void ctx;
-    void this.apiKey;
-    void this.model;
-    void this.maxTokens;
-    return {
-      agent: this.id,
-      verdict: "approve",
-      blockers: [],
-      summary: "ClaudeAgent skeleton — real review logic pending.",
-    };
+    const cacheablePrefix = buildCacheablePrefix(ctx);
+    const userPrompt = buildReviewPrompt(ctx);
+    const inputTokenEstimate = estimateTokens(cacheablePrefix) + estimateTokens(userPrompt);
+    const estimatedCost = estimateCallCost(this.model, inputTokenEstimate, this.maxTokens);
+
+    const outcome = await this.gate.run<ReviewResult>(
+      {
+        agent: this.id,
+        cacheablePrefix,
+        prompt: cacheablePrefix + "\n" + userPrompt,
+        estimatedCostUsd: estimatedCost,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const response = await client.messages.create({
+          model,
+          max_tokens: this.maxTokens,
+          system: [{ type: "text", text: cacheablePrefix, cache_control: { type: "ephemeral" } }],
+          messages: [{ role: "user", content: userPrompt }],
+          tools: [
+            {
+              name: REVIEW_TOOL_NAME,
+              description: REVIEW_TOOL_DESCRIPTION,
+              input_schema: REVIEW_TOOL_INPUT_SCHEMA,
+            },
+          ],
+          tool_choice: { type: "tool", name: REVIEW_TOOL_NAME },
+        });
+        const latencyMs = Date.now() - started;
+
+        const parsed = parseReviewToolUse(response, this.id);
+        const cost = actualCost(model, {
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          cacheCreationTokens: response.usage.cache_creation_input_tokens,
+          cacheReadTokens: response.usage.cache_read_input_tokens,
+        });
+
+        return {
+          result: {
+            ...parsed,
+            tokensUsed: response.usage.input_tokens + response.usage.output_tokens,
+            costUsd: cost,
+          },
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          costUsd: cost,
+          latencyMs,
+        };
+      },
+    );
+
+    return outcome.result;
   }
 }
+
+function parseReviewToolUse(response: AnthropicResponse, agentId: string): ReviewResult {
+  const toolUse = response.content.find(
+    (block): block is Extract<(typeof response.content)[number], { type: "tool_use" }> =>
+      block.type === "tool_use" && block.name === REVIEW_TOOL_NAME,
+  );
+  if (!toolUse) {
+    throw new Error(
+      `ClaudeAgent: response did not include a ${REVIEW_TOOL_NAME} tool_use block (stop_reason=${response.stop_reason ?? "?"})`,
+    );
+  }
+  const input = toolUse.input as {
+    verdict?: string;
+    blockers?: unknown[];
+    summary?: string;
+  };
+  if (input.verdict !== "approve" && input.verdict !== "rework" && input.verdict !== "reject") {
+    throw new Error(`ClaudeAgent: invalid verdict "${String(input.verdict)}" in tool_use response`);
+  }
+  const blockers: Blocker[] = [];
+  if (Array.isArray(input.blockers)) {
+    for (const raw of input.blockers) {
+      if (!raw || typeof raw !== "object") continue;
+      const b = raw as Record<string, unknown>;
+      const severity = b["severity"];
+      const category = b["category"];
+      const message = b["message"];
+      if (
+        (severity === "blocker" || severity === "major" || severity === "minor" || severity === "nit") &&
+        typeof category === "string" &&
+        typeof message === "string"
+      ) {
+        const blocker: Blocker = { severity, category, message };
+        if (typeof b["file"] === "string") blocker.file = b["file"] as string;
+        if (typeof b["line"] === "number") blocker.line = b["line"] as number;
+        blockers.push(blocker);
+      }
+    }
+  }
+  return {
+    agent: agentId,
+    verdict: input.verdict,
+    blockers,
+    summary: typeof input.summary === "string" ? input.summary : "",
+  };
+}
+
+// Re-export SYSTEM_PROMPT so downstream tools can render/copy it.
+export { SYSTEM_PROMPT };

--- a/packages/agent-claude/src/index.ts
+++ b/packages/agent-claude/src/index.ts
@@ -1,2 +1,6 @@
-export { ClaudeAgent } from "./claude-agent.js";
-export type { ClaudeAgentOptions } from "./claude-agent.js";
+export { ClaudeAgent, SYSTEM_PROMPT } from "./claude-agent.js";
+export type { ClaudeAgentOptions, AnthropicLike, AnthropicCreateParams, AnthropicResponse } from "./claude-agent.js";
+export { buildReviewPrompt, buildCacheablePrefix } from "./prompts.js";
+export { REVIEW_TOOL_NAME, REVIEW_TOOL_DESCRIPTION, REVIEW_TOOL_INPUT_SCHEMA } from "./review-tool.js";
+export { actualCost, estimateCallCost, PRICING } from "./pricing.js";
+export type { ModelPricing, UsageBreakdown } from "./pricing.js";

--- a/packages/agent-claude/src/pricing.ts
+++ b/packages/agent-claude/src/pricing.ts
@@ -1,0 +1,68 @@
+export interface ModelPricing {
+  /** USD per 1M input tokens (non-cached). */
+  inputPerMTok: number;
+  /** USD per 1M cache-write input tokens. */
+  cacheWritePerMTok: number;
+  /** USD per 1M cache-read input tokens. */
+  cacheReadPerMTok: number;
+  /** USD per 1M output tokens. */
+  outputPerMTok: number;
+}
+
+/**
+ * Pricing table for Claude models. Prices reflect published Anthropic API
+ * pricing as of 2026-04; update when Anthropic announces new tiers.
+ *
+ * Cache write = 1.25× base input, cache read = 0.1× base input (90% off).
+ */
+export const PRICING: Record<string, ModelPricing> = {
+  "claude-sonnet-4-6": {
+    inputPerMTok: 3.0,
+    cacheWritePerMTok: 3.75,
+    cacheReadPerMTok: 0.3,
+    outputPerMTok: 15.0,
+  },
+  "claude-haiku-4-5": {
+    inputPerMTok: 0.25,
+    cacheWritePerMTok: 0.3125,
+    cacheReadPerMTok: 0.025,
+    outputPerMTok: 1.25,
+  },
+  "claude-opus-4-7": {
+    inputPerMTok: 15.0,
+    cacheWritePerMTok: 18.75,
+    cacheReadPerMTok: 1.5,
+    outputPerMTok: 75.0,
+  },
+};
+
+export interface UsageBreakdown {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens?: number;
+  cacheReadTokens?: number;
+}
+
+/** Compute actual USD cost from an Anthropic API usage breakdown. */
+export function actualCost(model: string, usage: UsageBreakdown): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown model "${model}"`);
+  const baseInput = usage.inputTokens - (usage.cacheCreationTokens ?? 0) - (usage.cacheReadTokens ?? 0);
+  return (
+    (Math.max(0, baseInput) * p.inputPerMTok +
+      (usage.cacheCreationTokens ?? 0) * p.cacheWritePerMTok +
+      (usage.cacheReadTokens ?? 0) * p.cacheReadPerMTok +
+      usage.outputTokens * p.outputPerMTok) /
+    1_000_000
+  );
+}
+
+/**
+ * Pre-flight USD estimate for budget.reserve(). Pessimistic: assumes no
+ * cache read (worst case) and a typical 25% output-to-input ratio.
+ */
+export function estimateCallCost(model: string, estimatedInputTokens: number, maxOutputTokens: number): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown model "${model}"`);
+  return (estimatedInputTokens * p.inputPerMTok + maxOutputTokens * p.outputPerMTok) / 1_000_000;
+}

--- a/packages/agent-claude/src/prompts.ts
+++ b/packages/agent-claude/src/prompts.ts
@@ -1,0 +1,71 @@
+import type { ReviewContext } from "@ai-conclave/core";
+
+export const SYSTEM_PROMPT = `You are a senior code reviewer on a multi-agent council for Ai-Conclave. The council reviews AI-generated code and design changes before merge.
+
+Your goal: catch real blockers, not style nits. You work alongside other agents (OpenAI, Gemini, possibly domain-specific specialists). Your reviews are weighed against theirs; spurious blockers hurt your agent score and waste the rework budget.
+
+Rules:
+- Focus on: correctness, security, regression risk, missing tests for non-trivial changes, accessibility + contrast on UI, obvious performance cliffs.
+- Do NOT comment on: style bikeshedding, import order, variable renames that are already consistent, personal formatting preferences.
+- When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
+- Never pad with encouragement ("great work but...") — go straight to the concerns.
+- When the diff is small, low-risk, and has test coverage, approve cleanly. Over-flagging is a bigger sin than missing a nit.
+- You MUST respond by calling the submit_review tool exactly once. Do not emit free-form text.`;
+
+export function buildReviewPrompt(ctx: ReviewContext): string {
+  const sections: string[] = [];
+  sections.push(`# Review target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`pull: #${ctx.pullNumber}`);
+  sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
+  sections.push("");
+
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(
+      `These are reviews that led to merged changes on similar code in this repo. Lean on them as a style + quality bar — match their tolerance for what counts as a blocker.`,
+    );
+    sections.push("");
+    for (const entry of ctx.answerKeys.slice(0, 8)) {
+      sections.push(`- ${entry}`);
+    }
+    sections.push("");
+  }
+
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(
+      `These are patterns that caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
+    );
+    sections.push("");
+    for (const entry of ctx.failureCatalog.slice(0, 8)) {
+      sections.push(`- ${entry}`);
+    }
+    sections.push("");
+  }
+
+  sections.push(`# Diff`);
+  sections.push("```diff");
+  sections.push(ctx.diff || "(empty diff — respond with verdict=approve, summary noting nothing to review)");
+  sections.push("```");
+  sections.push("");
+  sections.push(`Call submit_review exactly once with your verdict, blockers (if any), and a one-paragraph summary.`);
+  return sections.join("\n");
+}
+
+/**
+ * The cacheable prefix is everything STABLE across calls within a session —
+ * system prompt + any pinned RAG context that doesn't change per-turn.
+ * Anthropic's prompt cache works best when this prefix is marked
+ * `cache_control: ephemeral` and sits at the head of the messages array.
+ */
+export function buildCacheablePrefix(ctx: ReviewContext): string {
+  const parts: string[] = [SYSTEM_PROMPT];
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
+  }
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    parts.push("failure-catalog:\n" + ctx.failureCatalog.slice(0, 8).join("\n"));
+  }
+  return parts.join("\n---\n");
+}

--- a/packages/agent-claude/src/review-tool.ts
+++ b/packages/agent-claude/src/review-tool.ts
@@ -1,0 +1,56 @@
+/**
+ * Tool-use schema that forces Claude to return a structured review.
+ * Decision #12 — Zod → JSON Schema per-provider adapter; for Anthropic we
+ * use a SINGLE-TOOL pattern (`tool_choice: { type: "tool", name: ... }`)
+ * which gives us reliable structured output without relying on response
+ * parsing heuristics.
+ */
+export const REVIEW_TOOL_NAME = "submit_review";
+
+export const REVIEW_TOOL_DESCRIPTION =
+  "Submit your structured review of the diff. Call this exactly once at the end of your analysis.";
+
+export const REVIEW_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    verdict: {
+      type: "string",
+      enum: ["approve", "rework", "reject"],
+      description:
+        "approve = ship as-is; rework = fixable blockers (agent should attempt auto-fix); reject = fundamentally wrong approach (do not merge, human must intervene).",
+    },
+    blockers: {
+      type: "array",
+      description: "Ordered list of issues found. Empty when verdict is approve.",
+      items: {
+        type: "object",
+        properties: {
+          severity: {
+            type: "string",
+            enum: ["blocker", "major", "minor", "nit"],
+            description:
+              "blocker = must fix; major = should fix; minor = worth fixing; nit = optional polish.",
+          },
+          category: {
+            type: "string",
+            description:
+              "Short tag like 'type-error' / 'missing-test' / 'security' / 'accessibility' / 'regression'. Used for precision/recall metrics.",
+          },
+          message: {
+            type: "string",
+            description: "One-sentence description of the problem + what to change.",
+          },
+          file: { type: "string", description: "Relative path to the file, if applicable." },
+          line: { type: "number", description: "Line number, if applicable." },
+        },
+        required: ["severity", "category", "message"],
+      },
+    },
+    summary: {
+      type: "string",
+      description:
+        "One-paragraph summary of the review. Include the overall verdict reasoning, not just a restatement of blockers.",
+    },
+  },
+  required: ["verdict", "blockers", "summary"],
+} as const;

--- a/packages/agent-claude/test/claude-agent.test.mjs
+++ b/packages/agent-claude/test/claude-agent.test.mjs
@@ -1,0 +1,157 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EfficiencyGate } from "@ai-conclave/core";
+import { ClaudeAgent } from "../dist/index.js";
+
+function makeMockClient(responses) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    messages: {
+      create: async (params) => {
+        calls.push(params);
+        const r = responses[Math.min(i, responses.length - 1)];
+        i += 1;
+        return r;
+      },
+    },
+  };
+}
+
+function okResponse({ verdict = "approve", blockers = [], summary = "ok", inputTokens = 1_000, outputTokens = 100, cacheRead = 0 } = {}) {
+  return {
+    id: "msg_test",
+    model: "claude-sonnet-4-6",
+    content: [
+      {
+        type: "tool_use",
+        id: "tool_1",
+        name: "submit_review",
+        input: { verdict, blockers, summary },
+      },
+    ],
+    stop_reason: "tool_use",
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cache_read_input_tokens: cacheRead,
+    },
+  };
+}
+
+const ctx = {
+  diff: "diff --git a/x b/x\n+added",
+  repo: "acme/x",
+  pullNumber: 1,
+  newSha: "abc123",
+};
+
+test("ClaudeAgent: parses approve verdict through the efficiency gate", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse({ verdict: "approve", summary: "LGTM" })]);
+  const agent = new ClaudeAgent({ apiKey: "test-key", gate, client });
+  const result = await agent.review(ctx);
+  assert.equal(result.agent, "claude");
+  assert.equal(result.verdict, "approve");
+  assert.equal(result.blockers.length, 0);
+  assert.equal(result.summary, "LGTM");
+  assert.ok(typeof result.costUsd === "number" && result.costUsd > 0);
+  assert.ok(typeof result.tokensUsed === "number" && result.tokensUsed === 1_100);
+});
+
+test("ClaudeAgent: parses rework verdict with blockers", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([
+    okResponse({
+      verdict: "rework",
+      blockers: [
+        { severity: "blocker", category: "type-error", message: "ts2345 on line 7", file: "src/x.ts", line: 7 },
+        { severity: "minor", category: "missing-test", message: "no test for new branch" },
+        { invalid: "shape", should: "drop" },
+      ],
+      summary: "1 blocker, 1 minor",
+    }),
+  ]);
+  const agent = new ClaudeAgent({ apiKey: "test-key", gate, client });
+  const result = await agent.review(ctx);
+  assert.equal(result.verdict, "rework");
+  assert.equal(result.blockers.length, 2);
+  assert.equal(result.blockers[0].severity, "blocker");
+  assert.equal(result.blockers[0].file, "src/x.ts");
+  assert.equal(result.blockers[0].line, 7);
+  assert.equal(result.blockers[1].severity, "minor");
+});
+
+test("ClaudeAgent: throws when response has no tool_use block", async () => {
+  const client = {
+    calls: [],
+    messages: {
+      create: async () => ({
+        id: "msg",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "I forgot to call the tool" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 100, output_tokens: 10 },
+      }),
+    },
+  };
+  const agent = new ClaudeAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /did not include a submit_review tool_use/);
+});
+
+test("ClaudeAgent: throws on invalid verdict value", async () => {
+  const client = makeMockClient([okResponse({ verdict: "ship-it-lol" })]);
+  const agent = new ClaudeAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /invalid verdict/);
+});
+
+test("ClaudeAgent: records a metric on the shared gate", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse({ verdict: "approve", inputTokens: 5_000, outputTokens: 200 })]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const summary = gate.metrics.summary();
+  assert.equal(summary.callCount, 1);
+  assert.equal(summary.byAgent["claude"].calls, 1);
+  assert.ok(summary.totalCostUsd > 0);
+});
+
+test("ClaudeAgent: sends system prompt with cache_control ephemeral", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse()]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const params = client.calls[0];
+  assert.ok(Array.isArray(params.system), "system should be an array of blocks for cache control");
+  assert.equal(params.system[0].cache_control?.type, "ephemeral");
+});
+
+test("ClaudeAgent: forces submit_review tool via tool_choice", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse()]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const params = client.calls[0];
+  assert.equal(params.tool_choice.type, "tool");
+  assert.equal(params.tool_choice.name, "submit_review");
+});
+
+test("ClaudeAgent: respects a shared budget cap across calls", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 0.005 }); // tiny budget
+  const client = makeMockClient([
+    okResponse({ inputTokens: 10_000, outputTokens: 500 }), // ~$0.0375 → exceeds 0.005
+  ]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await assert.rejects(() => agent.review(ctx), /budget/);
+});
+
+test("ClaudeAgent: missing API key AND no injected client throws in constructor", () => {
+  const orig = process.env.ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  try {
+    assert.throws(() => new ClaudeAgent());
+  } finally {
+    if (orig !== undefined) process.env.ANTHROPIC_API_KEY = orig;
+  }
+});

--- a/packages/agent-claude/test/pricing.test.mjs
+++ b/packages/agent-claude/test/pricing.test.mjs
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { actualCost, estimateCallCost, PRICING } from "../dist/index.js";
+
+test("PRICING table has all three Claude tiers", () => {
+  assert.ok(PRICING["claude-sonnet-4-6"]);
+  assert.ok(PRICING["claude-haiku-4-5"]);
+  assert.ok(PRICING["claude-opus-4-7"]);
+});
+
+test("actualCost: Sonnet baseline — 1000 in, 500 out, no cache", () => {
+  const cost = actualCost("claude-sonnet-4-6", { inputTokens: 1_000, outputTokens: 500 });
+  // 1000 * 3 + 500 * 15 = 3000 + 7500 = 10_500 / 1_000_000 = 0.0105
+  assert.equal(cost.toFixed(4), "0.0105");
+});
+
+test("actualCost: cache read discount applied", () => {
+  const noCache = actualCost("claude-sonnet-4-6", { inputTokens: 10_000, outputTokens: 200 });
+  const cached = actualCost("claude-sonnet-4-6", {
+    inputTokens: 10_000,
+    outputTokens: 200,
+    cacheReadTokens: 9_000,
+  });
+  // 9k cache read at 0.3/MTok instead of 3.0/MTok = 0.0027 vs 0.027 → $0.0243 savings
+  assert.ok(cached < noCache, "cached call must cost less");
+  assert.equal((noCache - cached).toFixed(4), "0.0243");
+});
+
+test("actualCost: cache write premium applied", () => {
+  const noCache = actualCost("claude-sonnet-4-6", { inputTokens: 5_000, outputTokens: 100 });
+  const cacheWrite = actualCost("claude-sonnet-4-6", {
+    inputTokens: 5_000,
+    outputTokens: 100,
+    cacheCreationTokens: 5_000,
+  });
+  // cache write is 1.25× input cost
+  assert.ok(cacheWrite > noCache);
+});
+
+test("actualCost: Haiku is ~12× cheaper than Sonnet per input token", () => {
+  const sonnet = actualCost("claude-sonnet-4-6", { inputTokens: 100_000, outputTokens: 0 });
+  const haiku = actualCost("claude-haiku-4-5", { inputTokens: 100_000, outputTokens: 0 });
+  const ratio = sonnet / haiku;
+  assert.ok(ratio >= 11 && ratio <= 13, `expected ratio ~12, got ${ratio}`);
+});
+
+test("actualCost: throws on unknown model", () => {
+  assert.throws(() => actualCost("claude-does-not-exist", { inputTokens: 1, outputTokens: 1 }));
+});
+
+test("estimateCallCost: pessimistic pre-flight matches reserve-before-call flow", () => {
+  const est = estimateCallCost("claude-sonnet-4-6", 5_000, 1_000);
+  // 5k * 3/M + 1k * 15/M = 15e-3 + 15e-3 = 0.03
+  assert.equal(est.toFixed(3), "0.030");
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./efficiency": {
+      "types": "./dist/efficiency/index.d.ts",
+      "import": "./dist/efficiency/index.js"
     }
   },
   "files": [

--- a/packages/core/src/efficiency/budget.ts
+++ b/packages/core/src/efficiency/budget.ts
@@ -1,0 +1,83 @@
+export interface BudgetOptions {
+  /** Max total USD that may be spent across all LLM calls within this run. */
+  perPrUsd: number;
+  /** Optional soft-warning threshold as a fraction of perPrUsd (0..1). Defaults to 0.8. */
+  warnAt?: number;
+}
+
+/** Thrown when a spend attempt would exceed the per-PR budget cap. */
+export class BudgetExceededError extends Error {
+  readonly attemptedUsd: number;
+  readonly capUsd: number;
+  readonly spentUsd: number;
+
+  constructor(attemptedUsd: number, capUsd: number, spentUsd: number) {
+    super(
+      `budget: attempt to spend $${attemptedUsd.toFixed(4)} would take total to $${(spentUsd + attemptedUsd).toFixed(4)} (cap $${capUsd.toFixed(2)})`,
+    );
+    this.name = "BudgetExceededError";
+    this.attemptedUsd = attemptedUsd;
+    this.capUsd = capUsd;
+    this.spentUsd = spentUsd;
+  }
+}
+
+/** Default per-PR budget per decision #20. User-configurable via opts.perPrUsd. */
+export const DEFAULT_PER_PR_BUDGET_USD = 0.5;
+
+export class BudgetTracker {
+  private readonly capUsd: number;
+  private readonly warnAt: number;
+  private spent = 0;
+  private warned = false;
+  private warningHandler: ((spentUsd: number, capUsd: number) => void) | undefined;
+
+  constructor(opts: BudgetOptions) {
+    if (opts.perPrUsd <= 0) throw new Error("budget: perPrUsd must be > 0");
+    this.capUsd = opts.perPrUsd;
+    this.warnAt = opts.warnAt ?? 0.8;
+    if (this.warnAt < 0 || this.warnAt > 1) {
+      throw new Error("budget: warnAt must be in [0, 1]");
+    }
+  }
+
+  /** Attach a one-shot warning callback that fires when spending crosses the warn threshold. */
+  onWarning(handler: (spentUsd: number, capUsd: number) => void): void {
+    this.warningHandler = handler;
+  }
+
+  /** Throws BudgetExceededError if adding `usd` would exceed the cap. Call BEFORE the LLM call. */
+  reserve(usd: number): void {
+    if (usd < 0) throw new Error("budget: cannot reserve negative USD");
+    if (this.spent + usd > this.capUsd) {
+      throw new BudgetExceededError(usd, this.capUsd, this.spent);
+    }
+  }
+
+  /** Record actual spend after the call lands. No throw — we've already reserved. */
+  commit(usd: number): void {
+    if (usd < 0) throw new Error("budget: cannot commit negative USD");
+    this.spent += usd;
+    if (!this.warned && this.spent / this.capUsd >= this.warnAt) {
+      this.warned = true;
+      this.warningHandler?.(this.spent, this.capUsd);
+    }
+  }
+
+  get spentUsd(): number {
+    return this.spent;
+  }
+
+  get remainingUsd(): number {
+    return Math.max(0, this.capUsd - this.spent);
+  }
+
+  get capacityUsd(): number {
+    return this.capUsd;
+  }
+
+  reset(): void {
+    this.spent = 0;
+    this.warned = false;
+  }
+}

--- a/packages/core/src/efficiency/cache.ts
+++ b/packages/core/src/efficiency/cache.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+
+export interface CacheEntry<T> {
+  value: T;
+  storedAt: number;
+}
+
+export interface CacheOptions {
+  /** Time-to-live in milliseconds. Defaults to Anthropic's 5-minute prompt-cache window. */
+  ttlMs?: number;
+  /** Max entries held in memory. Oldest-first eviction. */
+  maxEntries?: number;
+}
+
+/**
+ * Anthropic prompt-cache 5-minute TTL is the design constraint:
+ * - On a HIT, downstream can signal `cache_control: ephemeral` to the API and save ~90% input cost
+ * - On a MISS within a live window, the request should still mark the large static prefix as `ephemeral`
+ *   so the NEXT identical call within 5 min hits the provider cache.
+ *
+ * PromptCache here tracks our view of whether we've recently issued a matching prefix — it does not
+ * store LLM output. The provider is the source of truth for what's actually cached server-side.
+ */
+export const ANTHROPIC_PROMPT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+export class PromptCache {
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+  private readonly store = new Map<string, CacheEntry<true>>();
+  private hits = 0;
+  private misses = 0;
+
+  constructor(opts: CacheOptions = {}) {
+    this.ttlMs = opts.ttlMs ?? ANTHROPIC_PROMPT_CACHE_TTL_MS;
+    this.maxEntries = opts.maxEntries ?? 1024;
+  }
+
+  /** Stable hash of a prefix string. Exported for tests + debugging. */
+  static key(prefix: string, model: string): string {
+    return createHash("sha256").update(`${model}\u0000${prefix}`).digest("hex");
+  }
+
+  isLive(prefix: string, model: string, now: number = Date.now()): boolean {
+    const k = PromptCache.key(prefix, model);
+    const entry = this.store.get(k);
+    if (!entry) {
+      this.misses += 1;
+      return false;
+    }
+    if (now - entry.storedAt > this.ttlMs) {
+      this.store.delete(k);
+      this.misses += 1;
+      return false;
+    }
+    this.hits += 1;
+    return true;
+  }
+
+  mark(prefix: string, model: string, now: number = Date.now()): void {
+    const k = PromptCache.key(prefix, model);
+    if (!this.store.has(k) && this.store.size >= this.maxEntries) {
+      const oldest = this.store.keys().next().value;
+      if (oldest !== undefined) this.store.delete(oldest);
+    }
+    this.store.set(k, { value: true, storedAt: now });
+  }
+
+  hitRate(): number {
+    const total = this.hits + this.misses;
+    return total === 0 ? 0 : this.hits / total;
+  }
+
+  get stats(): { hits: number; misses: number; size: number } {
+    return { hits: this.hits, misses: this.misses, size: this.store.size };
+  }
+
+  reset(): void {
+    this.store.clear();
+    this.hits = 0;
+    this.misses = 0;
+  }
+}

--- a/packages/core/src/efficiency/compact.ts
+++ b/packages/core/src/efficiency/compact.ts
@@ -1,0 +1,87 @@
+export interface CompactableMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+  /** Tokens for this message (estimate). */
+  tokens: number;
+  /** If true, never compact or drop — used for the current turn's user ask and system prompt. */
+  pin?: boolean;
+}
+
+export interface CompactOptions {
+  /** Target token budget for the conversation after compaction. */
+  targetTokens: number;
+  /** Optional summarizer. If provided, older messages are collapsed into a summary message. */
+  summarize?: (messages: readonly CompactableMessage[]) => Promise<string>;
+}
+
+export interface CompactResult {
+  messages: CompactableMessage[];
+  droppedCount: number;
+  summarizedCount: number;
+  finalTokens: number;
+}
+
+/**
+ * Round-to-round context compression.
+ *
+ * Strategy:
+ *   1. Keep all `pin: true` messages (system prompt, current turn).
+ *   2. Walk remaining messages newest-to-oldest, keeping until budget is hit.
+ *   3. If a `summarize` function is provided, collapse the dropped tail into
+ *      a single assistant-role summary message at the head of unpinned history.
+ *
+ * The real implementation uses Haiku for the summary call — kept as an
+ * injected function so callers can swap in a cached/noop variant for tests.
+ */
+export async function compact(
+  messages: readonly CompactableMessage[],
+  opts: CompactOptions,
+): Promise<CompactResult> {
+  const pinned = messages.filter((m) => m.pin);
+  const unpinned = messages.filter((m) => !m.pin);
+
+  const pinnedTokens = pinned.reduce((sum, m) => sum + m.tokens, 0);
+  const budget = opts.targetTokens - pinnedTokens;
+
+  if (budget <= 0) {
+    return {
+      messages: pinned,
+      droppedCount: unpinned.length,
+      summarizedCount: 0,
+      finalTokens: pinnedTokens,
+    };
+  }
+
+  // Fit newest-first.
+  const kept: CompactableMessage[] = [];
+  let used = 0;
+  for (let i = unpinned.length - 1; i >= 0; i -= 1) {
+    const m = unpinned[i]!;
+    if (used + m.tokens > budget) break;
+    kept.unshift(m);
+    used += m.tokens;
+  }
+  const dropped = unpinned.slice(0, unpinned.length - kept.length);
+
+  let summarized = 0;
+  if (dropped.length > 0 && opts.summarize) {
+    const summaryText = await opts.summarize(dropped);
+    const summaryTokens = Math.ceil(summaryText.length / 4);
+    if (summaryTokens <= budget - used) {
+      kept.unshift({
+        role: "assistant",
+        content: `[compacted summary of ${dropped.length} earlier messages]\n${summaryText}`,
+        tokens: summaryTokens,
+      });
+      used += summaryTokens;
+      summarized = dropped.length;
+    }
+  }
+
+  return {
+    messages: [...pinned, ...kept],
+    droppedCount: dropped.length - summarized,
+    summarizedCount: summarized,
+    finalTokens: pinnedTokens + used,
+  };
+}

--- a/packages/core/src/efficiency/gate.ts
+++ b/packages/core/src/efficiency/gate.ts
@@ -1,0 +1,95 @@
+import { PromptCache } from "./cache.js";
+import { BudgetTracker, DEFAULT_PER_PR_BUDGET_USD } from "./budget.js";
+import { MetricsRecorder, type CallMetric } from "./metrics.js";
+import { selectModel, estimateTokens, type ModelChoice } from "./router.js";
+
+export interface EfficiencyGateOptions {
+  perPrUsd?: number;
+  cache?: PromptCache;
+  budget?: BudgetTracker;
+  metrics?: MetricsRecorder;
+}
+
+export interface GateCallInput {
+  agent: string;
+  /** The prefix that is safe to prompt-cache (system prompt + pinned RAG context). */
+  cacheablePrefix: string;
+  /** The full prompt (prefix + volatile tail). Used for token estimation. */
+  prompt: string;
+  /** Pre-flight cost estimate in USD (caller computes from token budget + model pricing). */
+  estimatedCostUsd: number;
+  /** Override model routing if the caller has a specific requirement. */
+  forceModel?: string;
+}
+
+export interface GateCallOutcome<T> {
+  result: T;
+  metric: CallMetric;
+  modelChoice: ModelChoice;
+}
+
+export interface GateExecuteFn<T> {
+  (args: { model: string; cacheHit: boolean }): Promise<{
+    result: T;
+    inputTokens: number;
+    outputTokens: number;
+    costUsd: number;
+    latencyMs: number;
+  }>;
+}
+
+/**
+ * EfficiencyGate — central orchestrator. Every agent's LLM call MUST route
+ * through `run()` so cache, budget, routing, and metrics are uniform.
+ *
+ * Direct SDK calls outside this gate are a contract violation (decision #22).
+ */
+export class EfficiencyGate {
+  readonly cache: PromptCache;
+  readonly budget: BudgetTracker;
+  readonly metrics: MetricsRecorder;
+
+  constructor(opts: EfficiencyGateOptions = {}) {
+    this.cache = opts.cache ?? new PromptCache();
+    this.budget = opts.budget ?? new BudgetTracker({ perPrUsd: opts.perPrUsd ?? DEFAULT_PER_PR_BUDGET_USD });
+    this.metrics = opts.metrics ?? new MetricsRecorder();
+  }
+
+  async run<T>(input: GateCallInput, execute: GateExecuteFn<T>): Promise<GateCallOutcome<T>> {
+    // 1. Reserve budget BEFORE the call — throws if over cap.
+    this.budget.reserve(input.estimatedCostUsd);
+
+    // 2. Route to a model class.
+    const tokens = estimateTokens(input.prompt);
+    const choice: ModelChoice = input.forceModel
+      ? { model: input.forceModel, class: "sonnet", reason: "forced by caller" }
+      : selectModel(tokens);
+
+    // 3. Check cache liveness for the cacheable prefix.
+    const cacheHit = this.cache.isLive(input.cacheablePrefix, choice.model);
+
+    // 4. Execute.
+    const call = await execute({ model: choice.model, cacheHit });
+
+    // 5. Mark cache so the NEXT identical call within TTL reports a hit.
+    this.cache.mark(input.cacheablePrefix, choice.model);
+
+    // 6. Commit actual spend.
+    this.budget.commit(call.costUsd);
+
+    // 7. Record metric.
+    const metric: CallMetric = {
+      agent: input.agent,
+      model: choice.model,
+      inputTokens: call.inputTokens,
+      outputTokens: call.outputTokens,
+      costUsd: call.costUsd,
+      latencyMs: call.latencyMs,
+      cacheHit,
+      timestamp: Date.now(),
+    };
+    this.metrics.record(metric);
+
+    return { result: call.result, metric, modelChoice: choice };
+  }
+}

--- a/packages/core/src/efficiency/index.ts
+++ b/packages/core/src/efficiency/index.ts
@@ -1,0 +1,32 @@
+export { PromptCache, ANTHROPIC_PROMPT_CACHE_TTL_MS } from "./cache.js";
+export type { CacheEntry, CacheOptions } from "./cache.js";
+
+export { BudgetTracker, BudgetExceededError, DEFAULT_PER_PR_BUDGET_USD } from "./budget.js";
+export type { BudgetOptions } from "./budget.js";
+
+export { MetricsRecorder } from "./metrics.js";
+export type { CallMetric, MetricsSummary, MetricsSink } from "./metrics.js";
+
+export {
+  triageReview,
+  touchesRiskyPath,
+  DEFAULT_RISKY_PATH_PATTERNS,
+} from "./triage.js";
+export type { TriagePath, TriageInput, TriageOptions, TriageOutcome } from "./triage.js";
+
+export { selectModel, estimateTokens, DEFAULT_MODELS } from "./router.js";
+export type { ModelClass, ModelChoice, RouterOptions } from "./router.js";
+
+export { compact } from "./compact.js";
+export type { CompactableMessage, CompactOptions, CompactResult } from "./compact.js";
+
+export { buildRelevanceContext, inferTestPath } from "./relevance.js";
+export type { RelevanceChunk, RelevanceInput, RelevanceOptions } from "./relevance.js";
+
+export { EfficiencyGate } from "./gate.js";
+export type {
+  EfficiencyGateOptions,
+  GateCallInput,
+  GateCallOutcome,
+  GateExecuteFn,
+} from "./gate.js";

--- a/packages/core/src/efficiency/metrics.ts
+++ b/packages/core/src/efficiency/metrics.ts
@@ -1,0 +1,104 @@
+export interface CallMetric {
+  agent: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+  cacheHit: boolean;
+  timestamp: number;
+}
+
+export interface MetricsSummary {
+  callCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+  totalLatencyMs: number;
+  cacheHitRate: number;
+  byAgent: Record<string, { calls: number; costUsd: number }>;
+  byModel: Record<string, { calls: number; costUsd: number }>;
+}
+
+export interface MetricsSink {
+  record(metric: CallMetric): void;
+}
+
+/**
+ * MetricsRecorder — collects per-call metrics in memory and optionally
+ * forwards to an external sink (Langfuse self-hosted planned; stub here).
+ *
+ * Real Langfuse OTLP wiring lands when observability package is added;
+ * until then this is the source of truth for cost/tokens/latency.
+ */
+export class MetricsRecorder {
+  private readonly records: CallMetric[] = [];
+  private readonly sink: MetricsSink | undefined;
+
+  constructor(opts: { sink?: MetricsSink } = {}) {
+    this.sink = opts.sink;
+  }
+
+  record(metric: CallMetric): void {
+    this.records.push(metric);
+    this.sink?.record(metric);
+  }
+
+  all(): readonly CallMetric[] {
+    return this.records;
+  }
+
+  summary(): MetricsSummary {
+    if (this.records.length === 0) {
+      return {
+        callCount: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalCostUsd: 0,
+        totalLatencyMs: 0,
+        cacheHitRate: 0,
+        byAgent: {},
+        byModel: {},
+      };
+    }
+
+    const byAgent: Record<string, { calls: number; costUsd: number }> = {};
+    const byModel: Record<string, { calls: number; costUsd: number }> = {};
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let costUsd = 0;
+    let latencyMs = 0;
+    let cacheHits = 0;
+
+    for (const r of this.records) {
+      inputTokens += r.inputTokens;
+      outputTokens += r.outputTokens;
+      costUsd += r.costUsd;
+      latencyMs += r.latencyMs;
+      if (r.cacheHit) cacheHits += 1;
+      const ag = byAgent[r.agent] ?? { calls: 0, costUsd: 0 };
+      ag.calls += 1;
+      ag.costUsd += r.costUsd;
+      byAgent[r.agent] = ag;
+      const md = byModel[r.model] ?? { calls: 0, costUsd: 0 };
+      md.calls += 1;
+      md.costUsd += r.costUsd;
+      byModel[r.model] = md;
+    }
+
+    return {
+      callCount: this.records.length,
+      totalInputTokens: inputTokens,
+      totalOutputTokens: outputTokens,
+      totalCostUsd: costUsd,
+      totalLatencyMs: latencyMs,
+      cacheHitRate: cacheHits / this.records.length,
+      byAgent,
+      byModel,
+    };
+  }
+
+  reset(): void {
+    this.records.length = 0;
+  }
+}

--- a/packages/core/src/efficiency/relevance.ts
+++ b/packages/core/src/efficiency/relevance.ts
@@ -1,0 +1,104 @@
+export interface RelevanceChunk {
+  path: string;
+  excerpt: string;
+  reason: "diff" | "import-of-diff" | "imported-by-diff" | "test-of-diff";
+  estimatedTokens: number;
+}
+
+export interface RelevanceInput {
+  diff: string;
+  diffPaths: readonly string[];
+  /** Optional resolver: given a path, return its full content (for selective excerpts). */
+  readFile?: (path: string) => Promise<string | null>;
+  /** Optional resolver: given a path, return its direct imports (for graph walk). */
+  importsOf?: (path: string) => Promise<readonly string[]>;
+}
+
+export interface RelevanceOptions {
+  /** Max tokens to spend on the assembled context. Default 20_000. */
+  tokenBudget?: number;
+  /** Depth of import-graph walk. Default 1 (direct imports only). */
+  graphDepth?: number;
+}
+
+/**
+ * Build a relevance context for a review call.
+ *
+ * Priority (in token-budget order):
+ *   1. Full diff (always included; truncated to budget if oversized)
+ *   2. Test files matching diffed paths (critical for missing-coverage checks)
+ *   3. Direct imports of diffed paths (next PR may import these; reviewer needs the interfaces)
+ *   4. Files that import the diffed paths (potential breakage surface)
+ *
+ * The function is deliberately conservative: if `readFile` / `importsOf` are
+ * not provided, it returns just the diff. Scm-github (v2.0) will supply the
+ * real resolvers; for scaffolding we keep this pure.
+ */
+export async function buildRelevanceContext(
+  input: RelevanceInput,
+  opts: RelevanceOptions = {},
+): Promise<{ chunks: RelevanceChunk[]; totalTokens: number }> {
+  const budget = opts.tokenBudget ?? 20_000;
+  const chunks: RelevanceChunk[] = [];
+  let used = 0;
+
+  const diffTokens = Math.ceil(input.diff.length / 4);
+  const diffChunk: RelevanceChunk = {
+    path: "__diff__",
+    excerpt: diffTokens > budget ? input.diff.slice(0, budget * 4) : input.diff,
+    reason: "diff",
+    estimatedTokens: Math.min(diffTokens, budget),
+  };
+  chunks.push(diffChunk);
+  used += diffChunk.estimatedTokens;
+  if (used >= budget) return { chunks, totalTokens: used };
+
+  if (input.readFile) {
+    for (const p of input.diffPaths) {
+      if (used >= budget) break;
+      const testPath = inferTestPath(p);
+      if (!testPath) continue;
+      const content = await input.readFile(testPath);
+      if (!content) continue;
+      const tokens = Math.ceil(content.length / 4);
+      if (used + tokens > budget) continue;
+      chunks.push({ path: testPath, excerpt: content, reason: "test-of-diff", estimatedTokens: tokens });
+      used += tokens;
+    }
+  }
+
+  if (input.importsOf && (opts.graphDepth ?? 1) > 0) {
+    const seen = new Set(input.diffPaths);
+    for (const p of input.diffPaths) {
+      if (used >= budget) break;
+      const imports = await input.importsOf(p);
+      for (const imp of imports) {
+        if (used >= budget) break;
+        if (seen.has(imp)) continue;
+        seen.add(imp);
+        const content = input.readFile ? await input.readFile(imp) : null;
+        if (!content) continue;
+        const tokens = Math.ceil(content.length / 4);
+        if (used + tokens > budget) continue;
+        chunks.push({
+          path: imp,
+          excerpt: content,
+          reason: "import-of-diff",
+          estimatedTokens: tokens,
+        });
+        used += tokens;
+      }
+    }
+  }
+
+  return { chunks, totalTokens: used };
+}
+
+/** Heuristic: map a source file path to its conventional test path. Returns null if none inferable. */
+export function inferTestPath(source: string): string | null {
+  if (/\.(test|spec)\.(ts|tsx|js|mjs)$/.test(source)) return source;
+  const m = source.match(/^(.*)\/([^/]+?)\.(ts|tsx|js|mjs)$/);
+  if (!m) return null;
+  const [, dir, base, ext] = m;
+  return `${dir}/${base}.test.${ext}`;
+}

--- a/packages/core/src/efficiency/router.ts
+++ b/packages/core/src/efficiency/router.ts
@@ -1,0 +1,63 @@
+export type ModelClass = "haiku" | "sonnet" | "opus" | "long-context";
+
+export interface ModelChoice {
+  /** Provider-specific model identifier. */
+  model: string;
+  /** Logical class for metrics grouping. */
+  class: ModelClass;
+  /** Reason text for logs / traces. */
+  reason: string;
+}
+
+export interface RouterOptions {
+  /** Upper bound (input tokens) for Haiku path. Default 8_000. */
+  haikuMax?: number;
+  /** Upper bound (input tokens) for Sonnet path. Default 50_000. */
+  sonnetMax?: number;
+  /** Override default model IDs if needed (e.g. preview releases). */
+  models?: Partial<Record<ModelClass, string>>;
+}
+
+/**
+ * Default model identifiers per 34-decision tech stack (2026-04-19):
+ *   haiku   → fast triage, nightly episodic→catalog classification
+ *   sonnet  → main reviewer workhorse (decision-core default)
+ *   long    → Gemini 2.5 Pro for >50K input tokens (long-context slot)
+ */
+export const DEFAULT_MODELS: Record<ModelClass, string> = {
+  haiku: "claude-haiku-4-5",
+  sonnet: "claude-sonnet-4-6",
+  opus: "claude-opus-4-7",
+  "long-context": "gemini-2.5-pro",
+};
+
+/**
+ * Route by input size. Output-size driven routing is intentionally excluded
+ * for now — output tends to be bounded by the prompt structure, not a
+ * separate routing axis.
+ */
+export function selectModel(
+  inputTokenEstimate: number,
+  opts: RouterOptions = {},
+): ModelChoice {
+  const haikuMax = opts.haikuMax ?? 8_000;
+  const sonnetMax = opts.sonnetMax ?? 50_000;
+  const models = { ...DEFAULT_MODELS, ...opts.models };
+
+  if (inputTokenEstimate <= haikuMax) {
+    return { model: models.haiku, class: "haiku", reason: `input ${inputTokenEstimate} ≤ ${haikuMax}` };
+  }
+  if (inputTokenEstimate <= sonnetMax) {
+    return { model: models.sonnet, class: "sonnet", reason: `input ${inputTokenEstimate} ≤ ${sonnetMax}` };
+  }
+  return {
+    model: models["long-context"],
+    class: "long-context",
+    reason: `input ${inputTokenEstimate} > ${sonnetMax}`,
+  };
+}
+
+/** Rough input-size estimator. Real impl should use tiktoken / Anthropic tokenizer; this is a placeholder. */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}

--- a/packages/core/src/efficiency/triage.ts
+++ b/packages/core/src/efficiency/triage.ts
@@ -1,0 +1,75 @@
+export type TriagePath = "lite" | "full";
+
+export interface TriageInput {
+  /** Net lines changed (adds + deletes). */
+  linesChanged: number;
+  /** Number of files in the diff. */
+  fileCount: number;
+  /** Whether the diff touches any test files. */
+  hasTests: boolean;
+  /** Whether any of the changed files matches a "risky path" pattern (e.g. schema/, migrations/, auth/, payments/). */
+  touchesRiskyPath: boolean;
+  /** Total added/deleted characters (optional, used as a size tiebreaker). */
+  sizeBytes?: number;
+}
+
+export interface TriageOptions {
+  /** Under this many lines of change, a PR is considered lite-eligible. Default 40. */
+  liteLineThreshold?: number;
+  /** Under this many files, a PR is considered lite-eligible. Default 3. */
+  liteFileThreshold?: number;
+}
+
+export interface TriageOutcome {
+  path: TriagePath;
+  /** Human-readable reason the path was chosen. */
+  reason: string;
+}
+
+const DEFAULT_LITE_LINES = 40;
+const DEFAULT_LITE_FILES = 3;
+
+/**
+ * Classifies a review as "lite" (single agent, short review) or "full" (3-round council).
+ *
+ * Rules in priority order:
+ *   1. Risky-path touches always go full — missing a security/schema bug is more expensive than the review cost.
+ *   2. Large PRs (>threshold lines OR >threshold files) go full.
+ *   3. PRs that TOUCH but don't ADD tests for changed logic go full (we want the second agent to catch missing coverage).
+ *   4. Everything else → lite.
+ */
+export function triageReview(input: TriageInput, opts: TriageOptions = {}): TriageOutcome {
+  const lineThreshold = opts.liteLineThreshold ?? DEFAULT_LITE_LINES;
+  const fileThreshold = opts.liteFileThreshold ?? DEFAULT_LITE_FILES;
+
+  if (input.touchesRiskyPath) {
+    return { path: "full", reason: "diff touches a risky path (schema / auth / payment / migration)" };
+  }
+  if (input.linesChanged > lineThreshold) {
+    return { path: "full", reason: `linesChanged ${input.linesChanged} > ${lineThreshold}` };
+  }
+  if (input.fileCount > fileThreshold) {
+    return { path: "full", reason: `fileCount ${input.fileCount} > ${fileThreshold}` };
+  }
+  if (!input.hasTests && input.linesChanged >= 10) {
+    return { path: "full", reason: "non-trivial diff without any test files touched" };
+  }
+  return { path: "lite", reason: "small, low-risk, has test coverage or trivial" };
+}
+
+/** Default patterns that force a full council review when touched. */
+export const DEFAULT_RISKY_PATH_PATTERNS = [
+  /(^|\/)(schema|schemas)\//i,
+  /(^|\/)migrations?\//i,
+  /(^|\/)auth\//i,
+  /(^|\/)(payment|payments|billing)\//i,
+  /\.sql$/i,
+  /prisma\/schema\.prisma$/i,
+] as const;
+
+export function touchesRiskyPath(
+  paths: readonly string[],
+  patterns: readonly RegExp[] = DEFAULT_RISKY_PATH_PATTERNS,
+): boolean {
+  return paths.some((p) => patterns.some((re) => re.test(p)));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,44 @@
 export type { Agent, ReviewContext, ReviewResult, Blocker, Severity } from "./agent.js";
 export { Council } from "./council.js";
 export { ReviewResultSchema, BlockerSchema } from "./schema.js";
+
+// Efficiency Gate (decision #22: first-class from day 1) — every LLM call
+// routes through `EfficiencyGate.run(...)`. Re-exported here for convenience;
+// the dedicated subpath export lives at @ai-conclave/core/efficiency.
+export {
+  EfficiencyGate,
+  PromptCache,
+  BudgetTracker,
+  BudgetExceededError,
+  MetricsRecorder,
+  selectModel,
+  estimateTokens,
+  triageReview,
+  touchesRiskyPath,
+  compact,
+  buildRelevanceContext,
+  DEFAULT_PER_PR_BUDGET_USD,
+  DEFAULT_MODELS,
+  ANTHROPIC_PROMPT_CACHE_TTL_MS,
+} from "./efficiency/index.js";
+export type {
+  CallMetric,
+  MetricsSummary,
+  MetricsSink,
+  TriagePath,
+  TriageInput,
+  TriageOutcome,
+  ModelClass,
+  ModelChoice,
+  RouterOptions,
+  CompactableMessage,
+  CompactOptions,
+  CompactResult,
+  RelevanceChunk,
+  RelevanceInput,
+  RelevanceOptions,
+  EfficiencyGateOptions,
+  GateCallInput,
+  GateCallOutcome,
+  GateExecuteFn,
+} from "./efficiency/index.js";

--- a/packages/core/test/budget.test.mjs
+++ b/packages/core/test/budget.test.mjs
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { BudgetTracker, BudgetExceededError, DEFAULT_PER_PR_BUDGET_USD } from "../dist/index.js";
+
+test("BudgetTracker: happy path reserve + commit", () => {
+  const b = new BudgetTracker({ perPrUsd: 1 });
+  b.reserve(0.2);
+  b.commit(0.15);
+  b.reserve(0.3);
+  b.commit(0.3);
+  assert.equal(b.spentUsd, 0.45);
+  assert.equal(b.remainingUsd, 0.55);
+});
+
+test("BudgetTracker: reserve beyond cap throws BudgetExceededError", () => {
+  const b = new BudgetTracker({ perPrUsd: 1 });
+  b.reserve(0.6);
+  b.commit(0.6);
+  assert.throws(() => b.reserve(0.5), (err) => {
+    assert.ok(err instanceof BudgetExceededError);
+    assert.equal(err.capUsd, 1);
+    assert.equal(err.spentUsd, 0.6);
+    return true;
+  });
+});
+
+test("BudgetTracker: warning handler fires once at threshold", () => {
+  const b = new BudgetTracker({ perPrUsd: 1, warnAt: 0.5 });
+  const events = [];
+  b.onWarning((spent, cap) => events.push({ spent, cap }));
+  b.commit(0.2);
+  assert.equal(events.length, 0);
+  b.commit(0.4); // 0.6 >= 0.5 cap
+  assert.equal(events.length, 1);
+  b.commit(0.3); // already warned — no second fire
+  assert.equal(events.length, 1);
+});
+
+test("BudgetTracker: default perPrUsd exported constant equals 0.5 per decision #20", () => {
+  assert.equal(DEFAULT_PER_PR_BUDGET_USD, 0.5);
+});
+
+test("BudgetTracker: rejects invalid opts", () => {
+  assert.throws(() => new BudgetTracker({ perPrUsd: 0 }));
+  assert.throws(() => new BudgetTracker({ perPrUsd: -1 }));
+  assert.throws(() => new BudgetTracker({ perPrUsd: 1, warnAt: -0.1 }));
+  assert.throws(() => new BudgetTracker({ perPrUsd: 1, warnAt: 1.1 }));
+});

--- a/packages/core/test/cache.test.mjs
+++ b/packages/core/test/cache.test.mjs
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PromptCache, ANTHROPIC_PROMPT_CACHE_TTL_MS } from "../dist/index.js";
+
+test("PromptCache: mark then isLive reports hit", () => {
+  const c = new PromptCache();
+  assert.equal(c.isLive("prefix-A", "claude-sonnet-4-6"), false);
+  c.mark("prefix-A", "claude-sonnet-4-6");
+  assert.equal(c.isLive("prefix-A", "claude-sonnet-4-6"), true);
+});
+
+test("PromptCache: keys are model-scoped", () => {
+  const c = new PromptCache();
+  c.mark("same-prefix", "claude-sonnet-4-6");
+  assert.equal(c.isLive("same-prefix", "claude-haiku-4-5"), false);
+});
+
+test("PromptCache: expires after TTL", () => {
+  const c = new PromptCache({ ttlMs: 100 });
+  c.mark("p", "m", 1_000);
+  assert.equal(c.isLive("p", "m", 1_050), true);
+  assert.equal(c.isLive("p", "m", 1_101), false);
+});
+
+test("PromptCache: hitRate reflects hits + misses", () => {
+  const c = new PromptCache();
+  c.isLive("x", "m"); // miss
+  c.mark("x", "m");
+  c.isLive("x", "m"); // hit
+  c.isLive("y", "m"); // miss
+  assert.equal(c.hitRate().toFixed(3), "0.333");
+});
+
+test("PromptCache: maxEntries evicts oldest", () => {
+  const c = new PromptCache({ maxEntries: 2 });
+  c.mark("a", "m", 1);
+  c.mark("b", "m", 2);
+  c.mark("c", "m", 3); // evicts "a"
+  assert.equal(c.isLive("a", "m", 4), false);
+  assert.equal(c.isLive("b", "m", 4), true);
+  assert.equal(c.isLive("c", "m", 4), true);
+});
+
+test("PromptCache: default TTL matches Anthropic 5-minute window", () => {
+  assert.equal(ANTHROPIC_PROMPT_CACHE_TTL_MS, 300_000);
+});

--- a/packages/core/test/compact.test.mjs
+++ b/packages/core/test/compact.test.mjs
@@ -1,0 +1,65 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { compact } from "../dist/index.js";
+
+function msg(role, content, tokens, pin = false) {
+  return { role, content, tokens, pin };
+}
+
+test("compact: all messages fit under budget → no drops", async () => {
+  const messages = [
+    msg("system", "you are a reviewer", 10, true),
+    msg("user", "here is the diff", 20),
+    msg("assistant", "looks fine", 15),
+  ];
+  const out = await compact(messages, { targetTokens: 100 });
+  assert.equal(out.droppedCount, 0);
+  assert.equal(out.summarizedCount, 0);
+  assert.equal(out.messages.length, 3);
+});
+
+test("compact: pinned messages are always kept", async () => {
+  const messages = [
+    msg("system", "pinned system", 80, true),
+    msg("user", "ancient user msg", 50),
+    msg("user", "recent user msg", 10),
+  ];
+  const out = await compact(messages, { targetTokens: 100 });
+  assert.ok(out.messages.some((m) => m.content === "pinned system"));
+});
+
+test("compact: newest-first fits under budget, older dropped", async () => {
+  const messages = [
+    msg("user", "oldest", 40),
+    msg("user", "middle", 40),
+    msg("user", "newest", 40),
+  ];
+  const out = await compact(messages, { targetTokens: 80 });
+  assert.equal(out.droppedCount, 1);
+  const kept = out.messages.map((m) => m.content);
+  assert.deepEqual(kept, ["middle", "newest"]);
+});
+
+test("compact: summarizer collapses dropped tail", async () => {
+  const messages = [
+    msg("user", "oldest", 40),
+    msg("user", "middle", 40),
+    msg("user", "newest", 40),
+  ];
+  const out = await compact(messages, {
+    targetTokens: 90, // enough for newest + small summary
+    summarize: async (dropped) => `summary of ${dropped.length}`,
+  });
+  assert.equal(out.summarizedCount, 2);
+  assert.ok(out.messages[0].content.startsWith("[compacted summary of 2 earlier messages]"));
+});
+
+test("compact: returns only pinned when pinned already consume budget", async () => {
+  const messages = [
+    msg("system", "huge pinned prompt", 1_000, true),
+    msg("user", "will not fit", 50),
+  ];
+  const out = await compact(messages, { targetTokens: 500 });
+  assert.equal(out.messages.length, 1);
+  assert.equal(out.droppedCount, 1);
+});

--- a/packages/core/test/council.test.mjs
+++ b/packages/core/test/council.test.mjs
@@ -1,0 +1,66 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Council } from "../dist/index.js";
+
+function fakeAgent(id, verdict) {
+  return {
+    id,
+    displayName: id,
+    review: async () => ({
+      agent: id,
+      verdict,
+      blockers: [],
+      summary: `${id} says ${verdict}`,
+    }),
+  };
+}
+
+const ctx = { diff: "", repo: "acme/x", pullNumber: 1, newSha: "HEAD" };
+
+test("Council: empty agents throws", () => {
+  assert.throws(() => new Council({ agents: [] }));
+});
+
+test("Council: single approve → approve + consensus", async () => {
+  const council = new Council({ agents: [fakeAgent("claude", "approve")] });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.verdict, "approve");
+  assert.equal(outcome.consensusReached, true);
+  assert.equal(outcome.results.length, 1);
+});
+
+test("Council: all approve → approve", async () => {
+  const council = new Council({
+    agents: [fakeAgent("claude", "approve"), fakeAgent("openai", "approve")],
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.verdict, "approve");
+  assert.equal(outcome.consensusReached, true);
+});
+
+test("Council: any reject → reject (consensus)", async () => {
+  const council = new Council({
+    agents: [fakeAgent("claude", "approve"), fakeAgent("openai", "reject")],
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.verdict, "reject");
+  assert.equal(outcome.consensusReached, true);
+});
+
+test("Council: mixed approve + rework → rework (no consensus)", async () => {
+  const council = new Council({
+    agents: [fakeAgent("claude", "approve"), fakeAgent("openai", "rework")],
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.verdict, "rework");
+  assert.equal(outcome.consensusReached, false);
+});
+
+test("Council: exposes config", async () => {
+  const council = new Council({
+    agents: [fakeAgent("a", "approve"), fakeAgent("b", "approve")],
+    maxRounds: 5,
+  });
+  assert.equal(council.agentCount, 2);
+  assert.equal(council.roundLimit, 5);
+});

--- a/packages/core/test/gate.test.mjs
+++ b/packages/core/test/gate.test.mjs
@@ -1,0 +1,95 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EfficiencyGate, BudgetExceededError } from "../dist/index.js";
+
+async function fakeExecute(spec) {
+  return async ({ model, cacheHit }) => ({
+    result: { ok: true, model, cacheHit },
+    inputTokens: spec.inputTokens ?? 1_000,
+    outputTokens: spec.outputTokens ?? 200,
+    costUsd: spec.costUsd ?? 0.015,
+    latencyMs: spec.latencyMs ?? 1_100,
+  });
+}
+
+test("EfficiencyGate.run: happy path routes, executes, records", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const { result, metric, modelChoice } = await gate.run(
+    {
+      agent: "claude",
+      cacheablePrefix: "system + pinned RAG",
+      prompt: "some prompt",
+      estimatedCostUsd: 0.02,
+    },
+    await fakeExecute({ costUsd: 0.017 }),
+  );
+  assert.equal(result.ok, true);
+  assert.equal(metric.costUsd, 0.017);
+  assert.equal(metric.agent, "claude");
+  assert.equal(modelChoice.class, "haiku");
+  assert.equal(gate.budget.spentUsd, 0.017);
+});
+
+test("EfficiencyGate.run: second identical call sees cacheHit = true", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const input = {
+    agent: "claude",
+    cacheablePrefix: "identical prefix",
+    prompt: "p",
+    estimatedCostUsd: 0.01,
+  };
+  const first = await gate.run(input, await fakeExecute({ costUsd: 0.005 }));
+  assert.equal(first.result.cacheHit, false);
+  const second = await gate.run(input, await fakeExecute({ costUsd: 0.001 }));
+  assert.equal(second.result.cacheHit, true);
+});
+
+test("EfficiencyGate.run: reserve throws BudgetExceededError before execute runs", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 0.1 });
+  let executed = false;
+  await assert.rejects(
+    () =>
+      gate.run(
+        {
+          agent: "claude",
+          cacheablePrefix: "x",
+          prompt: "p",
+          estimatedCostUsd: 0.5, // blows the cap
+        },
+        async () => {
+          executed = true;
+          throw new Error("should not run");
+        },
+      ),
+    (err) => err instanceof BudgetExceededError,
+  );
+  assert.equal(executed, false);
+});
+
+test("EfficiencyGate.run: forceModel honored", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const { modelChoice } = await gate.run(
+    {
+      agent: "claude",
+      cacheablePrefix: "p",
+      prompt: "p",
+      estimatedCostUsd: 0.01,
+      forceModel: "claude-opus-4-7",
+    },
+    await fakeExecute({ costUsd: 0.01 }),
+  );
+  assert.equal(modelChoice.model, "claude-opus-4-7");
+});
+
+test("EfficiencyGate.run: multiple calls aggregate metrics", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  for (let i = 0; i < 3; i += 1) {
+    await gate.run(
+      { agent: "claude", cacheablePrefix: `p${i}`, prompt: "p", estimatedCostUsd: 0.01 },
+      await fakeExecute({ costUsd: 0.01 }),
+    );
+  }
+  const s = gate.metrics.summary();
+  assert.equal(s.callCount, 3);
+  assert.equal(s.totalCostUsd.toFixed(3), "0.030");
+});

--- a/packages/core/test/metrics.test.mjs
+++ b/packages/core/test/metrics.test.mjs
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MetricsRecorder } from "../dist/index.js";
+
+function mkMetric(overrides = {}) {
+  return {
+    agent: "claude",
+    model: "claude-sonnet-4-6",
+    inputTokens: 1_000,
+    outputTokens: 200,
+    costUsd: 0.015,
+    latencyMs: 1_200,
+    cacheHit: false,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+test("MetricsRecorder: empty summary", () => {
+  const r = new MetricsRecorder();
+  const s = r.summary();
+  assert.equal(s.callCount, 0);
+  assert.equal(s.totalCostUsd, 0);
+  assert.equal(s.cacheHitRate, 0);
+});
+
+test("MetricsRecorder: aggregates by agent and model", () => {
+  const r = new MetricsRecorder();
+  r.record(mkMetric({ agent: "claude", model: "claude-sonnet-4-6", costUsd: 0.02 }));
+  r.record(mkMetric({ agent: "claude", model: "claude-haiku-4-5", costUsd: 0.005 }));
+  r.record(mkMetric({ agent: "openai", model: "gpt-4.1", costUsd: 0.03 }));
+  const s = r.summary();
+  assert.equal(s.callCount, 3);
+  assert.equal(s.totalCostUsd.toFixed(3), "0.055");
+  assert.equal(s.byAgent["claude"].calls, 2);
+  assert.equal(s.byAgent["openai"].calls, 1);
+  assert.equal(s.byModel["claude-sonnet-4-6"].costUsd, 0.02);
+});
+
+test("MetricsRecorder: cache hit rate", () => {
+  const r = new MetricsRecorder();
+  r.record(mkMetric({ cacheHit: true }));
+  r.record(mkMetric({ cacheHit: true }));
+  r.record(mkMetric({ cacheHit: false }));
+  r.record(mkMetric({ cacheHit: false }));
+  assert.equal(r.summary().cacheHitRate, 0.5);
+});
+
+test("MetricsRecorder: forwards to external sink", () => {
+  const forwarded = [];
+  const r = new MetricsRecorder({ sink: { record: (m) => forwarded.push(m) } });
+  r.record(mkMetric({ agent: "claude" }));
+  assert.equal(forwarded.length, 1);
+  assert.equal(forwarded[0].agent, "claude");
+});
+
+test("MetricsRecorder: reset clears state", () => {
+  const r = new MetricsRecorder();
+  r.record(mkMetric());
+  r.reset();
+  assert.equal(r.summary().callCount, 0);
+});

--- a/packages/core/test/relevance.test.mjs
+++ b/packages/core/test/relevance.test.mjs
@@ -1,0 +1,63 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildRelevanceContext, inferTestPath } from "../dist/index.js";
+
+test("buildRelevanceContext: diff only when no readFile provided", async () => {
+  const out = await buildRelevanceContext({
+    diff: "diff --git a/foo.ts b/foo.ts\n+added line",
+    diffPaths: ["foo.ts"],
+  });
+  assert.equal(out.chunks.length, 1);
+  assert.equal(out.chunks[0].reason, "diff");
+});
+
+test("buildRelevanceContext: appends test file when discoverable", async () => {
+  const out = await buildRelevanceContext({
+    diff: "diff of foo.ts",
+    diffPaths: ["src/foo.ts"],
+    readFile: async (p) => (p === "src/foo.test.ts" ? "// test body" : null),
+  });
+  const testChunk = out.chunks.find((c) => c.reason === "test-of-diff");
+  assert.ok(testChunk, "expected test chunk");
+  assert.equal(testChunk.path, "src/foo.test.ts");
+});
+
+test("buildRelevanceContext: walks direct imports when graphDepth >= 1", async () => {
+  const files = new Map([
+    ["src/foo.ts", "// foo"],
+    ["src/bar.ts", "// bar"],
+  ]);
+  const out = await buildRelevanceContext(
+    {
+      diff: "diff",
+      diffPaths: ["src/foo.ts"],
+      readFile: async (p) => files.get(p) ?? null,
+      importsOf: async (p) => (p === "src/foo.ts" ? ["src/bar.ts"] : []),
+    },
+    { graphDepth: 1 },
+  );
+  const imp = out.chunks.find((c) => c.reason === "import-of-diff");
+  assert.ok(imp);
+  assert.equal(imp.path, "src/bar.ts");
+});
+
+test("buildRelevanceContext: respects tokenBudget", async () => {
+  const out = await buildRelevanceContext(
+    {
+      diff: "x".repeat(10_000),
+      diffPaths: ["huge.ts"],
+    },
+    { tokenBudget: 500 },
+  );
+  assert.ok(out.totalTokens <= 500);
+});
+
+test("inferTestPath: maps source → test path by convention", () => {
+  assert.equal(inferTestPath("src/foo.ts"), "src/foo.test.ts");
+  assert.equal(inferTestPath("src/a/b/c.tsx"), "src/a/b/c.test.tsx");
+  assert.equal(inferTestPath("pkg/mod.js"), "pkg/mod.test.js");
+  // Already a test file — returns itself so caller doesn't recurse.
+  assert.equal(inferTestPath("src/foo.test.ts"), "src/foo.test.ts");
+  assert.equal(inferTestPath("src/foo.spec.js"), "src/foo.spec.js");
+  assert.equal(inferTestPath("no-extension"), null);
+});

--- a/packages/core/test/router.test.mjs
+++ b/packages/core/test/router.test.mjs
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { selectModel, estimateTokens, DEFAULT_MODELS } from "../dist/index.js";
+
+test("selectModel: small input → haiku", () => {
+  const choice = selectModel(5_000);
+  assert.equal(choice.class, "haiku");
+  assert.equal(choice.model, DEFAULT_MODELS.haiku);
+});
+
+test("selectModel: medium input → sonnet", () => {
+  const choice = selectModel(20_000);
+  assert.equal(choice.class, "sonnet");
+  assert.equal(choice.model, DEFAULT_MODELS.sonnet);
+});
+
+test("selectModel: large input → long-context (gemini)", () => {
+  const choice = selectModel(100_000);
+  assert.equal(choice.class, "long-context");
+  assert.equal(choice.model, DEFAULT_MODELS["long-context"]);
+});
+
+test("selectModel: boundary at haikuMax is inclusive of haiku", () => {
+  const choice = selectModel(8_000);
+  assert.equal(choice.class, "haiku");
+});
+
+test("selectModel: custom thresholds honored", () => {
+  const choice = selectModel(2_000, { haikuMax: 1_000, sonnetMax: 5_000 });
+  assert.equal(choice.class, "sonnet");
+});
+
+test("selectModel: model override via opts.models", () => {
+  const choice = selectModel(5_000, { models: { haiku: "custom-haiku" } });
+  assert.equal(choice.model, "custom-haiku");
+});
+
+test("estimateTokens: ~4 chars per token heuristic", () => {
+  assert.equal(estimateTokens("a".repeat(40)), 10);
+  assert.equal(estimateTokens(""), 0);
+  assert.equal(estimateTokens("abc"), 1);
+});

--- a/packages/core/test/triage.test.mjs
+++ b/packages/core/test/triage.test.mjs
@@ -1,0 +1,77 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { triageReview, touchesRiskyPath } from "../dist/index.js";
+
+test("triageReview: risky path forces full regardless of size", () => {
+  const out = triageReview({
+    linesChanged: 1,
+    fileCount: 1,
+    hasTests: true,
+    touchesRiskyPath: true,
+  });
+  assert.equal(out.path, "full");
+  assert.match(out.reason, /risky/i);
+});
+
+test("triageReview: small + tests + not risky → lite", () => {
+  const out = triageReview({
+    linesChanged: 20,
+    fileCount: 2,
+    hasTests: true,
+    touchesRiskyPath: false,
+  });
+  assert.equal(out.path, "lite");
+});
+
+test("triageReview: large lines → full", () => {
+  const out = triageReview({
+    linesChanged: 500,
+    fileCount: 1,
+    hasTests: true,
+    touchesRiskyPath: false,
+  });
+  assert.equal(out.path, "full");
+  assert.match(out.reason, /linesChanged/);
+});
+
+test("triageReview: many files → full", () => {
+  const out = triageReview({
+    linesChanged: 10,
+    fileCount: 10,
+    hasTests: true,
+    touchesRiskyPath: false,
+  });
+  assert.equal(out.path, "full");
+  assert.match(out.reason, /fileCount/);
+});
+
+test("triageReview: non-trivial diff without tests → full", () => {
+  const out = triageReview({
+    linesChanged: 30,
+    fileCount: 2,
+    hasTests: false,
+    touchesRiskyPath: false,
+  });
+  assert.equal(out.path, "full");
+  assert.match(out.reason, /without any test/);
+});
+
+test("triageReview: trivial diff without tests still lite (not worth full council)", () => {
+  const out = triageReview({
+    linesChanged: 5,
+    fileCount: 1,
+    hasTests: false,
+    touchesRiskyPath: false,
+  });
+  assert.equal(out.path, "lite");
+});
+
+test("touchesRiskyPath: schema / migrations / auth / payments / .sql / prisma schema match", () => {
+  assert.equal(touchesRiskyPath(["src/auth/login.ts"]), true);
+  assert.equal(touchesRiskyPath(["db/migrations/001_init.sql"]), true);
+  assert.equal(touchesRiskyPath(["payments/stripe.ts"]), true);
+  assert.equal(touchesRiskyPath(["prisma/schema.prisma"]), true);
+  assert.equal(touchesRiskyPath(["sql/analytics.sql"]), true);
+  assert.equal(touchesRiskyPath(["src/components/Button.tsx"]), false);
+  assert.equal(touchesRiskyPath([]), false);
+});


### PR DESCRIPTION
## Summary

Lands the **Efficiency Gate** (decision #22 — first-class from day 1) in `@ai-conclave/core`. Every LLM call in ai-conclave must route through `EfficiencyGate.run(...)` from this PR forward; direct SDK calls outside the gate are a contract violation.

Stacked on [#1](https://github.com/seunghunbae-3svs/ai-conclave/pull/1) (initial monorepo scaffold). Base branch = `scaffold/initial-monorepo`.

## Modules

| Module | Responsibility |
|---|---|
| `cache.ts` | Anthropic 5-min TTL prompt-cache scheduler (SHA-256 keyed, LRU-evicted). |
| `budget.ts` | \$0.50 default per-PR cap (decision #20). Reserve-before-call throws `BudgetExceededError`. 80% warning handler. |
| `triage.ts` | Lite (single agent) vs Full (3-round council). Risky paths (schema/migrations/auth/payments/.sql/prisma) always full. |
| `router.ts` | Input-size routing: Haiku ≤ 8k → Sonnet ≤ 50k → Gemini 2.5 Pro long-context slot. |
| `compact.ts` | Round-to-round context compression. Pinned-message preservation, newest-first fit, injectable summarizer. |
| `relevance.ts` | Diff + test-file + import-graph assembly under token budget. Safe diff-only default when resolvers absent. |
| `metrics.ts` | Per-call cost / tokens / latency / cache-hit. Per-agent + per-model aggregation. Pluggable sink for Langfuse. |
| `gate.ts` | Central orchestrator: reserve → route → cache-check → execute → mark → commit → record. |

## Exports

- `@ai-conclave/core/efficiency` — dedicated subpath export for agent packages.
- Top-level `@ai-conclave/core` re-exports everything for convenience.

## Tests

`node --test` native runner — 9 files, 45+ cases. Covers every module's
happy path, boundary conditions, and error paths. Council deliberation
outcome logic covered separately (approve / reject / rework combinations).

## Deferred (not this PR)

- Real Langfuse OTLP wiring — sink stub in place; observability package lands separately.
- Real Haiku summarizer for compaction — callback injection pattern lets callers supply their own; next PR wires it.
- Agent-claude integration through the gate — **next PR** wires the real `@anthropic-ai/sdk` tool-use loop + RAG over answer-keys through `EfficiencyGate.run`.

## Verification

- [ ] `pnpm install` then `pnpm --filter @ai-conclave/core build` emits `dist/efficiency/*`
- [ ] `pnpm --filter @ai-conclave/core test` — all assertions pass
- [ ] `pnpm typecheck` passes under strict + `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes`
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)