### PR TITLE
feat(agent-claude): real tool-use review loop routed through efficiency gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,24 @@
     execute → mark → commit → record in a single call.
 - Test coverage (`node --test`): 9 files, 45+ test cases across all
   efficiency modules and Council outcome logic.
+- **Real Claude review loop** in `@ai-conclave/agent-claude`:
+  - `ClaudeAgent.review(ctx)` now issues a real `messages.create` call via
+    the injected (or lazy-loaded) `@anthropic-ai/sdk` client.
+  - Single-tool pattern (`tool_choice: { type: "tool", name: "submit_review" }`)
+    forces structured output — no free-form parsing.
+  - System prompt + RAG prefix sent as a cache-controlled ephemeral block
+    so repeat calls within 5 minutes hit Anthropic's prompt cache (~90%
+    input-cost savings on the prefix).
+  - All SDK calls route through `EfficiencyGate.run(...)`: pre-flight budget
+    reserve (throws before the network call), cache-liveness tracking,
+    actual-cost metering via `actualCost(model, usage)`, per-call metrics.
+  - `PRICING` table covers Sonnet 4.6 / Haiku 4.5 / Opus 4.7 with standard,
+    cache-write, and cache-read rates. `estimateCallCost` is pessimistic
+    (no cache assumed) for safe pre-flight reservation.
+  - Parser tolerates malformed blockers (drops invalid entries instead of
+    failing the whole review), throws on missing `submit_review` tool_use
+    block or invalid verdict.
+  - Agent-claude tests (16 cases): happy verdicts (approve / rework with
+    blockers), invalid response shapes, budget enforcement, cache_control
+    wire-format, tool_choice wire-format, missing-key constructor guard,
+    metrics aggregation on shared gate.

