### PR TITLE
feat(integration-telegram): Telegram notifier + pluggable Notifier interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,40 @@
     flows, response_format shape assertion, refusal throw, invalid-JSON
     throw, invalid-verdict throw, no-key constructor throw, metrics
     aggregation, pre-flight budget short-circuits the network call.
+- **`@ai-conclave/integration-telegram`** — first notification surface
+  (decision #24 — Telegram / Discord / Slack / Email are equal-weight;
+  none is hero):
+  - `Notifier` interface added to `@ai-conclave/core`
+    (`notifyReview(input)` contract). Pluggable — any future integration
+    package implements this.
+  - `TelegramClient`: thin native-fetch wrapper over Bot API sendMessage.
+    No SDK dep; sub-200 lines; injectable `fetch` for tests.
+  - `TelegramNotifier`: implements `Notifier`. Builds HTML-mode message
+    with per-agent verdict + top-3 blockers (severity-sorted) + summary
+    + footer (cost + episodic id). Inline action buttons emit
+    `callback_data = "ep:<id>:<outcome>"` — future callback handler can
+    call `OutcomeWriter.recordOutcome` directly.
+  - Message formatter (`formatReviewForTelegram`): HTML-escapes `& < >`,
+    links to PR URL when supplied, truncates to 4090 chars, shows
+    `+N more` when blocker count exceeds 3.
+  - CLI integration: new `.conclaverc.json` `integrations.telegram.{enabled, chatId, includeActionButtons}` block.
+    `conclave review` fires the notifier after deliberation. Failures
+    never affect the verdict exit code.
+  - Env: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`. Missing credentials
+    skip with stderr warning unless `integrations.telegram.enabled: true`
+    is explicitly set — then it errors.
+  - 21 test cases (`format`, `client`, `notifier`): HTML emoji header,
+    PR URL anchor, HTML-special-char escaping (`<never>` → `&lt;never&gt;`,
+    `a & b` → `a &amp; b`), severity-sorted top-3 + "+N more" counter,
+    no-consensus tag, footer cost+id, 4096-char truncation, (no
+    blockers) placeholder; `TelegramClient` rejects empty token, POST
+    request shape assertion, `ok:false` throws with description + code,
+    non-JSON response throws with status + snippet, baseUrl override;
+    `TelegramNotifier` missing-token + missing-chatId throws,
+    numeric-string chat id coercion, HTML parse_mode + disable_web_page_preview,
+    inline keyboard present by default, includeActionButtons:false
+    omits reply_markup, env fallback for TELEGRAM_BOT_TOKEN +
+    TELEGRAM_CHAT_ID, `Notifier` interface conformance.
 - **`@ai-conclave/observability-langfuse`** — first observability sink
   (decision #13 — self-hosted Langfuse):
   - `LangfuseMetricsSink` implements core's `MetricsSink`. Each per-call

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -14,6 +14,8 @@ import { ClaudeAgent } from "@ai-conclave/agent-claude";
 import { OpenAIAgent } from "@ai-conclave/agent-openai";
 import { GeminiAgent } from "@ai-conclave/agent-gemini";
 import { LangfuseMetricsSink } from "@ai-conclave/observability-langfuse";
+import { TelegramNotifier } from "@ai-conclave/integration-telegram";
+import type { Notifier } from "@ai-conclave/core";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
 import { renderReview, verdictToExitCode } from "../lib/output.js";
@@ -177,6 +179,48 @@ export async function review(argv: string[]): Promise<void> {
       `  when the PR lands, close the loop with:\n` +
       `    conclave record-outcome --id ${episodic.id} --result merged\n`,
   );
+
+  // 8. Optional integrations — equal-weight per decision #24. Missing
+  //    credentials skip with stderr warning; integration failures never
+  //    kill the review exit code.
+  const notifiers: Notifier[] = [];
+  const tg = config.integrations?.telegram;
+  if (tg?.enabled !== false) {
+    const hasToken = !!process.env["TELEGRAM_BOT_TOKEN"];
+    const hasChat = tg?.chatId !== undefined || !!process.env["TELEGRAM_CHAT_ID"];
+    if (tg?.enabled === true && !hasToken) {
+      process.stderr.write("conclave review: TELEGRAM_BOT_TOKEN not set — skipping Telegram notifier\n");
+    } else if (hasToken && hasChat) {
+      const opts: ConstructorParameters<typeof TelegramNotifier>[0] = {};
+      if (tg?.chatId !== undefined) opts.chatId = tg.chatId;
+      if (tg?.includeActionButtons !== undefined) opts.includeActionButtons = tg.includeActionButtons;
+      try {
+        notifiers.push(new TelegramNotifier(opts));
+      } catch (err) {
+        process.stderr.write(`conclave review: Telegram notifier init failed — ${(err as Error).message}\n`);
+      }
+    }
+  }
+  if (notifiers.length > 0) {
+    const notifyInput = {
+      outcome,
+      ctx: reviewCtx,
+      episodicId: episodic.id,
+      totalCostUsd: gate.metrics.summary().totalCostUsd,
+      ...(loaded.pullNumber && loaded.source === "gh-pr"
+        ? { prUrl: `https://github.com/${loaded.repo}/pull/${loaded.pullNumber}` }
+        : {}),
+    };
+    await Promise.all(
+      notifiers.map(async (n) => {
+        try {
+          await n.notifyReview(notifyInput);
+        } catch (err) {
+          process.stderr.write(`conclave review: ${n.id} notifier failed — ${(err as Error).message}\n`);
+        }
+      }),
+    );
+  }
 
   if (langfuseSink) {
     await langfuseSink.shutdown();

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -38,6 +38,17 @@ export const ConclaveConfigSchema = z.object({
         .optional(),
     })
     .optional(),
+  integrations: z
+    .object({
+      telegram: z
+        .object({
+          enabled: z.boolean().default(true),
+          chatId: z.union([z.number(), z.string()]).optional(),
+          includeActionButtons: z.boolean().default(true),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 
 export type ConclaveConfig = z.infer<typeof ConclaveConfigSchema>;

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../agent-claude" },
     { "path": "../agent-gemini" },
     { "path": "../agent-openai" },
+    { "path": "../integration-telegram" },
     { "path": "../observability-langfuse" },
     { "path": "../scm-github" }
   ]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,8 @@
 export type { Agent, ReviewContext, ReviewResult, Blocker, Severity } from "./agent.js";
 export { Council } from "./council.js";
+export type { CouncilOutcome } from "./council.js";
 export { ReviewResultSchema, BlockerSchema } from "./schema.js";
+export type { Notifier, NotifyReviewInput } from "./notifier.js";
 
 // Memory substrate (decision #17: 정답지 + 오답지 duality as core primitive).
 // Re-exported here for convenience; dedicated subpath at @ai-conclave/core/memory.

--- a/packages/core/src/notifier.ts
+++ b/packages/core/src/notifier.ts
@@ -1,0 +1,34 @@
+import type { ReviewContext } from "./agent.js";
+import type { CouncilOutcome } from "./council.js";
+
+export interface NotifyReviewInput {
+  outcome: CouncilOutcome;
+  ctx: ReviewContext;
+  episodicId: string;
+  totalCostUsd: number;
+  /** Optional PR URL if the SCM adapter resolved one — lets notifiers link directly. */
+  prUrl?: string;
+}
+
+/**
+ * Notifier — pluggable notification surface.
+ *
+ * Decision #24: Telegram / Discord / Slack / Email are EQUAL-WEIGHT
+ * integrations alongside CLI / Web / IDE. None is the "hero". Any
+ * integration package implements this interface and consumers register
+ * zero-or-more notifiers on the council run.
+ *
+ * Contract:
+ *   - `notifyReview` is called once per completed council deliberation.
+ *   - Implementations are fire-and-forget from the caller's perspective.
+ *     They may throw; the caller is expected to catch + log + continue
+ *     (a failed notification must not kill a review).
+ *   - Implementations should NOT call LLM APIs. If they need
+ *     summarization, take a pre-summarized field on NotifyReviewInput or
+ *     compose the summary from existing `outcome.results[].summary`.
+ */
+export interface Notifier {
+  readonly id: string;
+  readonly displayName: string;
+  notifyReview(input: NotifyReviewInput): Promise<void>;
+}

--- a/packages/integration-telegram/README.md
+++ b/packages/integration-telegram/README.md
@@ -1,0 +1,56 @@
+# @ai-conclave/integration-telegram
+
+Telegram notifier for Ai-Conclave council reviews. Implements the
+`Notifier` interface from `@ai-conclave/core`.
+
+Decision #24: equal-weight integration alongside Discord / Slack / Email
+/ CLI. No hero surface.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/integration-telegram @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { TelegramNotifier } from "@ai-conclave/integration-telegram";
+
+const telegram = new TelegramNotifier({
+  token: process.env.TELEGRAM_BOT_TOKEN,
+  chatId: process.env.TELEGRAM_CHAT_ID,
+});
+
+// After Council.deliberate:
+await telegram.notifyReview({
+  outcome,
+  ctx,
+  episodicId: episodic.id,
+  totalCostUsd: gate.metrics.summary().totalCostUsd,
+  prUrl: "https://github.com/acme/app/pull/42",
+});
+```
+
+## Setup
+
+1. Create a bot via [@BotFather](https://t.me/BotFather) and save the token
+2. Open a chat with the bot OR add it to a group
+3. Get your chat id:
+   ```bash
+   curl "https://api.telegram.org/bot<TOKEN>/getUpdates"
+   ```
+   (Send a message to the bot first, then the chat id appears in the result.)
+4. Set `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in your env.
+
+## What's in the message
+
+- Header: verdict emoji + repo + PR link (if supplied)
+- Per-agent verdict + top-3 blockers by severity
+- Summary per agent
+- Footer: total cost + episodic id (for later `conclave record-outcome`)
+- Inline action buttons: ✅ Approve / 🔧 Rework / ❌ Reject
+
+Inline buttons emit `callback_data = "ep:<episodicId>:<outcome>"` — a
+callback handler in a future package can close the loop by invoking
+`OutcomeWriter.recordOutcome` directly.

--- a/packages/integration-telegram/package.json
+++ b/packages/integration-telegram/package.json
@@ -1,13 +1,16 @@
 {
-  "name": "@ai-conclave/cli",
+  "name": "@ai-conclave/integration-telegram",
   "version": "0.0.0",
-  "description": "Ai-Conclave CLI — the `conclave` binary.",
+  "description": "Ai-Conclave Telegram notifier — posts review outcomes to a Telegram chat via Bot API.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "conclave": "./dist/bin/conclave.js"
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",
@@ -22,14 +25,7 @@
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {
-    "@ai-conclave/agent-claude": "workspace:*",
-    "@ai-conclave/agent-gemini": "workspace:*",
-    "@ai-conclave/agent-openai": "workspace:*",
-    "@ai-conclave/core": "workspace:*",
-    "@ai-conclave/integration-telegram": "workspace:*",
-    "@ai-conclave/observability-langfuse": "workspace:*",
-    "@ai-conclave/scm-github": "workspace:*",
-    "zod": "^3.24.0"
+    "@ai-conclave/core": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/packages/integration-telegram/src/client.ts
+++ b/packages/integration-telegram/src/client.ts
@@ -1,0 +1,80 @@
+export interface TelegramSendMessageParams {
+  chat_id: number | string;
+  text: string;
+  parse_mode?: "HTML" | "MarkdownV2";
+  disable_web_page_preview?: boolean;
+  reply_markup?: TelegramInlineKeyboard;
+}
+
+export interface TelegramInlineKeyboard {
+  inline_keyboard: TelegramInlineKeyboardButton[][];
+}
+
+export interface TelegramInlineKeyboardButton {
+  text: string;
+  callback_data?: string;
+  url?: string;
+}
+
+export interface TelegramResponse<T> {
+  ok: boolean;
+  result?: T;
+  description?: string;
+  error_code?: number;
+}
+
+export interface HttpFetch {
+  (url: string, init: { method: string; headers: Record<string, string>; body: string }): Promise<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+    text: () => Promise<string>;
+  }>;
+}
+
+/**
+ * Thin Telegram Bot API wrapper. Uses native fetch (Node 20+) by default;
+ * accepts an injected `HttpFetch` for tests.
+ *
+ * Intentionally limited to the methods the notifier needs — any expansion
+ * stays under ~200 lines to keep dep surface thin. Full bot command-loop
+ * + webhook listener lives in a separate package if/when Bae wants it.
+ */
+export class TelegramClient {
+  private readonly token: string;
+  private readonly baseUrl: string;
+  private readonly fetchFn: HttpFetch;
+
+  constructor(opts: { token: string; baseUrl?: string; fetch?: HttpFetch }) {
+    if (!opts.token) throw new Error("TelegramClient: token is required");
+    this.token = opts.token;
+    this.baseUrl = opts.baseUrl ?? "https://api.telegram.org";
+    this.fetchFn = opts.fetch ?? ((...args) => fetch(...(args as Parameters<typeof fetch>)) as ReturnType<HttpFetch>);
+  }
+
+  async sendMessage(params: TelegramSendMessageParams): Promise<TelegramResponse<unknown>> {
+    return this.call("sendMessage", params);
+  }
+
+  private async call<T>(method: string, body: unknown): Promise<TelegramResponse<T>> {
+    const url = `${this.baseUrl}/bot${this.token}/${method}`;
+    const res = await this.fetchFn(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    let data: TelegramResponse<T>;
+    try {
+      data = (await res.json()) as TelegramResponse<T>;
+    } catch {
+      const text = await res.text();
+      throw new Error(`TelegramClient: ${method} returned non-JSON (status ${res.status}): ${text.slice(0, 200)}`);
+    }
+    if (!data.ok) {
+      throw new Error(
+        `TelegramClient: ${method} failed — ${data.description ?? "no description"} (code ${data.error_code ?? "?"})`,
+      );
+    }
+    return data;
+  }
+}

--- a/packages/integration-telegram/src/format.ts
+++ b/packages/integration-telegram/src/format.ts
@@ -1,0 +1,77 @@
+import type { NotifyReviewInput } from "@ai-conclave/core";
+
+const VERDICT_EMOJI: Record<"approve" | "rework" | "reject", string> = {
+  approve: "✅",
+  rework: "🔧",
+  reject: "❌",
+};
+
+const SEVERITY_EMOJI: Record<"blocker" | "major" | "minor" | "nit", string> = {
+  blocker: "🛑",
+  major: "⚠️",
+  minor: "🔹",
+  nit: "💬",
+};
+
+/** Telegram HTML mode allows <b>, <i>, <code>, <pre>, <a href>. Escape &, <, >. */
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Render a NotifyReviewInput into a Telegram HTML-mode message body.
+ *
+ * Contract:
+ *   - Max length 4096 chars per Telegram (longer → truncated with ellipsis).
+ *   - Per-agent sections, each capped to the top-3 blockers by severity.
+ *   - Repo + PR link line at the top if `prUrl` is set.
+ *   - Cost + episodic id in a footer for ops visibility.
+ */
+export function formatReviewForTelegram(input: NotifyReviewInput): string {
+  const { outcome, ctx, totalCostUsd, prUrl, episodicId } = input;
+  const lines: string[] = [];
+
+  const verdictBadge = `${VERDICT_EMOJI[outcome.verdict]} <b>${outcome.verdict.toUpperCase()}</b>`;
+  const header = prUrl
+    ? `${verdictBadge} — <a href="${esc(prUrl)}">${esc(ctx.repo)} #${ctx.pullNumber}</a>`
+    : `${verdictBadge} — <b>${esc(ctx.repo)}${ctx.pullNumber ? ` #${ctx.pullNumber}` : ""}</b>`;
+  lines.push(header);
+  if (!outcome.consensusReached) lines.push("<i>no consensus reached</i>");
+  lines.push("");
+
+  for (const result of outcome.results) {
+    lines.push(
+      `<b>${esc(result.agent)}</b> → ${VERDICT_EMOJI[result.verdict]} <i>${result.verdict}</i>`,
+    );
+    if (result.blockers.length === 0) {
+      lines.push("  (no blockers)");
+    } else {
+      const sorted = [...result.blockers]
+        .sort((a, b) => severityOrder(a.severity) - severityOrder(b.severity))
+        .slice(0, 3);
+      for (const b of sorted) {
+        const where = b.file ? ` <code>${esc(b.file)}${b.line ? `:${b.line}` : ""}</code>` : "";
+        lines.push(
+          `  ${SEVERITY_EMOJI[b.severity]} <b>${b.severity}</b> (${esc(b.category)})${where}`,
+        );
+        lines.push(`    ${esc(b.message)}`);
+      }
+      if (result.blockers.length > 3) lines.push(`  … +${result.blockers.length - 3} more`);
+    }
+    if (result.summary) lines.push(`  <i>${esc(truncate(result.summary, 240))}</i>`);
+    lines.push("");
+  }
+
+  lines.push(`<i>cost: $${totalCostUsd.toFixed(4)} · episodic: <code>${esc(episodicId)}</code></i>`);
+
+  const message = lines.join("\n");
+  return message.length <= 4090 ? message : message.slice(0, 4085) + "\n…";
+}
+
+function severityOrder(s: "blocker" | "major" | "minor" | "nit"): number {
+  return { blocker: 0, major: 1, minor: 2, nit: 3 }[s];
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}

--- a/packages/integration-telegram/src/index.ts
+++ b/packages/integration-telegram/src/index.ts
@@ -1,0 +1,11 @@
+export { TelegramClient } from "./client.js";
+export type {
+  TelegramSendMessageParams,
+  TelegramInlineKeyboard,
+  TelegramInlineKeyboardButton,
+  TelegramResponse,
+  HttpFetch,
+} from "./client.js";
+export { TelegramNotifier } from "./notifier.js";
+export type { TelegramNotifierOptions } from "./notifier.js";
+export { formatReviewForTelegram } from "./format.js";

--- a/packages/integration-telegram/src/notifier.ts
+++ b/packages/integration-telegram/src/notifier.ts
@@ -1,0 +1,84 @@
+import type { Notifier, NotifyReviewInput } from "@ai-conclave/core";
+import { TelegramClient, type HttpFetch, type TelegramInlineKeyboard } from "./client.js";
+import { formatReviewForTelegram } from "./format.js";
+
+export interface TelegramNotifierOptions {
+  /** Bot token from BotFather. If omitted, read from TELEGRAM_BOT_TOKEN env. */
+  token?: string;
+  /** Chat id (user or group). If omitted, read from TELEGRAM_CHAT_ID env. */
+  chatId?: number | string;
+  /** Pre-built client (tests). */
+  client?: TelegramClient;
+  /** Inject fetch for tests. */
+  fetch?: HttpFetch;
+  /** Base URL override (tests or self-hosted bot API). */
+  baseUrl?: string;
+  /** If true, attaches inline buttons (approve/reject/rework) to the message. Default true. */
+  includeActionButtons?: boolean;
+}
+
+/**
+ * TelegramNotifier — posts review outcomes to a Telegram chat.
+ *
+ * Decision #24: Telegram is an equal-weight integration alongside
+ * Discord / Slack / Email / CLI. No "hero" surface. This notifier is
+ * intentionally minimal — sendMessage + optional action buttons.
+ * Inbound bot command handling (approve via button, /status, etc.) lives
+ * in a separate command-surface package if/when added.
+ */
+export class TelegramNotifier implements Notifier {
+  readonly id = "telegram";
+  readonly displayName = "Telegram";
+
+  private readonly chatId: number | string;
+  private readonly client: TelegramClient;
+  private readonly includeActionButtons: boolean;
+
+  constructor(opts: TelegramNotifierOptions = {}) {
+    const token = opts.token ?? process.env["TELEGRAM_BOT_TOKEN"] ?? "";
+    const chatRaw = opts.chatId ?? process.env["TELEGRAM_CHAT_ID"] ?? "";
+    if (!token && !opts.client) {
+      throw new Error("TelegramNotifier: TELEGRAM_BOT_TOKEN not set (pass opts.token, opts.client, or env)");
+    }
+    if (!chatRaw) {
+      throw new Error("TelegramNotifier: TELEGRAM_CHAT_ID not set (pass opts.chatId or env)");
+    }
+    this.chatId = typeof chatRaw === "string" && /^-?\d+$/.test(chatRaw) ? Number(chatRaw) : chatRaw;
+    if (opts.client) {
+      this.client = opts.client;
+    } else {
+      const clientOpts: ConstructorParameters<typeof TelegramClient>[0] = { token };
+      if (opts.fetch) clientOpts.fetch = opts.fetch;
+      if (opts.baseUrl) clientOpts.baseUrl = opts.baseUrl;
+      this.client = new TelegramClient(clientOpts);
+    }
+    this.includeActionButtons = opts.includeActionButtons ?? true;
+  }
+
+  async notifyReview(input: NotifyReviewInput): Promise<void> {
+    const text = formatReviewForTelegram(input);
+    const sendParams: Parameters<TelegramClient["sendMessage"]>[0] = {
+      chat_id: this.chatId,
+      text,
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+    };
+    if (this.includeActionButtons) {
+      sendParams.reply_markup = buildActionKeyboard(input);
+    }
+    await this.client.sendMessage(sendParams);
+  }
+}
+
+function buildActionKeyboard(input: NotifyReviewInput): TelegramInlineKeyboard {
+  // callback_data is constrained to 64 bytes by Telegram — keep it compact.
+  const id = input.episodicId;
+  const row = [
+    { text: "✅ Approve", callback_data: `ep:${id}:merged` },
+    { text: "🔧 Rework", callback_data: `ep:${id}:reworked` },
+    { text: "❌ Reject", callback_data: `ep:${id}:rejected` },
+  ];
+  // If the button callback_data is too long, drop it. Episodic ids are
+  // ~40 chars so `ep:${id}:merged` ≈ 50 chars — within 64-byte limit.
+  return { inline_keyboard: [row] };
+}

--- a/packages/integration-telegram/test/client.test.mjs
+++ b/packages/integration-telegram/test/client.test.mjs
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { TelegramClient } from "../dist/index.js";
+
+function mockFetch(responses) {
+  let i = 0;
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: async () => r.json,
+      text: async () => r.text ?? JSON.stringify(r.json),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+test("TelegramClient: rejects empty token", () => {
+  assert.throws(() => new TelegramClient({ token: "" }));
+});
+
+test("TelegramClient: sendMessage issues POST to /botTOKEN/sendMessage", async () => {
+  const f = mockFetch([{ json: { ok: true, result: { message_id: 1 } } }]);
+  const client = new TelegramClient({ token: "test-token", fetch: f });
+  await client.sendMessage({ chat_id: 123, text: "hi" });
+  assert.equal(f.calls.length, 1);
+  assert.equal(f.calls[0].url, "https://api.telegram.org/bottest-token/sendMessage");
+  assert.equal(f.calls[0].init.method, "POST");
+  assert.equal(f.calls[0].init.headers["content-type"], "application/json");
+  assert.match(f.calls[0].init.body, /"chat_id":123/);
+});
+
+test("TelegramClient: throws on ok=false with Telegram description", async () => {
+  const f = mockFetch([
+    { json: { ok: false, description: "chat not found", error_code: 400 } },
+  ]);
+  const client = new TelegramClient({ token: "t", fetch: f });
+  await assert.rejects(
+    () => client.sendMessage({ chat_id: 0, text: "x" }),
+    /chat not found.*code 400/,
+  );
+});
+
+test("TelegramClient: throws on non-JSON response with status + snippet", async () => {
+  const f = async () => ({
+    ok: false,
+    status: 502,
+    json: async () => {
+      throw new Error("invalid json");
+    },
+    text: async () => "upstream error page".repeat(50),
+  });
+  const client = new TelegramClient({ token: "t", fetch: f });
+  await assert.rejects(() => client.sendMessage({ chat_id: 0, text: "x" }), /non-JSON.*status 502/);
+});
+
+test("TelegramClient: honors baseUrl override", async () => {
+  const f = mockFetch([{ json: { ok: true, result: {} } }]);
+  const client = new TelegramClient({ token: "t", fetch: f, baseUrl: "https://telegram.local" });
+  await client.sendMessage({ chat_id: 1, text: "hi" });
+  assert.ok(f.calls[0].url.startsWith("https://telegram.local/"));
+});

--- a/packages/integration-telegram/test/format.test.mjs
+++ b/packages/integration-telegram/test/format.test.mjs
@@ -1,0 +1,137 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatReviewForTelegram } from "../dist/index.js";
+
+function mkInput(overrides = {}) {
+  return {
+    outcome: {
+      verdict: "approve",
+      rounds: 1,
+      results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+      consensusReached: true,
+    },
+    ctx: {
+      diff: "",
+      repo: "acme/app",
+      pullNumber: 42,
+      newSha: "abc123",
+    },
+    episodicId: "ep-test-1",
+    totalCostUsd: 0.0153,
+    ...overrides,
+  };
+}
+
+test("formatReviewForTelegram: approve with HTML emoji header", () => {
+  const msg = formatReviewForTelegram(mkInput());
+  assert.match(msg, /✅ <b>APPROVE<\/b>/);
+  assert.match(msg, /acme\/app.*#42/);
+  assert.match(msg, /LGTM/);
+});
+
+test("formatReviewForTelegram: link to prUrl when supplied", () => {
+  const msg = formatReviewForTelegram(mkInput({ prUrl: "https://github.com/acme/app/pull/42" }));
+  assert.match(msg, /<a href="https:\/\/github\.com\/acme\/app\/pull\/42">/);
+});
+
+test("formatReviewForTelegram: escapes HTML-special chars in content", () => {
+  const msg = formatReviewForTelegram(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: true,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [
+              { severity: "blocker", category: "type-error", message: "got <never> expected <string>", file: "x<.ts" },
+            ],
+            summary: "a & b",
+          },
+        ],
+      },
+    }),
+  );
+  assert.ok(!msg.includes("<never>"), "raw angle brackets must be escaped");
+  assert.match(msg, /&lt;never&gt;/);
+  assert.match(msg, /a &amp; b/);
+});
+
+test("formatReviewForTelegram: severity-sorts blockers and caps at 3", () => {
+  const blockers = [
+    { severity: "nit", category: "style", message: "nit 1" },
+    { severity: "blocker", category: "security", message: "block 1" },
+    { severity: "minor", category: "dead-code", message: "minor 1" },
+    { severity: "major", category: "regression", message: "major 1" },
+    { severity: "blocker", category: "type-error", message: "block 2" },
+  ];
+  const msg = formatReviewForTelegram(
+    mkInput({
+      outcome: {
+        verdict: "reject",
+        rounds: 1,
+        consensusReached: true,
+        results: [{ agent: "claude", verdict: "reject", blockers, summary: "" }],
+      },
+    }),
+  );
+  // Top-3 by severity: block 1, block 2, major 1
+  const order = ["block 1", "block 2", "major 1"];
+  let lastIdx = -1;
+  for (const label of order) {
+    const idx = msg.indexOf(label);
+    assert.ok(idx > lastIdx, `expected "${label}" to appear in order`);
+    lastIdx = idx;
+  }
+  assert.match(msg, /\+2 more/); // 5 blockers minus 3 shown = 2 more
+});
+
+test("formatReviewForTelegram: no-consensus tag", () => {
+  const msg = formatReviewForTelegram(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: false,
+        results: [{ agent: "claude", verdict: "rework", blockers: [], summary: "" }],
+      },
+    }),
+  );
+  assert.match(msg, /no consensus/);
+});
+
+test("formatReviewForTelegram: footer includes cost + episodic id", () => {
+  const msg = formatReviewForTelegram(mkInput({ totalCostUsd: 0.0345, episodicId: "ep-xyz" }));
+  assert.match(msg, /\$0\.0345/);
+  assert.match(msg, /ep-xyz/);
+});
+
+test("formatReviewForTelegram: truncates if longer than 4096 chars", () => {
+  const huge = "x".repeat(12_000);
+  const msg = formatReviewForTelegram(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: true,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [{ severity: "blocker", category: "security", message: huge }],
+            summary: "",
+          },
+        ],
+      },
+    }),
+  );
+  assert.ok(msg.length <= 4096, `expected ≤ 4096 chars, got ${msg.length}`);
+  assert.ok(msg.endsWith("…"));
+});
+
+test("formatReviewForTelegram: (no blockers) placeholder when empty", () => {
+  const msg = formatReviewForTelegram(mkInput());
+  assert.match(msg, /no blockers/);
+});

