### PR TITLE
feat(integration-slack): Slack Block Kit webhook notifier (decision #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,31 @@
     flows, response_format shape assertion, refusal throw, invalid-JSON
     throw, invalid-verdict throw, no-key constructor throw, metrics
     aggregation, pre-flight budget short-circuits the network call.
+- **`@ai-conclave/integration-slack`** — third notification surface
+  (decision #24, Block Kit format, webhook-based same as Discord):
+  - `SlackNotifier` implements `Notifier`. Posts to a Slack incoming
+    webhook using Block Kit layout (section + context + divider blocks).
+  - URL validation restricts to `https://hooks.slack.com/services/...`.
+  - Header section links to PR URL with Slack mrkdwn `<url|text>`
+    syntax when supplied.
+  - Per-agent sections show top-3 severity-sorted blockers + summary.
+  - Footer context block carries cost + episodic id.
+  - Fallback top-level `text` mirrors verdict + repo for mobile push
+    notifications (where Block Kit won't render).
+  - Slack-specific escaping for `< > &` on user-supplied strings.
+  - Auto-truncates at Slack limits: block text 2900 chars, top-level
+    text 1000 chars, ≤ 50 blocks total.
+  - CLI `integrations.slack.{enabled, webhookUrl, username, iconUrl,
+    iconEmoji}`. Env fallback: `SLACK_WEBHOOK_URL`. `iconUrl` wins over
+    `iconEmoji` when both supplied.
+  - 19 test cases across `format` (text fallback, mrkdwn link, no-
+    consensus context, special-char escape, severity-sorted top-3 +
+    `+N more`, footer cost+id, dividers bracket sections, 50-block cap,
+    no-blockers placeholder, 2900-char truncation) and `notifier`
+    (missing URL throws, non-Slack URL throws, POST + JSON shape,
+    default username, iconUrl wins + iconEmoji alone, non-200 throw
+    with body, SLACK_WEBHOOK_URL env fallback, Notifier interface
+    conformance).
 - **`@ai-conclave/integration-discord`** — second notification surface
   (decision #24, same `Notifier` pattern as Telegram):
   - `DiscordNotifier` implements `Notifier`. Posts to an incoming

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "@ai-conclave/agent-openai": "workspace:*",
     "@ai-conclave/core": "workspace:*",
     "@ai-conclave/integration-discord": "workspace:*",
+    "@ai-conclave/integration-slack": "workspace:*",
     "@ai-conclave/integration-telegram": "workspace:*",
     "@ai-conclave/observability-langfuse": "workspace:*",
     "@ai-conclave/scm-github": "workspace:*",

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -16,6 +16,7 @@ import { GeminiAgent } from "@ai-conclave/agent-gemini";
 import { LangfuseMetricsSink } from "@ai-conclave/observability-langfuse";
 import { TelegramNotifier } from "@ai-conclave/integration-telegram";
 import { DiscordNotifier } from "@ai-conclave/integration-discord";
+import { SlackNotifier } from "@ai-conclave/integration-slack";
 import type { Notifier } from "@ai-conclave/core";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
@@ -218,6 +219,24 @@ export async function review(argv: string[]): Promise<void> {
         notifiers.push(new DiscordNotifier(opts));
       } catch (err) {
         process.stderr.write(`conclave review: Discord notifier init failed — ${(err as Error).message}\n`);
+      }
+    }
+  }
+  const sl = config.integrations?.slack;
+  if (sl?.enabled !== false) {
+    const hasUrl = !!(sl?.webhookUrl || process.env["SLACK_WEBHOOK_URL"]);
+    if (sl?.enabled === true && !hasUrl) {
+      process.stderr.write("conclave review: SLACK_WEBHOOK_URL not set — skipping Slack notifier\n");
+    } else if (hasUrl) {
+      const opts: ConstructorParameters<typeof SlackNotifier>[0] = {};
+      if (sl?.webhookUrl) opts.webhookUrl = sl.webhookUrl;
+      if (sl?.username) opts.username = sl.username;
+      if (sl?.iconUrl) opts.iconUrl = sl.iconUrl;
+      if (sl?.iconEmoji) opts.iconEmoji = sl.iconEmoji;
+      try {
+        notifiers.push(new SlackNotifier(opts));
+      } catch (err) {
+        process.stderr.write(`conclave review: Slack notifier init failed — ${(err as Error).message}\n`);
       }
     }
   }

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -55,6 +55,15 @@ export const ConclaveConfigSchema = z.object({
           avatarUrl: z.string().url().optional(),
         })
         .optional(),
+      slack: z
+        .object({
+          enabled: z.boolean().default(true),
+          webhookUrl: z.string().url().optional(),
+          username: z.string().optional(),
+          iconUrl: z.string().url().optional(),
+          iconEmoji: z.string().optional(),
+        })
+        .optional(),
     })
     .optional(),
 });

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "../agent-gemini" },
     { "path": "../agent-openai" },
     { "path": "../integration-discord" },
