### PR TITLE
feat(observability-langfuse,cli): Langfuse sink for efficiency-gate metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,30 @@
     flows, response_format shape assertion, refusal throw, invalid-JSON
     throw, invalid-verdict throw, no-key constructor throw, metrics
     aggregation, pre-flight budget short-circuits the network call.
+- **`@ai-conclave/observability-langfuse`** — first observability sink
+  (decision #13 — self-hosted Langfuse):
+  - `LangfuseMetricsSink` implements core's `MetricsSink`. Each per-call
+    metric becomes a Langfuse `generation` with name = `review.<agent>`,
+    model, input/output tokens, totalCost, cacheHit + latency in
+    metadata, start/end times derived from `timestamp - latencyMs`.
+  - Self-hosted is the intended deployment (baseUrl override); cloud
+    identical. LANGFUSE_PUBLIC_KEY + LANGFUSE_SECRET_KEY required.
+  - Fire-and-forget on `record()` per the synchronous MetricsSink
+    contract; Langfuse SDK's internal queue handles HTTP. Errors
+    captured + logged to stderr so observability failures never kill
+    the review.
+  - `setTraceId(id)` groups all metrics in a single review under one
+    Langfuse trace. `flush()` / `shutdown()` for clean exit.
+  - CLI integration: new `observability.langfuse.{enabled, baseUrl?}`
+    config block. `conclave review` wires the sink when
+    `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` env are set; trace
+    id = `conclave-<owner>-<repo>-<pr>-<sha8>`. Sink flushed before
+    process exit.
+  - 10 sink tests: generation params mapping, metadata for cacheHit +
+    latency, start/end time derivation, traceId static + dynamic
+    (setTraceId between records), error-swallowing on client throw,
+    flush + shutdown paths (shutdownAsync preferred, flushAsync
+    fallback), lazy one-shot client factory init.
 - **`@ai-conclave/scm-github`** — GitHub SCM adapter + automatic outcome
   capture (closes the manual `record-outcome` gap):
   - `fetchPrState(repo, prNumber)` wraps `gh pr view` to resolve current

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -3,14 +3,17 @@ import {
   Council,
   EfficiencyGate,
   FileSystemMemoryStore,
+  MetricsRecorder,
   OutcomeWriter,
   formatAnswerKeyForPrompt,
   formatFailureForPrompt,
+  type MetricsSink,
   type ReviewContext,
 } from "@ai-conclave/core";
 import { ClaudeAgent } from "@ai-conclave/agent-claude";
 import { OpenAIAgent } from "@ai-conclave/agent-openai";
 import { GeminiAgent } from "@ai-conclave/agent-gemini";
+import { LangfuseMetricsSink } from "@ai-conclave/observability-langfuse";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
 import { renderReview, verdictToExitCode } from "../lib/output.js";
@@ -79,12 +82,29 @@ export async function review(argv: string[]): Promise<void> {
   const queryText = `${loaded.repo} ${loaded.diff.slice(0, 4_000)}`;
   const retrieval = await store.retrieve({ query: queryText, repo: loaded.repo, k: 8 });
 
-  // 3. Build the efficiency gate with config-driven budget
+  // 3. Build the efficiency gate with config-driven budget + optional Langfuse sink
   const budget = new BudgetTracker({ perPrUsd: config.budget.perPrUsd });
   budget.onWarning((spent, cap) => {
     process.stderr.write(`conclave review: budget warning — spent $${spent.toFixed(4)} of $${cap.toFixed(2)} cap\n`);
   });
-  const gate = new EfficiencyGate({ budget });
+  let langfuseSink: LangfuseMetricsSink | null = null;
+  const sink: MetricsSink | undefined = (() => {
+    const lf = config.observability?.langfuse;
+    if (!lf?.enabled) return undefined;
+    if (!process.env["LANGFUSE_PUBLIC_KEY"] || !process.env["LANGFUSE_SECRET_KEY"]) {
+      process.stderr.write(
+        "conclave review: langfuse configured but LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set — skipping\n",
+      );
+      return undefined;
+    }
+    const sinkOpts: ConstructorParameters<typeof LangfuseMetricsSink>[0] = {};
+    if (lf.baseUrl) sinkOpts.baseUrl = lf.baseUrl;
+    sinkOpts.traceId = `conclave-${loaded.repo.replace(/\//g, "-")}-${loaded.pullNumber || "local"}-${loaded.newSha.slice(0, 8)}`;
+    langfuseSink = new LangfuseMetricsSink(sinkOpts);
+    return langfuseSink;
+  })();
+  const metrics = sink ? new MetricsRecorder({ sink }) : new MetricsRecorder();
+  const gate = new EfficiencyGate({ budget, metrics });
 
   // 4. Instantiate the council. Agents enabled in config.agents. An agent
   //    is only included if its credentials are available; others are skipped
@@ -157,6 +177,10 @@ export async function review(argv: string[]): Promise<void> {
       `  when the PR lands, close the loop with:\n` +
       `    conclave record-outcome --id ${episodic.id} --result merged\n`,
   );
+
+  if (langfuseSink) {
+    await langfuseSink.shutdown();
+  }
 
   process.exit(verdictToExitCode(outcome.verdict));
 }

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -28,6 +28,16 @@ export const ConclaveConfigSchema = z.object({
       answerKeysDir: ".conclave/answer-keys",
       failureCatalogDir: ".conclave/failure-catalog",
     }),
+  observability: z
+    .object({
+      langfuse: z
+        .object({
+          enabled: z.boolean().default(true),
+          baseUrl: z.string().url().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 
 export type ConclaveConfig = z.infer<typeof ConclaveConfigSchema>;

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../agent-claude" },
     { "path": "../agent-gemini" },
     { "path": "../agent-openai" },
+    { "path": "../observability-langfuse" },
     { "path": "../scm-github" }
   ]
 }

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -1,0 +1,41 @@
+# @ai-conclave/observability-langfuse
+
+Langfuse sink for Ai-Conclave's efficiency-gate metrics. Forwards every
+LLM call's cost / tokens / latency / cache-hit to Langfuse for trace
+inspection.
+
+Self-hosted is the intended deployment target per decision #13. Cloud
+works identically — pass the cloud base URL.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/observability-langfuse @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { EfficiencyGate, MetricsRecorder } from "@ai-conclave/core";
+import { LangfuseMetricsSink } from "@ai-conclave/observability-langfuse";
+
+const sink = new LangfuseMetricsSink({
+  publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+  secretKey: process.env.LANGFUSE_SECRET_KEY,
+  baseUrl: process.env.LANGFUSE_BASEURL, // self-hosted URL (optional for cloud)
+});
+
+const gate = new EfficiencyGate({
+  metrics: new MetricsRecorder({ sink }),
+});
+```
+
+Call `sink.shutdown()` at process exit to flush pending events.
+
+## Env variables
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `LANGFUSE_PUBLIC_KEY` | ✓ | Public key from your Langfuse project |
+| `LANGFUSE_SECRET_KEY` | ✓ | Secret key from your Langfuse project |
+| `LANGFUSE_BASEURL` | optional | Self-hosted URL (defaults to Langfuse cloud) |

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -1,13 +1,16 @@
 {
-  "name": "@ai-conclave/cli",
+  "name": "@ai-conclave/observability-langfuse",
   "version": "0.0.0",
-  "description": "Ai-Conclave CLI — the `conclave` binary.",
+  "description": "Ai-Conclave observability sink — forwards efficiency-gate metrics to Langfuse (self-hosted per decision #13).",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "conclave": "./dist/bin/conclave.js"
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",
@@ -22,13 +25,8 @@
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {
-    "@ai-conclave/agent-claude": "workspace:*",
-    "@ai-conclave/agent-gemini": "workspace:*",
-    "@ai-conclave/agent-openai": "workspace:*",
     "@ai-conclave/core": "workspace:*",
-    "@ai-conclave/observability-langfuse": "workspace:*",
-    "@ai-conclave/scm-github": "workspace:*",
-    "zod": "^3.24.0"
+    "langfuse": "^3.30.0"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/packages/observability-langfuse/src/index.ts
+++ b/packages/observability-langfuse/src/index.ts
@@ -1,0 +1,7 @@
+export { LangfuseMetricsSink } from "./sink.js";
+export type {
+  LangfuseLike,
+  LangfuseGenerationParams,
+  LangfuseGenerationHandle,
+  LangfuseSinkOptions,
+} from "./sink.js";

--- a/packages/observability-langfuse/src/sink.ts
+++ b/packages/observability-langfuse/src/sink.ts
@@ -1,0 +1,162 @@
+import type { CallMetric, MetricsSink } from "@ai-conclave/core";
+
+/**
+ * Minimal subset of the Langfuse SDK surface the sink consumes. Typed
+ * narrowly so tests never instantiate the real client and SDK minor
+ * version bumps don't break the build.
+ */
+export interface LangfuseLike {
+  generation(params: LangfuseGenerationParams): LangfuseGenerationHandle;
+  flushAsync(): Promise<void>;
+  shutdownAsync?(): Promise<void>;
+}
+
+export interface LangfuseGenerationParams {
+  name: string;
+  model: string;
+  startTime?: Date;
+  endTime?: Date;
+  input?: unknown;
+  output?: unknown;
+  metadata?: Record<string, unknown>;
+  usage?: {
+    input?: number;
+    output?: number;
+    total?: number;
+    unit?: "TOKENS" | "CHARACTERS";
+    inputCost?: number;
+    outputCost?: number;
+    totalCost?: number;
+  };
+  traceId?: string;
+}
+
+export interface LangfuseGenerationHandle {
+  end(update?: Partial<LangfuseGenerationParams>): void;
+}
+
+export interface LangfuseSinkOptions {
+  /** Pre-built Langfuse client. Used by tests + callers who want shared state. */
+  client?: LangfuseLike;
+  /** Factory invoked when `client` is not supplied. Defaults to lazy import of `langfuse`. */
+  clientFactory?: () => Promise<LangfuseLike>;
+  /** Host override for self-hosted (decision #13). Defaults to env LANGFUSE_BASEURL. */
+  baseUrl?: string;
+  publicKey?: string;
+  secretKey?: string;
+  /** Optional trace id so all metrics in a single review share a parent span. */
+  traceId?: string;
+}
+
+async function defaultClientFactory(opts: LangfuseSinkOptions): Promise<LangfuseLike> {
+  const publicKey = opts.publicKey ?? process.env["LANGFUSE_PUBLIC_KEY"];
+  const secretKey = opts.secretKey ?? process.env["LANGFUSE_SECRET_KEY"];
+  const baseUrl = opts.baseUrl ?? process.env["LANGFUSE_BASEURL"];
+  if (!publicKey || !secretKey) {
+    throw new Error("LangfuseMetricsSink: LANGFUSE_PUBLIC_KEY + LANGFUSE_SECRET_KEY required");
+  }
+  const mod = (await import("langfuse")) as unknown as {
+    Langfuse: new (opts: {
+      publicKey: string;
+      secretKey: string;
+      baseUrl?: string;
+    }) => LangfuseLike;
+  };
+  const ctorOpts: { publicKey: string; secretKey: string; baseUrl?: string } = {
+    publicKey,
+    secretKey,
+  };
+  if (baseUrl) ctorOpts.baseUrl = baseUrl;
+  return new mod.Langfuse(ctorOpts);
+}
+
+/**
+ * LangfuseMetricsSink — drops in as the `sink` on `MetricsRecorder`.
+ * Every per-call metric becomes a Langfuse `generation` (the SDK's model
+ * for a single LLM invocation).
+ *
+ * The sink is fire-and-forget on the record() path (synchronous per
+ * MetricsSink contract); actual HTTP is Langfuse's internal queue. Call
+ * `shutdown()` at process exit to flush pending events.
+ *
+ * Self-hosted Langfuse is the deployment target per decision #13. Cloud
+ * works identically (`baseUrl` omitted or set to the cloud URL).
+ */
+export class LangfuseMetricsSink implements MetricsSink {
+  private readonly opts: LangfuseSinkOptions;
+  private readonly clientFactory: () => Promise<LangfuseLike>;
+  private clientPromise: Promise<LangfuseLike> | null;
+  private clientReady: LangfuseLike | null;
+  private traceId: string | undefined;
+
+  constructor(opts: LangfuseSinkOptions = {}) {
+    this.opts = opts;
+    this.clientFactory = opts.clientFactory ?? (() => defaultClientFactory(opts));
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+    this.clientReady = opts.client ?? null;
+    this.traceId = opts.traceId;
+  }
+
+  setTraceId(id: string | undefined): void {
+    this.traceId = id;
+  }
+
+  /**
+   * MetricsSink.record is synchronous — we kick off the Langfuse call and
+   * let the SDK queue handle delivery. Errors are swallowed to stderr so
+   * observability failure never kills a running review.
+   */
+  record(metric: CallMetric): void {
+    this.submit(metric).catch((err) => {
+      process.stderr.write(
+        `[langfuse] failed to record metric for ${metric.agent}/${metric.model}: ${(err as Error).message}\n`,
+      );
+    });
+  }
+
+  private async submit(metric: CallMetric): Promise<void> {
+    const client = await this.getClient();
+    const startTime = new Date(metric.timestamp - metric.latencyMs);
+    const endTime = new Date(metric.timestamp);
+    const params: LangfuseGenerationParams = {
+      name: `review.${metric.agent}`,
+      model: metric.model,
+      startTime,
+      endTime,
+      usage: {
+        input: metric.inputTokens,
+        output: metric.outputTokens,
+        total: metric.inputTokens + metric.outputTokens,
+        unit: "TOKENS",
+        totalCost: metric.costUsd,
+      },
+      metadata: {
+        cacheHit: metric.cacheHit,
+        latencyMs: metric.latencyMs,
+      },
+    };
+    if (this.traceId) params.traceId = this.traceId;
+    const gen = client.generation(params);
+    // Generations in the Langfuse SDK expect an `end()` call to finalize.
+    gen.end();
+  }
+
+  private async getClient(): Promise<LangfuseLike> {
+    if (!this.clientPromise) this.clientPromise = this.clientFactory();
+    if (!this.clientReady) this.clientReady = await this.clientPromise;
+    return this.clientReady;
+  }
+
+  async flush(): Promise<void> {
+    if (!this.clientPromise) return;
+    const client = await this.clientPromise;
+    await client.flushAsync();
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.clientPromise) return;
+    const client = await this.clientPromise;
+    if (client.shutdownAsync) await client.shutdownAsync();
+    else await client.flushAsync();
+  }
+}

--- a/packages/observability-langfuse/test/sink.test.mjs
+++ b/packages/observability-langfuse/test/sink.test.mjs
@@ -1,0 +1,189 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { LangfuseMetricsSink } from "../dist/index.js";
+
+function mockClient() {
+  const generated = [];
+  const ended = [];
+  let flushes = 0;
+  let shutdowns = 0;
+  return {
+    generated,
+    ended,
+    get flushes() {
+      return flushes;
+    },
+    get shutdowns() {
+      return shutdowns;
+    },
+    generation: (params) => {
+      generated.push(params);
+      return {
+        end: (update) => {
+          ended.push({ params, update });
+        },
+      };
+    },
+    flushAsync: async () => {
+      flushes += 1;
+    },
+    shutdownAsync: async () => {
+      shutdowns += 1;
+    },
+  };
+}
+
+function mkMetric(overrides = {}) {
+  return {
+    agent: "claude",
+    model: "claude-sonnet-4-6",
+    inputTokens: 1_000,
+    outputTokens: 200,
+    costUsd: 0.015,
+    latencyMs: 1_200,
+    cacheHit: false,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+async function tick() {
+  // Allow queued microtasks from record() to resolve.
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+test("LangfuseMetricsSink: record() creates a generation with mapped usage", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  sink.record(mkMetric({ inputTokens: 500, outputTokens: 100, costUsd: 0.01 }));
+  await tick();
+  assert.equal(client.generated.length, 1);
+  const g = client.generated[0];
+  assert.equal(g.name, "review.claude");
+  assert.equal(g.model, "claude-sonnet-4-6");
+  assert.equal(g.usage.input, 500);
+  assert.equal(g.usage.output, 100);
+  assert.equal(g.usage.total, 600);
+  assert.equal(g.usage.totalCost, 0.01);
+  assert.equal(g.usage.unit, "TOKENS");
+  assert.equal(client.ended.length, 1);
+});
+
+test("LangfuseMetricsSink: metadata carries cacheHit + latencyMs", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  sink.record(mkMetric({ cacheHit: true, latencyMs: 850 }));
+  await tick();
+  const g = client.generated[0];
+  assert.equal(g.metadata.cacheHit, true);
+  assert.equal(g.metadata.latencyMs, 850);
+});
+
+test("LangfuseMetricsSink: startTime / endTime derived from timestamp + latency", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  const now = 1_700_000_000_000;
+  sink.record(mkMetric({ timestamp: now, latencyMs: 1_000 }));
+  await tick();
+  const g = client.generated[0];
+  assert.equal(g.endTime.getTime(), now);
+  assert.equal(g.startTime.getTime(), now - 1_000);
+});
+
+test("LangfuseMetricsSink: traceId propagates when set", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client, traceId: "trace-123" });
+  sink.record(mkMetric());
+  await tick();
+  assert.equal(client.generated[0].traceId, "trace-123");
+});
+
+test("LangfuseMetricsSink: setTraceId updates for subsequent records", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  sink.setTraceId("first");
+  sink.record(mkMetric());
+  sink.setTraceId("second");
+  sink.record(mkMetric());
+  await tick();
+  assert.equal(client.generated[0].traceId, "first");
+  assert.equal(client.generated[1].traceId, "second");
+});
+
+test("LangfuseMetricsSink: client errors are swallowed to stderr, not thrown", async () => {
+  const client = {
+    generation: () => {
+      throw new Error("langfuse down");
+    },
+    flushAsync: async () => {},
+  };
+  const sink = new LangfuseMetricsSink({ client });
+  // Capture stderr writes
+  const origStderr = process.stderr.write.bind(process.stderr);
+  const chunks = [];
+  process.stderr.write = (c) => {
+    chunks.push(String(c));
+    return true;
+  };
+  try {
+    sink.record(mkMetric()); // must not throw
+    await tick();
+  } finally {
+    process.stderr.write = origStderr;
+  }
+  assert.match(chunks.join(""), /langfuse.*failed to record/i);
+});
+
+test("LangfuseMetricsSink: flush awaits client.flushAsync", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  sink.record(mkMetric());
+  await tick();
+  await sink.flush();
+  assert.equal(client.flushes, 1);
+});
+
+test("LangfuseMetricsSink: shutdown prefers shutdownAsync over flushAsync", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  sink.record(mkMetric());
+  await tick();
+  await sink.shutdown();
+  assert.equal(client.shutdowns, 1);
+  assert.equal(client.flushes, 0);
+});
+
+test("LangfuseMetricsSink: shutdown falls back to flushAsync when shutdownAsync absent", async () => {
+  const client = {
+    generation: () => ({ end: () => {} }),
+    flushAsync: async () => {},
+  };
+  let flushed = 0;
+  client.flushAsync = async () => {
+    flushed += 1;
+  };
+  const sink = new LangfuseMetricsSink({ client });
+  sink.record(mkMetric());
+  await tick();
+  await sink.shutdown();
+  assert.equal(flushed, 1);
+});
+
+test("LangfuseMetricsSink: lazy client init — no client request until first record()", async () => {
+  let factoryCalls = 0;
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({
+    clientFactory: async () => {
+      factoryCalls += 1;
+      return client;
+    },
+  });
+  assert.equal(factoryCalls, 0);
+  sink.record(mkMetric());
+  await tick();
+  assert.equal(factoryCalls, 1);
+  sink.record(mkMetric());
+  await tick();
+  assert.equal(factoryCalls, 1, "factory should only be called once");
+});

--- a/packages/observability-langfuse/tsconfig.json
+++ b/packages/observability-langfuse/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}


### PR DESCRIPTION
## Summary

Lands the first observability sink per decision #13 (self-hosted Langfuse). Every per-call metric emitted by the efficiency gate (PR #2) now flows into Langfuse as a `generation` record — visible cost trends, cache hit rate, per-agent latency, and per-model spend without any extra instrumentation in the agents.

Stacked on [#9](https://github.com/seunghunbae-3svs/ai-conclave/pull/9). Base = `scaffold/scm-github`.

## Data model

| Field in Langfuse `generation` | Source |
|---|---|
| `name` | `review.<agent>` (e.g. `review.claude`) |
| `model` | EfficiencyGate's routed model |
| `usage.input / output / total` | `metric.inputTokens / outputTokens` |
| `usage.totalCost` | `metric.costUsd` (actualCost from provider pricing) |
| `metadata.cacheHit` | `metric.cacheHit` |
| `metadata.latencyMs` | `metric.latencyMs` |
| `startTime` | `new Date(timestamp - latencyMs)` |
| `endTime` | `new Date(timestamp)` |
| `traceId` | `conclave-<owner>-<repo>-<pr>-<sha8>` (set by CLI per review) |

## Design

- **Fire-and-forget** on `record()` — Langfuse SDK's internal queue handles HTTP. Observability failures never propagate to the running review.
- **Lazy client init** — no SDK load cost until the first `record()` call.
- **Shutdown path** — CLI awaits `sink.shutdown()` before `process.exit`, flushing pending events. Prefers Langfuse's `shutdownAsync`, falls back to `flushAsync`.
- **Self-hosted first** per decision #13 — `baseUrl` config / `LANGFUSE_BASEURL` env. Cloud works identically with baseUrl omitted.

## Config

```json
{
  "observability": {
    "langfuse": { "enabled": true, "baseUrl": "https://langfuse.mycompany.com" }
  }
}
```

Runtime env:
- `LANGFUSE_PUBLIC_KEY` — required
- `LANGFUSE_SECRET_KEY` — required
- `LANGFUSE_BASEURL` — optional (overrides `config.baseUrl` if both set)

Missing credentials: stderr warning + skip. Never fatal.

## Tests — 10 cases (`sink.test.mjs`)

- Generation params: usage / name / model / totalCost
- Metadata: cacheHit + latencyMs
- Start / end time derivation from timestamp + latencyMs
- `traceId` static (constructor) + dynamic (`setTraceId` between records)
- Client throw on `generation()` → swallowed + stderr message
- `flush()` awaits `client.flushAsync`
- `shutdown()` prefers `shutdownAsync`; falls back to `flushAsync`
- Lazy factory: not called until first record(); called exactly once across multiple records

## Deferred

- `CouncilTracer` that wraps `Council.deliberate()` with a parent trace span (current sink emits generations but no hierarchy).
- Optional OTLP endpoint for alt backends (Datadog / Honeycomb / New Relic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)