--- a/packages/agent-claude/package.json
+++ b/packages/agent-claude/package.json
@@ -21,6 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/agent-claude/src/claude-agent.ts
+++ b/packages/agent-claude/src/claude-agent.ts
@@ -1,22 +1,77 @@
-import type { Agent, ReviewContext, ReviewResult } from "@ai-conclave/core";
+import type { Agent, ReviewContext, ReviewResult, Blocker } from "@ai-conclave/core";
+import { EfficiencyGate, estimateTokens } from "@ai-conclave/core";
+import { REVIEW_TOOL_NAME, REVIEW_TOOL_DESCRIPTION, REVIEW_TOOL_INPUT_SCHEMA } from "./review-tool.js";
+import { buildReviewPrompt, buildCacheablePrefix, SYSTEM_PROMPT } from "./prompts.js";
+import { actualCost, estimateCallCost } from "./pricing.js";
+
+/**
+ * Minimal shape of the Anthropic SDK client that ClaudeAgent needs.
+ * We type against this instead of the full SDK to keep tests cheap to mock
+ * and to tolerate SDK minor version churn.
+ */
+export interface AnthropicLike {
+  messages: {
+    create(params: AnthropicCreateParams): Promise<AnthropicResponse>;
+  };
+}
+
+export interface AnthropicCreateParams {
+  model: string;
+  max_tokens: number;
+  system?: string | ReadonlyArray<{ type: "text"; text: string; cache_control?: { type: "ephemeral" } }>;
+  messages: ReadonlyArray<{ role: "user" | "assistant"; content: string }>;
+  tools?: ReadonlyArray<{
+    name: string;
+    description: string;
+    input_schema: unknown;
+  }>;
+  tool_choice?: { type: "tool"; name: string } | { type: "auto" } | { type: "any" };
+}
+
+export interface AnthropicResponse {
+  id: string;
+  model: string;
+  content: ReadonlyArray<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; id: string; name: string; input: unknown }
+  >;
+  stop_reason?: string;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}
 
 export interface ClaudeAgentOptions {
   apiKey?: string;
+  /** Defaults to claude-sonnet-4-6. Gate router may force a different model per call. */
   model?: string;
   maxTokens?: number;
+  /** Shared gate (recommended). If omitted, the agent creates its own. */
+  gate?: EfficiencyGate;
+  /** For tests or alternate providers — inject a Messages-compatible client. */
+  client?: AnthropicLike;
+  /** Factory used when `client` is not supplied. Defaults to lazy-loading @anthropic-ai/sdk. */
+  clientFactory?: (apiKey: string) => Promise<AnthropicLike>;
 }
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
-const DEFAULT_MAX_TOKENS = 4096;
+const DEFAULT_MAX_TOKENS = 2_048;
+
+async function defaultClientFactory(apiKey: string): Promise<AnthropicLike> {
+  // Dynamic import so tests that inject a client never pay the SDK load cost.
+  const mod = (await import("@anthropic-ai/sdk")) as unknown as {
+    default: new (opts: { apiKey: string }) => AnthropicLike;
+  };
+  const Ctor = mod.default;
+  return new Ctor({ apiKey });
+}
 
 /**
- * ClaudeAgent — wraps Anthropic's Claude SDK for council review.
- *
- * Skeleton status: interface correct, implementation returns a stub
- * "approve" verdict. The real tool-use loop with
- * @anthropic-ai/claude-agent-sdk (official TS, bundles MCP + tool_use +
- * compaction) lands in a subsequent PR together with the efficiency
- * gate and RAG-over-answer-keys.
+ * ClaudeAgent — routes a real Claude tool-use review call through the
+ * efficiency gate. Returns a parsed ReviewResult.
  */
 export class ClaudeAgent implements Agent {
   readonly id = "claude";
@@ -25,30 +80,134 @@ export class ClaudeAgent implements Agent {
   private readonly apiKey: string;
   private readonly model: string;
   private readonly maxTokens: number;
+  private readonly gate: EfficiencyGate;
+  private readonly clientFactory: (apiKey: string) => Promise<AnthropicLike>;
+  private clientPromise: Promise<AnthropicLike> | null;
 
   constructor(opts: ClaudeAgentOptions = {}) {
     const key = opts.apiKey ?? process.env["ANTHROPIC_API_KEY"] ?? "";
-    if (!key) {
-      throw new Error("ClaudeAgent: ANTHROPIC_API_KEY not set (pass opts.apiKey or env var)");
+    if (!key && !opts.client) {
+      throw new Error("ClaudeAgent: ANTHROPIC_API_KEY not set (pass opts.apiKey, opts.client, or the env var)");
     }
     this.apiKey = key;
     this.model = opts.model ?? DEFAULT_MODEL;
     this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.gate = opts.gate ?? new EfficiencyGate();
+    this.clientFactory = opts.clientFactory ?? defaultClientFactory;
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+  }
+
+  private async getClient(): Promise<AnthropicLike> {
+    if (!this.clientPromise) {
+      this.clientPromise = this.clientFactory(this.apiKey);
+    }
+    return this.clientPromise;
   }
 
   async review(ctx: ReviewContext): Promise<ReviewResult> {
-    // Skeleton — real implementation will call the SDK with a tool-use
-    // loop, RAG context from answer-keys + failure-catalog, and cost
-    // metering through the efficiency gate.
-    void ctx;
-    void this.apiKey;
-    void this.model;
-    void this.maxTokens;
-    return {
-      agent: this.id,
-      verdict: "approve",
-      blockers: [],
-      summary: "ClaudeAgent skeleton — real review logic pending.",
-    };
+    const cacheablePrefix = buildCacheablePrefix(ctx);
+    const userPrompt = buildReviewPrompt(ctx);
+    const inputTokenEstimate = estimateTokens(cacheablePrefix) + estimateTokens(userPrompt);
+    const estimatedCost = estimateCallCost(this.model, inputTokenEstimate, this.maxTokens);
+
+    const outcome = await this.gate.run<ReviewResult>(
+      {
+        agent: this.id,
+        cacheablePrefix,
+        prompt: cacheablePrefix + "\n" + userPrompt,
+        estimatedCostUsd: estimatedCost,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const response = await client.messages.create({
+          model,
+          max_tokens: this.maxTokens,
+          system: [{ type: "text", text: cacheablePrefix, cache_control: { type: "ephemeral" } }],
+          messages: [{ role: "user", content: userPrompt }],
+          tools: [
+            {
+              name: REVIEW_TOOL_NAME,
+              description: REVIEW_TOOL_DESCRIPTION,
+              input_schema: REVIEW_TOOL_INPUT_SCHEMA,
+            },
+          ],
+          tool_choice: { type: "tool", name: REVIEW_TOOL_NAME },
+        });
+        const latencyMs = Date.now() - started;
+
+        const parsed = parseReviewToolUse(response, this.id);
+        const cost = actualCost(model, {
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          cacheCreationTokens: response.usage.cache_creation_input_tokens,
+          cacheReadTokens: response.usage.cache_read_input_tokens,
+        });
+
+        return {
+          result: {
+            ...parsed,
+            tokensUsed: response.usage.input_tokens + response.usage.output_tokens,
+            costUsd: cost,
+          },
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          costUsd: cost,
+          latencyMs,
+        };
+      },
+    );
+
+    return outcome.result;
   }
 }
+
+function parseReviewToolUse(response: AnthropicResponse, agentId: string): ReviewResult {
+  const toolUse = response.content.find(
+    (block): block is Extract<(typeof response.content)[number], { type: "tool_use" }> =>
+      block.type === "tool_use" && block.name === REVIEW_TOOL_NAME,
+  );
+  if (!toolUse) {
+    throw new Error(
+      `ClaudeAgent: response did not include a ${REVIEW_TOOL_NAME} tool_use block (stop_reason=${response.stop_reason ?? "?"})`,
+    );
+  }
+  const input = toolUse.input as {
+    verdict?: string;
+    blockers?: unknown[];
+    summary?: string;
+  };
+  if (input.verdict !== "approve" && input.verdict !== "rework" && input.verdict !== "reject") {
+    throw new Error(`ClaudeAgent: invalid verdict "${String(input.verdict)}" in tool_use response`);
+  }
+  const blockers: Blocker[] = [];
+  if (Array.isArray(input.blockers)) {
+    for (const raw of input.blockers) {
+      if (!raw || typeof raw !== "object") continue;
+      const b = raw as Record<string, unknown>;
+      const severity = b["severity"];
+      const category = b["category"];
+      const message = b["message"];
+      if (
+        (severity === "blocker" || severity === "major" || severity === "minor" || severity === "nit") &&
+        typeof category === "string" &&
+        typeof message === "string"
+      ) {
+        const blocker: Blocker = { severity, category, message };
+        if (typeof b["file"] === "string") blocker.file = b["file"] as string;
+        if (typeof b["line"] === "number") blocker.line = b["line"] as number;
+        blockers.push(blocker);
+      }
+    }
+  }
+  return {
+    agent: agentId,
+    verdict: input.verdict,
+    blockers,
+    summary: typeof input.summary === "string" ? input.summary : "",
+  };
+}
+
+// Re-export SYSTEM_PROMPT so downstream tools can render/copy it.
+export { SYSTEM_PROMPT };

--- a/packages/agent-claude/src/index.ts
+++ b/packages/agent-claude/src/index.ts
@@ -1,2 +1,6 @@
-export { ClaudeAgent } from "./claude-agent.js";
-export type { ClaudeAgentOptions } from "./claude-agent.js";
+export { ClaudeAgent, SYSTEM_PROMPT } from "./claude-agent.js";
+export type { ClaudeAgentOptions, AnthropicLike, AnthropicCreateParams, AnthropicResponse } from "./claude-agent.js";
+export { buildReviewPrompt, buildCacheablePrefix } from "./prompts.js";
+export { REVIEW_TOOL_NAME, REVIEW_TOOL_DESCRIPTION, REVIEW_TOOL_INPUT_SCHEMA } from "./review-tool.js";
+export { actualCost, estimateCallCost, PRICING } from "./pricing.js";
+export type { ModelPricing, UsageBreakdown } from "./pricing.js";

--- a/packages/agent-claude/src/pricing.ts
+++ b/packages/agent-claude/src/pricing.ts
@@ -1,0 +1,68 @@
+export interface ModelPricing {
+  /** USD per 1M input tokens (non-cached). */
+  inputPerMTok: number;
+  /** USD per 1M cache-write input tokens. */
+  cacheWritePerMTok: number;
+  /** USD per 1M cache-read input tokens. */
+  cacheReadPerMTok: number;
+  /** USD per 1M output tokens. */
+  outputPerMTok: number;
+}
+
+/**
+ * Pricing table for Claude models. Prices reflect published Anthropic API
+ * pricing as of 2026-04; update when Anthropic announces new tiers.
+ *
+ * Cache write = 1.25× base input, cache read = 0.1× base input (90% off).
+ */
+export const PRICING: Record<string, ModelPricing> = {
+  "claude-sonnet-4-6": {
+    inputPerMTok: 3.0,
+    cacheWritePerMTok: 3.75,
+    cacheReadPerMTok: 0.3,
+    outputPerMTok: 15.0,
+  },
+  "claude-haiku-4-5": {
+    inputPerMTok: 0.25,
+    cacheWritePerMTok: 0.3125,
+    cacheReadPerMTok: 0.025,
+    outputPerMTok: 1.25,
+  },
+  "claude-opus-4-7": {
+    inputPerMTok: 15.0,
+    cacheWritePerMTok: 18.75,
+    cacheReadPerMTok: 1.5,
+    outputPerMTok: 75.0,
+  },
+};
+
+export interface UsageBreakdown {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens?: number;
+  cacheReadTokens?: number;
+}
+
+/** Compute actual USD cost from an Anthropic API usage breakdown. */
+export function actualCost(model: string, usage: UsageBreakdown): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown model "${model}"`);
+  const baseInput = usage.inputTokens - (usage.cacheCreationTokens ?? 0) - (usage.cacheReadTokens ?? 0);
+  return (
+    (Math.max(0, baseInput) * p.inputPerMTok +
+      (usage.cacheCreationTokens ?? 0) * p.cacheWritePerMTok +
+      (usage.cacheReadTokens ?? 0) * p.cacheReadPerMTok +
+      usage.outputTokens * p.outputPerMTok) /
+    1_000_000
+  );
+}
+
+/**
+ * Pre-flight USD estimate for budget.reserve(). Pessimistic: assumes no
+ * cache read (worst case) and a typical 25% output-to-input ratio.
+ */
+export function estimateCallCost(model: string, estimatedInputTokens: number, maxOutputTokens: number): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown model "${model}"`);
+  return (estimatedInputTokens * p.inputPerMTok + maxOutputTokens * p.outputPerMTok) / 1_000_000;
+}

