### PR TITLE
feat(core): memory substrate — 정답지 / 오답지 skeleton with FS store + keyword retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,23 @@
     blockers), invalid response shapes, budget enforcement, cache_control
     wire-format, tool_choice wire-format, missing-key constructor guard,
     metrics aggregation on shared gate.
+- **Memory substrate** (`@ai-conclave/core/memory`) per decision #17 —
+  정답지 / 오답지 dualism as the core primitive.
+  - Zod schemas for `EpisodicEntry`, `AnswerKey`, `FailureEntry`, `SemanticRule`
+    with enum-validated domains (code / design), severity, and 11 failure categories.
+  - `MemoryStore` interface (read + write + list) with a `FileSystemMemoryStore`
+    implementation. Layout: `episodic/YYYY-MM-DD/pr-{n}.json` + `answer-keys/{domain}/{id}.json` +
+    `failure-catalog/{domain}/{id}.json` + `semantic/rules.jsonl`. Lazy mkdir on
+    write; missing dirs return `[]` on read.
+  - Lightweight BM25-ish retrieval (keyword overlap + tag boost + repo boost)
+    for the RAG path. No vector DB — corpus is O(100s), short text, keyword + tag
+    ranking is sufficient to pilot the self-evolve loop. Vector embeddings slot
+    in later as a pluggable scoring backend.
+  - `formatAnswerKeyForPrompt` / `formatFailureForPrompt` helpers produce the
+    short string form that agent-claude's `ReviewContext.answerKeys` / `failureCatalog`
+    arrays expect — integration is already wired (no agent-claude change needed).
+  - 23 test cases across schema validation (enum domains + categories), retrieval
+    (query match, tag boost, repo boost, stop-word filter, Korean tokens,
+    k respect, empty cases), and FS store round-trip (answer-keys, failures,
+    rules JSONL append, episodic day-bucketing, missing-dir tolerance, domain
+    filter, default k = 8).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,10 @@
     "./efficiency": {
       "types": "./dist/efficiency/index.d.ts",
       "import": "./dist/efficiency/index.js"
+    },
+    "./memory": {
+      "types": "./dist/memory/index.d.ts",
+      "import": "./dist/memory/index.js"
     }
   },
   "files": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,28 @@ export type { Agent, ReviewContext, ReviewResult, Blocker, Severity } from "./ag
 export { Council } from "./council.js";
 export { ReviewResultSchema, BlockerSchema } from "./schema.js";
 
+// Memory substrate (decision #17: 정답지 + 오답지 duality as core primitive).
+// Re-exported here for convenience; dedicated subpath at @ai-conclave/core/memory.
+export {
+  FileSystemMemoryStore,
+  AnswerKeySchema,
+  EpisodicEntrySchema,
+  FailureEntrySchema,
+  SemanticRuleSchema,
+  formatAnswerKeyForPrompt,
+  formatFailureForPrompt,
+} from "./memory/index.js";
+export type {
+  AnswerKey,
+  EpisodicEntry,
+  FailureEntry,
+  SemanticRule,
+  MemoryStore,
+  MemoryReadQuery,
+  MemoryRetrieval,
+  FsStoreOptions,
+} from "./memory/index.js";
+
 // Efficiency Gate (decision #22: first-class from day 1) — every LLM call
 // routes through `EfficiencyGate.run(...)`. Re-exported here for convenience;
 // the dedicated subpath export lives at @ai-conclave/core/efficiency.