+    { "path": "../integration-slack" },
     { "path": "../integration-telegram" },
     { "path": "../observability-langfuse" },
     { "path": "../scm-github" }

--- a/packages/integration-slack/README.md
+++ b/packages/integration-slack/README.md
@@ -1,0 +1,51 @@
+# @ai-conclave/integration-slack
+
+Slack notifier for Ai-Conclave council reviews. Implements the
+`Notifier` interface from `@ai-conclave/core`.
+
+Decision #24: equal-weight integration alongside Telegram / Discord /
+Email / CLI.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/integration-slack @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { SlackNotifier } from "@ai-conclave/integration-slack";
+
+const slack = new SlackNotifier({
+  webhookUrl: process.env.SLACK_WEBHOOK_URL,
+});
+
+await slack.notifyReview({
+  outcome,
+  ctx,
+  episodicId: episodic.id,
+  totalCostUsd: gate.metrics.summary().totalCostUsd,
+  prUrl: "https://github.com/acme/app/pull/42",
+});
+```
+
+## Setup
+
+1. https://api.slack.com/apps → Create App → From scratch
+2. **Incoming Webhooks** → toggle on → **Add New Webhook to Workspace**
+3. Pick a channel, copy the URL
+4. `export SLACK_WEBHOOK_URL='https://hooks.slack.com/services/…'`
+
+## Message shape
+
+- Block Kit body (sections + context + dividers)
+- Verdict header with emoji, links to PR URL when supplied
+- Per-agent section: top-3 severity-sorted blockers + summary
+- Footer context block: cost + episodic id
+- Fallback `text` field for mobile push notifications
+
+## Inbound interactivity
+
+Not supported here (webhooks are write-only). For slash commands or
+button clicks, add a separate Slack app with OAuth + event subscriptions.

--- a/packages/integration-slack/package.json
+++ b/packages/integration-slack/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ai-conclave/integration-slack",
+  "version": "0.0.0",
+  "description": "Ai-Conclave Slack notifier — posts review outcomes to a Slack channel via incoming webhook.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@ai-conclave/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/integration-slack/src/format.ts
+++ b/packages/integration-slack/src/format.ts
@@ -1,0 +1,117 @@
+import type { NotifyReviewInput } from "@ai-conclave/core";
+
+const VERDICT_EMOJI: Record<"approve" | "rework" | "reject", string> = {
+  approve: ":white_check_mark:",
+  rework: ":wrench:",
+  reject: ":x:",
+};
+
+const SEVERITY_EMOJI: Record<"blocker" | "major" | "minor" | "nit", string> = {
+  blocker: ":no_entry:",
+  major: ":warning:",
+  minor: ":small_blue_diamond:",
+  nit: ":speech_balloon:",
+};
+
+export interface SlackBlock {
+  type: string;
+  text?: { type: "mrkdwn" | "plain_text"; text: string; emoji?: boolean };
+  fields?: Array<{ type: "mrkdwn" | "plain_text"; text: string }>;
+  elements?: Array<{ type: "mrkdwn"; text: string }>;
+}
+
+export interface SlackWebhookPayload {
+  text: string;
+  username?: string;
+  icon_url?: string;
+  icon_emoji?: string;
+  blocks: SlackBlock[];
+}
+
+/**
+ * Render a NotifyReviewInput as a Slack incoming-webhook payload.
+ *
+ * Uses Block Kit (blocks[]) for the rich body; `text` is a fallback for
+ * notifications (mobile banner, push digest). The fallback mirrors the
+ * verdict + repo so notifications are meaningful even when the full
+ * layout doesn't render.
+ *
+ * Slack limits:
+ *   - top-level `text` ≤ 40_000 chars (soft); we truncate at 1_000.
+ *   - each block's text ≤ 3_000 chars; we truncate at 2_900 to leave
+ *     room for wrappers.
+ *   - ≤ 50 blocks per message; we cap on per-agent section count.
+ */
+export function formatReviewForSlack(input: NotifyReviewInput): SlackWebhookPayload {
+  const { outcome, ctx, totalCostUsd, prUrl, episodicId } = input;
+  const verdictTag = `${VERDICT_EMOJI[outcome.verdict]} *${outcome.verdict.toUpperCase()}*`;
+  const title = `${verdictTag} — ${ctx.repo}${ctx.pullNumber ? ` #${ctx.pullNumber}` : ""}`;
+
+  const blocks: SlackBlock[] = [];
+
+  const headerText = prUrl
+    ? `${verdictTag} — <${prUrl}|${escapeText(ctx.repo)} #${ctx.pullNumber}>`
+    : title;
+  blocks.push({ type: "section", text: { type: "mrkdwn", text: trunc(headerText, 2900) } });
+  if (!outcome.consensusReached) {
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: "_no consensus reached_" }],
+    });
+  }
+  blocks.push({ type: "divider" });
+
+  for (const r of outcome.results) {
+    if (blocks.length >= 46) break; // leave slack for divider + footer
+    const header = `${VERDICT_EMOJI[r.verdict]} *${r.agent}* — _${r.verdict}_`;
+    const lines: string[] = [header];
+    if (r.blockers.length === 0) {
+      lines.push("_(no blockers)_");
+    } else {
+      const sorted = [...r.blockers]
+        .sort((a, b) => severityOrder(a.severity) - severityOrder(b.severity))
+        .slice(0, 3);
+      for (const b of sorted) {
+        const where = b.file ? ` \`${b.file}${b.line ? `:${b.line}` : ""}\`` : "";
+        lines.push(`${SEVERITY_EMOJI[b.severity]} *${b.severity}* (${b.category})${where}`);
+        lines.push(`    ${escapeText(b.message)}`);
+      }
+      if (r.blockers.length > 3) lines.push(`_… +${r.blockers.length - 3} more_`);
+    }
+    if (r.summary) lines.push(`_${escapeText(trunc(r.summary, 400))}_`);
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: trunc(lines.join("\n"), 2900) },
+    });
+  }
+
+  blocks.push({ type: "divider" });
+  blocks.push({
+    type: "context",
+    elements: [
+      { type: "mrkdwn", text: `cost \`$${totalCostUsd.toFixed(4)}\` · episodic \`${episodicId}\`` },
+    ],
+  });
+
+  return {
+    text: trunc(title, 1000),
+    blocks,
+  };
+}
+
+function severityOrder(s: "blocker" | "major" | "minor" | "nit"): number {
+  return { blocker: 0, major: 1, minor: 2, nit: 3 }[s];
+}
+
+function trunc(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}
+
+/**
+ * Slack mrkdwn requires escaping `<`, `>`, `&` to avoid entity parsing.
+ * Code fences (backticks) are safe, so blocker `file:line` paths are
+ * wrapped in backticks upstream rather than escaped.
+ */
+function escapeText(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/packages/integration-slack/src/index.ts
+++ b/packages/integration-slack/src/index.ts
@@ -1,0 +1,4 @@
+export { SlackNotifier } from "./notifier.js";
+export type { SlackNotifierOptions, HttpFetch } from "./notifier.js";
+export { formatReviewForSlack } from "./format.js";
+export type { SlackBlock, SlackWebhookPayload } from "./format.js";

--- a/packages/integration-slack/src/notifier.ts
+++ b/packages/integration-slack/src/notifier.ts
@@ -1,0 +1,75 @@
+import type { Notifier, NotifyReviewInput } from "@ai-conclave/core";
+import { formatReviewForSlack } from "./format.js";
+
+export interface HttpFetch {
+  (url: string, init: { method: string; headers: Record<string, string>; body: string }): Promise<{
+    ok: boolean;
+    status: number;
+    text: () => Promise<string>;
+  }>;
+}
+
+export interface SlackNotifierOptions {
+  /** Incoming webhook URL (or set via SLACK_WEBHOOK_URL env). */
+  webhookUrl?: string;
+  /** Override display username. */
+  username?: string;
+  /** Override icon URL or emoji. At most one used; url wins if both set. */
+  iconUrl?: string;
+  iconEmoji?: string;
+  /** Inject fetch for tests. */
+  fetch?: HttpFetch;
+}
+
+const DEFAULT_USERNAME = "Ai-Conclave";
+
+/**
+ * SlackNotifier — posts review outcomes to a Slack channel via incoming
+ * webhook. Same pattern as `@ai-conclave/integration-discord` — write-only,
+ * no OAuth.
+ */
+export class SlackNotifier implements Notifier {
+  readonly id = "slack";
+  readonly displayName = "Slack";
+
+  private readonly webhookUrl: string;
+  private readonly username: string;
+  private readonly iconUrl: string | undefined;
+  private readonly iconEmoji: string | undefined;
+  private readonly fetchFn: HttpFetch;
+
+  constructor(opts: SlackNotifierOptions = {}) {
+    const url = opts.webhookUrl ?? process.env["SLACK_WEBHOOK_URL"] ?? "";
+    if (!url) {
+      throw new Error("SlackNotifier: SLACK_WEBHOOK_URL not set (pass opts.webhookUrl or env)");
+    }
+    if (!/^https:\/\/hooks\.slack\.com\/services\//i.test(url)) {
+      throw new Error("SlackNotifier: webhookUrl must be an https://hooks.slack.com/services/... URL");
+    }
+    this.webhookUrl = url;
+    this.username = opts.username ?? DEFAULT_USERNAME;
+    this.iconUrl = opts.iconUrl;
+    this.iconEmoji = opts.iconEmoji;
+    this.fetchFn =
+      opts.fetch ?? ((...args) => fetch(...(args as Parameters<typeof fetch>)) as ReturnType<HttpFetch>);
+  }
+
+  async notifyReview(input: NotifyReviewInput): Promise<void> {
+    const payload = formatReviewForSlack(input);
+    payload.username = this.username;
+    if (this.iconUrl) payload.icon_url = this.iconUrl;
+    else if (this.iconEmoji) payload.icon_emoji = this.iconEmoji;
+
+    const res = await this.fetchFn(this.webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `SlackNotifier: webhook POST failed (status ${res.status}): ${text.slice(0, 200)}`,
+      );
+    }
+  }
+}