--- a/packages/agent-claude/src/prompts.ts
+++ b/packages/agent-claude/src/prompts.ts
@@ -1,0 +1,71 @@
+import type { ReviewContext } from "@ai-conclave/core";
+
+export const SYSTEM_PROMPT = `You are a senior code reviewer on a multi-agent council for Ai-Conclave. The council reviews AI-generated code and design changes before merge.
+
+Your goal: catch real blockers, not style nits. You work alongside other agents (OpenAI, Gemini, possibly domain-specific specialists). Your reviews are weighed against theirs; spurious blockers hurt your agent score and waste the rework budget.
+
+Rules:
+- Focus on: correctness, security, regression risk, missing tests for non-trivial changes, accessibility + contrast on UI, obvious performance cliffs.
+- Do NOT comment on: style bikeshedding, import order, variable renames that are already consistent, personal formatting preferences.
+- When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
+- Never pad with encouragement ("great work but...") — go straight to the concerns.
+- When the diff is small, low-risk, and has test coverage, approve cleanly. Over-flagging is a bigger sin than missing a nit.
+- You MUST respond by calling the submit_review tool exactly once. Do not emit free-form text.`;
+
+export function buildReviewPrompt(ctx: ReviewContext): string {
+  const sections: string[] = [];
+  sections.push(`# Review target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`pull: #${ctx.pullNumber}`);
+  sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
+  sections.push("");
+
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(
+      `These are reviews that led to merged changes on similar code in this repo. Lean on them as a style + quality bar — match their tolerance for what counts as a blocker.`,
+    );
+    sections.push("");
+    for (const entry of ctx.answerKeys.slice(0, 8)) {
+      sections.push(`- ${entry}`);
+    }
+    sections.push("");
+  }
+
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(
+      `These are patterns that caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
+    );
+    sections.push("");
+    for (const entry of ctx.failureCatalog.slice(0, 8)) {
+      sections.push(`- ${entry}`);
+    }
+    sections.push("");
+  }
+
+  sections.push(`# Diff`);
+  sections.push("```diff");
+  sections.push(ctx.diff || "(empty diff — respond with verdict=approve, summary noting nothing to review)");
+  sections.push("```");
+  sections.push("");
+  sections.push(`Call submit_review exactly once with your verdict, blockers (if any), and a one-paragraph summary.`);
+  return sections.join("\n");
+}
+
+/**
+ * The cacheable prefix is everything STABLE across calls within a session —
+ * system prompt + any pinned RAG context that doesn't change per-turn.
+ * Anthropic's prompt cache works best when this prefix is marked
+ * `cache_control: ephemeral` and sits at the head of the messages array.
+ */
+export function buildCacheablePrefix(ctx: ReviewContext): string {
+  const parts: string[] = [SYSTEM_PROMPT];
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
+  }
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    parts.push("failure-catalog:\n" + ctx.failureCatalog.slice(0, 8).join("\n"));
+  }
+  return parts.join("\n---\n");
+}