--- a/packages/integration-telegram/test/notifier.test.mjs
+++ b/packages/integration-telegram/test/notifier.test.mjs
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { TelegramNotifier } from "../dist/index.js";
+
+function mockFetch(response = { ok: true, result: { message_id: 1 } }) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init, body: JSON.parse(init.body) });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => response,
+      text: async () => JSON.stringify(response),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const baseInput = {
+  outcome: {
+    verdict: "approve",
+    rounds: 1,
+    consensusReached: true,
+    results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+  },
+  ctx: { diff: "", repo: "acme/app", pullNumber: 42, newSha: "abc" },
+  episodicId: "ep-test",
+  totalCostUsd: 0.01,
+};
+
+test("TelegramNotifier: constructor throws on missing token", () => {
+  const orig = process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  try {
+    assert.throws(() => new TelegramNotifier({ chatId: 1 }));
+  } finally {
+    if (orig !== undefined) process.env.TELEGRAM_BOT_TOKEN = orig;
+  }
+});
+
+test("TelegramNotifier: constructor throws on missing chatId", () => {
+  const orig = process.env.TELEGRAM_CHAT_ID;
+  delete process.env.TELEGRAM_CHAT_ID;
+  try {
+    assert.throws(() => new TelegramNotifier({ token: "t" }));
+  } finally {
+    if (orig !== undefined) process.env.TELEGRAM_CHAT_ID = orig;
+  }
+});
+
+test("TelegramNotifier: numeric-string chat id is coerced to number", async () => {
+  const f = mockFetch();
+  const n = new TelegramNotifier({ token: "t", chatId: "-100123", fetch: f });
+  await n.notifyReview(baseInput);
+  assert.equal(typeof f.calls[0].body.chat_id, "number");
+  assert.equal(f.calls[0].body.chat_id, -100123);
+});
+
+test("TelegramNotifier: notifyReview posts HTML + disable_web_page_preview", async () => {
+  const f = mockFetch();
+  const n = new TelegramNotifier({ token: "t", chatId: 999, fetch: f });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.parse_mode, "HTML");
+  assert.equal(f.calls[0].body.disable_web_page_preview, true);
+  assert.match(f.calls[0].body.text, /APPROVE/);
+});
+
+test("TelegramNotifier: includes inline action keyboard by default", async () => {
+  const f = mockFetch();
+  const n = new TelegramNotifier({ token: "t", chatId: 999, fetch: f });
+  await n.notifyReview(baseInput);
+  const kb = f.calls[0].body.reply_markup?.inline_keyboard;
+  assert.ok(Array.isArray(kb));
+  assert.equal(kb[0].length, 3);
+  const callbacks = kb[0].map((b) => b.callback_data);
+  assert.ok(callbacks[0].startsWith("ep:ep-test:merged"));
+  assert.ok(callbacks[1].startsWith("ep:ep-test:reworked"));
+  assert.ok(callbacks[2].startsWith("ep:ep-test:rejected"));
+});
+
+test("TelegramNotifier: includeActionButtons:false omits reply_markup", async () => {
+  const f = mockFetch();
+  const n = new TelegramNotifier({ token: "t", chatId: 999, fetch: f, includeActionButtons: false });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.reply_markup, undefined);
+});
+
+test("TelegramNotifier: uses TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID env fallback", async () => {
+  const origT = process.env.TELEGRAM_BOT_TOKEN;
+  const origC = process.env.TELEGRAM_CHAT_ID;
+  process.env.TELEGRAM_BOT_TOKEN = "env-token";
+  process.env.TELEGRAM_CHAT_ID = "555";
+  const f = mockFetch();
+  try {
+    const n = new TelegramNotifier({ fetch: f });
+    await n.notifyReview(baseInput);
+    assert.ok(f.calls[0].url.includes("env-token"));
+    assert.equal(f.calls[0].body.chat_id, 555);
+  } finally {
+    if (origT !== undefined) process.env.TELEGRAM_BOT_TOKEN = origT;
+    else delete process.env.TELEGRAM_BOT_TOKEN;
+    if (origC !== undefined) process.env.TELEGRAM_CHAT_ID = origC;
+    else delete process.env.TELEGRAM_CHAT_ID;
+  }
+});
+
+test("TelegramNotifier: conforms to Notifier interface", () => {
+  const n = new TelegramNotifier({ token: "t", chatId: 1, fetch: async () => ({ ok: true, status: 200, json: async () => ({ ok: true, result: {} }), text: async () => "" }) });
+  assert.equal(n.id, "telegram");
+  assert.equal(n.displayName, "Telegram");
+  assert.equal(typeof n.notifyReview, "function");
+});

