### PR TITLE
feat(core,cli): outcome writer closes the self-evolve loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,3 +97,26 @@
     happy path + missing-owner throw, git-diff with/without remote, file
     diff), and output rendering (all verdicts, severity sort, no-consensus
     tag, metrics formatting, exit-code mapping).
+- **Outcome writer — self-evolve loop closure** (decision #17, write side):
+  - `OutcomeWriter.writeReview(...)` persists an `EpisodicEntry` with
+    `outcome: "pending"` at the end of every `conclave review` call.
+  - `OutcomeWriter.recordOutcome({ episodicId, outcome })` updates the
+    stored episodic entry (merged / rejected / reworked) and invokes a
+    `Classifier` to produce `AnswerKey` (on merge) or `FailureEntry[]`
+    (on reject/rework — one per unique blocker, nits excluded).
+  - `RuleBasedClassifier` — deterministic extraction without an LLM.
+    Pattern = `by-repo/<repo>`; tags derived from blocker categories;
+    free-form category strings normalized to the 11 allowed enum values.
+    Haiku-backed classifier is a future drop-in behind the same interface.
+  - `MemoryStore.findEpisodic(id)` + FS walker so outcome can be recorded
+    in a fresh process (review → close PR → merge can span sessions).
+  - **CLI wired**: `conclave review` now prints the episodic id + a copy-paste
+    `conclave record-outcome --id ... --result merged` instruction. New
+    `conclave record-outcome` command closes the loop end-to-end.
+  - 16 test cases: merged → single answer-key; rejected/reworked → one
+    failure per unique blocker; nit exclusion; cross-agent dedup;
+    category normalization (`"Type Error"` → `type-error`, `"a11y"` →
+    `accessibility`, `"UNUSED IMPORT"` → `dead-code`); tag derivation;
+    stable ids for same input; round-trip through disk; fresh-process
+    reconstruction via `findEpisodic`; unknown-id throw; idempotent
+    re-writes with caller-provided `episodicId`.

--- a/packages/cli/src/commands/record-outcome.ts
+++ b/packages/cli/src/commands/record-outcome.ts
@@ -1,0 +1,62 @@
+import { FileSystemMemoryStore, OutcomeWriter, type OutcomeResult } from "@ai-conclave/core";
+import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
+
+const HELP = `conclave record-outcome — close the self-evolve loop
+
+Usage:
+  conclave record-outcome --id <episodic-id> --result merged|rejected|reworked
+
+On merged PRs, a new answer-key (정답지) is derived from the review summary.
+On rejected / reworked PRs, a failure-catalog entry (오답지) is derived per
+unique blocker (ignoring nits).
+`;
+
+function parseArgv(argv: string[]): { id?: string; result?: OutcomeResult; help: boolean } {
+  const out: { id?: string; result?: OutcomeResult; help: boolean } = { help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--id" && argv[i + 1]) {
+      out.id = argv[i + 1];
+      i += 1;
+    } else if (a === "--result" && argv[i + 1]) {
+      const r = argv[i + 1];
+      if (r === "merged" || r === "rejected" || r === "reworked") out.result = r;
+      i += 1;
+    }
+  }
+  return out;
+}
+
+export async function recordOutcome(argv: string[]): Promise<void> {
+  const args = parseArgv(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  if (!args.id) {
+    process.stderr.write("conclave record-outcome: --id is required\n\n" + HELP);
+    process.exit(2);
+    return;
+  }
+  if (!args.result) {
+    process.stderr.write("conclave record-outcome: --result must be merged|rejected|reworked\n\n" + HELP);
+    process.exit(2);
+    return;
+  }
+
+  const { config, configDir } = await loadConfig();
+  const memoryRoot = resolveMemoryRoot(config, configDir);
+  const store = new FileSystemMemoryStore({ root: memoryRoot });
+  const writer = new OutcomeWriter({ store });
+
+  const output = await writer.recordOutcome({ episodicId: args.id, outcome: args.result });
+
+  process.stdout.write(
+    `conclave record-outcome:\n` +
+      `  episodic:     ${args.id}\n` +
+      `  outcome:      ${args.result}\n` +
+      `  answer-keys:  ${output.answerKeys.length} written\n` +
+      `  failures:     ${output.failures.length} written\n`,
+  );
+}

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -3,6 +3,7 @@ import {
   Council,
   EfficiencyGate,
   FileSystemMemoryStore,
+  OutcomeWriter,
   formatAnswerKeyForPrompt,
   formatFailureForPrompt,
   type ReviewContext,
@@ -106,7 +107,17 @@ export async function review(argv: string[]): Promise<void> {
 
   const outcome = await council.deliberate(reviewCtx);
 
-  // 6. Render + exit with a verdict-derived code
+  // 6. Persist the episodic entry (outcome: "pending") so `conclave
+  //    record-outcome` can classify it later into answer-keys / failures.
+  const writer = new OutcomeWriter({ store });
+  const episodic = await writer.writeReview({
+    ctx: reviewCtx,
+    reviews: outcome.results,
+    councilVerdict: outcome.verdict,
+    costUsd: gate.metrics.summary().totalCostUsd,
+  });
+
+  // 7. Render + exit with a verdict-derived code
   process.stdout.write(
     renderReview({
       repo: loaded.repo,
@@ -118,6 +129,11 @@ export async function review(argv: string[]): Promise<void> {
       results: outcome.results,
       metrics: gate.metrics.summary(),
     }),
+  );
+  process.stdout.write(
+    `\nepisodic: ${episodic.id}\n` +
+      `  when the PR lands, close the loop with:\n` +
+      `    conclave record-outcome --id ${episodic.id} --result merged\n`,
   );
 
   process.exit(verdictToExitCode(outcome.verdict));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,8 @@
 import { init } from "./commands/init.js";
 import { review } from "./commands/review.js";
+import { recordOutcome } from "./commands/record-outcome.js";
 
-const HELP = `conclave — Ai-Conclave CLI (skeleton)
+const HELP = `conclave — Ai-Conclave CLI
 
 Usage:
   conclave <command> [options]
@@ -9,12 +10,14 @@ Usage:
 Commands:
   init                  Set up conclave in the current repo (config + skeleton)
   review                Run a council review on the current branch
+  record-outcome        Record a PR's merge/reject/rework outcome (closes self-evolve loop)
   --help, -h            Show this
   --version, -v         Show version
 
 Examples:
   conclave init
   conclave review --pr 42
+  conclave record-outcome --id ep-... --result merged
 `;
 
 export async function run(argv: string[]): Promise<void> {
@@ -36,6 +39,9 @@ export async function run(argv: string[]): Promise<void> {
       return;
     case "review":
       await review(rest);
+      return;
+    case "record-outcome":
+      await recordOutcome(rest);
       return;
     default:
       process.stderr.write(`Unknown command: ${cmd}\n\n${HELP}`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,9 @@ export {
   SemanticRuleSchema,
   formatAnswerKeyForPrompt,
   formatFailureForPrompt,
+  OutcomeWriter,
+  RuleBasedClassifier,
+  newEpisodicId,
 } from "./memory/index.js";
 export type {
   AnswerKey,
@@ -22,6 +25,12 @@ export type {
   MemoryReadQuery,
   MemoryRetrieval,
   FsStoreOptions,
+  WriteReviewInput,
+  RecordOutcomeInput,
+  RecordOutcomeOutput,
+  Classifier,
+  ClassificationOutput,
+  OutcomeResult,
 } from "./memory/index.js";
 
 // Efficiency Gate (decision #22: first-class from day 1) — every LLM call

--- a/packages/core/src/memory/classifier.ts
+++ b/packages/core/src/memory/classifier.ts
@@ -1,0 +1,150 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { EpisodicEntry, AnswerKey, FailureEntry } from "./schema.js";
+import type { Blocker } from "../agent.js";
+
+export type OutcomeResult = "merged" | "rejected" | "reworked";
+
+export interface ClassificationOutput {
+  answerKeys: AnswerKey[];
+  failures: FailureEntry[];
+}
+
+export interface Classifier {
+  classify(episodic: EpisodicEntry, outcome: OutcomeResult): ClassificationOutput;
+}
+
+/**
+ * RuleBasedClassifier — deterministic extraction of answer-keys + failures
+ * from an EpisodicEntry without an LLM call.
+ *
+ * Rules:
+ *   - merged + all agents approved → one `AnswerKey` from the consensus
+ *     summary. Pattern = `by-repo/<repo>`; tags derived from diff file
+ *     extensions + blocker categories that appeared but were fixed.
+ *   - rejected / reworked → one `FailureEntry` per unique (category, severity)
+ *     blocker seen across all agent reviews. Title from blocker.message
+ *     (first sentence), body combines message + file:line context.
+ *
+ * Haiku-backed classifier lands later as a drop-in replacement; interface
+ * is stable.
+ */
+export class RuleBasedClassifier implements Classifier {
+  classify(episodic: EpisodicEntry, outcome: OutcomeResult): ClassificationOutput {
+    if (outcome === "merged") {
+      return { answerKeys: [this.extractAnswerKey(episodic)], failures: [] };
+    }
+    return { answerKeys: [], failures: this.extractFailures(episodic) };
+  }
+
+  private extractAnswerKey(episodic: EpisodicEntry): AnswerKey {
+    const summaries = episodic.reviews
+      .map((r) => r.summary)
+      .filter((s) => s && s.trim().length > 0)
+      .slice(0, 3)
+      .join(" | ");
+    const lesson = summaries || `Merged without blockers — ${episodic.repo} #${episodic.pullNumber}`;
+    const tags = this.deriveTags(episodic);
+    const key: AnswerKey = {
+      id: `ak-${shortHash(episodic.id + ":" + episodic.sha)}`,
+      createdAt: episodic.createdAt,
+      domain: "code",
+      pattern: `by-repo/${episodic.repo}`,
+      lesson,
+      tags,
+      repo: episodic.repo,
+      episodicId: episodic.id,
+    };
+    return key;
+  }
+
+  private extractFailures(episodic: EpisodicEntry): FailureEntry[] {
+    const seen = new Map<string, FailureEntry>();
+    for (const review of episodic.reviews) {
+      for (const blocker of review.blockers) {
+        if (blocker.severity === "nit") continue;
+        const key = `${blocker.category}|${blocker.severity}|${truncate(blocker.message, 80)}`;
+        if (seen.has(key)) continue;
+        seen.set(key, toFailureEntry(blocker, episodic));
+      }
+    }
+    return [...seen.values()];
+  }
+
+  private deriveTags(episodic: EpisodicEntry): string[] {
+    const tags = new Set<string>();
+    for (const review of episodic.reviews) {
+      for (const b of review.blockers) tags.add(b.category);
+    }
+    return [...tags];
+  }
+}
+
+function toFailureEntry(blocker: Blocker, episodic: EpisodicEntry): FailureEntry {
+  const category = mapCategory(blocker.category);
+  const severity: FailureEntry["severity"] =
+    blocker.severity === "blocker" ? "blocker" : blocker.severity === "major" ? "major" : "minor";
+  const file = blocker.file ? `${blocker.file}${blocker.line ? `:${blocker.line}` : ""}` : undefined;
+  const entry: FailureEntry = {
+    id: `fc-${shortHash(episodic.id + ":" + blocker.category + ":" + blocker.message)}`,
+    createdAt: episodic.createdAt,
+    domain: "code",
+    category,
+    severity,
+    title: titleFrom(blocker.message),
+    body: [blocker.message, file ? `at ${file}` : null].filter(Boolean).join(" "),
+    tags: [blocker.category],
+    seedBlocker: blocker,
+    episodicId: episodic.id,
+  };
+  return entry;
+}
+
+const ALLOWED_CATEGORIES: FailureEntry["category"][] = [
+  "type-error",
+  "missing-test",
+  "regression",
+  "security",
+  "accessibility",
+  "contrast",
+  "performance",
+  "dead-code",
+  "api-misuse",
+  "schema-drift",
+  "other",
+];
+
+function mapCategory(raw: string): FailureEntry["category"] {
+  const normalized = raw.toLowerCase().replace(/\s+/g, "-");
+  for (const c of ALLOWED_CATEGORIES) {
+    if (c === normalized) return c;
+  }
+  if (normalized.includes("test")) return "missing-test";
+  if (normalized.includes("type")) return "type-error";
+  if (normalized.includes("security") || normalized.includes("secret")) return "security";
+  if (normalized.includes("a11y") || normalized.includes("accessibility")) return "accessibility";
+  if (normalized.includes("perf")) return "performance";
+  if (normalized.includes("dead") || normalized.includes("unused")) return "dead-code";
+  if (normalized.includes("regress")) return "regression";
+  if (normalized.includes("contrast")) return "contrast";
+  if (normalized.includes("schema") || normalized.includes("migration")) return "schema-drift";
+  if (normalized.includes("api")) return "api-misuse";
+  return "other";
+}
+
+function titleFrom(message: string): string {
+  const firstSentence = message.split(/[.!?]\s/)[0] ?? message;
+  return truncate(firstSentence.trim(), 120);
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}
+
+function shortHash(s: string): string {
+  return createHash("sha256").update(s).digest("hex").slice(0, 12);
+}
+
+/** Factory helper for a new EpisodicEntry id (used by CLI / outcome-writer). */
+export function newEpisodicId(): string {
+  return `ep-${randomUUID()}`;
+}

--- a/packages/core/src/memory/fs-store.ts
+++ b/packages/core/src/memory/fs-store.ts
@@ -143,6 +143,26 @@ export class FileSystemMemoryStore implements MemoryStore {
     return out;
   }
 
+  async findEpisodic(id: string): Promise<EpisodicEntry | null> {
+    const episRoot = path.join(this.root, "episodic");
+    const days = await safeReaddir(episRoot);
+    for (const day of days) {
+      const dir = path.join(episRoot, day);
+      const files = await safeReaddir(dir);
+      for (const f of files) {
+        if (!f.includes(id) || !f.endsWith(".json")) continue;
+        try {
+          const raw = await fs.readFile(path.join(dir, f), "utf8");
+          const parsed = EpisodicEntrySchema.safeParse(JSON.parse(raw));
+          if (parsed.success && parsed.data.id === id) return parsed.data;
+        } catch {
+          continue;
+        }
+      }
+    }
+    return null;
+  }
+
   async listRules(): Promise<SemanticRule[]> {
     const file = path.join(this.root, "semantic", "rules.jsonl");
     try {

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -22,3 +22,13 @@ export type { RetrievalFieldExtractor, RetrievalOptions, ScoredDoc } from "./ret
 
 export { FileSystemMemoryStore } from "./fs-store.js";
 export type { FsStoreOptions } from "./fs-store.js";
+
+export { OutcomeWriter } from "./outcome-writer.js";
+export type {
+  WriteReviewInput,
+  RecordOutcomeInput,
+  RecordOutcomeOutput,
+} from "./outcome-writer.js";
+
+export { RuleBasedClassifier, newEpisodicId } from "./classifier.js";
+export type { Classifier, ClassificationOutput, OutcomeResult } from "./classifier.js";

--- a/packages/core/src/memory/outcome-writer.ts
+++ b/packages/core/src/memory/outcome-writer.ts
@@ -1,0 +1,97 @@
+import { createHash } from "node:crypto";
+import type { EpisodicEntry, AnswerKey, FailureEntry } from "./schema.js";
+import type { MemoryStore } from "./store.js";
+import { RuleBasedClassifier, newEpisodicId, type Classifier, type OutcomeResult } from "./classifier.js";
+import type { ReviewContext, ReviewResult } from "../agent.js";
+
+export interface WriteReviewInput {
+  ctx: ReviewContext;
+  reviews: readonly ReviewResult[];
+  councilVerdict: "approve" | "rework" | "reject";
+  costUsd: number;
+  /** Provide a stable id to make the write idempotent (re-runs update instead of dup). Defaults to a UUID. */
+  episodicId?: string;
+}
+
+export interface RecordOutcomeInput {
+  episodicId: string;
+  outcome: OutcomeResult;
+}
+
+export interface RecordOutcomeOutput {
+  answerKeys: AnswerKey[];
+  failures: FailureEntry[];
+}
+
+/**
+ * OutcomeWriter — closes the self-evolve loop.
+ *
+ * Called from two points in the lifecycle:
+ *   1. `writeReview(...)` — at the end of `conclave review`, persists an
+ *      `EpisodicEntry` with `outcome: "pending"`.
+ *   2. `recordOutcome(...)` — when the PR lands (merged / rejected /
+ *      reworked), updates the stored episodic entry and invokes the
+ *      classifier to produce `AnswerKey` + `FailureEntry` records.
+ *
+ * The classifier is pluggable (decision #17). Default is the rule-based
+ * extractor — no LLM cost. A Haiku-backed classifier will slot in later
+ * as a subtype, behind the same `Classifier` interface.
+ */
+export class OutcomeWriter {
+  private readonly store: MemoryStore;
+  private readonly classifier: Classifier;
+  private readonly episodicIndex: Map<string, EpisodicEntry>;
+
+  constructor(opts: { store: MemoryStore; classifier?: Classifier }) {
+    this.store = opts.store;
+    this.classifier = opts.classifier ?? new RuleBasedClassifier();
+    this.episodicIndex = new Map();
+  }
+
+  async writeReview(input: WriteReviewInput): Promise<EpisodicEntry> {
+    const id = input.episodicId ?? newEpisodicId();
+    const entry: EpisodicEntry = {
+      id,
+      createdAt: new Date().toISOString(),
+      repo: input.ctx.repo,
+      pullNumber: input.ctx.pullNumber,
+      sha: input.ctx.newSha,
+      diffSha256: sha256(input.ctx.diff),
+      reviews: [...input.reviews],
+      councilVerdict: input.councilVerdict,
+      outcome: "pending",
+      costUsd: input.costUsd,
+    };
+    await this.store.writeEpisodic(entry);
+    this.episodicIndex.set(id, entry);
+    return entry;
+  }
+
+  async recordOutcome(input: RecordOutcomeInput): Promise<RecordOutcomeOutput> {
+    const existing = this.episodicIndex.get(input.episodicId) ?? (await this.loadEpisodicFromDisk(input.episodicId));
+    if (!existing) {
+      throw new Error(`OutcomeWriter: no episodic entry found for id ${input.episodicId}`);
+    }
+    const updated: EpisodicEntry = { ...existing, outcome: input.outcome };
+    await this.store.writeEpisodic(updated);
+    this.episodicIndex.set(input.episodicId, updated);
+
+    const classification = this.classifier.classify(updated, input.outcome);
+    for (const key of classification.answerKeys) await this.store.writeAnswerKey(key);
+    for (const entry of classification.failures) await this.store.writeFailure(entry);
+    return classification;
+  }
+
+  private async loadEpisodicFromDisk(id: string): Promise<EpisodicEntry | null> {
+    return this.store.findEpisodic(id);
+  }
+
+  /** Test helper: inject an episodic entry into the in-memory index. */
+  _setEpisodicForTest(entry: EpisodicEntry): void {
+    this.episodicIndex.set(entry.id, entry);
+  }
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -39,6 +39,8 @@ export interface MemoryStore {
   listAnswerKeys(domain?: "code" | "design"): Promise<AnswerKey[]>;
   listFailures(domain?: "code" | "design"): Promise<FailureEntry[]>;
   listRules(): Promise<SemanticRule[]>;
+  /** Find a single episodic entry by id. Returns null if not found. */
+  findEpisodic(id: string): Promise<EpisodicEntry | null>;
 }
 
 /**

--- a/packages/core/test/classifier.test.mjs
+++ b/packages/core/test/classifier.test.mjs
@@ -1,0 +1,154 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { RuleBasedClassifier, newEpisodicId } from "../dist/index.js";
+
+const now = () => new Date().toISOString();
+
+function mkEpisodic(reviews, overrides = {}) {
+  return {
+    id: "ep-test",
+    createdAt: now(),
+    repo: "acme/app",
+    pullNumber: 7,
+    sha: "abc1234",
+    diffSha256: "a".repeat(64),
+    reviews,
+    councilVerdict: overrides.councilVerdict ?? "approve",
+    outcome: overrides.outcome ?? "pending",
+    costUsd: 0.01,
+    ...overrides,
+  };
+}
+
+test("newEpisodicId: returns ep-prefixed UUID-shape", () => {
+  const id = newEpisodicId();
+  assert.match(id, /^ep-[0-9a-f-]+$/);
+});
+
+test("classify merged: single answer-key, no failures", () => {
+  const c = new RuleBasedClassifier();
+  const out = c.classify(
+    mkEpisodic([{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }]),
+    "merged",
+  );
+  assert.equal(out.answerKeys.length, 1);
+  assert.equal(out.failures.length, 0);
+  assert.equal(out.answerKeys[0].domain, "code");
+  assert.match(out.answerKeys[0].pattern, /by-repo\/acme\/app/);
+  assert.match(out.answerKeys[0].lesson, /LGTM/);
+});
+
+test("classify merged: empty summary falls back to default lesson", () => {
+  const c = new RuleBasedClassifier();
+  const out = c.classify(
+    mkEpisodic([{ agent: "claude", verdict: "approve", blockers: [], summary: "" }]),
+    "merged",
+  );
+  assert.match(out.answerKeys[0].lesson, /Merged without blockers/);
+});
+
+test("classify rejected: one failure per unique (category, severity, message)", () => {
+  const c = new RuleBasedClassifier();
+  const out = c.classify(
+    mkEpisodic([
+      {
+        agent: "claude",
+        verdict: "reject",
+        blockers: [
+          { severity: "blocker", category: "type-error", message: "ts2345 mismatch", file: "x.ts", line: 10 },
+          { severity: "major", category: "security", message: "secret in source" },
+          { severity: "nit", category: "style", message: "trailing whitespace" },
+        ],
+        summary: "2 blockers + 1 nit",
+      },
+    ]),
+    "rejected",
+  );
+  assert.equal(out.answerKeys.length, 0);
+  assert.equal(out.failures.length, 2); // nit excluded
+  const categories = out.failures.map((f) => f.category);
+  assert.ok(categories.includes("type-error"));
+  assert.ok(categories.includes("security"));
+});
+
+test("classify rejected: dedupes same (category, severity, message) across agents", () => {
+  const c = new RuleBasedClassifier();
+  const sameBlocker = { severity: "blocker", category: "security", message: "same leak" };
+  const out = c.classify(
+    mkEpisodic([
+      { agent: "claude", verdict: "reject", blockers: [sameBlocker], summary: "" },
+      { agent: "openai", verdict: "reject", blockers: [sameBlocker], summary: "" },
+    ]),
+    "rejected",
+  );
+  assert.equal(out.failures.length, 1);
+});
+
+test("classify reworked: behaves like rejected (writes failures)", () => {
+  const c = new RuleBasedClassifier();
+  const out = c.classify(
+    mkEpisodic([
+      {
+        agent: "claude",
+        verdict: "rework",
+        blockers: [{ severity: "major", category: "missing-test", message: "no test for new branch" }],
+        summary: "1 major",
+      },
+    ]),
+    "reworked",
+  );
+  assert.equal(out.answerKeys.length, 0);
+  assert.equal(out.failures.length, 1);
+  assert.equal(out.failures[0].category, "missing-test");
+});
+
+test("category mapping: free-form strings normalize to allowed enum", () => {
+  const c = new RuleBasedClassifier();
+  const { failures } = c.classify(
+    mkEpisodic([
+      {
+        agent: "claude",
+        verdict: "reject",
+        blockers: [
+          { severity: "blocker", category: "Type Error", message: "a" },
+          { severity: "blocker", category: "UNUSED IMPORT", message: "b" },
+          { severity: "blocker", category: "a11y", message: "c" },
+          { severity: "blocker", category: "weird-custom", message: "d" },
+        ],
+        summary: "",
+      },
+    ]),
+    "rejected",
+  );
+  const cats = failures.map((f) => f.category);
+  assert.ok(cats.includes("type-error"));
+  assert.ok(cats.includes("dead-code"));
+  assert.ok(cats.includes("accessibility"));
+  assert.ok(cats.includes("other"));
+});
+
+test("classify merged: tags derived from categories seen in review", () => {
+  const c = new RuleBasedClassifier();
+  const { answerKeys } = c.classify(
+    mkEpisodic([
+      {
+        agent: "claude",
+        verdict: "approve",
+        blockers: [{ severity: "minor", category: "unused-imports", message: "ok" }],
+        summary: "all fine after rework",
+      },
+    ]),
+    "merged",
+  );
+  assert.ok(answerKeys[0].tags.includes("unused-imports"));
+});
+
+test("classify: ids are stable for the same input", () => {
+  const c = new RuleBasedClassifier();
+  const ep = mkEpisodic([
+    { agent: "claude", verdict: "reject", blockers: [{ severity: "blocker", category: "security", message: "leak" }], summary: "" },
+  ]);
+  const a = c.classify(ep, "rejected");
+  const b = c.classify(ep, "rejected");
+  assert.equal(a.failures[0].id, b.failures[0].id);
+});

--- a/packages/core/test/outcome-writer.test.mjs
+++ b/packages/core/test/outcome-writer.test.mjs
@@ -1,0 +1,160 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FileSystemMemoryStore, OutcomeWriter } from "../dist/index.js";
+
+function freshFs() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aic-outcome-"));
+  return { store: new FileSystemMemoryStore({ root }), root };
+}
+function cleanup(root) {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+const baseCtx = { diff: "diff --git a/x b/x\n+added", repo: "acme/app", pullNumber: 42, newSha: "sha-head" };
+const approveReview = { agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" };
+const rejectReview = {
+  agent: "claude",
+  verdict: "reject",
+  blockers: [{ severity: "blocker", category: "security", message: "hardcoded key" }],
+  summary: "blocker",
+};
+
+test("writeReview: persists an episodic entry with outcome=pending", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const entry = await writer.writeReview({
+      ctx: baseCtx,
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.02,
+    });
+    assert.equal(entry.outcome, "pending");
+    assert.equal(entry.reviews.length, 1);
+    // Round-trip: the file exists and is findable.
+    const found = await store.findEpisodic(entry.id);
+    assert.ok(found);
+    assert.equal(found.id, entry.id);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("recordOutcome merged: writes one answer-key", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const ep = await writer.writeReview({
+      ctx: baseCtx,
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+    });
+    const out = await writer.recordOutcome({ episodicId: ep.id, outcome: "merged" });
+    assert.equal(out.answerKeys.length, 1);
+    assert.equal(out.failures.length, 0);
+    const aks = await store.listAnswerKeys();
+    assert.equal(aks.length, 1);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("recordOutcome rejected: writes failures from each blocker", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const ep = await writer.writeReview({
+      ctx: baseCtx,
+      reviews: [rejectReview],
+      councilVerdict: "reject",
+      costUsd: 0.03,
+    });
+    const out = await writer.recordOutcome({ episodicId: ep.id, outcome: "rejected" });
+    assert.equal(out.failures.length, 1);
+    const failures = await store.listFailures();
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].category, "security");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("recordOutcome: updates episodic outcome field from pending → merged/rejected/reworked", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const ep = await writer.writeReview({
+      ctx: baseCtx,
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+    });
+    await writer.recordOutcome({ episodicId: ep.id, outcome: "merged" });
+    const after = await store.findEpisodic(ep.id);
+    assert.equal(after.outcome, "merged");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("recordOutcome: reconstructs episodic from disk if in-memory index is cold", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writerA = new OutcomeWriter({ store });
+    const ep = await writerA.writeReview({
+      ctx: baseCtx,
+      reviews: [rejectReview],
+      councilVerdict: "reject",
+      costUsd: 0.01,
+    });
+    // Simulate a fresh process: new OutcomeWriter without the id in its index.
+    const writerB = new OutcomeWriter({ store });
+    const out = await writerB.recordOutcome({ episodicId: ep.id, outcome: "rejected" });
+    assert.equal(out.failures.length, 1);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("recordOutcome: unknown episodic id throws actionable error", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    await assert.rejects(
+      () => writer.recordOutcome({ episodicId: "ep-does-not-exist", outcome: "merged" }),
+      /no episodic entry found/,
+    );
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("writeReview: caller-provided episodicId makes the write idempotent", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const id = "ep-stable-1";
+    await writer.writeReview({
+      ctx: baseCtx,
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+      episodicId: id,
+    });
+    await writer.writeReview({
+      ctx: { ...baseCtx, newSha: "sha-newer" },
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.02,
+      episodicId: id,
+    });
+    const found = await store.findEpisodic(id);
+    assert.equal(found.sha, "sha-newer"); // latest write wins
+  } finally {
+    cleanup(root);
+  }
+});


### PR DESCRIPTION
## Summary

Closes the **self-evolve training loop** (decision #17, write side). PR #4 landed the read/RAG path; this PR wires the writes. Every review now persists an episodic entry, and every landed PR outcome produces 정답지 (merged) or 오답지 (rejected / reworked) records that the NEXT review retrieves.

Stacked on [#5](https://github.com/seunghunbae-3svs/ai-conclave/pull/5). Base = `scaffold/cli-wire-review`.

## Loop diagram

```
conclave review → writeReview()           → episodic (outcome: pending)
       ↓ (PR lands hours/days later)
conclave record-outcome                    → classifier.classify(ep, result)
       ↓                                        ↓
       updates episodic.outcome    +     writeAnswerKey() or writeFailure[]()
                                              ↓
                                          NEXT review's retrieve() picks these up as RAG
```

## Modules

### Core
| File | What |
|---|---|
| `memory/classifier.ts` | `Classifier` interface + `RuleBasedClassifier` (deterministic, no LLM). Category normalization maps free-form strings to the 11 allowed enum values. |
| `memory/outcome-writer.ts` | `OutcomeWriter.writeReview(...)` persists episodic `outcome: pending`. `recordOutcome(...)` updates + classifies + writes catalog records. |
| `memory/fs-store.ts` | New `findEpisodic(id)` walks `episodic/*/pr-*-<id>.json`. Required because review and outcome often span processes. |
| `memory/store.ts` | `MemoryStore.findEpisodic(id)` added to interface. |

### CLI
| Change | Why |
|---|---|
| `review` writes episodic + prints id + copy-paste instruction | User doesn't have to hunt for the id when the PR lands. |
| New `record-outcome --id <ep-id> --result merged\|rejected\|reworked` command | Closes the loop from the CLI; no external infra needed. |

## What the classifier does

| Input | Output |
|---|---|
| merged + `[claude: approve (LGTM)]` | `AnswerKey { pattern: "by-repo/acme/app", lesson: "LGTM", tags: [] }` |
| rejected + 3 blockers (2 non-nit) | 2 `FailureEntry` records (one per unique (category, severity, message)), nit dropped |
| rejected + same blocker reported by 2 agents | 1 `FailureEntry` (cross-agent dedup) |
| reworked + 1 blocker | 1 `FailureEntry` — same path as rejected |
| free-form category `"Type Error"` | normalized to enum `type-error` |
| free-form category `"a11y"` | normalized to enum `accessibility` |
| free-form category `"UNUSED IMPORT"` | normalized to enum `dead-code` |
| unrecognized category | normalized to enum `other` |

## Tests (16 cases)

### `classifier.test.mjs` (9)
- merged → single AK, no failures
- empty summary → fallback lesson
- rejected → one failure per unique blocker, nit excluded
- cross-agent dedup
- reworked behaves like rejected
- category normalization for 4 free-form strings
- tags derived from categories seen in review
- deterministic id stability for same input
- `newEpisodicId` returns `ep-<UUID>` shape

### `outcome-writer.test.mjs` (7)
- writeReview persists + findEpisodic round-trip
- recordOutcome merged writes exactly 1 AK
- recordOutcome rejected writes one failure per blocker (surfaces the right category)
- recordOutcome updates `outcome: pending → merged/rejected/reworked` on disk
- recordOutcome reconstructs from disk when in-memory index is cold (fresh process)
- unknown id throws with actionable error
- caller-provided episodicId makes writeReview idempotent (latest write wins)

## Usage

```bash
conclave review --pr 42
# → ... review output ...
# → episodic: ep-abc12345-6789-...
# →   when the PR lands, close the loop with:
# →     conclave record-outcome --id ep-abc12345-6789-... --result merged

# (later, when the PR merges:)
conclave record-outcome --id ep-abc12345-6789-... --result merged
# → answer-keys:  1 written
# → failures:     0 written
```

## Deferred

- **Auto outcome recording** when GitHub PR state changes — needs `scm-github` webhook listener.
- **Haiku-backed classifier** for richer lesson extraction (current is deterministic / mechanical).
- **Seeding** from solo-cto-agent's `failure-catalog.json` (decision #18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)