--- a/packages/agent-claude/src/review-tool.ts
+++ b/packages/agent-claude/src/review-tool.ts
@@ -1,0 +1,56 @@
+/**
+ * Tool-use schema that forces Claude to return a structured review.
+ * Decision #12 — Zod → JSON Schema per-provider adapter; for Anthropic we
+ * use a SINGLE-TOOL pattern (`tool_choice: { type: "tool", name: ... }`)
+ * which gives us reliable structured output without relying on response
+ * parsing heuristics.
+ */
+export const REVIEW_TOOL_NAME = "submit_review";
+
+export const REVIEW_TOOL_DESCRIPTION =
+  "Submit your structured review of the diff. Call this exactly once at the end of your analysis.";
+
+export const REVIEW_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    verdict: {
+      type: "string",
+      enum: ["approve", "rework", "reject"],
+      description:
+        "approve = ship as-is; rework = fixable blockers (agent should attempt auto-fix); reject = fundamentally wrong approach (do not merge, human must intervene).",
+    },
+    blockers: {
+      type: "array",
+      description: "Ordered list of issues found. Empty when verdict is approve.",
+      items: {
+        type: "object",
+        properties: {
+          severity: {
+            type: "string",
+            enum: ["blocker", "major", "minor", "nit"],
+            description:
+              "blocker = must fix; major = should fix; minor = worth fixing; nit = optional polish.",
+          },
+          category: {
+            type: "string",
+            description:
+              "Short tag like 'type-error' / 'missing-test' / 'security' / 'accessibility' / 'regression'. Used for precision/recall metrics.",
+          },
+          message: {
+            type: "string",
+            description: "One-sentence description of the problem + what to change.",
+          },
+          file: { type: "string", description: "Relative path to the file, if applicable." },
+          line: { type: "number", description: "Line number, if applicable." },
+        },
+        required: ["severity", "category", "message"],
+      },
+    },
+    summary: {
+      type: "string",
+      description:
+        "One-paragraph summary of the review. Include the overall verdict reasoning, not just a restatement of blockers.",
+    },
+  },
+  required: ["verdict", "blockers", "summary"],
+} as const;