--- a/packages/integration-slack/test/format.test.mjs
+++ b/packages/integration-slack/test/format.test.mjs
@@ -1,0 +1,159 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatReviewForSlack } from "../dist/index.js";
+
+function mkInput(overrides = {}) {
+  return {
+    outcome: {
+      verdict: "approve",
+      rounds: 1,
+      consensusReached: true,
+      results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+    },
+    ctx: { diff: "", repo: "acme/app", pullNumber: 42, newSha: "sha-head" },
+    episodicId: "ep-slack-1",
+    totalCostUsd: 0.0123,
+    ...overrides,
+  };
+}
+
+test("formatReviewForSlack: top-level text fallback summarizes verdict + repo", () => {
+  const p = formatReviewForSlack(mkInput());
+  assert.match(p.text, /APPROVE/);
+  assert.match(p.text, /acme\/app #42/);
+});
+
+test("formatReviewForSlack: header section uses slack mrkdwn link when prUrl supplied", () => {
+  const p = formatReviewForSlack(mkInput({ prUrl: "https://github.com/acme/app/pull/42" }));
+  const first = p.blocks.find((b) => b.type === "section");
+  assert.match(first.text.text, /<https:\/\/github\.com\/acme\/app\/pull\/42\|/);
+});
+
+test("formatReviewForSlack: no-consensus context block", () => {
+  const p = formatReviewForSlack(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: false,
+        results: [{ agent: "claude", verdict: "rework", blockers: [], summary: "" }],
+      },
+    }),
+  );
+  const ctx = p.blocks.find((b) => b.type === "context" && b.elements?.[0]?.text?.includes("consensus"));
+  assert.ok(ctx);
+});
+
+test("formatReviewForSlack: escapes slack-special chars (< > &)", () => {
+  const p = formatReviewForSlack(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: true,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [{ severity: "blocker", category: "type-error", message: "got <never> expected" }],
+            summary: "a & b",
+          },
+        ],
+      },
+    }),
+  );
+  const agentSection = p.blocks.find((b) => b.type === "section" && b.text?.text?.includes("claude"));
+  assert.ok(agentSection);
+  assert.match(agentSection.text.text, /&lt;never&gt;/);
+  assert.match(agentSection.text.text, /a &amp; b/);
+});
+
+test("formatReviewForSlack: severity-sorted top-3 + overflow count", () => {
+  const blockers = [
+    { severity: "nit", category: "style", message: "nit one" },
+    { severity: "blocker", category: "security", message: "block one" },
+    { severity: "minor", category: "dead-code", message: "minor one" },
+    { severity: "major", category: "regression", message: "major one" },
+    { severity: "blocker", category: "type-error", message: "block two" },
+  ];
+  const p = formatReviewForSlack(
+    mkInput({
+      outcome: {
+        verdict: "reject",
+        rounds: 1,
+        consensusReached: true,
+        results: [{ agent: "claude", verdict: "reject", blockers, summary: "" }],
+      },
+    }),
+  );
+  const section = p.blocks.find((b) => b.type === "section" && b.text?.text?.includes("claude"));
+  const txt = section.text.text;
+  const i1 = txt.indexOf("block one");
+  const i2 = txt.indexOf("block two");
+  const i3 = txt.indexOf("major one");
+  assert.ok(i1 < i2);
+  assert.ok(i2 < i3);
+  assert.match(txt, /\+2 more/);
+});
+
+test("formatReviewForSlack: footer context block has cost + episodic id", () => {
+  const p = formatReviewForSlack(mkInput({ totalCostUsd: 0.0345, episodicId: "ep-z" }));
+  const footer = p.blocks[p.blocks.length - 1];
+  assert.equal(footer.type, "context");
+  assert.match(footer.elements[0].text, /\$0\.0345/);
+  assert.match(footer.elements[0].text, /ep-z/);
+});
+
+test("formatReviewForSlack: dividers bracket the per-agent sections", () => {
+  const p = formatReviewForSlack(mkInput());
+  const dividers = p.blocks.filter((b) => b.type === "divider");
+  assert.equal(dividers.length, 2);
+});
+
+test("formatReviewForSlack: caps total blocks under 50", () => {
+  const many = [];
+  for (let i = 0; i < 60; i += 1) {
+    many.push({ agent: `a-${i}`, verdict: "approve", blockers: [], summary: "" });
+  }
+  const p = formatReviewForSlack(
+    mkInput({
+      outcome: {
+        verdict: "approve",
+        rounds: 1,
+        consensusReached: true,
+        results: many,
+      },
+    }),
+  );
+  assert.ok(p.blocks.length <= 50);
+});
+
+test("formatReviewForSlack: (no blockers) placeholder per agent", () => {
+  const p = formatReviewForSlack(mkInput());
+  const section = p.blocks.find((b) => b.type === "section" && b.text?.text?.includes("claude"));
+  assert.match(section.text.text, /no blockers/);
+});
+
+test("formatReviewForSlack: truncates section text at 2900 chars", () => {
+  const huge = "x".repeat(10_000);
+  const p = formatReviewForSlack(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: true,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [{ severity: "blocker", category: "security", message: huge }],
+            summary: "",
+          },
+        ],
+      },
+    }),
+  );
+  for (const b of p.blocks) {
+    if (b.text) assert.ok(b.text.text.length <= 2900, `block text too long: ${b.text.text.length}`);
+  }
+});