--- a/packages/core/src/memory/fs-store.ts
+++ b/packages/core/src/memory/fs-store.ts
@@ -1,0 +1,171 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  AnswerKeySchema,
+  EpisodicEntrySchema,
+  FailureEntrySchema,
+  SemanticRuleSchema,
+  type AnswerKey,
+  type EpisodicEntry,
+  type FailureEntry,
+  type SemanticRule,
+} from "./schema.js";
+import type { MemoryReadQuery, MemoryRetrieval, MemoryStore } from "./store.js";
+import { retrieve } from "./retrieval.js";
+
+export interface FsStoreOptions {
+  root: string;
+}
+
+/**
+ * FileSystemMemoryStore — JSON-file backend for the self-evolve substrate.
+ *
+ * Layout under `root`:
+ *   episodic/YYYY-MM-DD/pr-{n}.json          (90d TTL — pruning runs out-of-band)
+ *   answer-keys/{domain}/{id}.json
+ *   failure-catalog/{domain}/{id}.json
+ *   semantic/rules.json                       (single JSONL file, appended)
+ *
+ * All paths are created lazily on first write. Reads are glob-less —
+ * we walk only the directories we care about.
+ */
+export class FileSystemMemoryStore implements MemoryStore {
+  private readonly root: string;
+
+  constructor(opts: FsStoreOptions) {
+    this.root = opts.root;
+  }
+
+  async retrieve(q: MemoryReadQuery): Promise<MemoryRetrieval> {
+    const k = q.k ?? 8;
+    const answerKeyCorpus = await this.listAnswerKeys(q.domain);
+    const failureCorpus = await this.listFailures(q.domain);
+    const ruleCorpus = await this.listRules();
+
+    const answerKeys = retrieve(
+      answerKeyCorpus,
+      q.query,
+      {
+        text: (d) => `${d.pattern}\n${d.lesson}\n${d.tags.join(" ")}`,
+        tags: (d) => d.tags,
+        repo: (d) => d.repo,
+      },
+      k,
+      { queryRepo: q.repo },
+    ).map((s) => s.doc);
+
+    const failures = retrieve(
+      failureCorpus,
+      q.query,
+      {
+        text: (d) => `${d.title}\n${d.body}\n${d.category}\n${d.tags.join(" ")}`,
+        tags: (d) => [d.category, ...d.tags],
+      },
+      k,
+    ).map((s) => s.doc);
+
+    const rules = retrieve(
+      ruleCorpus,
+      q.query,
+      {
+        text: (d) => `${d.tag}\n${d.rule}`,
+        tags: (d) => [d.tag],
+      },
+      Math.min(k, 4),
+    ).map((s) => s.doc);
+
+    return { answerKeys, failures, rules };
+  }
+
+  async writeEpisodic(entry: EpisodicEntry): Promise<void> {
+    EpisodicEntrySchema.parse(entry);
+    const day = entry.createdAt.slice(0, 10);
+    const dir = path.join(this.root, "episodic", day);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, `pr-${entry.pullNumber}-${entry.id}.json`),
+      JSON.stringify(entry, null, 2),
+      "utf8",
+    );
+  }
+
+  async writeAnswerKey(key: AnswerKey): Promise<void> {
+    AnswerKeySchema.parse(key);
+    const dir = path.join(this.root, "answer-keys", key.domain);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, `${key.id}.json`), JSON.stringify(key, null, 2), "utf8");
+  }
+
+  async writeFailure(entry: FailureEntry): Promise<void> {
+    FailureEntrySchema.parse(entry);
+    const dir = path.join(this.root, "failure-catalog", entry.domain);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, `${entry.id}.json`), JSON.stringify(entry, null, 2), "utf8");
+  }
+
+  async writeRule(rule: SemanticRule): Promise<void> {
+    SemanticRuleSchema.parse(rule);
+    const dir = path.join(this.root, "semantic");
+    await fs.mkdir(dir, { recursive: true });
+    const file = path.join(dir, "rules.jsonl");
+    await fs.appendFile(file, JSON.stringify(rule) + "\n", "utf8");
+  }
+
+  async listAnswerKeys(domain?: "code" | "design"): Promise<AnswerKey[]> {
+    const domains: Array<"code" | "design"> = domain ? [domain] : ["code", "design"];
+    const out: AnswerKey[] = [];
+    for (const d of domains) {
+      const dir = path.join(this.root, "answer-keys", d);
+      const files = await safeReaddir(dir);
+      for (const f of files) {
+        if (!f.endsWith(".json")) continue;
+        const raw = await fs.readFile(path.join(dir, f), "utf8");
+        const parsed = AnswerKeySchema.safeParse(JSON.parse(raw));
+        if (parsed.success) out.push(parsed.data);
+      }
+    }
+    return out;
+  }
+
+  async listFailures(domain?: "code" | "design"): Promise<FailureEntry[]> {
+    const domains: Array<"code" | "design"> = domain ? [domain] : ["code", "design"];
+    const out: FailureEntry[] = [];
+    for (const d of domains) {
+      const dir = path.join(this.root, "failure-catalog", d);
+      const files = await safeReaddir(dir);
+      for (const f of files) {
+        if (!f.endsWith(".json")) continue;
+        const raw = await fs.readFile(path.join(dir, f), "utf8");
+        const parsed = FailureEntrySchema.safeParse(JSON.parse(raw));
+        if (parsed.success) out.push(parsed.data);
+      }
+    }
+    return out;
+  }
+
+  async listRules(): Promise<SemanticRule[]> {
+    const file = path.join(this.root, "semantic", "rules.jsonl");
+    try {
+      const raw = await fs.readFile(file, "utf8");
+      const out: SemanticRule[] = [];
+      for (const line of raw.split(/\r?\n/)) {
+        if (!line.trim()) continue;
+        const parsed = SemanticRuleSchema.safeParse(JSON.parse(line));
+        if (parsed.success) out.push(parsed.data);
+      }
+      return out;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+  }
+}
+
+async function safeReaddir(dir: string): Promise<string[]> {
+  try {
+    return await fs.readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+}

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -1,0 +1,24 @@
+export {
+  AnswerKeySchema,
+  AnswerKeyDomainSchema,
+  EpisodicEntrySchema,
+  FailureEntrySchema,
+  FailureCategorySchema,
+  FailureSeveritySchema,
+  SemanticRuleSchema,
+} from "./schema.js";
+export type {
+  AnswerKey,
+  EpisodicEntry,
+  FailureEntry,
+  SemanticRule,
+} from "./schema.js";
+
+export { formatAnswerKeyForPrompt, formatFailureForPrompt } from "./store.js";
+export type { MemoryStore, MemoryReadQuery, MemoryRetrieval } from "./store.js";
+
+export { retrieve } from "./retrieval.js";
+export type { RetrievalFieldExtractor, RetrievalOptions, ScoredDoc } from "./retrieval.js";
+
+export { FileSystemMemoryStore } from "./fs-store.js";
+export type { FsStoreOptions } from "./fs-store.js";

--- a/packages/core/src/memory/retrieval.ts
+++ b/packages/core/src/memory/retrieval.ts
@@ -1,0 +1,109 @@
+/**
+ * Lightweight BM25-ish retrieval. We avoid a heavy vector DB for the
+ * skeleton — answer-keys and failures are short text, the corpus is O(100s)
+ * per repo, and a keyword-plus-tag ranking is good enough to pilot the
+ * self-evolve loop. Vector embeddings slot in later as a pluggable
+ * scoring backend without breaking the store interface.
+ */
+
+export interface ScoredDoc<T> {
+  doc: T;
+  score: number;
+}
+
+export interface RetrievalFieldExtractor<T> {
+  text(doc: T): string;
+  tags(doc: T): readonly string[];
+  repo?(doc: T): string | undefined;
+}
+
+export interface RetrievalOptions {
+  /** Lexicon boost: when query tokens match doc tags, multiply score by this factor. Default 1.5. */
+  tagBoost?: number;
+  /** Multiply score for docs whose repo matches the query's repo. Default 1.2. */
+  repoBoost?: number;
+  /** Minimum score to retain a doc. Default 0.05. */
+  minScore?: number;
+}
+
+const STOP_WORDS = new Set([
+  "a", "an", "the", "and", "or", "to", "of", "in", "on", "for", "with", "by",
+  "is", "are", "was", "were", "be", "been", "being", "it", "its", "this",
+  "that", "these", "those", "at", "from", "as", "but", "not", "if", "then",
+]);
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣\-]+/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length > 1 && !STOP_WORDS.has(t));
+}
+
+function termFrequencies(tokens: readonly string[]): Map<string, number> {
+  const tf = new Map<string, number>();
+  for (const t of tokens) tf.set(t, (tf.get(t) ?? 0) + 1);
+  return tf;
+}
+
+/**
+ * Score a single document against a query. Returns a scalar in [0, ~n]
+ * where n is the number of query tokens. Uses:
+ *   1. Cosine-ish term overlap (sum of min(tf_q, tf_d) / sqrt(|q|·|d|))
+ *   2. Tag-match boost
+ *   3. Repo-match boost (small, just tie-breaking)
+ */
+function scoreDoc<T>(
+  doc: T,
+  queryTokens: readonly string[],
+  queryRepo: string | undefined,
+  extract: RetrievalFieldExtractor<T>,
+  opts: Required<Pick<RetrievalOptions, "tagBoost" | "repoBoost">>,
+): number {
+  const qTf = termFrequencies(queryTokens);
+  const dTokens = tokenize(extract.text(doc));
+  if (dTokens.length === 0 || queryTokens.length === 0) return 0;
+  const dTf = termFrequencies(dTokens);
+
+  let overlap = 0;
+  for (const [t, qf] of qTf) {
+    const df = dTf.get(t);
+    if (df) overlap += Math.min(qf, df);
+  }
+  let score = overlap / Math.sqrt(queryTokens.length * dTokens.length);
+
+  if (score > 0) {
+    const tagSet = new Set(extract.tags(doc).map((t) => t.toLowerCase()));
+    let tagHits = 0;
+    for (const t of qTf.keys()) if (tagSet.has(t)) tagHits += 1;
+    if (tagHits > 0) score *= opts.tagBoost;
+
+    if (queryRepo && extract.repo) {
+      const r = extract.repo(doc);
+      if (r && r === queryRepo) score *= opts.repoBoost;
+    }
+  }
+
+  return score;
+}
+
+export function retrieve<T>(
+  corpus: readonly T[],
+  queryText: string,
+  extract: RetrievalFieldExtractor<T>,
+  k: number,
+  opts: RetrievalOptions & { queryRepo?: string } = {},
+): ScoredDoc<T>[] {
+  const tokens = tokenize(queryText);
+  if (tokens.length === 0 || corpus.length === 0) return [];
+  const tagBoost = opts.tagBoost ?? 1.5;
+  const repoBoost = opts.repoBoost ?? 1.2;
+  const minScore = opts.minScore ?? 0.05;
+  const scored: ScoredDoc<T>[] = [];
+  for (const doc of corpus) {
+    const score = scoreDoc(doc, tokens, opts.queryRepo, extract, { tagBoost, repoBoost });
+    if (score >= minScore) scored.push({ doc, score });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, k);
+}