--- a/packages/agent-claude/test/claude-agent.test.mjs
+++ b/packages/agent-claude/test/claude-agent.test.mjs
@@ -1,0 +1,157 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EfficiencyGate } from "@ai-conclave/core";
+import { ClaudeAgent } from "../dist/index.js";
+
+function makeMockClient(responses) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    messages: {
+      create: async (params) => {
+        calls.push(params);
+        const r = responses[Math.min(i, responses.length - 1)];
+        i += 1;
+        return r;
+      },
+    },
+  };
+}
+
+function okResponse({ verdict = "approve", blockers = [], summary = "ok", inputTokens = 1_000, outputTokens = 100, cacheRead = 0 } = {}) {
+  return {
+    id: "msg_test",
+    model: "claude-sonnet-4-6",
+    content: [
+      {
+        type: "tool_use",
+        id: "tool_1",
+        name: "submit_review",
+        input: { verdict, blockers, summary },
+      },
+    ],
+    stop_reason: "tool_use",
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cache_read_input_tokens: cacheRead,
+    },
+  };
+}
+
+const ctx = {
+  diff: "diff --git a/x b/x\n+added",
+  repo: "acme/x",
+  pullNumber: 1,
+  newSha: "abc123",
+};
+
+test("ClaudeAgent: parses approve verdict through the efficiency gate", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse({ verdict: "approve", summary: "LGTM" })]);
+  const agent = new ClaudeAgent({ apiKey: "test-key", gate, client });
+  const result = await agent.review(ctx);
+  assert.equal(result.agent, "claude");
+  assert.equal(result.verdict, "approve");
+  assert.equal(result.blockers.length, 0);
+  assert.equal(result.summary, "LGTM");
+  assert.ok(typeof result.costUsd === "number" && result.costUsd > 0);
+  assert.ok(typeof result.tokensUsed === "number" && result.tokensUsed === 1_100);
+});
+
+test("ClaudeAgent: parses rework verdict with blockers", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([
+    okResponse({
+      verdict: "rework",
+      blockers: [
+        { severity: "blocker", category: "type-error", message: "ts2345 on line 7", file: "src/x.ts", line: 7 },
+        { severity: "minor", category: "missing-test", message: "no test for new branch" },
+        { invalid: "shape", should: "drop" },
+      ],
+      summary: "1 blocker, 1 minor",
+    }),
+  ]);
+  const agent = new ClaudeAgent({ apiKey: "test-key", gate, client });
+  const result = await agent.review(ctx);
+  assert.equal(result.verdict, "rework");
+  assert.equal(result.blockers.length, 2);
+  assert.equal(result.blockers[0].severity, "blocker");
+  assert.equal(result.blockers[0].file, "src/x.ts");
+  assert.equal(result.blockers[0].line, 7);
+  assert.equal(result.blockers[1].severity, "minor");
+});
+
+test("ClaudeAgent: throws when response has no tool_use block", async () => {
+  const client = {
+    calls: [],
+    messages: {
+      create: async () => ({
+        id: "msg",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "I forgot to call the tool" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 100, output_tokens: 10 },
+      }),
+    },
+  };
+  const agent = new ClaudeAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /did not include a submit_review tool_use/);
+});
+
+test("ClaudeAgent: throws on invalid verdict value", async () => {
+  const client = makeMockClient([okResponse({ verdict: "ship-it-lol" })]);
+  const agent = new ClaudeAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /invalid verdict/);
+});
+
+test("ClaudeAgent: records a metric on the shared gate", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse({ verdict: "approve", inputTokens: 5_000, outputTokens: 200 })]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const summary = gate.metrics.summary();
+  assert.equal(summary.callCount, 1);
+  assert.equal(summary.byAgent["claude"].calls, 1);
+  assert.ok(summary.totalCostUsd > 0);
+});
+
+test("ClaudeAgent: sends system prompt with cache_control ephemeral", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse()]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const params = client.calls[0];
+  assert.ok(Array.isArray(params.system), "system should be an array of blocks for cache control");
+  assert.equal(params.system[0].cache_control?.type, "ephemeral");
+});
+
+test("ClaudeAgent: forces submit_review tool via tool_choice", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse()]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const params = client.calls[0];
+  assert.equal(params.tool_choice.type, "tool");
+  assert.equal(params.tool_choice.name, "submit_review");
+});
+
+test("ClaudeAgent: respects a shared budget cap across calls", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 0.005 }); // tiny budget
+  const client = makeMockClient([
+    okResponse({ inputTokens: 10_000, outputTokens: 500 }), // ~$0.0375 → exceeds 0.005
+  ]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await assert.rejects(() => agent.review(ctx), /budget/);
+});
+
+test("ClaudeAgent: missing API key AND no injected client throws in constructor", () => {
+  const orig = process.env.ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  try {
+    assert.throws(() => new ClaudeAgent());
+  } finally {
+    if (orig !== undefined) process.env.ANTHROPIC_API_KEY = orig;
+  }
+});