--- a/packages/integration-slack/test/notifier.test.mjs
+++ b/packages/integration-slack/test/notifier.test.mjs
@@ -1,0 +1,115 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { SlackNotifier } from "../dist/index.js";
+
+function mockFetch(response = { ok: true, status: 200, text: "ok" }) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init, body: JSON.parse(init.body) });
+    return {
+      ok: response.ok,
+      status: response.status,
+      text: async () => response.text,
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const baseInput = {
+  outcome: {
+    verdict: "approve",
+    rounds: 1,
+    consensusReached: true,
+    results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+  },
+  ctx: { diff: "", repo: "acme/app", pullNumber: 42, newSha: "abc" },
+  episodicId: "ep-s",
+  totalCostUsd: 0.01,
+};
+
+const GOOD_WEBHOOK = "https://hooks.slack.com/services/T000/B000/xxxx";
+
+test("SlackNotifier: missing webhook URL throws", () => {
+  const orig = process.env.SLACK_WEBHOOK_URL;
+  delete process.env.SLACK_WEBHOOK_URL;
+  try {
+    assert.throws(() => new SlackNotifier());
+  } finally {
+    if (orig !== undefined) process.env.SLACK_WEBHOOK_URL = orig;
+  }
+});
+
+test("SlackNotifier: non-hooks.slack.com URL throws", () => {
+  assert.throws(() => new SlackNotifier({ webhookUrl: "https://evil.example.com/wh" }));
+});
+
+test("SlackNotifier: POST + JSON body", async () => {
+  const f = mockFetch();
+  const n = new SlackNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: f });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls.length, 1);
+  assert.equal(f.calls[0].url, GOOD_WEBHOOK);
+  assert.equal(f.calls[0].init.method, "POST");
+  assert.equal(f.calls[0].init.headers["content-type"], "application/json");
+});
+
+test("SlackNotifier: default username + iconEmoji/iconUrl behavior", async () => {
+  const f = mockFetch();
+  const n = new SlackNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: f });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.username, "Ai-Conclave");
+  assert.equal(f.calls[0].body.icon_url, undefined);
+  assert.equal(f.calls[0].body.icon_emoji, undefined);
+});
+
+test("SlackNotifier: iconUrl wins over iconEmoji when both supplied", async () => {
+  const f = mockFetch();
+  const n = new SlackNotifier({
+    webhookUrl: GOOD_WEBHOOK,
+    fetch: f,
+    iconUrl: "https://example.com/img.png",
+    iconEmoji: ":robot_face:",
+  });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.icon_url, "https://example.com/img.png");
+  assert.equal(f.calls[0].body.icon_emoji, undefined);
+});
+
+test("SlackNotifier: iconEmoji used when iconUrl absent", async () => {
+  const f = mockFetch();
+  const n = new SlackNotifier({
+    webhookUrl: GOOD_WEBHOOK,
+    fetch: f,
+    iconEmoji: ":robot_face:",
+  });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.icon_emoji, ":robot_face:");
+});
+
+test("SlackNotifier: non-200 throws with status + body snippet", async () => {
+  const f = mockFetch({ ok: false, status: 400, text: "invalid_payload" });
+  const n = new SlackNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: f });
+  await assert.rejects(() => n.notifyReview(baseInput), /status 400.*invalid_payload/);
+});
+
+test("SlackNotifier: SLACK_WEBHOOK_URL env fallback", async () => {
+  const orig = process.env.SLACK_WEBHOOK_URL;
+  process.env.SLACK_WEBHOOK_URL = GOOD_WEBHOOK;
+  const f = mockFetch();
+  try {
+    const n = new SlackNotifier({ fetch: f });
+    await n.notifyReview(baseInput);
+    assert.equal(f.calls[0].url, GOOD_WEBHOOK);
+  } finally {
+    if (orig !== undefined) process.env.SLACK_WEBHOOK_URL = orig;
+    else delete process.env.SLACK_WEBHOOK_URL;
+  }
+});
+
+test("SlackNotifier: Notifier interface conformance", () => {
+  const n = new SlackNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: async () => ({ ok: true, status: 200, text: async () => "" }) });
+  assert.equal(n.id, "slack");
+  assert.equal(n.displayName, "Slack");
+  assert.equal(typeof n.notifyReview, "function");
+});