--- a/packages/integration-telegram/tsconfig.json
+++ b/packages/integration-telegram/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}


### PR DESCRIPTION
## Summary

Decision #24 locks Telegram / Discord / Slack / Email as **equal-weight** integrations (none is hero). This PR lands:

1. **`Notifier` interface** in `@ai-conclave/core` — pluggable, parallel to the `Agent` pattern.
2. **`@ai-conclave/integration-telegram`** — first implementation.
3. **CLI wiring** — post-review notification; failures never kill the exit code.

Base = `scaffold/scm-github` (which on origin contains PR #1-10 content after the PR #10 merge).

## Message format

```
✅ APPROVE — acme/app #42     (linked to PR URL when supplied)

claude → ✅ approve
  (no blockers)
  summary: LGTM

cost: $0.0153 · episodic: ep-abc12345...
```

Severity-sorted top-3 blockers per agent. HTML-escaped. Truncated at 4090 chars.

## Inline action buttons

Each message carries three callbacks:
- `✅ Approve` → `ep:<episodicId>:merged`
- `🔧 Rework` → `ep:<episodicId>:reworked`
- `❌ Reject` → `ep:<episodicId>:rejected`

Within Telegram's 64-byte callback_data limit. Future callback handler can invoke `OutcomeWriter.recordOutcome` to close the self-evolve loop from the phone.

## Config

```json
{
  "integrations": {
    "telegram": {
      "enabled": true,
      "chatId": "-1001234567890",
      "includeActionButtons": true
    }
  }
}
```

Env:
- `TELEGRAM_BOT_TOKEN` (required)
- `TELEGRAM_CHAT_ID` (required if not in config)

## Tests — 21 cases

| File | Cases | Coverage |
|---|---|---|
| `format.test.mjs` | 8 | Emoji header, prUrl anchor, HTML escape, severity sort + cap, no-consensus, footer, truncation, no-blockers placeholder |
| `client.test.mjs` | 5 | Empty token reject, POST shape, `ok:false` throw, non-JSON throw, baseUrl override |
| `notifier.test.mjs` | 8 | Missing-token + chatId throws, numeric-string coercion, HTML mode + preview disable, keyboard default, opt-out, env fallback, Notifier interface conformance |

## Deferred

- Callback handler (consumes `ep:*` buttons) — needs long-poll or webhook listener
- Discord / Slack / Email notifiers — same pattern, drop-in
- Inbound command surface (`/status`, `/do`, `/rework`) — separate package

🤖 Generated with [Claude Code](https://claude.com/claude-code)