--- a/packages/agent-claude/test/pricing.test.mjs
+++ b/packages/agent-claude/test/pricing.test.mjs
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { actualCost, estimateCallCost, PRICING } from "../dist/index.js";
+
+test("PRICING table has all three Claude tiers", () => {
+  assert.ok(PRICING["claude-sonnet-4-6"]);
+  assert.ok(PRICING["claude-haiku-4-5"]);
+  assert.ok(PRICING["claude-opus-4-7"]);
+});
+
+test("actualCost: Sonnet baseline — 1000 in, 500 out, no cache", () => {
+  const cost = actualCost("claude-sonnet-4-6", { inputTokens: 1_000, outputTokens: 500 });
+  // 1000 * 3 + 500 * 15 = 3000 + 7500 = 10_500 / 1_000_000 = 0.0105
+  assert.equal(cost.toFixed(4), "0.0105");
+});
+
+test("actualCost: cache read discount applied", () => {
+  const noCache = actualCost("claude-sonnet-4-6", { inputTokens: 10_000, outputTokens: 200 });
+  const cached = actualCost("claude-sonnet-4-6", {
+    inputTokens: 10_000,
+    outputTokens: 200,
+    cacheReadTokens: 9_000,
+  });
+  // 9k cache read at 0.3/MTok instead of 3.0/MTok = 0.0027 vs 0.027 → $0.0243 savings
+  assert.ok(cached < noCache, "cached call must cost less");
+  assert.equal((noCache - cached).toFixed(4), "0.0243");
+});
+
+test("actualCost: cache write premium applied", () => {
+  const noCache = actualCost("claude-sonnet-4-6", { inputTokens: 5_000, outputTokens: 100 });
+  const cacheWrite = actualCost("claude-sonnet-4-6", {
+    inputTokens: 5_000,
+    outputTokens: 100,
+    cacheCreationTokens: 5_000,
+  });
+  // cache write is 1.25× input cost
+  assert.ok(cacheWrite > noCache);
+});
+
+test("actualCost: Haiku is ~12× cheaper than Sonnet per input token", () => {
+  const sonnet = actualCost("claude-sonnet-4-6", { inputTokens: 100_000, outputTokens: 0 });
+  const haiku = actualCost("claude-haiku-4-5", { inputTokens: 100_000, outputTokens: 0 });
+  const ratio = sonnet / haiku;
+  assert.ok(ratio >= 11 && ratio <= 13, `expected ratio ~12, got ${ratio}`);
+});
+
+test("actualCost: throws on unknown model", () => {
+  assert.throws(() => actualCost("claude-does-not-exist", { inputTokens: 1, outputTokens: 1 }));
+});
+
+test("estimateCallCost: pessimistic pre-flight matches reserve-before-call flow", () => {
+  const est = estimateCallCost("claude-sonnet-4-6", 5_000, 1_000);
+  // 5k * 3/M + 1k * 15/M = 15e-3 + 15e-3 = 0.03
+  assert.equal(est.toFixed(3), "0.030");
+});