--- a/packages/integration-slack/tsconfig.json
+++ b/packages/integration-slack/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}


### PR DESCRIPTION
## Summary

Third `Notifier` implementation — rounds out the webhook-based surfaces alongside Discord. Equal-weight per decision #24.

Stacked on [#13](https://github.com/seunghunbae-3svs/ai-conclave/pull/13). Base = `scaffold/integration-discord`.

## Layout (Slack Block Kit)

```
┌─ section:  ✅ APPROVE — <pr-url|acme/app #42>
├─ context:  (optional "no consensus reached")
├─ divider
├─ section:  ✅ claude — approve
│            (no blockers) / LGTM
├─ section:  …per agent…
├─ divider
└─ context:  cost $0.0153 · episodic ep-abc...
```

Fallback `text` field populated for mobile push notifications (Block Kit doesn't render there).

## Slack-specific handling

| Concern | Handling |
|---|---|
| Escaping | `< > &` on user-supplied strings (Slack mrkdwn entity rules differ from Telegram HTML) |
| PR URL | Rendered as `<url|label>` mrkdwn link |
| Truncation | block text ≤ 2900, top-level text ≤ 1000, ≤ 50 blocks |
| URL validation | Rejects anything outside `hooks.slack.com/services/…` |
| Icon | `iconUrl` wins over `iconEmoji` when both supplied |

## Config

```json
{
  "integrations": {
    "slack": {
      "enabled": true,
      "webhookUrl": "https://hooks.slack.com/services/…",
      "username": "Conclave Bot",
      "iconEmoji": ":robot_face:"
    }
  }
}
```

Env fallback: `SLACK_WEBHOOK_URL`.

## Tests — 19 cases

### `format.test.mjs` (10)
Text fallback with verdict + repo, mrkdwn link for prUrl, no-consensus context, special-char escape, severity-sorted top-3 + `+N more`, footer cost + id, dividers bracket sections, 50-block cap with 60 agents, no-blockers placeholder, 2900-char truncation.

### `notifier.test.mjs` (9)
Missing URL throws, non-Slack URL throws, POST + `content-type: application/json`, default username `Ai-Conclave`, `iconUrl` wins over `iconEmoji`, `iconEmoji` alone, non-200 throws with body snippet, `SLACK_WEBHOOK_URL` env fallback, Notifier interface conformance.

## Status — decision #24 coverage

- ✅ Telegram (PR #11)
- ✅ Discord (PR #13)
- ✅ Slack (this PR)
- □ Email (last of the four; same write-only pattern via SMTP or transactional API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)