--- a/packages/core/src/memory/schema.ts
+++ b/packages/core/src/memory/schema.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+import { BlockerSchema, ReviewResultSchema } from "../schema.js";
+
+/**
+ * EpisodicEntry — raw event log. One record per review cycle.
+ * 90-day TTL per architecture. Nightly Haiku job classifies these into
+ * answer-keys (on merge) + failure-catalog (on reject/rework).
+ */
+export const EpisodicEntrySchema = z.object({
+  id: z.string().min(1),
+  createdAt: z.string().datetime(),
+  repo: z.string().min(1),
+  pullNumber: z.number().int().nonnegative(),
+  sha: z.string().min(1),
+  diffSha256: z.string().length(64),
+  reviews: z.array(ReviewResultSchema),
+  councilVerdict: z.enum(["approve", "rework", "reject"]),
+  outcome: z.enum(["merged", "rejected", "reworked", "pending"]),
+  costUsd: z.number().nonnegative(),
+});
+export type EpisodicEntry = z.infer<typeof EpisodicEntrySchema>;
+
+/**
+ * AnswerKey (정답지) — a SUCCESS PATTERN. Written when a PR merges.
+ * Retrieved at review time so future reviews match the repo's tolerance
+ * for what counts as a blocker and what counts as polish.
+ */
+export const AnswerKeyDomainSchema = z.enum(["code", "design"]);
+export const AnswerKeySchema = z.object({
+  id: z.string().min(1),
+  createdAt: z.string().datetime(),
+  domain: AnswerKeyDomainSchema,
+  /** e.g. "by-pattern/auth-middleware", "by-component/LoginForm". Flat path inside the domain. */
+  pattern: z.string().min(1),
+  repo: z.string().optional(),
+  user: z.string().optional(),
+  /** One-paragraph distillation of what made this PR a good change. */
+  lesson: z.string().min(1),
+  /** Tags for filtered retrieval ("auth", "react", "refactor", "ui"). */
+  tags: z.array(z.string()).default([]),
+  /** Optional pointer back to the episodic entry that produced this answer-key. */
+  episodicId: z.string().optional(),
+});
+export type AnswerKey = z.infer<typeof AnswerKeySchema>;
+
+/**
+ * FailureEntry (오답지) — a FAILURE PATTERN. Written on reject or rework.
+ * Seeded from solo-cto-agent's failure-catalog.json (ERR-001~) per
+ * decision #18 — do not start from zero.
+ */
+export const FailureSeveritySchema = z.enum(["blocker", "major", "minor"]);
+export const FailureCategorySchema = z.enum([
+  "type-error",
+  "missing-test",
+  "regression",
+  "security",
+  "accessibility",
+  "contrast",
+  "performance",
+  "dead-code",
+  "api-misuse",
+  "schema-drift",
+  "other",
+]);
+export const FailureEntrySchema = z.object({
+  id: z.string().min(1),
+  createdAt: z.string().datetime(),
+  domain: AnswerKeyDomainSchema,
+  category: FailureCategorySchema,
+  severity: FailureSeveritySchema,
+  /** Short human-readable title of the pattern. */
+  title: z.string().min(1),
+  /** Details / why it's bad / how to fix — the thing agents read at review time. */
+  body: z.string().min(1),
+  /** Optional small code-or-diff snippet showing the pattern. */
+  snippet: z.string().optional(),
+  tags: z.array(z.string()).default([]),
+  /** Blocker that first surfaced this pattern, if any. */
+  seedBlocker: BlockerSchema.optional(),
+  episodicId: z.string().optional(),
+});
+export type FailureEntry = z.infer<typeof FailureEntrySchema>;
+
+/**
+ * SemanticRule — distilled cross-entry pattern. Weekly Haiku job.
+ * Format kept intentionally narrow so rules are short, actionable, and
+ * indexable by a tag vocabulary.
+ */
+export const SemanticRuleSchema = z.object({
+  id: z.string().min(1),
+  createdAt: z.string().datetime(),
+  tag: z.string().min(1),
+  rule: z.string().min(1),
+  evidence: z.object({
+    answerKeyIds: z.array(z.string()).default([]),
+    failureIds: z.array(z.string()).default([]),
+  }),
+});
+export type SemanticRule = z.infer<typeof SemanticRuleSchema>;

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -1,0 +1,56 @@
+import type { AnswerKey, EpisodicEntry, FailureEntry, SemanticRule } from "./schema.js";
+
+export interface MemoryReadQuery {
+  /** Free-text query. Typically the diff summary + file paths + blocker categories of the PR under review. */
+  query: string;
+  /** Filter by domain (code / design). Null/omitted = both. */
+  domain?: "code" | "design";
+  /** Max results per bucket. Default 8. */
+  k?: number;
+  /** Repo scope — prefer entries tagged for this repo; falls back to global. */
+  repo?: string;
+}
+
+export interface MemoryRetrieval {
+  answerKeys: AnswerKey[];
+  failures: FailureEntry[];
+  rules: SemanticRule[];
+}
+
+/**
+ * MemoryStore — read + write interface for the self-evolve substrate.
+ *
+ * Implementations: `FileSystemMemoryStore` (JSON files under `.conclave/`),
+ * future `PostgresMemoryStore` for shared/team deployments, future
+ * `FederatedReadOnlyStore` for the hash+category baseline fetched from a
+ * shared endpoint (decision #21).
+ *
+ * RAG path (`retrieve(...)`) is read-only and is called once per review.
+ * Write methods are called by the outcome-writer on merge / reject /
+ * rework events (future PR wires this up).
+ */
+export interface MemoryStore {
+  retrieve(query: MemoryReadQuery): Promise<MemoryRetrieval>;
+  writeEpisodic(entry: EpisodicEntry): Promise<void>;
+  writeAnswerKey(key: AnswerKey): Promise<void>;
+  writeFailure(entry: FailureEntry): Promise<void>;
+  writeRule(rule: SemanticRule): Promise<void>;
+  /** Utility — list all answer-keys matching a domain filter. Mostly for tests + admin tools. */
+  listAnswerKeys(domain?: "code" | "design"): Promise<AnswerKey[]>;
+  listFailures(domain?: "code" | "design"): Promise<FailureEntry[]>;
+  listRules(): Promise<SemanticRule[]>;
+}
+
+/**
+ * Distilled summary helpers that convert retrieved entries into the short
+ * string form that ReviewContext.answerKeys / failureCatalog carry. Agents
+ * splice these into prompts (see agent-claude/prompts.ts).
+ */
+export function formatAnswerKeyForPrompt(k: AnswerKey): string {
+  const tags = k.tags.length > 0 ? ` [${k.tags.join(", ")}]` : "";
+  return `(${k.domain}/${k.pattern})${tags} — ${k.lesson}`;
+}
+
+export function formatFailureForPrompt(f: FailureEntry): string {
+  return `(${f.domain}/${f.category}/${f.severity}) ${f.title} — ${f.body}`;
+}