### PR DESCRIPTION
## Summary

Replaces the PR-#1 stub `ClaudeAgent.review()` with a real end-to-end review call. All SDK traffic is forced through `EfficiencyGate.run(...)` from [PR #2](https://github.com/seunghunbae-3svs/ai-conclave/pull/2) — no direct SDK escape hatches.

Stacked on [#2](https://github.com/seunghunbae-3svs/ai-conclave/pull/2). Base = `scaffold/efficiency-gate`.

## Design choices

| Concern | Choice | Why |
|---|---|---|
| Structured output | `tool_choice: { type: \"tool\", name: \"submit_review\" }` single-tool pattern | Decision #12. Guarantees well-formed verdict/blockers/summary — no fragile regex parsing. |
| Prompt cache | System + RAG prefix sent as one ephemeral `cache_control` block | Identical-prefix calls within 5 min hit the prompt cache; cache-read price is ~10% of normal input — the biggest single cost saver. |
| Cost metering | `actualCost(model, response.usage)` reading cache-write / cache-read tokens explicitly | Matches Anthropic's billing breakdown; pre-flight `estimateCallCost` is pessimistic so reserve never under-budgets. |
| Error surface | Parser tolerates malformed individual blockers, throws on missing `submit_review` tool_use or invalid verdict | Losing 1 of 5 blockers to bad JSON is acceptable; losing the whole review is not. |
| Testability | Inject `client: AnthropicLike` via constructor opt; lazy-load `@anthropic-ai/sdk` default | Tests never pay the real SDK load cost; production never pays the mock-harness cost. |

## Tests — 16 cases (`node --test`)

### `pricing.test.mjs`
- Table covers Sonnet 4.6 / Haiku 4.5 / Opus 4.7.
- Baseline Sonnet cost (1k in + 500 out = \$0.0105).
- Cache read discount verified: 9k cached of 10k → \$0.0243 saved vs no-cache.
- Cache write premium verified.
- Haiku ~12× cheaper than Sonnet per input token.
- Unknown model throws.
- `estimateCallCost` matches reserve-before-call expectations.

### `claude-agent.test.mjs`
- Approve verdict flows end-to-end through the gate.
- Rework verdict with mixed valid + malformed blockers — invalid ones dropped.
- Missing `submit_review` tool_use → throws with actionable message.
- Invalid verdict value (`\"ship-it-lol\"`) → throws.
- Shared gate's `metrics.summary()` aggregates the call (agent + model).
- `system` field sent as array of blocks with `cache_control.type === \"ephemeral\"`.
- `tool_choice.type === \"tool\"` + `name === \"submit_review\"`.
- Tiny budget (\$0.005) → pre-flight `BudgetExceededError`, mock client never called.
- Missing `ANTHROPIC_API_KEY` + no injected `client` → constructor throws.

## Verification checklist

- [ ] `pnpm install` — adds @anthropic-ai/sdk to node_modules
- [ ] `pnpm build` — emits `dist/` for core and agent-claude (turbo's `^build`)
- [ ] `pnpm test` — 16 agent-claude cases green
- [ ] `pnpm typecheck` — strict + noUncheckedIndexedAccess clean
- [ ] Manual smoke: `ANTHROPIC_API_KEY=... conclave review` — PR-#1 CLI still works; next stacked PR will wire real diff loading.

## Deferred

- Migration to `@anthropic-ai/claude-agent-sdk` per decision #8 — a few-line swap; kept as a follow-up so this PR's diff stays focused on the gate integration.
- Real RAG retrieval from memory substrate (next PR).
- Mastra 3-round debate (Council still runs 1 round; PR #6 in the plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)