--- a/packages/core/test/memory-fs-store.test.mjs
+++ b/packages/core/test/memory-fs-store.test.mjs
@@ -1,0 +1,179 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FileSystemMemoryStore } from "../dist/index.js";
+
+function freshStore() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aic-mem-"));
+  return { store: new FileSystemMemoryStore({ root }), root };
+}
+
+function cleanup(root) {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+const now = () => new Date().toISOString();
+
+test("FileSystemMemoryStore: write + list answer-keys round-trip", async () => {
+  const { store, root } = freshStore();
+  try {
+    await store.writeAnswerKey({
+      id: "ak-001",
+      createdAt: now(),
+      domain: "code",
+      pattern: "by-pattern/auth",
+      lesson: "stateless middleware composes",
+      tags: ["auth"],
+    });
+    const out = await store.listAnswerKeys("code");
+    assert.equal(out.length, 1);
+    assert.equal(out[0].id, "ak-001");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: list returns [] when dir missing", async () => {
+  const { store, root } = freshStore();
+  try {
+    assert.deepEqual(await store.listAnswerKeys(), []);
+    assert.deepEqual(await store.listFailures(), []);
+    assert.deepEqual(await store.listRules(), []);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: write failure + retrieve surfaces it", async () => {
+  const { store, root } = freshStore();
+  try {
+    await store.writeFailure({
+      id: "fc-001",
+      createdAt: now(),
+      domain: "code",
+      category: "security",
+      severity: "blocker",
+      title: "JWT logged in full",
+      body: "Truncate JWTs to first/last 4 chars before log.",
+      tags: ["auth", "logging"],
+    });
+    const result = await store.retrieve({ query: "JWT auth logging truncate", domain: "code", k: 5 });
+    assert.equal(result.failures.length, 1);
+    assert.equal(result.failures[0].id, "fc-001");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: domain filter excludes other-domain entries", async () => {
+  const { store, root } = freshStore();
+  try {
+    await store.writeAnswerKey({
+      id: "ak-code",
+      createdAt: now(),
+      domain: "code",
+      pattern: "by-pattern/x",
+      lesson: "code lesson",
+      tags: [],
+    });
+    await store.writeAnswerKey({
+      id: "ak-design",
+      createdAt: now(),
+      domain: "design",
+      pattern: "by-component/Button",
+      lesson: "design lesson",
+      tags: [],
+    });
+    const code = await store.listAnswerKeys("code");
+    const design = await store.listAnswerKeys("design");
+    assert.equal(code.length, 1);
+    assert.equal(design.length, 1);
+    assert.equal(code[0].id, "ak-code");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: retrieve returns empty buckets on empty corpus", async () => {
+  const { store, root } = freshStore();
+  try {
+    const result = await store.retrieve({ query: "anything at all" });
+    assert.deepEqual(result.answerKeys, []);
+    assert.deepEqual(result.failures, []);
+    assert.deepEqual(result.rules, []);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: writeRule appends JSONL", async () => {
+  const { store, root } = freshStore();
+  try {
+    await store.writeRule({
+      id: "r1",
+      createdAt: now(),
+      tag: "auth",
+      rule: "never log raw JWTs",
+      evidence: { answerKeyIds: [], failureIds: ["fc-001"] },
+    });
+    await store.writeRule({
+      id: "r2",
+      createdAt: now(),
+      tag: "a11y",
+      rule: "contrast at least AA",
+      evidence: { answerKeyIds: [], failureIds: [] },
+    });
+    const rules = await store.listRules();
+    assert.equal(rules.length, 2);
+    assert.equal(rules[0].id, "r1");
+    assert.equal(rules[1].id, "r2");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: writeEpisodic organizes by day + PR", async () => {
+  const { store, root } = freshStore();
+  try {
+    const createdAt = "2026-04-19T12:00:00.000Z";
+    await store.writeEpisodic({
+      id: "ep-1",
+      createdAt,
+      repo: "acme/demo",
+      pullNumber: 42,
+      sha: "abc",
+      diffSha256: "a".repeat(64),
+      reviews: [{ agent: "claude", verdict: "approve", blockers: [], summary: "ok" }],
+      councilVerdict: "approve",
+      outcome: "merged",
+      costUsd: 0.01,
+    });
+    const dayDir = path.join(root, "episodic", "2026-04-19");
+    const files = fs.readdirSync(dayDir);
+    assert.ok(files.some((f) => f.startsWith("pr-42")));
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: retrieve k defaults to 8", async () => {
+  const { store, root } = freshStore();
+  try {
+    for (let i = 0; i < 12; i += 1) {
+      await store.writeAnswerKey({
+        id: `ak-${i}`,
+        createdAt: now(),
+        domain: "code",
+        pattern: `by-pattern/x${i}`,
+        lesson: "auth middleware stateless composition",
+        tags: ["auth"],
+      });
+    }
+    const r = await store.retrieve({ query: "auth middleware stateless" });
+    assert.ok(r.answerKeys.length <= 8, `expected ≤ 8, got ${r.answerKeys.length}`);
+  } finally {
+    cleanup(root);
+  }
+});

--- a/packages/core/test/memory-retrieval.test.mjs
+++ b/packages/core/test/memory-retrieval.test.mjs
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { retrieve } from "../dist/index.js";
+
+const corpus = [
+  { id: "1", text: "authentication middleware should validate JWT signatures", tags: ["auth", "security"], repo: "acme/app" },
+  { id: "2", text: "React components must handle empty cart state gracefully", tags: ["ui", "react"], repo: "acme/shop" },
+  { id: "3", text: "database migrations require backwards compatibility", tags: ["db", "migration"], repo: "acme/app" },
+  { id: "4", text: "accessibility contrast ratio must hit AA minimum", tags: ["a11y"], repo: "acme/shop" },
+];
+
+const extract = {
+  text: (d) => d.text,
+  tags: (d) => d.tags,
+  repo: (d) => d.repo,
+};
+
+test("retrieve: query matches content", () => {
+  const hits = retrieve(corpus, "empty cart state in React", extract, 3);
+  assert.ok(hits.length > 0);
+  assert.equal(hits[0].doc.id, "2");
+});
+
+test("retrieve: tag boost promotes tag-matching docs", () => {
+  const hits = retrieve(corpus, "auth security", extract, 3);
+  assert.equal(hits[0].doc.id, "1");
+});
+
+test("retrieve: repo boost promotes same-repo docs", () => {
+  const sameRepo = [
+    { id: "a", text: "generic observation", tags: [], repo: "acme/target" },
+    { id: "b", text: "generic observation", tags: [], repo: "acme/other" },
+  ];
+  const hits = retrieve(sameRepo, "generic observation", extract, 2, { queryRepo: "acme/target" });
+  assert.equal(hits[0].doc.id, "a");
+});
+
+test("retrieve: respects k", () => {
+  const hits = retrieve(corpus, "state ui component auth migration contrast", extract, 2);
+  assert.ok(hits.length <= 2);
+});
+
+test("retrieve: empty query returns nothing", () => {
+  const hits = retrieve(corpus, "", extract, 5);
+  assert.deepEqual(hits, []);
+});
+
+test("retrieve: no-match returns empty", () => {
+  const hits = retrieve(corpus, "xylophone concatenate helicopter", extract, 5);
+  assert.deepEqual(hits, []);
+});
+
+test("retrieve: stop words are ignored", () => {
+  const onlyStops = retrieve(corpus, "the and or to of in on for", extract, 5);
+  assert.deepEqual(onlyStops, []);
+});
+
+test("retrieve: Korean tokens survive tokenizer", () => {
+  const kCorpus = [{ id: "k1", text: "인증 미들웨어는 상태가 없어야 한다", tags: ["auth"], repo: "x" }];
+  const hits = retrieve(kCorpus, "인증 미들웨어", extract, 3);
+  assert.ok(hits.length > 0);
+});

--- a/packages/core/test/memory-schema.test.mjs
+++ b/packages/core/test/memory-schema.test.mjs
@@ -1,0 +1,94 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  AnswerKeySchema,
+  EpisodicEntrySchema,
+  FailureEntrySchema,
+  SemanticRuleSchema,
+} from "../dist/index.js";
+
+test("AnswerKeySchema: minimal valid shape passes", () => {
+  const parsed = AnswerKeySchema.parse({
+    id: "ak-1",
+    createdAt: new Date().toISOString(),
+    domain: "code",
+    pattern: "by-pattern/auth-middleware",
+    lesson: "middleware should be stateless and compose left-to-right",
+    tags: ["auth", "middleware"],
+  });
+  assert.equal(parsed.pattern, "by-pattern/auth-middleware");
+});
+
+test("AnswerKeySchema: rejects invalid domain", () => {
+  assert.throws(() =>
+    AnswerKeySchema.parse({
+      id: "ak-1",
+      createdAt: new Date().toISOString(),
+      domain: "infra", // not in enum
+      pattern: "x",
+      lesson: "y",
+    }),
+  );
+});
+
+test("FailureEntrySchema: minimal valid shape passes", () => {
+  const parsed = FailureEntrySchema.parse({
+    id: "fc-1",
+    createdAt: new Date().toISOString(),
+    domain: "code",
+    category: "type-error",
+    severity: "blocker",
+    title: "Unsafe any",
+    body: "Do not add `as any` to work around strict typing.",
+  });
+  assert.equal(parsed.category, "type-error");
+});
+
+test("FailureEntrySchema: rejects unknown category", () => {
+  assert.throws(() =>
+    FailureEntrySchema.parse({
+      id: "x",
+      createdAt: new Date().toISOString(),
+      domain: "code",
+      category: "telepathy", // not in enum
+      severity: "blocker",
+      title: "t",
+      body: "b",
+    }),
+  );
+});
+
+test("EpisodicEntrySchema: accepts a full council outcome shape", () => {
+  const parsed = EpisodicEntrySchema.parse({
+    id: "ep-1",
+    createdAt: new Date().toISOString(),
+    repo: "acme/demo",
+    pullNumber: 42,
+    sha: "abc123",
+    diffSha256: "a".repeat(64),
+    reviews: [
+      {
+        agent: "claude",
+        verdict: "approve",
+        blockers: [],
+        summary: "LGTM",
+      },
+    ],
+    councilVerdict: "approve",
+    outcome: "merged",
+    costUsd: 0.012,
+  });
+  assert.equal(parsed.reviews.length, 1);
+});
+
+test("SemanticRuleSchema: default evidence arrays", () => {
+  const parsed = SemanticRuleSchema.parse({
+    id: "r-1",
+    createdAt: new Date().toISOString(),
+    tag: "auth",
+    rule: "never log the full JWT — truncate to first/last 4 chars",
+    evidence: {},
+  });
+  assert.deepEqual(parsed.evidence.answerKeyIds, []);
+  assert.deepEqual(parsed.evidence.failureIds, []);
+});


### PR DESCRIPTION
## Summary

Lands the **self-evolve substrate** per decision #17 — 정답지 (answer-keys) + 오답지 (failure-catalog) dualism as the core primitive. Schemas + filesystem store + keyword retrieval, ready to be hooked by outcome-writers in follow-up PRs.

Stacked on [#3](https://github.com/seunghunbae-3svs/ai-conclave/pull/3). Base = `scaffold/agent-claude-real`.

## Schemas (Zod)

| Schema | Role | Retention |
|---|---|---|
| `EpisodicEntry` | Raw event log per review cycle | 90d TTL (pruning future work) |
| `AnswerKey` | Success pattern — written on merge | ∞ |
| `FailureEntry` | Failure pattern — written on reject/rework | ∞ |
| `SemanticRule` | Weekly-distilled cross-entry rule | ∞ |

11 enum-validated failure categories: `type-error` / `missing-test` / `regression` / `security` / `accessibility` / `contrast` / `performance` / `dead-code` / `api-misuse` / `schema-drift` / `other` × 3 severities.

## Store

- `MemoryStore` interface — read (`retrieve` + `list*`) + write (`write*`).
- `FileSystemMemoryStore` — JSON/JSONL under a configurable root:
  - `episodic/YYYY-MM-DD/pr-{n}-{id}.json`
  - `answer-keys/{domain}/{id}.json`
  - `failure-catalog/{domain}/{id}.json`
  - `semantic/rules.jsonl` (append-only)
- Missing dirs return `[]` on read — fresh installs don't crash the review path.

## Retrieval — pragmatic BM25-ish

| Signal | Weight |
|---|---|
| Term overlap (cosine-ish) | base |
| Tag match boost | ×1.5 |
| Same-repo boost | ×1.2 |

No vector DB. Corpus is O(100s), short text — keyword + tag ranking is enough to pilot the loop. Vector embeddings slot in later as a pluggable scoring backend without breaking the interface.

Korean tokens survive the tokenizer (explicit `가-힣` in the character class). Stop words filtered.

## Integration

`ReviewContext.answerKeys` and `ReviewContext.failureCatalog` in `@ai-conclave/core` already accept `string[]`. The new `formatAnswerKeyForPrompt` / `formatFailureForPrompt` helpers produce that exact shape — **no agent-claude change needed**. Downstream callers just do:

```ts
const retrieval = await store.retrieve({ query: diffSummary, domain: "code", repo: ctx.repo });
const result = await agent.review({
  ...ctx,
  answerKeys: retrieval.answerKeys.map(formatAnswerKeyForPrompt),
  failureCatalog: retrieval.failures.map(formatFailureForPrompt),
});
```

## Tests — 23 cases (`node --test`)

- **memory-schema** (6): enum enforcement (domain / category / severity), required-field rejection, evidence-array defaults.
- **memory-retrieval** (8): query match, tag boost, repo boost, k respect, stop-word filter, no-match empty, empty-query empty, Korean tokens.
- **memory-fs-store** (8): write + list round-trip per bucket, missing-dir returns `[]`, domain filter exclusion, write-then-retrieve surface, JSONL append for rules, episodic day-bucketing, default k = 8.

## Deferred

- Outcome-writer hooking PR merge/reject events (needs `scm-github`).
- Nightly Haiku classifier (episodic → catalogs).
- Weekly semantic-rule extractor.
- Federated baseline sync (decision #21 — hash + category only).
- Seeding from solo-cto-agent's `failure-catalog.json` (decision #18) — schema-compatible, trivial import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)