### PR TITLE
feat(integration-email): Email notifier with pluggable transport (decision #24 complete)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      # No `cache: pnpm` yet — lockfile lands after first successful install.
+      # Swap to `pnpm install --frozen-lockfile` + cache once pnpm-lock.yaml is committed.
+      - run: pnpm install
+      - run: pnpm typecheck
+      - run: pnpm build
+      - run: pnpm test

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,229 @@
+# Ai-Conclave Architecture
+
+**Status:** architecture finalized 2026-04-19. Decisions 1–34 are locked; do
+not re-litigate without explicit reopen. This document is the source of
+truth for scaffolding.
+
+## Product
+
+- **Brand**: Ai-Conclave (hero display may be stylized `Con{claude}ve`)
+- **npm scope**: `@ai-conclave` (fallbacks: `conclaveai`, `ai-conclave-io`)
+- **CLI binary**: `conclave`
+- **Positioning (α)**: *"AI drafted. Council refined."*
+- **Tagline**: *A multi-agent council reviews your AI-generated code and
+  design, debates issues, auto-fixes blockers, and learns your preferences
+  over time. Built for solo makers who ship with AI.*
+- **Target persona**: users of Cursor / Claude Code / Windsurf / v0 /
+  Lovable / Bolt whose AI-generated output is mediocre, off-style, or
+  needs human polish. Not seasoned engineers polishing their own code.
+
+## 7-Layer Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Layer 1 — USER SURFACE (equal weight, any subset)          │
+│  CLI · Web · VSCode · Telegram · Discord · Slack · Email    │
+└───────────────────────────┬─────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│  Layer 2 — EFFICIENCY GATE (every LLM call routes through)  │
+│  cache · triage · budget · compact · route · metrics        │
+└───────────────────────────┬─────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│  Layer 3 — DECISION CORE                                    │
+│  Council (Mastra graph, N pluggable agents)                 │
+│  Tool-use loops (Claude Agent SDK + OpenAI Agents SDK)      │
+│  Structured I/O (Zod schemas, MCP protocol)                 │
+│  Scoring (Build 40% / Review 30% / Time 20% / Rework 10%)   │
+└────────┬────────────────────────────────┬───────────────────┘
+         ↕                                ↕
+┌────────────────────────┐  ┌────────────────────────────────┐
+│  Layer 4 — AGENTS      │  │  Layer 5 — INFRASTRUCTURE      │
+│  @ai-conclave/agent-*  │  │  scm / platform / integration  │
+│  (pluggable npm pkgs)  │  │  packages                      │
+│  claude, openai,       │  │  GitHub/Vercel/Netlify/...     │
+│  gemini, grok,         │  │  Telegram/Discord/Slack/Email  │
+│  deepseek, qwen,       │  │                                │
+│  bedrock, vertex,      │  │                                │
+│  cheetah (Triton),     │  │                                │
+│  ollama (local),       │  │                                │
+│  custom user-authored  │  │                                │
+└────────────────────────┘  └────────────────────────────────┘
+         ↕                                ↕
+┌────────────────────────┐  ┌────────────────────────────────┐
+│  Layer 6 —             │  │  Layer 7 — OBSERVABILITY       │
+│  SELF-EVOLVE           │  │  Langfuse self-hosted          │
+│  (정답지 + 오답지)     │  │  per-PR trace                  │
+│  episodic (90d)        │  │  cache hit rate                │
+│  answer-keys (∞)       │  │  cost + tokens per call        │
+│  failure-catalog (∞)   │  │  precision/recall per category │
+│  semantic rules        │  │  agent scores over time        │
+│  procedural playbooks  │  │  budget compliance             │
+│  federated baseline    │  │                                │
+│  (hash+cat, DP)        │  │                                │
+└────────────────────────┘  └────────────────────────────────┘
+```
+
+## Self-Evolve Substrate (정답지/오답지 duality — the moat)
+
+```
+packages/core/src/memory/
+├── episodic/                      # raw event log, 90d TTL
+│   └── YYYY-MM-DD/pr-{n}.json
+├── answer-keys/ (정답지)          # ★ SUCCESS PATTERNS
+│   ├── code/{by-pattern,by-user,by-repo}/
+│   └── design/{by-pattern,by-component}/
+├── failure-catalog/ (오답지)      # ★ FAILURE PATTERNS
+│   ├── code/by-category/{type-errors,missing-tests,regression,security,...}
+│   └── design/{accessibility-fails,contrast-fails,...}
+├── semantic/rules.json            # extracted rules (nightly Haiku compression)
+├── procedural/playbooks.md        # promoted how-to (weekly)
+└── federated-sync/                # cross-user (hash+category ONLY)
+    ├── answer-keys-baseline/
+    └── failure-baseline/
+```
+
+**Training loop:**
+- Merge → write to answer-keys (positive)
+- Reject → write to failure-catalog (negative)
+- Rework → failure (1st version) + answer-key (final accepted)
+- Every review READS: top-K answer-keys + top-K failures + procedural
+  rules + federated baseline signal (RAG into system prompt)
+- Nightly: episodic → classify into catalogs (Haiku, cheap)
+- Weekly: catalog → semantic rules
+- Monthly: semantic → procedural + federated sync
+
+## Efficiency Gate (day-1 requirement)
+
+```
+packages/core/src/efficiency/
+├── cache.ts        # Anthropic prompt-cache 5-min TTL aware scheduling
+├── compact.ts      # Round-to-round context compression (Haiku summary)
+├── triage.ts       # Small/simple PR → lite path (single agent)
+│                   # Complex PR → full council (3-round)
+├── budget.ts       # Hard cost caps: per-PR default $0.50
+├── relevance.ts    # Selective context (diff + import graph)
+├── router.ts       # Model by input size (Haiku / Sonnet / Gemini 2.5 Pro)
+└── metrics.ts      # Per-call cost/tokens/latency → Langfuse
+```
+
+**All LLM calls route through efficiency gate. Direct SDK calls forbidden.**
+
+Expected (compounded): $0.50 default PR budget → $0.08–0.15 actual average.
+
+## Scoring (ported from solo-cto-agent)
+
+Rolling weighted score per agent:
+- Build pass rate: 40%
+- Review approval rate: 30%
+- Time to resolution: 20%
+- Rework frequency: 10%
+
+Plus new metrics:
+- Precision / recall per blocker category (per agent)
+- Cache hit rate (efficiency)
+- Cost per PR (budget compliance)
+
+## Tech Stack (locked)
+
+| Purpose | Tech |
+|---|---|
+| Language | TypeScript (strict) |
+| Monorepo | pnpm workspaces + turbo |
+| Orchestration | **Mastra** (TS-native multi-agent) |
+| Claude agent loop | `@anthropic-ai/claude-agent-sdk` (official TS) |
+| OpenAI agent loop | `@openai/agents` v0.8.x (official TS) |
+| Gemini | `@google/genai` with 2.5 Pro (long-context slot) |
+| Structured output | Zod → JSON Schema + per-provider adapter |
+| Tool protocol | MCP (filesystem, Figma Dev Mode, GitHub, custom) |
+| Observability | **Langfuse self-hosted** |
+| Workflow engine | GitHub Actions (Trigger.dev v3 fallback only if 6h hit) |
+| Visual diff | `odiff` + Playwright + vision-model semantic judge |
+| Plugin loading | `cosmiconfig` + dynamic `import()` |
+
+## Monorepo Layout
+
+```
+ai-conclave/
+├── package.json                  # pnpm workspace root
+├── pnpm-workspace.yaml
+├── turbo.json
+├── tsconfig.base.json
+├── README.md
+├── ARCHITECTURE.md               # this doc
+├── LICENSE
+├── packages/
+│   ├── core/                     # @ai-conclave/core
+│   │   └── src/
+│   │       ├── agent.ts          # Agent interface
+│   │       ├── council.ts        # Mastra-based N-agent graph
+│   │       ├── schema/           # Zod schemas
+│   │       ├── memory/           # self-evolve 정답지/오답지
+│   │       ├── efficiency/       # cache/triage/budget/compact/route
+│   │       ├── scoring/          # ported from solo-cto-agent
+│   │       ├── guards.ts         # anti-loop + circuit breaker
+│   │       └── registry.ts       # plugin registration
+│   ├── agent-claude/             # wraps @anthropic-ai/claude-agent-sdk
+│   ├── agent-openai/             # wraps @openai/agents          (v2.1)
+│   ├── agent-gemini/             # (v2.1)
+│   ├── agent-{grok,deepseek,qwen,bedrock,vertex,cheetah,ollama}/ (v2.1)
+│   ├── scm-github/               # v2.0
+│   ├── scm-{gitlab,bitbucket,gitea}/                              (v2.1)
+│   ├── platform-{vercel,netlify,railway,cloudflare,fly,render,
+│   │              replit,vertex-deploy,docker-local,
+│   │              deployment-status}/
+│   ├── integration-{telegram,discord,slack,email}/
+│   ├── cli/                      # @ai-conclave/cli, binary `conclave`
+│   └── orchestrator-template/    # GitHub Actions YAML templates
+├── apps/
+│   ├── web-dashboard/            # v2.1 — cost/trace viz
+│   └── vscode-extension/
+└── docs/
+```
+
+## End-to-End Pipeline
+
+1. **Intent Capture** — CLI / Telegram / Discord / Web / IDE → raw NL
+2. **Intent Parse** — router agent (Haiku) → structured Intent (Zod)
+3. **Work Dispatch** — SCM labeled issue OR direct dispatch
+4. **Worker Execution** — tool-use loop → PR with commits (reads
+   answer-keys + procedural memory for style)
+5. **Council Consensus** — 3-round debate (or early-exit). Each agent
+   reads answer-keys + failure-catalog + federated baseline as RAG
+6. **Rework Loop** — on blocker: rework agent → commits → re-review
+   (bounded by maxRounds + circuit breaker)
+7. **Visual Verify** — resolve preview URL (any platform) → Playwright +
+   odiff → vision-model semantic judgment → attach to PR + notifications
+8. **Delivery** — consolidated message to configured channels, action
+   buttons
+9. **Merge + Final Notify** — GitHub auto-merge on CI green
+10. **Learning** — outcome writes to episodic → nightly classify → weekly
+    extract rules → monthly federate
+
+## Migration From solo-cto-agent
+
+Port directly (no redesign):
+- `failure-catalog.json` (ERR-001~) → seed `failure-catalog/code/`
+- Agent scoring weights → `scoring/` package
+- Anti-loop 7-layer guards → `guards.ts` middleware
+- Circuit breaker → `guards.ts`
+- `diff-guard.js` secret detection → new `secret-guard/` package
+- Orchestrator workflow templates → `orchestrator-template/`
+
+solo-cto-agent 1.4.x stays on npm in maintenance (security fixes only).
+`conclave migrate` CLI at v2.0 RC.
+
+## Novelty Self-Assessment (locked)
+
+- Individual features: 4.5/10 (prior art exists)
+- Architectural sophistication: **8.5/10**
+- Self-evolve as moat (정답지/오답지 duality + federated): **9/10**
+- Overall product thesis: **8.5/10**
+- Execution risk pulls shipped value: TBD
+
+**Differentiators (priority order):**
+1. 정답지 + 오답지 dual catalog as RLHF-like substrate without fine-tuning
+2. Efficiency gate built in from day 1 (most multi-agent systems die from cost)
+3. Architectural coherence (all 7 layers woven, not bolted-on)
+4. Pluggable agents including self-hosted Triton-based + local Ollama

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,39 @@
     flows, response_format shape assertion, refusal throw, invalid-JSON
     throw, invalid-verdict throw, no-key constructor throw, metrics
     aggregation, pre-flight budget short-circuits the network call.
+- **Legacy failure-catalog seeding** (decision #18: port solo-cto-agent's
+  `failure-catalog.json` directly; do not start from zero):
+  - `LegacyCatalogSchema` + `LegacyEntrySchema` (Zod) validate the
+    solo-cto-agent shape.
+  - `mapLegacyCategory` — heuristic mapper from free-form legacy
+    category + pattern + description to the 11 canonical enum values.
+    Priority-ordered regex: type-error → missing-test → schema-drift →
+    security → accessibility → contrast → performance → dead-code →
+    regression → api-misuse → other.
+  - `toFailureEntry(legacy, opts)` produces a canonical `FailureEntry`
+    with a stable `id` (`fc-legacy-<legacyId>-<hash>` keyed on pattern),
+    tags = `[legacyCategory, "legacy", "solo-cto-agent"]` by default,
+    body = `<description> Fix: <fix>`.
+  - `seedFromLegacyCatalog(rawJson, store, opts)` parses + derives +
+    writes. `{ write: false }` returns entries without touching the
+    store. `createdAt` inherits the catalog's `updated_at` normalized to
+    ISO (YYYY-MM-DD → `T00:00:00.000Z`).
+  - `seedFromLegacyCatalogPath(path, store, opts)` reads from disk.
+  - **Bundled catalog** — `packages/core/src/memory/seeds/solo-cto-agent-failure-catalog.json`
+    ships with `@ai-conclave/core`. Post-build script
+    (`scripts/copy-seeds.mjs`) mirrors `src/memory/seeds/` →
+    `dist/memory/seeds/` since tsc does not copy non-TS files.
+  - **New CLI command `conclave seed [--from <path>]`** — zero-config
+    seeding from the bundled catalog, or custom path. Prints
+    per-category count (type-error=X, schema-drift=Y, ...) for auditing.
+  - 15 test cases (`seeder.test.mjs`): 7 mapping rules (type-error,
+    schema-drift, performance, dead-code, security, api-misuse, other
+    fallback), id stability across calls, tag merge with legacy
+    category + extras, body format, LegacyCatalogSchema accepts real
+    shape + rejects wrong version, write round-trip + byCategory
+    correctness, `{ write: false }` no-op, createdAt normalization from
+    YYYY-MM-DD to ISO, bundled catalog smoke test (15 entries all tagged
+    "solo-cto-agent").
 - **`@ai-conclave/integration-telegram`** — first notification surface
   (decision #24 — Telegram / Discord / Slack / Email are equal-weight;
   none is hero):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,30 @@
     flows, response_format shape assertion, refusal throw, invalid-JSON
     throw, invalid-verdict throw, no-key constructor throw, metrics
     aggregation, pre-flight budget short-circuits the network call.
+- **`@ai-conclave/observability-langfuse`** — first observability sink
+  (decision #13 — self-hosted Langfuse):
+  - `LangfuseMetricsSink` implements core's `MetricsSink`. Each per-call
+    metric becomes a Langfuse `generation` with name = `review.<agent>`,
+    model, input/output tokens, totalCost, cacheHit + latency in
+    metadata, start/end times derived from `timestamp - latencyMs`.
+  - Self-hosted is the intended deployment (baseUrl override); cloud
+    identical. LANGFUSE_PUBLIC_KEY + LANGFUSE_SECRET_KEY required.
+  - Fire-and-forget on `record()` per the synchronous MetricsSink
+    contract; Langfuse SDK's internal queue handles HTTP. Errors
+    captured + logged to stderr so observability failures never kill
+    the review.
+  - `setTraceId(id)` groups all metrics in a single review under one
+    Langfuse trace. `flush()` / `shutdown()` for clean exit.
+  - CLI integration: new `observability.langfuse.{enabled, baseUrl?}`
+    config block. `conclave review` wires the sink when
+    `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` env are set; trace
+    id = `conclave-<owner>-<repo>-<pr>-<sha8>`. Sink flushed before
+    process exit.
+  - 10 sink tests: generation params mapping, metadata for cacheHit +
+    latency, start/end time derivation, traceId static + dynamic
+    (setTraceId between records), error-swallowing on client throw,
+    flush + shutdown paths (shutdownAsync preferred, flushAsync
+    fallback), lazy one-shot client factory init.
 - **`@ai-conclave/scm-github`** — GitHub SCM adapter + automatic outcome
   capture (closes the manual `record-outcome` gap):
   - `fetchPrState(repo, prNumber)` wraps `gh pr view` to resolve current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,31 @@
     flows, response_format shape assertion, refusal throw, invalid-JSON
     throw, invalid-verdict throw, no-key constructor throw, metrics
     aggregation, pre-flight budget short-circuits the network call.
+- **`@ai-conclave/integration-slack`** — third notification surface
+  (decision #24, Block Kit format, webhook-based same as Discord):
+  - `SlackNotifier` implements `Notifier`. Posts to a Slack incoming
+    webhook using Block Kit layout (section + context + divider blocks).
+  - URL validation restricts to `https://hooks.slack.com/services/...`.
+  - Header section links to PR URL with Slack mrkdwn `<url|text>`
+    syntax when supplied.
+  - Per-agent sections show top-3 severity-sorted blockers + summary.
+  - Footer context block carries cost + episodic id.
+  - Fallback top-level `text` mirrors verdict + repo for mobile push
+    notifications (where Block Kit won't render).
+  - Slack-specific escaping for `< > &` on user-supplied strings.
+  - Auto-truncates at Slack limits: block text 2900 chars, top-level
+    text 1000 chars, ≤ 50 blocks total.
+  - CLI `integrations.slack.{enabled, webhookUrl, username, iconUrl,
+    iconEmoji}`. Env fallback: `SLACK_WEBHOOK_URL`. `iconUrl` wins over
+    `iconEmoji` when both supplied.
+  - 19 test cases across `format` (text fallback, mrkdwn link, no-
+    consensus context, special-char escape, severity-sorted top-3 +
+    `+N more`, footer cost+id, dividers bracket sections, 50-block cap,
+    no-blockers placeholder, 2900-char truncation) and `notifier`
+    (missing URL throws, non-Slack URL throws, POST + JSON shape,
+    default username, iconUrl wins + iconEmoji alone, non-200 throw
+    with body, SLACK_WEBHOOK_URL env fallback, Notifier interface
+    conformance).
 - **`@ai-conclave/integration-discord`** — second notification surface
   (decision #24, same `Notifier` pattern as Telegram):
   - `DiscordNotifier` implements `Notifier`. Posts to an incoming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,24 @@
 - `ARCHITECTURE.md`: locked 7-layer design for the council, efficiency gate,
   self-evolve substrate (정답지 + 오답지), and migration path from solo-cto-agent.
 - GitHub Actions CI: typecheck + build + test on push/PR.
+- **Efficiency Gate** (`@ai-conclave/core/efficiency`) per decision #22 —
+  first-class from day 1. Every LLM call must route through
+  `EfficiencyGate.run(...)`; direct SDK calls are forbidden by contract.
+  - `PromptCache` — Anthropic 5-min TTL aware scheduler (sha256-keyed, LRU-evicted).
+  - `BudgetTracker` — $0.50 default per-PR cap (decision #20), throws
+    `BudgetExceededError` on reserve-beyond-cap, warning handler at 80% default.
+  - `triageReview` — lite (single agent) vs full (3-round council) classification.
+    Risky paths (schema / migrations / auth / payments / `.sql` / prisma) always
+    force full regardless of size.
+  - `selectModel` — input-size routing: Haiku ≤ 8k tokens → Sonnet ≤ 50k →
+    Gemini 2.5 Pro for long-context slot (override-able).
+  - `compact` — round-to-round context compression (summarizer injected;
+    pinned-message preservation; newest-first fit under budget).
+  - `buildRelevanceContext` — diff + test-file + direct-import graph walk
+    under a token budget (safe defaults when `readFile` / `importsOf` omitted).
+  - `MetricsRecorder` — per-call cost / tokens / latency / cache-hit with
+    per-agent + per-model aggregation; pluggable external sink for Langfuse.
+  - `EfficiencyGate.run(...)` — orchestrates reserve → route → cache-check →
+    execute → mark → commit → record in a single call.
+- Test coverage (`node --test`): 9 files, 45+ test cases across all
+  efficiency modules and Council outcome logic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,23 @@
     blockers), invalid response shapes, budget enforcement, cache_control
     wire-format, tool_choice wire-format, missing-key constructor guard,
     metrics aggregation on shared gate.
+- **Memory substrate** (`@ai-conclave/core/memory`) per decision #17 —
+  정답지 / 오답지 dualism as the core primitive.
+  - Zod schemas for `EpisodicEntry`, `AnswerKey`, `FailureEntry`, `SemanticRule`
+    with enum-validated domains (code / design), severity, and 11 failure categories.
+  - `MemoryStore` interface (read + write + list) with a `FileSystemMemoryStore`
+    implementation. Layout: `episodic/YYYY-MM-DD/pr-{n}.json` + `answer-keys/{domain}/{id}.json` +
+    `failure-catalog/{domain}/{id}.json` + `semantic/rules.jsonl`. Lazy mkdir on
+    write; missing dirs return `[]` on read.
+  - Lightweight BM25-ish retrieval (keyword overlap + tag boost + repo boost)
+    for the RAG path. No vector DB — corpus is O(100s), short text, keyword + tag
+    ranking is sufficient to pilot the self-evolve loop. Vector embeddings slot
+    in later as a pluggable scoring backend.
+  - `formatAnswerKeyForPrompt` / `formatFailureForPrompt` helpers produce the
+    short string form that agent-claude's `ReviewContext.answerKeys` / `failureCatalog`
+    arrays expect — integration is already wired (no agent-claude change needed).
+  - 23 test cases across schema validation (enum domains + categories), retrieval
+    (query match, tag boost, repo boost, stop-word filter, Korean tokens,
+    k respect, empty cases), and FS store round-trip (answer-keys, failures,
+    rules JSONL append, episodic day-bucketing, missing-dir tolerance, domain
+    filter, default k = 8).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,28 @@
     k respect, empty cases), and FS store round-trip (answer-keys, failures,
     rules JSONL append, episodic day-bucketing, missing-dir tolerance, domain
     filter, default k = 8).
+- **`conclave review` is now end-to-end functional** — glues core + gate +
+  memory + agent-claude through the CLI:
+  - `conclave review --pr N` — fetches the PR diff + metadata via `gh pr diff`
+    and `gh pr view`; review context includes the real repo slug, PR number,
+    head SHA, and base SHA.
+  - `conclave review --diff <file>` — reviews a local unified-diff file.
+  - `conclave review` (no flag) — `git diff <base>..HEAD` (default base
+    `origin/main`), parses the repo slug from `git remote get-url origin`.
+  - Config auto-discovery: walks up from cwd looking for `.conclaverc.json`,
+    validates with Zod, merges over defaults. Memory root resolved relative
+    to the config directory unless absolute.
+  - RAG wired: retrieves top-K answer-keys + failures from
+    `FileSystemMemoryStore`, formats via `formatAnswerKeyForPrompt` /
+    `formatFailureForPrompt`, threads them into `ReviewContext`.
+  - Efficiency gate uses config-driven `budget.perPrUsd`; warning callback
+    prints to stderr at 80% cap.
+  - Output: pretty-printed per-agent verdict + blockers (severity-sorted) +
+    summary + metrics block (calls / tokens / cost / latency / cache hit rate).
+  - Exit codes: 0 (approve) / 1 (rework) / 2 (reject) for CI-friendly
+    scripting.
+  - 22 test cases across config loading (defaults, walk-up, malformed JSON,
+    schema-invalid), diff-source (https/ssh/no-git URL parsing, gh pr
+    happy path + missing-owner throw, git-diff with/without remote, file
+    diff), and output rendering (all verdicts, severity sort, no-consensus
+    tag, metrics formatting, exit-code mapping).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,40 @@
     flows, response_format shape assertion, refusal throw, invalid-JSON
     throw, invalid-verdict throw, no-key constructor throw, metrics
     aggregation, pre-flight budget short-circuits the network call.
+- **`@ai-conclave/integration-telegram`** — first notification surface
+  (decision #24 — Telegram / Discord / Slack / Email are equal-weight;
+  none is hero):
+  - `Notifier` interface added to `@ai-conclave/core`
+    (`notifyReview(input)` contract). Pluggable — any future integration
+    package implements this.
+  - `TelegramClient`: thin native-fetch wrapper over Bot API sendMessage.
+    No SDK dep; sub-200 lines; injectable `fetch` for tests.
+  - `TelegramNotifier`: implements `Notifier`. Builds HTML-mode message
+    with per-agent verdict + top-3 blockers (severity-sorted) + summary
+    + footer (cost + episodic id). Inline action buttons emit
+    `callback_data = "ep:<id>:<outcome>"` — future callback handler can
+    call `OutcomeWriter.recordOutcome` directly.
+  - Message formatter (`formatReviewForTelegram`): HTML-escapes `& < >`,
+    links to PR URL when supplied, truncates to 4090 chars, shows
+    `+N more` when blocker count exceeds 3.
+  - CLI integration: new `.conclaverc.json` `integrations.telegram.{enabled, chatId, includeActionButtons}` block.
+    `conclave review` fires the notifier after deliberation. Failures
+    never affect the verdict exit code.
+  - Env: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`. Missing credentials
+    skip with stderr warning unless `integrations.telegram.enabled: true`
+    is explicitly set — then it errors.
+  - 21 test cases (`format`, `client`, `notifier`): HTML emoji header,
+    PR URL anchor, HTML-special-char escaping (`<never>` → `&lt;never&gt;`,
+    `a & b` → `a &amp; b`), severity-sorted top-3 + "+N more" counter,
+    no-consensus tag, footer cost+id, 4096-char truncation, (no
+    blockers) placeholder; `TelegramClient` rejects empty token, POST
+    request shape assertion, `ok:false` throws with description + code,
+    non-JSON response throws with status + snippet, baseUrl override;
+    `TelegramNotifier` missing-token + missing-chatId throws,
+    numeric-string chat id coercion, HTML parse_mode + disable_web_page_preview,
+    inline keyboard present by default, includeActionButtons:false
+    omits reply_markup, env fallback for TELEGRAM_BOT_TOKEN +
+    TELEGRAM_CHAT_ID, `Notifier` interface conformance.
 - **`@ai-conclave/observability-langfuse`** — first observability sink
   (decision #13 — self-hosted Langfuse):
   - `LangfuseMetricsSink` implements core's `MetricsSink`. Each per-call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,3 +146,33 @@
     flows, response_format shape assertion, refusal throw, invalid-JSON
     throw, invalid-verdict throw, no-key constructor throw, metrics
     aggregation, pre-flight budget short-circuits the network call.
+- **`@ai-conclave/agent-gemini`** — third council voice, long-context slot
+  (decision #10: Gemini 2.5 Pro as the >50K input tokens handler, flash
+  as triage. Deep Think skipped as Ultra-tier overkill):
+  - `GeminiAgent` wraps `@google/genai` via a minimal `GenAILike` client
+    interface. Lazy-loaded default factory.
+  - Structured output via `config.responseMimeType: "application/json"`
+    + `config.responseSchema` in OpenAPI-3-subset shape (Gemini
+    specifics: no `additionalProperties`; nullable via `nullable: true`).
+  - Cacheable prefix sent as `systemInstruction` — Gemini's context
+    cache bills the system part separately (75% discount on 2.5 family).
+  - Same efficiency-gate contract: pre-flight reserve, cache-liveness
+    mark, `actualCost(model, usage)` via `usageMetadata.cachedContentTokenCount`,
+    per-call metric.
+  - Env resolution: `GOOGLE_API_KEY` first, `GEMINI_API_KEY` fallback.
+  - Pricing table for `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.0-flash`
+    with max-context-tokens metadata for router use.
+  - Parser handles empty content with finishReason surfaced, invalid
+    JSON, invalid verdict, malformed blockers dropped individually.
+  - CLI `conclave review` instantiates Gemini when `config.agents`
+    includes `"gemini"` and `GOOGLE_API_KEY` / `GEMINI_API_KEY` is set;
+    otherwise skips with a stderr warning.
+  - 17 test cases across `pricing.test.mjs` (tiers present, baseline,
+    75% cached discount on 2.5-pro, 8× flash/pro ratio, unknown-model
+    throw, pre-flight estimate, `maxContextTokens` populated) and
+    `gemini-agent.test.mjs` (approve + rework flows, malformed blocker
+    drops, responseMimeType + responseSchema wire assertions,
+    systemInstruction parts shape, cached-token cost discount,
+    empty-text-with-finishReason throw, invalid-JSON throw,
+    invalid-verdict throw, no-key constructor throw, GEMINI_API_KEY
+    fallback when GOOGLE_API_KEY unset, pre-flight budget short-circuit).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,24 @@
     execute → mark → commit → record in a single call.
 - Test coverage (`node --test`): 9 files, 45+ test cases across all
   efficiency modules and Council outcome logic.
+- **Real Claude review loop** in `@ai-conclave/agent-claude`:
+  - `ClaudeAgent.review(ctx)` now issues a real `messages.create` call via
+    the injected (or lazy-loaded) `@anthropic-ai/sdk` client.
+  - Single-tool pattern (`tool_choice: { type: "tool", name: "submit_review" }`)
+    forces structured output — no free-form parsing.
+  - System prompt + RAG prefix sent as a cache-controlled ephemeral block
+    so repeat calls within 5 minutes hit Anthropic's prompt cache (~90%
+    input-cost savings on the prefix).
+  - All SDK calls route through `EfficiencyGate.run(...)`: pre-flight budget
+    reserve (throws before the network call), cache-liveness tracking,
+    actual-cost metering via `actualCost(model, usage)`, per-call metrics.
+  - `PRICING` table covers Sonnet 4.6 / Haiku 4.5 / Opus 4.7 with standard,
+    cache-write, and cache-read rates. `estimateCallCost` is pessimistic
+    (no cache assumed) for safe pre-flight reservation.
+  - Parser tolerates malformed blockers (drops invalid entries instead of
+    failing the whole review), throws on missing `submit_review` tool_use
+    block or invalid verdict.
+  - Agent-claude tests (16 cases): happy verdicts (approve / rework with
+    blockers), invalid response shapes, budget enforcement, cache_control
+    wire-format, tool_choice wire-format, missing-key constructor guard,
+    metrics aggregation on shared gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,35 @@
     flows, response_format shape assertion, refusal throw, invalid-JSON
     throw, invalid-verdict throw, no-key constructor throw, metrics
     aggregation, pre-flight budget short-circuits the network call.
+- **`@ai-conclave/integration-email`** — fourth notification surface,
+  completes decision #24's equal-weight set (CLI + Telegram + Discord +
+  Slack + Email):
+  - `EmailNotifier` implements `Notifier` using a pluggable
+    `EmailTransport` interface. Default transport = `ResendTransport`
+    (Resend REST API via native fetch; no SDK dependency).
+  - Swap transports for SMTP (nodemailer) / SES / Postmark / SendGrid /
+    Mailgun by passing `opts.transport` — the transport interface is
+    `{ id, send({ from, to, subject, text, html }) }`.
+  - Renders BOTH plaintext AND HTML bodies from the same source
+    (`renderEmail(input)`). HTML uses inline styles only; no `<style>`
+    blocks, no external stylesheets, email-client safe.
+  - Subject: `[conclave] VERDICT — repo #N` (override with
+    `subjectOverride`). Color-coded HTML headline (green/amber/red).
+    HTML escapes `< > & "`.
+  - Env: `RESEND_API_KEY` (default transport), `CONCLAVE_EMAIL_FROM`,
+    `CONCLAVE_EMAIL_TO` (comma-separated multi-recipient support).
+  - CLI `integrations.email.{enabled, from, to, subjectOverride}`.
+    Single recipient (string) or array accepted.
+  - 21 test cases across `format` (subject format with + without PR,
+    text body lines, no-consensus tag, severity-sorted top-5 + `+N
+    more`, footer cost + episodic id, HTML inline-styles-only
+    enforcement, HTML-special-char escape, HTML PR link, color-coded
+    verdict, no-blockers placeholder in both bodies) and `notifier`
+    (missing RESEND_API_KEY throws, Resend POST wire shape, `to` array
+    passthrough, non-200 throw; missing from + missing to throws,
+    comma-separated env fallback, subjectOverride wins, custom
+    transport plugs in, text + html both sent, Notifier interface
+    conformance).
 - **`@ai-conclave/integration-slack`** — third notification surface
   (decision #24, Block Kit format, webhook-based same as Discord):
   - `SlackNotifier` implements `Notifier`. Posts to a Slack incoming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+### Added
+- Monorepo skeleton (pnpm workspaces + turbo).
+- `@ai-conclave/core`: `Agent` / `Council` interfaces + Zod schemas.
+- `@ai-conclave/agent-claude`: Claude agent skeleton implementing `Agent`.
+- `@ai-conclave/cli`: `conclave` binary with `init` and `review` commands (skeleton).
+- `ARCHITECTURE.md`: locked 7-layer design for the council, efficiency gate,
+  self-evolve substrate (정답지 + 오답지), and migration path from solo-cto-agent.
+- GitHub Actions CI: typecheck + build + test on push/PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,31 @@
     flows, response_format shape assertion, refusal throw, invalid-JSON
     throw, invalid-verdict throw, no-key constructor throw, metrics
     aggregation, pre-flight budget short-circuits the network call.
+- **`@ai-conclave/integration-discord`** — second notification surface
+  (decision #24, same `Notifier` pattern as Telegram):
+  - `DiscordNotifier` implements `Notifier`. Posts to an incoming
+    webhook — simpler than bot API (no token, no chat id — just the
+    webhook URL).
+  - URL validation: only accepts
+    `https://discord.com/api/webhooks/…` or `discordapp.com` hosts.
+  - Embed payload with color-coded verdict (green approve / amber
+    rework / red reject), per-agent field showing top-3
+    severity-sorted blockers + summary, footer with cost + episodic id,
+    ISO timestamp. Auto-truncates title (256), description (4096),
+    per-field value (1024), and caps at 24 agent-fields to stay under
+    Discord's 25-field limit.
+  - CLI `integrations.discord.{enabled, webhookUrl, username, avatarUrl}`.
+    Env fallback: `DISCORD_WEBHOOK_URL`. Missing URL with explicit
+    `enabled: true` → hard error. Otherwise skip with stderr warning.
+  - 22 test cases across `format` (color per verdict, PR URL link,
+    no-consensus tag, severity-sorted top-3 + `+N more`, file:line
+    rendering, field-value truncation, footer cost+id, timestamp,
+    no-blockers placeholder, 24-field cap with overflow) and `notifier`
+    (missing URL throw, non-Discord URL throw, both discord.com /
+    discordapp.com accepted, POST + JSON content-type shape, default
+    username Ai-Conclave, username override, avatarUrl propagation,
+    non-200 throws with status + snippet, DISCORD_WEBHOOK_URL env
+    fallback, Notifier interface conformance).
 - **Legacy failure-catalog seeding** (decision #18: port solo-cto-agent's
   `failure-catalog.json` directly; do not start from zero):
   - `LegacyCatalogSchema` + `LegacyEntrySchema` (Zod) validate the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,36 @@
     flows, response_format shape assertion, refusal throw, invalid-JSON
     throw, invalid-verdict throw, no-key constructor throw, metrics
     aggregation, pre-flight budget short-circuits the network call.
+- **`@ai-conclave/scm-github`** — GitHub SCM adapter + automatic outcome
+  capture (closes the manual `record-outcome` gap):
+  - `fetchPrState(repo, prNumber)` wraps `gh pr view` to resolve current
+    state / merge SHA / head SHA / updatedAt. No GitHub token needed in
+    conclave's config — relies on `gh auth login` which `conclave
+    review --pr N` already requires.
+  - `classifyTransition(state, reviewedSha)` maps live PR state to the
+    outcome vocabulary used by `OutcomeWriter.recordOutcome`:
+    merged → `merged`, closed w/o merge → `rejected`, open with new head
+    commits since review → `reworked`, open with unchanged head →
+    `pending`.
+  - `pollOutcomes({ store, writer })` walks pending episodic entries,
+    fetches each PR's state, applies classification + writes catalog
+    records. gh errors per-PR are counted and surfaced without aborting
+    the scan.
+  - `MemoryStore.listEpisodic()` added; FS implementation walks
+    `episodic/*/` buckets. Required by the pending-entry filter so
+    polling is a single pass over disk.
+  - **New CLI command `conclave poll-outcomes`** — cron-friendly
+    auto-classification. Prints a summary line (scanned / merged /
+    rejected / reworked / pending / errors) plus per-PR detail for
+    anything that transitioned.
+  - 20 test cases across `pr-state.test.mjs` (open / merged / closed
+    mapping, merge-commit sha capture, unknown-state throw, missing
+    headRefOid throw, gh arg shape assertion, all 4 classifyTransition
+    rules) and `poll-runner.test.mjs` (empty store, merged → AnswerKey,
+    closed → FailureEntry, reworked with advanced head → FailureEntry,
+    same-head no-op, pullNumber=0 local review skipped, gh errors
+    counted but scan continues, already-resolved entries not re-polled,
+    listPendingEpisodics correctness).
 - **`@ai-conclave/agent-gemini`** — third council voice, long-context slot
   (decision #10: Gemini 2.5 Pro as the >50K input tokens handler, flash
   as triage. Deep Think skipped as Ultra-tier overkill):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,3 +97,26 @@
     happy path + missing-owner throw, git-diff with/without remote, file
     diff), and output rendering (all verdicts, severity sort, no-consensus
     tag, metrics formatting, exit-code mapping).
+- **Outcome writer — self-evolve loop closure** (decision #17, write side):
+  - `OutcomeWriter.writeReview(...)` persists an `EpisodicEntry` with
+    `outcome: "pending"` at the end of every `conclave review` call.
+  - `OutcomeWriter.recordOutcome({ episodicId, outcome })` updates the
+    stored episodic entry (merged / rejected / reworked) and invokes a
+    `Classifier` to produce `AnswerKey` (on merge) or `FailureEntry[]`
+    (on reject/rework — one per unique blocker, nits excluded).
+  - `RuleBasedClassifier` — deterministic extraction without an LLM.
+    Pattern = `by-repo/<repo>`; tags derived from blocker categories;
+    free-form category strings normalized to the 11 allowed enum values.
+    Haiku-backed classifier is a future drop-in behind the same interface.
+  - `MemoryStore.findEpisodic(id)` + FS walker so outcome can be recorded
+    in a fresh process (review → close PR → merge can span sessions).
+  - **CLI wired**: `conclave review` now prints the episodic id + a copy-paste
+    `conclave record-outcome --id ... --result merged` instruction. New
+    `conclave record-outcome` command closes the loop end-to-end.
+  - 16 test cases: merged → single answer-key; rejected/reworked → one
+    failure per unique blocker; nit exclusion; cross-agent dedup;
+    category normalization (`"Type Error"` → `type-error`, `"a11y"` →
+    `accessibility`, `"UNUSED IMPORT"` → `dead-code`); tag derivation;
+    stable ids for same input; round-trip through disk; fresh-process
+    reconstruction via `findEpisodic`; unknown-id throw; idempotent
+    re-writes with caller-provided `episodicId`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,3 +120,29 @@
     stable ids for same input; round-trip through disk; fresh-process
     reconstruction via `findEpisodic`; unknown-id throw; idempotent
     re-writes with caller-provided `episodicId`.
+- **`@ai-conclave/agent-openai`** — second council voice (decision #28 —
+  v2.0 launch council = Claude + OpenAI + Gemini):
+  - `OpenAIAgent` wraps the `openai` SDK via a minimal `OpenAILike`
+    client interface; default factory lazy-loads `openai` so tests never
+    pay the SDK cost.
+  - Strict `json_schema` response format (`name: "conclave_review"`,
+    `strict: true`) per decision #12 — structured output is guaranteed
+    well-formed without tool-use parsing.
+  - Same efficiency-gate contract as agent-claude: pre-flight
+    `budget.reserve`, cache-liveness mark, `actualCost(model, usage)`
+    post-call, per-call metric recorded.
+  - Pricing table for `gpt-4.1` / `gpt-4.1-mini` / `gpt-5` / `gpt-5-mini`
+    / `o5`. Cached-input discount applied via
+    `prompt_tokens_details.cached_tokens`.
+  - Parser handles refusals, non-JSON content, invalid verdicts, and
+    tolerates malformed blocker items (drops individually).
+  - CLI `conclave review` now instantiates the agents listed in
+    `config.agents`. Missing credentials for any agent skips that agent
+    with a stderr warning rather than failing the review. At least one
+    agent must resolve.
+  - 15 test cases (`pricing.test.mjs` + `openai-agent.test.mjs`):
+    pricing table coverage, cached-token discount vs fresh,
+    unknown-model throw, pre-flight estimate; parse approve + rework
+    flows, response_format shape assertion, refusal throw, invalid-JSON
+    throw, invalid-verdict throw, no-key constructor throw, metrics
+    aggregation, pre-flight budget short-circuits the network call.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "ai-conclave",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Ai-Conclave monorepo — AI drafted. Council refined.",
+  "license": "MIT",
+  "author": "Seunghun Bae",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/seunghunbae-3svs/ai-conclave.git"
+  },
+  "homepage": "https://github.com/seunghunbae-3svs/ai-conclave#readme",
+  "packageManager": "pnpm@9.15.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "test": "turbo run test",
+    "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
+    "clean": "turbo run clean && rm -rf node_modules"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "turbo": "^2.3.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/agent-claude/README.md
+++ b/packages/agent-claude/README.md
@@ -1,0 +1,25 @@
+# @ai-conclave/agent-claude
+
+Claude agent for Ai-Conclave council review. Implements the `Agent`
+interface from `@ai-conclave/core`.
+
+Skeleton status: interface correct, review stub returns `approve`. Real
+tool-use loop (via `@anthropic-ai/claude-agent-sdk`) with RAG over
+answer-keys + failure-catalog and efficiency-gate cost metering lands in
+a later PR.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/agent-claude @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { ClaudeAgent } from "@ai-conclave/agent-claude";
+import { Council } from "@ai-conclave/core";
+
+const agent = new ClaudeAgent({ apiKey: process.env.ANTHROPIC_API_KEY });
+const council = new Council({ agents: [agent] });
+```

--- a/packages/agent-claude/package.json
+++ b/packages/agent-claude/package.json
@@ -21,6 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/agent-claude/package.json
+++ b/packages/agent-claude/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ai-conclave/agent-claude",
+  "version": "0.0.0",
+  "description": "Ai-Conclave Claude agent — wraps @anthropic-ai/claude-agent-sdk.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@ai-conclave/core": "workspace:*",
+    "@anthropic-ai/sdk": "^0.65.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/agent-claude/src/claude-agent.ts
+++ b/packages/agent-claude/src/claude-agent.ts
@@ -1,0 +1,54 @@
+import type { Agent, ReviewContext, ReviewResult } from "@ai-conclave/core";
+
+export interface ClaudeAgentOptions {
+  apiKey?: string;
+  model?: string;
+  maxTokens?: number;
+}
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+const DEFAULT_MAX_TOKENS = 4096;
+
+/**
+ * ClaudeAgent — wraps Anthropic's Claude SDK for council review.
+ *
+ * Skeleton status: interface correct, implementation returns a stub
+ * "approve" verdict. The real tool-use loop with
+ * @anthropic-ai/claude-agent-sdk (official TS, bundles MCP + tool_use +
+ * compaction) lands in a subsequent PR together with the efficiency
+ * gate and RAG-over-answer-keys.
+ */
+export class ClaudeAgent implements Agent {
+  readonly id = "claude";
+  readonly displayName = "Claude";
+
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+
+  constructor(opts: ClaudeAgentOptions = {}) {
+    const key = opts.apiKey ?? process.env["ANTHROPIC_API_KEY"] ?? "";
+    if (!key) {
+      throw new Error("ClaudeAgent: ANTHROPIC_API_KEY not set (pass opts.apiKey or env var)");
+    }
+    this.apiKey = key;
+    this.model = opts.model ?? DEFAULT_MODEL;
+    this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+  }
+
+  async review(ctx: ReviewContext): Promise<ReviewResult> {
+    // Skeleton — real implementation will call the SDK with a tool-use
+    // loop, RAG context from answer-keys + failure-catalog, and cost
+    // metering through the efficiency gate.
+    void ctx;
+    void this.apiKey;
+    void this.model;
+    void this.maxTokens;
+    return {
+      agent: this.id,
+      verdict: "approve",
+      blockers: [],
+      summary: "ClaudeAgent skeleton — real review logic pending.",
+    };
+  }
+}

--- a/packages/agent-claude/src/claude-agent.ts
+++ b/packages/agent-claude/src/claude-agent.ts
@@ -1,22 +1,77 @@
-import type { Agent, ReviewContext, ReviewResult } from "@ai-conclave/core";
+import type { Agent, ReviewContext, ReviewResult, Blocker } from "@ai-conclave/core";
+import { EfficiencyGate, estimateTokens } from "@ai-conclave/core";
+import { REVIEW_TOOL_NAME, REVIEW_TOOL_DESCRIPTION, REVIEW_TOOL_INPUT_SCHEMA } from "./review-tool.js";
+import { buildReviewPrompt, buildCacheablePrefix, SYSTEM_PROMPT } from "./prompts.js";
+import { actualCost, estimateCallCost } from "./pricing.js";
+
+/**
+ * Minimal shape of the Anthropic SDK client that ClaudeAgent needs.
+ * We type against this instead of the full SDK to keep tests cheap to mock
+ * and to tolerate SDK minor version churn.
+ */
+export interface AnthropicLike {
+  messages: {
+    create(params: AnthropicCreateParams): Promise<AnthropicResponse>;
+  };
+}
+
+export interface AnthropicCreateParams {
+  model: string;
+  max_tokens: number;
+  system?: string | ReadonlyArray<{ type: "text"; text: string; cache_control?: { type: "ephemeral" } }>;
+  messages: ReadonlyArray<{ role: "user" | "assistant"; content: string }>;
+  tools?: ReadonlyArray<{
+    name: string;
+    description: string;
+    input_schema: unknown;
+  }>;
+  tool_choice?: { type: "tool"; name: string } | { type: "auto" } | { type: "any" };
+}
+
+export interface AnthropicResponse {
+  id: string;
+  model: string;
+  content: ReadonlyArray<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; id: string; name: string; input: unknown }
+  >;
+  stop_reason?: string;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}
 
 export interface ClaudeAgentOptions {
   apiKey?: string;
+  /** Defaults to claude-sonnet-4-6. Gate router may force a different model per call. */
   model?: string;
   maxTokens?: number;
+  /** Shared gate (recommended). If omitted, the agent creates its own. */
+  gate?: EfficiencyGate;
+  /** For tests or alternate providers — inject a Messages-compatible client. */
+  client?: AnthropicLike;
+  /** Factory used when `client` is not supplied. Defaults to lazy-loading @anthropic-ai/sdk. */
+  clientFactory?: (apiKey: string) => Promise<AnthropicLike>;
 }
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
-const DEFAULT_MAX_TOKENS = 4096;
+const DEFAULT_MAX_TOKENS = 2_048;
+
+async function defaultClientFactory(apiKey: string): Promise<AnthropicLike> {
+  // Dynamic import so tests that inject a client never pay the SDK load cost.
+  const mod = (await import("@anthropic-ai/sdk")) as unknown as {
+    default: new (opts: { apiKey: string }) => AnthropicLike;
+  };
+  const Ctor = mod.default;
+  return new Ctor({ apiKey });
+}
 
 /**
- * ClaudeAgent — wraps Anthropic's Claude SDK for council review.
- *
- * Skeleton status: interface correct, implementation returns a stub
- * "approve" verdict. The real tool-use loop with
- * @anthropic-ai/claude-agent-sdk (official TS, bundles MCP + tool_use +
- * compaction) lands in a subsequent PR together with the efficiency
- * gate and RAG-over-answer-keys.
+ * ClaudeAgent — routes a real Claude tool-use review call through the
+ * efficiency gate. Returns a parsed ReviewResult.
  */
 export class ClaudeAgent implements Agent {
   readonly id = "claude";
@@ -25,30 +80,134 @@ export class ClaudeAgent implements Agent {
   private readonly apiKey: string;
   private readonly model: string;
   private readonly maxTokens: number;
+  private readonly gate: EfficiencyGate;
+  private readonly clientFactory: (apiKey: string) => Promise<AnthropicLike>;
+  private clientPromise: Promise<AnthropicLike> | null;
 
   constructor(opts: ClaudeAgentOptions = {}) {
     const key = opts.apiKey ?? process.env["ANTHROPIC_API_KEY"] ?? "";
-    if (!key) {
-      throw new Error("ClaudeAgent: ANTHROPIC_API_KEY not set (pass opts.apiKey or env var)");
+    if (!key && !opts.client) {
+      throw new Error("ClaudeAgent: ANTHROPIC_API_KEY not set (pass opts.apiKey, opts.client, or the env var)");
     }
     this.apiKey = key;
     this.model = opts.model ?? DEFAULT_MODEL;
     this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.gate = opts.gate ?? new EfficiencyGate();
+    this.clientFactory = opts.clientFactory ?? defaultClientFactory;
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+  }
+
+  private async getClient(): Promise<AnthropicLike> {
+    if (!this.clientPromise) {
+      this.clientPromise = this.clientFactory(this.apiKey);
+    }
+    return this.clientPromise;
   }
 
   async review(ctx: ReviewContext): Promise<ReviewResult> {
-    // Skeleton — real implementation will call the SDK with a tool-use
-    // loop, RAG context from answer-keys + failure-catalog, and cost
-    // metering through the efficiency gate.
-    void ctx;
-    void this.apiKey;
-    void this.model;
-    void this.maxTokens;
-    return {
-      agent: this.id,
-      verdict: "approve",
-      blockers: [],
-      summary: "ClaudeAgent skeleton — real review logic pending.",
-    };
+    const cacheablePrefix = buildCacheablePrefix(ctx);
+    const userPrompt = buildReviewPrompt(ctx);
+    const inputTokenEstimate = estimateTokens(cacheablePrefix) + estimateTokens(userPrompt);
+    const estimatedCost = estimateCallCost(this.model, inputTokenEstimate, this.maxTokens);
+
+    const outcome = await this.gate.run<ReviewResult>(
+      {
+        agent: this.id,
+        cacheablePrefix,
+        prompt: cacheablePrefix + "\n" + userPrompt,
+        estimatedCostUsd: estimatedCost,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const response = await client.messages.create({
+          model,
+          max_tokens: this.maxTokens,
+          system: [{ type: "text", text: cacheablePrefix, cache_control: { type: "ephemeral" } }],
+          messages: [{ role: "user", content: userPrompt }],
+          tools: [
+            {
+              name: REVIEW_TOOL_NAME,
+              description: REVIEW_TOOL_DESCRIPTION,
+              input_schema: REVIEW_TOOL_INPUT_SCHEMA,
+            },
+          ],
+          tool_choice: { type: "tool", name: REVIEW_TOOL_NAME },
+        });
+        const latencyMs = Date.now() - started;
+
+        const parsed = parseReviewToolUse(response, this.id);
+        const cost = actualCost(model, {
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          cacheCreationTokens: response.usage.cache_creation_input_tokens,
+          cacheReadTokens: response.usage.cache_read_input_tokens,
+        });
+
+        return {
+          result: {
+            ...parsed,
+            tokensUsed: response.usage.input_tokens + response.usage.output_tokens,
+            costUsd: cost,
+          },
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          costUsd: cost,
+          latencyMs,
+        };
+      },
+    );
+
+    return outcome.result;
   }
 }
+
+function parseReviewToolUse(response: AnthropicResponse, agentId: string): ReviewResult {
+  const toolUse = response.content.find(
+    (block): block is Extract<(typeof response.content)[number], { type: "tool_use" }> =>
+      block.type === "tool_use" && block.name === REVIEW_TOOL_NAME,
+  );
+  if (!toolUse) {
+    throw new Error(
+      `ClaudeAgent: response did not include a ${REVIEW_TOOL_NAME} tool_use block (stop_reason=${response.stop_reason ?? "?"})`,
+    );
+  }
+  const input = toolUse.input as {
+    verdict?: string;
+    blockers?: unknown[];
+    summary?: string;
+  };
+  if (input.verdict !== "approve" && input.verdict !== "rework" && input.verdict !== "reject") {
+    throw new Error(`ClaudeAgent: invalid verdict "${String(input.verdict)}" in tool_use response`);
+  }
+  const blockers: Blocker[] = [];
+  if (Array.isArray(input.blockers)) {
+    for (const raw of input.blockers) {
+      if (!raw || typeof raw !== "object") continue;
+      const b = raw as Record<string, unknown>;
+      const severity = b["severity"];
+      const category = b["category"];
+      const message = b["message"];
+      if (
+        (severity === "blocker" || severity === "major" || severity === "minor" || severity === "nit") &&
+        typeof category === "string" &&
+        typeof message === "string"
+      ) {
+        const blocker: Blocker = { severity, category, message };
+        if (typeof b["file"] === "string") blocker.file = b["file"] as string;
+        if (typeof b["line"] === "number") blocker.line = b["line"] as number;
+        blockers.push(blocker);
+      }
+    }
+  }
+  return {
+    agent: agentId,
+    verdict: input.verdict,
+    blockers,
+    summary: typeof input.summary === "string" ? input.summary : "",
+  };
+}
+
+// Re-export SYSTEM_PROMPT so downstream tools can render/copy it.
+export { SYSTEM_PROMPT };

--- a/packages/agent-claude/src/index.ts
+++ b/packages/agent-claude/src/index.ts
@@ -1,0 +1,2 @@
+export { ClaudeAgent } from "./claude-agent.js";
+export type { ClaudeAgentOptions } from "./claude-agent.js";

--- a/packages/agent-claude/src/index.ts
+++ b/packages/agent-claude/src/index.ts
@@ -1,2 +1,6 @@
-export { ClaudeAgent } from "./claude-agent.js";
-export type { ClaudeAgentOptions } from "./claude-agent.js";
+export { ClaudeAgent, SYSTEM_PROMPT } from "./claude-agent.js";
+export type { ClaudeAgentOptions, AnthropicLike, AnthropicCreateParams, AnthropicResponse } from "./claude-agent.js";
+export { buildReviewPrompt, buildCacheablePrefix } from "./prompts.js";
+export { REVIEW_TOOL_NAME, REVIEW_TOOL_DESCRIPTION, REVIEW_TOOL_INPUT_SCHEMA } from "./review-tool.js";
+export { actualCost, estimateCallCost, PRICING } from "./pricing.js";
+export type { ModelPricing, UsageBreakdown } from "./pricing.js";

--- a/packages/agent-claude/src/pricing.ts
+++ b/packages/agent-claude/src/pricing.ts
@@ -1,0 +1,68 @@
+export interface ModelPricing {
+  /** USD per 1M input tokens (non-cached). */
+  inputPerMTok: number;
+  /** USD per 1M cache-write input tokens. */
+  cacheWritePerMTok: number;
+  /** USD per 1M cache-read input tokens. */
+  cacheReadPerMTok: number;
+  /** USD per 1M output tokens. */
+  outputPerMTok: number;
+}
+
+/**
+ * Pricing table for Claude models. Prices reflect published Anthropic API
+ * pricing as of 2026-04; update when Anthropic announces new tiers.
+ *
+ * Cache write = 1.25× base input, cache read = 0.1× base input (90% off).
+ */
+export const PRICING: Record<string, ModelPricing> = {
+  "claude-sonnet-4-6": {
+    inputPerMTok: 3.0,
+    cacheWritePerMTok: 3.75,
+    cacheReadPerMTok: 0.3,
+    outputPerMTok: 15.0,
+  },
+  "claude-haiku-4-5": {
+    inputPerMTok: 0.25,
+    cacheWritePerMTok: 0.3125,
+    cacheReadPerMTok: 0.025,
+    outputPerMTok: 1.25,
+  },
+  "claude-opus-4-7": {
+    inputPerMTok: 15.0,
+    cacheWritePerMTok: 18.75,
+    cacheReadPerMTok: 1.5,
+    outputPerMTok: 75.0,
+  },
+};
+
+export interface UsageBreakdown {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens?: number;
+  cacheReadTokens?: number;
+}
+
+/** Compute actual USD cost from an Anthropic API usage breakdown. */
+export function actualCost(model: string, usage: UsageBreakdown): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown model "${model}"`);
+  const baseInput = usage.inputTokens - (usage.cacheCreationTokens ?? 0) - (usage.cacheReadTokens ?? 0);
+  return (
+    (Math.max(0, baseInput) * p.inputPerMTok +
+      (usage.cacheCreationTokens ?? 0) * p.cacheWritePerMTok +
+      (usage.cacheReadTokens ?? 0) * p.cacheReadPerMTok +
+      usage.outputTokens * p.outputPerMTok) /
+    1_000_000
+  );
+}
+
+/**
+ * Pre-flight USD estimate for budget.reserve(). Pessimistic: assumes no
+ * cache read (worst case) and a typical 25% output-to-input ratio.
+ */
+export function estimateCallCost(model: string, estimatedInputTokens: number, maxOutputTokens: number): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown model "${model}"`);
+  return (estimatedInputTokens * p.inputPerMTok + maxOutputTokens * p.outputPerMTok) / 1_000_000;
+}

--- a/packages/agent-claude/src/prompts.ts
+++ b/packages/agent-claude/src/prompts.ts
@@ -1,0 +1,71 @@
+import type { ReviewContext } from "@ai-conclave/core";
+
+export const SYSTEM_PROMPT = `You are a senior code reviewer on a multi-agent council for Ai-Conclave. The council reviews AI-generated code and design changes before merge.
+
+Your goal: catch real blockers, not style nits. You work alongside other agents (OpenAI, Gemini, possibly domain-specific specialists). Your reviews are weighed against theirs; spurious blockers hurt your agent score and waste the rework budget.
+
+Rules:
+- Focus on: correctness, security, regression risk, missing tests for non-trivial changes, accessibility + contrast on UI, obvious performance cliffs.
+- Do NOT comment on: style bikeshedding, import order, variable renames that are already consistent, personal formatting preferences.
+- When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
+- Never pad with encouragement ("great work but...") — go straight to the concerns.
+- When the diff is small, low-risk, and has test coverage, approve cleanly. Over-flagging is a bigger sin than missing a nit.
+- You MUST respond by calling the submit_review tool exactly once. Do not emit free-form text.`;
+
+export function buildReviewPrompt(ctx: ReviewContext): string {
+  const sections: string[] = [];
+  sections.push(`# Review target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`pull: #${ctx.pullNumber}`);
+  sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
+  sections.push("");
+
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(
+      `These are reviews that led to merged changes on similar code in this repo. Lean on them as a style + quality bar — match their tolerance for what counts as a blocker.`,
+    );
+    sections.push("");
+    for (const entry of ctx.answerKeys.slice(0, 8)) {
+      sections.push(`- ${entry}`);
+    }
+    sections.push("");
+  }
+
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(
+      `These are patterns that caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
+    );
+    sections.push("");
+    for (const entry of ctx.failureCatalog.slice(0, 8)) {
+      sections.push(`- ${entry}`);
+    }
+    sections.push("");
+  }
+
+  sections.push(`# Diff`);
+  sections.push("```diff");
+  sections.push(ctx.diff || "(empty diff — respond with verdict=approve, summary noting nothing to review)");
+  sections.push("```");
+  sections.push("");
+  sections.push(`Call submit_review exactly once with your verdict, blockers (if any), and a one-paragraph summary.`);
+  return sections.join("\n");
+}
+
+/**
+ * The cacheable prefix is everything STABLE across calls within a session —
+ * system prompt + any pinned RAG context that doesn't change per-turn.
+ * Anthropic's prompt cache works best when this prefix is marked
+ * `cache_control: ephemeral` and sits at the head of the messages array.
+ */
+export function buildCacheablePrefix(ctx: ReviewContext): string {
+  const parts: string[] = [SYSTEM_PROMPT];
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
+  }
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    parts.push("failure-catalog:\n" + ctx.failureCatalog.slice(0, 8).join("\n"));
+  }
+  return parts.join("\n---\n");
+}

--- a/packages/agent-claude/src/review-tool.ts
+++ b/packages/agent-claude/src/review-tool.ts
@@ -1,0 +1,56 @@
+/**
+ * Tool-use schema that forces Claude to return a structured review.
+ * Decision #12 — Zod → JSON Schema per-provider adapter; for Anthropic we
+ * use a SINGLE-TOOL pattern (`tool_choice: { type: "tool", name: ... }`)
+ * which gives us reliable structured output without relying on response
+ * parsing heuristics.
+ */
+export const REVIEW_TOOL_NAME = "submit_review";
+
+export const REVIEW_TOOL_DESCRIPTION =
+  "Submit your structured review of the diff. Call this exactly once at the end of your analysis.";
+
+export const REVIEW_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    verdict: {
+      type: "string",
+      enum: ["approve", "rework", "reject"],
+      description:
+        "approve = ship as-is; rework = fixable blockers (agent should attempt auto-fix); reject = fundamentally wrong approach (do not merge, human must intervene).",
+    },
+    blockers: {
+      type: "array",
+      description: "Ordered list of issues found. Empty when verdict is approve.",
+      items: {
+        type: "object",
+        properties: {
+          severity: {
+            type: "string",
+            enum: ["blocker", "major", "minor", "nit"],
+            description:
+              "blocker = must fix; major = should fix; minor = worth fixing; nit = optional polish.",
+          },
+          category: {
+            type: "string",
+            description:
+              "Short tag like 'type-error' / 'missing-test' / 'security' / 'accessibility' / 'regression'. Used for precision/recall metrics.",
+          },
+          message: {
+            type: "string",
+            description: "One-sentence description of the problem + what to change.",
+          },
+          file: { type: "string", description: "Relative path to the file, if applicable." },
+          line: { type: "number", description: "Line number, if applicable." },
+        },
+        required: ["severity", "category", "message"],
+      },
+    },
+    summary: {
+      type: "string",
+      description:
+        "One-paragraph summary of the review. Include the overall verdict reasoning, not just a restatement of blockers.",
+    },
+  },
+  required: ["verdict", "blockers", "summary"],
+} as const;

--- a/packages/agent-claude/test/claude-agent.test.mjs
+++ b/packages/agent-claude/test/claude-agent.test.mjs
@@ -1,0 +1,157 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EfficiencyGate } from "@ai-conclave/core";
+import { ClaudeAgent } from "../dist/index.js";
+
+function makeMockClient(responses) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    messages: {
+      create: async (params) => {
+        calls.push(params);
+        const r = responses[Math.min(i, responses.length - 1)];
+        i += 1;
+        return r;
+      },
+    },
+  };
+}
+
+function okResponse({ verdict = "approve", blockers = [], summary = "ok", inputTokens = 1_000, outputTokens = 100, cacheRead = 0 } = {}) {
+  return {
+    id: "msg_test",
+    model: "claude-sonnet-4-6",
+    content: [
+      {
+        type: "tool_use",
+        id: "tool_1",
+        name: "submit_review",
+        input: { verdict, blockers, summary },
+      },
+    ],
+    stop_reason: "tool_use",
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cache_read_input_tokens: cacheRead,
+    },
+  };
+}
+
+const ctx = {
+  diff: "diff --git a/x b/x\n+added",
+  repo: "acme/x",
+  pullNumber: 1,
+  newSha: "abc123",
+};
+
+test("ClaudeAgent: parses approve verdict through the efficiency gate", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse({ verdict: "approve", summary: "LGTM" })]);
+  const agent = new ClaudeAgent({ apiKey: "test-key", gate, client });
+  const result = await agent.review(ctx);
+  assert.equal(result.agent, "claude");
+  assert.equal(result.verdict, "approve");
+  assert.equal(result.blockers.length, 0);
+  assert.equal(result.summary, "LGTM");
+  assert.ok(typeof result.costUsd === "number" && result.costUsd > 0);
+  assert.ok(typeof result.tokensUsed === "number" && result.tokensUsed === 1_100);
+});
+
+test("ClaudeAgent: parses rework verdict with blockers", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([
+    okResponse({
+      verdict: "rework",
+      blockers: [
+        { severity: "blocker", category: "type-error", message: "ts2345 on line 7", file: "src/x.ts", line: 7 },
+        { severity: "minor", category: "missing-test", message: "no test for new branch" },
+        { invalid: "shape", should: "drop" },
+      ],
+      summary: "1 blocker, 1 minor",
+    }),
+  ]);
+  const agent = new ClaudeAgent({ apiKey: "test-key", gate, client });
+  const result = await agent.review(ctx);
+  assert.equal(result.verdict, "rework");
+  assert.equal(result.blockers.length, 2);
+  assert.equal(result.blockers[0].severity, "blocker");
+  assert.equal(result.blockers[0].file, "src/x.ts");
+  assert.equal(result.blockers[0].line, 7);
+  assert.equal(result.blockers[1].severity, "minor");
+});
+
+test("ClaudeAgent: throws when response has no tool_use block", async () => {
+  const client = {
+    calls: [],
+    messages: {
+      create: async () => ({
+        id: "msg",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "I forgot to call the tool" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 100, output_tokens: 10 },
+      }),
+    },
+  };
+  const agent = new ClaudeAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /did not include a submit_review tool_use/);
+});
+
+test("ClaudeAgent: throws on invalid verdict value", async () => {
+  const client = makeMockClient([okResponse({ verdict: "ship-it-lol" })]);
+  const agent = new ClaudeAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /invalid verdict/);
+});
+
+test("ClaudeAgent: records a metric on the shared gate", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse({ verdict: "approve", inputTokens: 5_000, outputTokens: 200 })]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const summary = gate.metrics.summary();
+  assert.equal(summary.callCount, 1);
+  assert.equal(summary.byAgent["claude"].calls, 1);
+  assert.ok(summary.totalCostUsd > 0);
+});
+
+test("ClaudeAgent: sends system prompt with cache_control ephemeral", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse()]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const params = client.calls[0];
+  assert.ok(Array.isArray(params.system), "system should be an array of blocks for cache control");
+  assert.equal(params.system[0].cache_control?.type, "ephemeral");
+});
+
+test("ClaudeAgent: forces submit_review tool via tool_choice", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([okResponse()]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const params = client.calls[0];
+  assert.equal(params.tool_choice.type, "tool");
+  assert.equal(params.tool_choice.name, "submit_review");
+});
+
+test("ClaudeAgent: respects a shared budget cap across calls", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 0.005 }); // tiny budget
+  const client = makeMockClient([
+    okResponse({ inputTokens: 10_000, outputTokens: 500 }), // ~$0.0375 → exceeds 0.005
+  ]);
+  const agent = new ClaudeAgent({ apiKey: "k", gate, client });
+  await assert.rejects(() => agent.review(ctx), /budget/);
+});
+
+test("ClaudeAgent: missing API key AND no injected client throws in constructor", () => {
+  const orig = process.env.ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  try {
+    assert.throws(() => new ClaudeAgent());
+  } finally {
+    if (orig !== undefined) process.env.ANTHROPIC_API_KEY = orig;
+  }
+});

--- a/packages/agent-claude/test/pricing.test.mjs
+++ b/packages/agent-claude/test/pricing.test.mjs
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { actualCost, estimateCallCost, PRICING } from "../dist/index.js";
+
+test("PRICING table has all three Claude tiers", () => {
+  assert.ok(PRICING["claude-sonnet-4-6"]);
+  assert.ok(PRICING["claude-haiku-4-5"]);
+  assert.ok(PRICING["claude-opus-4-7"]);
+});
+
+test("actualCost: Sonnet baseline — 1000 in, 500 out, no cache", () => {
+  const cost = actualCost("claude-sonnet-4-6", { inputTokens: 1_000, outputTokens: 500 });
+  // 1000 * 3 + 500 * 15 = 3000 + 7500 = 10_500 / 1_000_000 = 0.0105
+  assert.equal(cost.toFixed(4), "0.0105");
+});
+
+test("actualCost: cache read discount applied", () => {
+  const noCache = actualCost("claude-sonnet-4-6", { inputTokens: 10_000, outputTokens: 200 });
+  const cached = actualCost("claude-sonnet-4-6", {
+    inputTokens: 10_000,
+    outputTokens: 200,
+    cacheReadTokens: 9_000,
+  });
+  // 9k cache read at 0.3/MTok instead of 3.0/MTok = 0.0027 vs 0.027 → $0.0243 savings
+  assert.ok(cached < noCache, "cached call must cost less");
+  assert.equal((noCache - cached).toFixed(4), "0.0243");
+});
+
+test("actualCost: cache write premium applied", () => {
+  const noCache = actualCost("claude-sonnet-4-6", { inputTokens: 5_000, outputTokens: 100 });
+  const cacheWrite = actualCost("claude-sonnet-4-6", {
+    inputTokens: 5_000,
+    outputTokens: 100,
+    cacheCreationTokens: 5_000,
+  });
+  // cache write is 1.25× input cost
+  assert.ok(cacheWrite > noCache);
+});
+
+test("actualCost: Haiku is ~12× cheaper than Sonnet per input token", () => {
+  const sonnet = actualCost("claude-sonnet-4-6", { inputTokens: 100_000, outputTokens: 0 });
+  const haiku = actualCost("claude-haiku-4-5", { inputTokens: 100_000, outputTokens: 0 });
+  const ratio = sonnet / haiku;
+  assert.ok(ratio >= 11 && ratio <= 13, `expected ratio ~12, got ${ratio}`);
+});
+
+test("actualCost: throws on unknown model", () => {
+  assert.throws(() => actualCost("claude-does-not-exist", { inputTokens: 1, outputTokens: 1 }));
+});
+
+test("estimateCallCost: pessimistic pre-flight matches reserve-before-call flow", () => {
+  const est = estimateCallCost("claude-sonnet-4-6", 5_000, 1_000);
+  // 5k * 3/M + 1k * 15/M = 15e-3 + 15e-3 = 0.03
+  assert.equal(est.toFixed(3), "0.030");
+});

--- a/packages/agent-claude/test/smoke.test.mjs
+++ b/packages/agent-claude/test/smoke.test.mjs
@@ -1,0 +1,7 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ClaudeAgent } from "../dist/index.js";
+
+test("agent-claude: ClaudeAgent is exported", () => {
+  assert.equal(typeof ClaudeAgent, "function");
+});

--- a/packages/agent-claude/tsconfig.json
+++ b/packages/agent-claude/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/agent-gemini/README.md
+++ b/packages/agent-gemini/README.md
@@ -1,0 +1,33 @@
+# @ai-conclave/agent-gemini
+
+Gemini agent for Ai-Conclave council review. Implements the `Agent`
+interface from `@ai-conclave/core`. Uses Gemini's `responseSchema`
+structured output (decision #10, long-context slot).
+
+## Install
+
+```bash
+pnpm add @ai-conclave/agent-gemini @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { GeminiAgent } from "@ai-conclave/agent-gemini";
+import { Council, EfficiencyGate } from "@ai-conclave/core";
+
+const gate = new EfficiencyGate();
+const council = new Council({ agents: [new GeminiAgent({ gate })] });
+```
+
+## Models
+
+Default: `gemini-2.5-pro` (long-context slot — 1M token window).
+
+Alternatives via `new GeminiAgent({ model: "gemini-2.5-flash" })` for
+cheap triage. Pricing table covers `gemini-2.5-pro`, `gemini-2.5-flash`,
+and `gemini-3.0-flash`.
+
+## Env
+
+Reads `GOOGLE_API_KEY` first, falls back to `GEMINI_API_KEY`.

--- a/packages/agent-gemini/package.json
+++ b/packages/agent-gemini/package.json
@@ -1,13 +1,16 @@
 {
-  "name": "@ai-conclave/cli",
+  "name": "@ai-conclave/agent-gemini",
   "version": "0.0.0",
-  "description": "Ai-Conclave CLI — the `conclave` binary.",
+  "description": "Ai-Conclave Gemini agent — wraps @google/genai with responseSchema structured output. Long-context slot per decision #10.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "conclave": "./dist/bin/conclave.js"
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",
@@ -22,11 +25,8 @@
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {
-    "@ai-conclave/agent-claude": "workspace:*",
-    "@ai-conclave/agent-gemini": "workspace:*",
-    "@ai-conclave/agent-openai": "workspace:*",
     "@ai-conclave/core": "workspace:*",
-    "zod": "^3.24.0"
+    "@google/genai": "^0.10.0"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/packages/agent-gemini/src/gemini-agent.ts
+++ b/packages/agent-gemini/src/gemini-agent.ts
@@ -1,0 +1,215 @@
+import type { Agent, ReviewContext, ReviewResult, Blocker } from "@ai-conclave/core";
+import { EfficiencyGate, estimateTokens } from "@ai-conclave/core";
+import { REVIEW_RESPONSE_SCHEMA } from "./review-schema.js";
+import { SYSTEM_PROMPT, buildReviewPrompt, buildCacheablePrefix } from "./prompts.js";
+import { actualCost, estimateCallCost } from "./pricing.js";
+
+/**
+ * Minimal shape of @google/genai we rely on. Typed narrowly so tests
+ * never instantiate the real SDK and SDK minor-version drift doesn't
+ * break the build.
+ */
+export interface GenAILike {
+  models: {
+    generateContent(params: GenerateContentParams): Promise<GenerateContentResponse>;
+  };
+}
+
+export interface GenerateContentParams {
+  model: string;
+  contents: ReadonlyArray<{
+    role: "user" | "model";
+    parts: ReadonlyArray<{ text: string }>;
+  }>;
+  config?: {
+    systemInstruction?: { parts: ReadonlyArray<{ text: string }> } | string;
+    maxOutputTokens?: number;
+    responseMimeType?: "application/json";
+    responseSchema?: unknown;
+    temperature?: number;
+  };
+}
+
+export interface GenerateContentResponse {
+  text?: string;
+  candidates?: ReadonlyArray<{
+    content?: { parts?: ReadonlyArray<{ text?: string }> };
+    finishReason?: string;
+  }>;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    cachedContentTokenCount?: number;
+  };
+}
+
+export interface GeminiAgentOptions {
+  apiKey?: string;
+  /** Default: gemini-2.5-pro (long-context slot per decision #10). */
+  model?: string;
+  maxTokens?: number;
+  gate?: EfficiencyGate;
+  client?: GenAILike;
+  clientFactory?: (apiKey: string) => Promise<GenAILike>;
+}
+
+const DEFAULT_MODEL = "gemini-2.5-pro";
+const DEFAULT_MAX_TOKENS = 2_048;
+
+async function defaultClientFactory(apiKey: string): Promise<GenAILike> {
+  const mod = (await import("@google/genai")) as unknown as {
+    GoogleGenAI: new (opts: { apiKey: string }) => GenAILike;
+  };
+  return new mod.GoogleGenAI({ apiKey });
+}
+
+export class GeminiAgent implements Agent {
+  readonly id = "gemini";
+  readonly displayName = "Gemini";
+
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly gate: EfficiencyGate;
+  private readonly clientFactory: (apiKey: string) => Promise<GenAILike>;
+  private clientPromise: Promise<GenAILike> | null;
+
+  constructor(opts: GeminiAgentOptions = {}) {
+    const key = opts.apiKey ?? process.env["GOOGLE_API_KEY"] ?? process.env["GEMINI_API_KEY"] ?? "";
+    if (!key && !opts.client) {
+      throw new Error("GeminiAgent: GOOGLE_API_KEY (or GEMINI_API_KEY) not set (pass opts.apiKey, opts.client, or the env var)");
+    }
+    this.apiKey = key;
+    this.model = opts.model ?? DEFAULT_MODEL;
+    this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.gate = opts.gate ?? new EfficiencyGate();
+    this.clientFactory = opts.clientFactory ?? defaultClientFactory;
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+  }
+
+  private async getClient(): Promise<GenAILike> {
+    if (!this.clientPromise) this.clientPromise = this.clientFactory(this.apiKey);
+    return this.clientPromise;
+  }
+
+  async review(ctx: ReviewContext): Promise<ReviewResult> {
+    const cacheablePrefix = buildCacheablePrefix(ctx);
+    const userPrompt = buildReviewPrompt(ctx);
+    const inputTokenEstimate = estimateTokens(cacheablePrefix) + estimateTokens(userPrompt);
+    const estimatedCost = estimateCallCost(this.model, inputTokenEstimate, this.maxTokens);
+
+    const outcome = await this.gate.run<ReviewResult>(
+      {
+        agent: this.id,
+        cacheablePrefix,
+        prompt: cacheablePrefix + "\n" + userPrompt,
+        estimatedCostUsd: estimatedCost,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const response = await client.models.generateContent({
+          model,
+          contents: [{ role: "user", parts: [{ text: userPrompt }] }],
+          config: {
+            systemInstruction: { parts: [{ text: cacheablePrefix }] },
+            maxOutputTokens: this.maxTokens,
+            responseMimeType: "application/json",
+            responseSchema: REVIEW_RESPONSE_SCHEMA,
+          },
+        });
+        const latencyMs = Date.now() - started;
+
+        const parsed = parseResponse(response, this.id);
+        const usage = response.usageMetadata ?? {};
+        const inputTokens = usage.promptTokenCount ?? inputTokenEstimate;
+        const outputTokens = usage.candidatesTokenCount ?? 0;
+        const cachedInput = usage.cachedContentTokenCount;
+        const costParts: { inputTokens: number; outputTokens: number; cachedInputTokens?: number } = {
+          inputTokens,
+          outputTokens,
+        };
+        if (cachedInput !== undefined) costParts.cachedInputTokens = cachedInput;
+        const cost = actualCost(model, costParts);
+
+        return {
+          result: {
+            ...parsed,
+            tokensUsed: inputTokens + outputTokens,
+            costUsd: cost,
+          },
+          inputTokens,
+          outputTokens,
+          costUsd: cost,
+          latencyMs,
+        };
+      },
+    );
+
+    return outcome.result;
+  }
+}
+
+function parseResponse(response: GenerateContentResponse, agentId: string): ReviewResult {
+  const text = extractText(response);
+  if (!text) {
+    const reason = response.candidates?.[0]?.finishReason ?? "unknown";
+    throw new Error(`GeminiAgent: response had no text (finishReason=${reason})`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new Error(`GeminiAgent: response text was not valid JSON: ${(err as Error).message}`);
+  }
+  return normalize(parsed, agentId);
+}
+
+function extractText(response: GenerateContentResponse): string | null {
+  if (typeof response.text === "string" && response.text) return response.text;
+  const cand = response.candidates?.[0];
+  if (!cand) return null;
+  const parts = cand.content?.parts;
+  if (!parts) return null;
+  let out = "";
+  for (const p of parts) {
+    if (typeof p.text === "string") out += p.text;
+  }
+  return out || null;
+}
+
+function normalize(raw: unknown, agentId: string): ReviewResult {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("GeminiAgent: response is not an object");
+  }
+  const v = (raw as { verdict?: unknown }).verdict;
+  if (v !== "approve" && v !== "rework" && v !== "reject") {
+    throw new Error(`GeminiAgent: invalid verdict "${String(v)}"`);
+  }
+  const blockersRaw = (raw as { blockers?: unknown[] }).blockers;
+  const blockers: Blocker[] = [];
+  if (Array.isArray(blockersRaw)) {
+    for (const item of blockersRaw) {
+      if (!item || typeof item !== "object") continue;
+      const b = item as Record<string, unknown>;
+      const severity = b["severity"];
+      const category = b["category"];
+      const message = b["message"];
+      if (
+        (severity === "blocker" || severity === "major" || severity === "minor" || severity === "nit") &&
+        typeof category === "string" &&
+        typeof message === "string"
+      ) {
+        const blocker: Blocker = { severity, category, message };
+        if (typeof b["file"] === "string") blocker.file = b["file"] as string;
+        if (typeof b["line"] === "number") blocker.line = b["line"] as number;
+        blockers.push(blocker);
+      }
+    }
+  }
+  const summary = typeof (raw as { summary?: unknown }).summary === "string" ? (raw as { summary: string }).summary : "";
+  return { agent: agentId, verdict: v, blockers, summary };
+}
+
+export { SYSTEM_PROMPT };

--- a/packages/agent-gemini/src/index.ts
+++ b/packages/agent-gemini/src/index.ts
@@ -1,0 +1,6 @@
+export { GeminiAgent, SYSTEM_PROMPT } from "./gemini-agent.js";
+export type { GeminiAgentOptions, GenAILike, GenerateContentParams, GenerateContentResponse } from "./gemini-agent.js";
+export { buildReviewPrompt, buildCacheablePrefix } from "./prompts.js";
+export { REVIEW_RESPONSE_SCHEMA } from "./review-schema.js";
+export { actualCost, estimateCallCost, PRICING } from "./pricing.js";
+export type { GeminiModelPricing, UsageBreakdown } from "./pricing.js";

--- a/packages/agent-gemini/src/pricing.ts
+++ b/packages/agent-gemini/src/pricing.ts
@@ -1,0 +1,67 @@
+export interface GeminiModelPricing {
+  /** USD per 1M input tokens. */
+  inputPerMTok: number;
+  /** USD per 1M output tokens. */
+  outputPerMTok: number;
+  /**
+   * Context-cache rate per 1M tokens for the cached prefix. Gemini's
+   * context cache bills separately from regular input. Undefined =
+   * charge at `inputPerMTok` conservatively.
+   */
+  cachedInputPerMTok?: number;
+  /** If published, max context window in tokens — useful for router long-context slot selection. */
+  maxContextTokens?: number;
+}
+
+/**
+ * Pricing for Gemini models used as the long-context slot per decision #10.
+ * 2026-04 Google AI pricing; revisit on publish.
+ *
+ * Decision #10: "skip Deep Think (Ultra-tier overkill); use 2.5 Flash as triage".
+ * Flash is a fallback for under-budget review on very small diffs; 2.5 Pro is
+ * the canonical long-context slot (>50K input tokens per router default).
+ */
+export const PRICING: Record<string, GeminiModelPricing> = {
+  "gemini-2.5-pro": {
+    inputPerMTok: 1.25,
+    outputPerMTok: 10.0,
+    cachedInputPerMTok: 0.3125,
+    maxContextTokens: 1_048_576,
+  },
+  "gemini-2.5-flash": {
+    inputPerMTok: 0.15,
+    outputPerMTok: 0.6,
+    cachedInputPerMTok: 0.0375,
+    maxContextTokens: 1_048_576,
+  },
+  "gemini-3.0-flash": {
+    inputPerMTok: 0.2,
+    outputPerMTok: 0.8,
+    cachedInputPerMTok: 0.05,
+    maxContextTokens: 2_097_152,
+  },
+};
+
+export interface UsageBreakdown {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens?: number;
+}
+
+export function actualCost(model: string, usage: UsageBreakdown): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown Gemini model "${model}"`);
+  const baseInput = usage.inputTokens - (usage.cachedInputTokens ?? 0);
+  return (
+    (Math.max(0, baseInput) * p.inputPerMTok +
+      (usage.cachedInputTokens ?? 0) * (p.cachedInputPerMTok ?? p.inputPerMTok) +
+      usage.outputTokens * p.outputPerMTok) /
+    1_000_000
+  );
+}
+
+export function estimateCallCost(model: string, estimatedInputTokens: number, maxOutputTokens: number): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown Gemini model "${model}"`);
+  return (estimatedInputTokens * p.inputPerMTok + maxOutputTokens * p.outputPerMTok) / 1_000_000;
+}

--- a/packages/agent-gemini/src/prompts.ts
+++ b/packages/agent-gemini/src/prompts.ts
@@ -1,0 +1,63 @@
+import type { ReviewContext } from "@ai-conclave/core";
+
+export const SYSTEM_PROMPT = `You are a senior code reviewer on a multi-agent council for Ai-Conclave. The council reviews AI-generated code and design changes before merge.
+
+You have a long-context window and are typically routed here when the diff + context exceeds what Claude or OpenAI handle efficiently. Use that capacity to consider the whole change surface, not just the diff in isolation.
+
+Goal: catch real blockers, not style nits. Spurious blockers hurt your agent score and waste rework budget.
+
+Rules:
+- Focus on: correctness, security, regression risk, missing tests for non-trivial changes, accessibility + contrast on UI, obvious performance cliffs, cross-file impact the other agents may miss given their smaller context.
+- Do NOT comment on: style bikeshedding, import order, variable renames that are already consistent, personal formatting preferences.
+- When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
+- Never pad with encouragement ("great work but...") — go straight to the concerns.
+- Small / low-risk diffs with test coverage — approve cleanly.
+- You MUST respond as JSON matching the provided response schema. Do not wrap the JSON in prose.`;
+
+export function buildReviewPrompt(ctx: ReviewContext): string {
+  const sections: string[] = [];
+  sections.push(`# Review target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`pull: #${ctx.pullNumber}`);
+  sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
+  sections.push("");
+
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(
+      `These are reviews that led to merged changes on similar code in this repo. Match their tolerance for what counts as a blocker.`,
+    );
+    sections.push("");
+    for (const entry of ctx.answerKeys.slice(0, 8)) sections.push(`- ${entry}`);
+    sections.push("");
+  }
+
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(
+      `These patterns caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
+    );
+    sections.push("");
+    for (const entry of ctx.failureCatalog.slice(0, 8)) sections.push(`- ${entry}`);
+    sections.push("");
+  }
+
+  sections.push(`# Diff`);
+  sections.push("```diff");
+  sections.push(ctx.diff || "(empty diff — respond with verdict=approve, summary noting nothing to review, blockers=[])");
+  sections.push("```");
+  sections.push("");
+  sections.push(`Respond as JSON matching the response schema (verdict, blockers, summary).`);
+  return sections.join("\n");
+}
+
+export function buildCacheablePrefix(ctx: ReviewContext): string {
+  const parts: string[] = [SYSTEM_PROMPT];
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
+  }
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    parts.push("failure-catalog:\n" + ctx.failureCatalog.slice(0, 8).join("\n"));
+  }
+  return parts.join("\n---\n");
+}

--- a/packages/agent-gemini/src/review-schema.ts
+++ b/packages/agent-gemini/src/review-schema.ts
@@ -1,0 +1,37 @@
+/**
+ * Gemini response schema for structured output.
+ *
+ * Gemini enforces structure via `generationConfig: { responseMimeType:
+ * "application/json", responseSchema: <OpenAPI-like schema> }`.
+ * The shape here mirrors agent-claude's tool_use schema + agent-openai's
+ * strict json_schema so all three agents emit compatible `ReviewResult`
+ * payloads.
+ *
+ * Gemini's schema is a subset of OpenAPI 3.0 — notably `additionalProperties`
+ * is NOT supported and `null` union is expressed by `nullable: true`.
+ */
+export const REVIEW_RESPONSE_SCHEMA = {
+  type: "OBJECT",
+  properties: {
+    verdict: {
+      type: "STRING",
+      enum: ["approve", "rework", "reject"],
+    },
+    blockers: {
+      type: "ARRAY",
+      items: {
+        type: "OBJECT",
+        properties: {
+          severity: { type: "STRING", enum: ["blocker", "major", "minor", "nit"] },
+          category: { type: "STRING" },
+          message: { type: "STRING" },
+          file: { type: "STRING", nullable: true },
+          line: { type: "INTEGER", nullable: true },
+        },
+        required: ["severity", "category", "message"],
+      },
+    },
+    summary: { type: "STRING" },
+  },
+  required: ["verdict", "blockers", "summary"],
+} as const;

--- a/packages/agent-gemini/test/gemini-agent.test.mjs
+++ b/packages/agent-gemini/test/gemini-agent.test.mjs
@@ -1,0 +1,180 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EfficiencyGate } from "@ai-conclave/core";
+import { GeminiAgent } from "../dist/index.js";
+
+function okResponse(payload, usage = {}) {
+  return {
+    candidates: [
+      {
+        content: { parts: [{ text: JSON.stringify(payload) }] },
+        finishReason: "STOP",
+      },
+    ],
+    usageMetadata: {
+      promptTokenCount: usage.inputTokens ?? 1_000,
+      candidatesTokenCount: usage.outputTokens ?? 100,
+      cachedContentTokenCount: usage.cachedInputTokens,
+    },
+  };
+}
+
+function mockClient(responses) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    models: {
+      generateContent: async (params) => {
+        calls.push(params);
+        const r = responses[Math.min(i, responses.length - 1)];
+        i += 1;
+        return r;
+      },
+    },
+  };
+}
+
+const ctx = {
+  diff: "diff --git a/x b/x\n+added",
+  repo: "acme/x",
+  pullNumber: 4,
+  newSha: "head-sha",
+};
+
+test("GeminiAgent: parses approve through the gate", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = mockClient([okResponse({ verdict: "approve", blockers: [], summary: "LGTM" })]);
+  const agent = new GeminiAgent({ apiKey: "k", gate, client });
+  const result = await agent.review(ctx);
+  assert.equal(result.agent, "gemini");
+  assert.equal(result.verdict, "approve");
+  assert.equal(result.summary, "LGTM");
+  assert.ok(typeof result.costUsd === "number" && result.costUsd > 0);
+});
+
+test("GeminiAgent: parses rework with blockers, drops malformed items", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = mockClient([
+    okResponse({
+      verdict: "rework",
+      blockers: [
+        { severity: "blocker", category: "type-error", message: "ts2345", file: "x.ts", line: 7 },
+        { severity: "minor", category: "dead-code", message: "unused", file: null, line: null },
+        { garbage: true },
+      ],
+      summary: "1 blocker + 1 minor",
+    }),
+  ]);
+  const agent = new GeminiAgent({ apiKey: "k", gate, client });
+  const result = await agent.review(ctx);
+  assert.equal(result.verdict, "rework");
+  assert.equal(result.blockers.length, 2);
+  assert.equal(result.blockers[0].line, 7);
+});
+
+test("GeminiAgent: wires responseMimeType + responseSchema", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = mockClient([okResponse({ verdict: "approve", blockers: [], summary: "" })]);
+  const agent = new GeminiAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const params = client.calls[0];
+  assert.equal(params.config?.responseMimeType, "application/json");
+  assert.ok(params.config?.responseSchema, "expected responseSchema set");
+});
+
+test("GeminiAgent: systemInstruction carries the cacheable prefix", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = mockClient([okResponse({ verdict: "approve", blockers: [], summary: "" })]);
+  const agent = new GeminiAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const sys = client.calls[0].config?.systemInstruction;
+  assert.ok(sys && typeof sys === "object" && "parts" in sys);
+});
+
+test("GeminiAgent: cached-token discount applied in actualCost", async () => {
+  const clientCached = mockClient([
+    okResponse({ verdict: "approve", blockers: [], summary: "" }, { inputTokens: 10_000, cachedInputTokens: 9_000 }),
+  ]);
+  const clientFresh = mockClient([
+    okResponse({ verdict: "approve", blockers: [], summary: "" }, { inputTokens: 10_000 }),
+  ]);
+  const cached = await new GeminiAgent({
+    apiKey: "k",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    client: clientCached,
+  }).review(ctx);
+  const fresh = await new GeminiAgent({
+    apiKey: "k",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    client: clientFresh,
+  }).review(ctx);
+  assert.ok(cached.costUsd < fresh.costUsd);
+});
+
+test("GeminiAgent: empty text response throws with finishReason", async () => {
+  const client = {
+    calls: [],
+    models: {
+      generateContent: async () => ({ candidates: [{ finishReason: "SAFETY" }] }),
+    },
+  };
+  const agent = new GeminiAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /finishReason=SAFETY/);
+});
+
+test("GeminiAgent: invalid JSON throws", async () => {
+  const client = {
+    calls: [],
+    models: {
+      generateContent: async () => ({
+        candidates: [{ content: { parts: [{ text: "not json" }] }, finishReason: "STOP" }],
+        usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 },
+      }),
+    },
+  };
+  const agent = new GeminiAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /not valid JSON/);
+});
+
+test("GeminiAgent: invalid verdict throws", async () => {
+  const client = mockClient([okResponse({ verdict: "yolo", blockers: [], summary: "" })]);
+  const agent = new GeminiAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /invalid verdict/);
+});
+
+test("GeminiAgent: missing API key + no client throws in constructor", () => {
+  const g = process.env.GOOGLE_API_KEY;
+  const m = process.env.GEMINI_API_KEY;
+  delete process.env.GOOGLE_API_KEY;
+  delete process.env.GEMINI_API_KEY;
+  try {
+    assert.throws(() => new GeminiAgent());
+  } finally {
+    if (g !== undefined) process.env.GOOGLE_API_KEY = g;
+    if (m !== undefined) process.env.GEMINI_API_KEY = m;
+  }
+});
+
+test("GeminiAgent: accepts GEMINI_API_KEY fallback when GOOGLE_API_KEY unset", () => {
+  const g = process.env.GOOGLE_API_KEY;
+  const m = process.env.GEMINI_API_KEY;
+  delete process.env.GOOGLE_API_KEY;
+  process.env.GEMINI_API_KEY = "fallback-key";
+  try {
+    const agent = new GeminiAgent();
+    assert.ok(agent);
+  } finally {
+    if (g !== undefined) process.env.GOOGLE_API_KEY = g;
+    if (m !== undefined) process.env.GEMINI_API_KEY = m;
+    else delete process.env.GEMINI_API_KEY;
+  }
+});
+
+test("GeminiAgent: pre-flight budget throws before network call", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 0.00001 });
+  const client = mockClient([okResponse({ verdict: "approve", blockers: [], summary: "" })]);
+  const agent = new GeminiAgent({ apiKey: "k", gate, client });
+  await assert.rejects(() => agent.review(ctx), /budget/);
+  assert.equal(client.calls.length, 0);
+});

--- a/packages/agent-gemini/test/pricing.test.mjs
+++ b/packages/agent-gemini/test/pricing.test.mjs
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { actualCost, estimateCallCost, PRICING } from "../dist/index.js";
+
+test("PRICING table has long-context + flash + next-gen tiers", () => {
+  assert.ok(PRICING["gemini-2.5-pro"]);
+  assert.ok(PRICING["gemini-2.5-flash"]);
+  assert.ok(PRICING["gemini-3.0-flash"]);
+});
+
+test("actualCost: gemini-2.5-pro baseline", () => {
+  // 1000 * 1.25 / M + 500 * 10 / M = 0.00125 + 0.005 = 0.00625
+  const cost = actualCost("gemini-2.5-pro", { inputTokens: 1_000, outputTokens: 500 });
+  assert.equal(cost.toFixed(5), "0.00625");
+});
+
+test("actualCost: cached input discount is 75% for gemini-2.5", () => {
+  // 2.5-pro: 1.25 normal, 0.3125 cached → 75% off on the cached portion.
+  const cost = actualCost("gemini-2.5-pro", {
+    inputTokens: 10_000,
+    outputTokens: 0,
+    cachedInputTokens: 10_000,
+  });
+  const noCache = actualCost("gemini-2.5-pro", { inputTokens: 10_000, outputTokens: 0 });
+  assert.equal((cost / noCache).toFixed(2), "0.25");
+});
+
+test("actualCost: flash is ~8× cheaper than pro on input", () => {
+  const pro = actualCost("gemini-2.5-pro", { inputTokens: 100_000, outputTokens: 0 });
+  const flash = actualCost("gemini-2.5-flash", { inputTokens: 100_000, outputTokens: 0 });
+  const ratio = pro / flash;
+  assert.ok(ratio >= 7 && ratio <= 9, `expected ~8, got ${ratio}`);
+});
+
+test("actualCost: throws on unknown model", () => {
+  assert.throws(() => actualCost("gemini-nope", { inputTokens: 1, outputTokens: 1 }));
+});
+
+test("estimateCallCost: pessimistic pre-flight matches reserve-before-call", () => {
+  // 2.5-pro: 5000 * 1.25 / M + 1000 * 10 / M = 0.00625 + 0.01 = 0.01625
+  const est = estimateCallCost("gemini-2.5-pro", 5_000, 1_000);
+  assert.equal(est.toFixed(5), "0.01625");
+});
+
+test("PRICING: maxContextTokens populated for long-context routing", () => {
+  assert.equal(PRICING["gemini-2.5-pro"].maxContextTokens, 1_048_576);
+  assert.equal(PRICING["gemini-3.0-flash"].maxContextTokens, 2_097_152);
+});

--- a/packages/agent-gemini/tsconfig.json
+++ b/packages/agent-gemini/tsconfig.json
@@ -7,9 +7,6 @@
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"],
   "references": [
-    { "path": "../core" },
-    { "path": "../agent-claude" },
-    { "path": "../agent-gemini" },
-    { "path": "../agent-openai" }
+    { "path": "../core" }
   ]
 }

--- a/packages/agent-openai/README.md
+++ b/packages/agent-openai/README.md
@@ -1,0 +1,31 @@
+# @ai-conclave/agent-openai
+
+OpenAI agent for Ai-Conclave council review. Implements the `Agent`
+interface from `@ai-conclave/core`. Uses strict JSON Schema response
+format (decision #12) for guaranteed well-formed `ReviewResult` output.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/agent-openai @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { OpenAIAgent } from "@ai-conclave/agent-openai";
+import { ClaudeAgent } from "@ai-conclave/agent-claude";
+import { Council, EfficiencyGate } from "@ai-conclave/core";
+
+const gate = new EfficiencyGate();
+const council = new Council({
+  agents: [new ClaudeAgent({ gate }), new OpenAIAgent({ gate })],
+});
+```
+
+## Models
+
+Default: `gpt-5-mini`. Override via `new OpenAIAgent({ model: "gpt-5" })`.
+
+Pricing table covers `gpt-4.1` / `gpt-4.1-mini` / `gpt-5` / `gpt-5-mini` /
+`o5` — revisit on publish in case OpenAI changes prices.

--- a/packages/agent-openai/package.json
+++ b/packages/agent-openai/package.json
@@ -1,13 +1,16 @@
 {
-  "name": "@ai-conclave/cli",
+  "name": "@ai-conclave/agent-openai",
   "version": "0.0.0",
-  "description": "Ai-Conclave CLI — the `conclave` binary.",
+  "description": "Ai-Conclave OpenAI agent — wraps the OpenAI SDK with strict-JSON-schema structured output.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "conclave": "./dist/bin/conclave.js"
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",
@@ -22,10 +25,8 @@
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {
-    "@ai-conclave/agent-claude": "workspace:*",
-    "@ai-conclave/agent-openai": "workspace:*",
     "@ai-conclave/core": "workspace:*",
-    "zod": "^3.24.0"
+    "openai": "^4.76.0"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/packages/agent-openai/src/index.ts
+++ b/packages/agent-openai/src/index.ts
@@ -1,0 +1,6 @@
+export { OpenAIAgent, SYSTEM_PROMPT } from "./openai-agent.js";
+export type { OpenAIAgentOptions, OpenAILike, ChatCompletionParams, ChatCompletionResponse } from "./openai-agent.js";
+export { buildReviewPrompt, buildCacheablePrefix } from "./prompts.js";
+export { REVIEW_SCHEMA_NAME, REVIEW_JSON_SCHEMA } from "./review-schema.js";
+export { actualCost, estimateCallCost, PRICING } from "./pricing.js";
+export type { OpenAIModelPricing, UsageBreakdown } from "./pricing.js";

--- a/packages/agent-openai/src/openai-agent.ts
+++ b/packages/agent-openai/src/openai-agent.ts
@@ -1,0 +1,216 @@
+import type { Agent, ReviewContext, ReviewResult, Blocker } from "@ai-conclave/core";
+import { EfficiencyGate, estimateTokens } from "@ai-conclave/core";
+import { REVIEW_SCHEMA_NAME, REVIEW_JSON_SCHEMA } from "./review-schema.js";
+import { SYSTEM_PROMPT, buildReviewPrompt, buildCacheablePrefix } from "./prompts.js";
+import { actualCost, estimateCallCost } from "./pricing.js";
+
+/**
+ * Minimal shape of the OpenAI SDK client that OpenAIAgent needs.
+ * Typed against this subset to keep tests cheap to mock and tolerate SDK
+ * minor-version churn.
+ */
+export interface OpenAILike {
+  chat: {
+    completions: {
+      create(params: ChatCompletionParams): Promise<ChatCompletionResponse>;
+    };
+  };
+}
+
+export interface ChatCompletionParams {
+  model: string;
+  max_completion_tokens?: number;
+  max_tokens?: number;
+  messages: ReadonlyArray<{ role: "system" | "user" | "assistant"; content: string }>;
+  response_format?: {
+    type: "json_schema";
+    json_schema: { name: string; strict: true; schema: unknown };
+  };
+}
+
+export interface ChatCompletionResponse {
+  id: string;
+  model: string;
+  choices: ReadonlyArray<{
+    index: number;
+    finish_reason: string;
+    message: {
+      role: "assistant";
+      content: string | null;
+      refusal?: string | null;
+    };
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    prompt_tokens_details?: { cached_tokens?: number };
+  };
+}
+
+export interface OpenAIAgentOptions {
+  apiKey?: string;
+  /** Defaults to gpt-5-mini. Gate router may override per call. */
+  model?: string;
+  maxTokens?: number;
+  gate?: EfficiencyGate;
+  client?: OpenAILike;
+  clientFactory?: (apiKey: string) => Promise<OpenAILike>;
+}
+
+const DEFAULT_MODEL = "gpt-5-mini";
+const DEFAULT_MAX_TOKENS = 2_048;
+
+async function defaultClientFactory(apiKey: string): Promise<OpenAILike> {
+  const mod = (await import("openai")) as unknown as {
+    default: new (opts: { apiKey: string }) => OpenAILike;
+  };
+  const Ctor = mod.default;
+  return new Ctor({ apiKey });
+}
+
+/**
+ * OpenAIAgent — routes a real OpenAI structured-output review call through
+ * the efficiency gate. Uses strict JSON Schema response format so the
+ * response is guaranteed to match `ReviewResult` shape (decision #12).
+ */
+export class OpenAIAgent implements Agent {
+  readonly id = "openai";
+  readonly displayName = "OpenAI";
+
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly gate: EfficiencyGate;
+  private readonly clientFactory: (apiKey: string) => Promise<OpenAILike>;
+  private clientPromise: Promise<OpenAILike> | null;
+
+  constructor(opts: OpenAIAgentOptions = {}) {
+    const key = opts.apiKey ?? process.env["OPENAI_API_KEY"] ?? "";
+    if (!key && !opts.client) {
+      throw new Error("OpenAIAgent: OPENAI_API_KEY not set (pass opts.apiKey, opts.client, or the env var)");
+    }
+    this.apiKey = key;
+    this.model = opts.model ?? DEFAULT_MODEL;
+    this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.gate = opts.gate ?? new EfficiencyGate();
+    this.clientFactory = opts.clientFactory ?? defaultClientFactory;
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+  }
+
+  private async getClient(): Promise<OpenAILike> {
+    if (!this.clientPromise) this.clientPromise = this.clientFactory(this.apiKey);
+    return this.clientPromise;
+  }
+
+  async review(ctx: ReviewContext): Promise<ReviewResult> {
+    const cacheablePrefix = buildCacheablePrefix(ctx);
+    const userPrompt = buildReviewPrompt(ctx);
+    const inputTokenEstimate = estimateTokens(cacheablePrefix) + estimateTokens(userPrompt);
+    const estimatedCost = estimateCallCost(this.model, inputTokenEstimate, this.maxTokens);
+
+    const outcome = await this.gate.run<ReviewResult>(
+      {
+        agent: this.id,
+        cacheablePrefix,
+        prompt: cacheablePrefix + "\n" + userPrompt,
+        estimatedCostUsd: estimatedCost,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const response = await client.chat.completions.create({
+          model,
+          max_completion_tokens: this.maxTokens,
+          messages: [
+            { role: "system", content: cacheablePrefix },
+            { role: "user", content: userPrompt },
+          ],
+          response_format: {
+            type: "json_schema",
+            json_schema: { name: REVIEW_SCHEMA_NAME, strict: true, schema: REVIEW_JSON_SCHEMA },
+          },
+        });
+        const latencyMs = Date.now() - started;
+
+        const parsed = parseReviewResponse(response, this.id);
+        const usage = response.usage;
+        const inputTokens = usage?.prompt_tokens ?? inputTokenEstimate;
+        const outputTokens = usage?.completion_tokens ?? 0;
+        const cachedInput = usage?.prompt_tokens_details?.cached_tokens;
+        const costParts: { inputTokens: number; outputTokens: number; cachedInputTokens?: number } = {
+          inputTokens,
+          outputTokens,
+        };
+        if (cachedInput !== undefined) costParts.cachedInputTokens = cachedInput;
+        const cost = actualCost(model, costParts);
+
+        return {
+          result: {
+            ...parsed,
+            tokensUsed: inputTokens + outputTokens,
+            costUsd: cost,
+          },
+          inputTokens,
+          outputTokens,
+          costUsd: cost,
+          latencyMs,
+        };
+      },
+    );
+
+    return outcome.result;
+  }
+}
+
+function parseReviewResponse(response: ChatCompletionResponse, agentId: string): ReviewResult {
+  const choice = response.choices[0];
+  if (!choice) throw new Error("OpenAIAgent: response had no choices");
+  if (choice.message.refusal) {
+    throw new Error(`OpenAIAgent: model refused to respond — ${choice.message.refusal}`);
+  }
+  const text = choice.message.content;
+  if (!text) throw new Error(`OpenAIAgent: response had no content (finish_reason=${choice.finish_reason})`);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new Error(`OpenAIAgent: response content was not valid JSON: ${(err as Error).message}`);
+  }
+  return normalizeReview(parsed, agentId);
+}
+
+function normalizeReview(raw: unknown, agentId: string): ReviewResult {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("OpenAIAgent: response is not an object");
+  }
+  const v = (raw as { verdict?: unknown }).verdict;
+  if (v !== "approve" && v !== "rework" && v !== "reject") {
+    throw new Error(`OpenAIAgent: invalid verdict "${String(v)}"`);
+  }
+  const blockersRaw = (raw as { blockers?: unknown[] }).blockers;
+  const blockers: Blocker[] = [];
+  if (Array.isArray(blockersRaw)) {
+    for (const item of blockersRaw) {
+      if (!item || typeof item !== "object") continue;
+      const b = item as Record<string, unknown>;
+      const severity = b["severity"];
+      const category = b["category"];
+      const message = b["message"];
+      if (
+        (severity === "blocker" || severity === "major" || severity === "minor" || severity === "nit") &&
+        typeof category === "string" &&
+        typeof message === "string"
+      ) {
+        const blocker: Blocker = { severity, category, message };
+        if (typeof b["file"] === "string") blocker.file = b["file"] as string;
+        if (typeof b["line"] === "number") blocker.line = b["line"] as number;
+        blockers.push(blocker);
+      }
+    }
+  }
+  const summary = typeof (raw as { summary?: unknown }).summary === "string" ? (raw as { summary: string }).summary : "";
+  return { agent: agentId, verdict: v, blockers, summary };
+}
+
+export { SYSTEM_PROMPT };

--- a/packages/agent-openai/src/pricing.ts
+++ b/packages/agent-openai/src/pricing.ts
@@ -1,0 +1,47 @@
+export interface OpenAIModelPricing {
+  /** USD per 1M input tokens. */
+  inputPerMTok: number;
+  /** USD per 1M output tokens. */
+  outputPerMTok: number;
+  /** USD per 1M cached-input tokens (OpenAI prompt-cache; ~50% discount on supported models). */
+  cachedInputPerMTok?: number;
+}
+
+/**
+ * Pricing table for OpenAI review-capable models. Numbers reflect
+ * published OpenAI API pricing as of 2026-04; revisit at each publish.
+ *
+ * Unknown / unpublished: caching discounts on reasoning models vary and
+ * are handled conservatively (no discount if cachedInputPerMTok absent).
+ */
+export const PRICING: Record<string, OpenAIModelPricing> = {
+  "gpt-4.1": { inputPerMTok: 2.5, outputPerMTok: 10.0, cachedInputPerMTok: 1.25 },
+  "gpt-4.1-mini": { inputPerMTok: 0.4, outputPerMTok: 1.6, cachedInputPerMTok: 0.2 },
+  "gpt-5": { inputPerMTok: 5.0, outputPerMTok: 20.0, cachedInputPerMTok: 2.5 },
+  "gpt-5-mini": { inputPerMTok: 0.5, outputPerMTok: 2.0, cachedInputPerMTok: 0.25 },
+  "o5": { inputPerMTok: 15.0, outputPerMTok: 60.0 },
+};
+
+export interface UsageBreakdown {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens?: number;
+}
+
+export function actualCost(model: string, usage: UsageBreakdown): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown OpenAI model "${model}"`);
+  const baseInput = usage.inputTokens - (usage.cachedInputTokens ?? 0);
+  return (
+    (Math.max(0, baseInput) * p.inputPerMTok +
+      (usage.cachedInputTokens ?? 0) * (p.cachedInputPerMTok ?? p.inputPerMTok) +
+      usage.outputTokens * p.outputPerMTok) /
+    1_000_000
+  );
+}
+
+export function estimateCallCost(model: string, estimatedInputTokens: number, maxOutputTokens: number): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown OpenAI model "${model}"`);
+  return (estimatedInputTokens * p.inputPerMTok + maxOutputTokens * p.outputPerMTok) / 1_000_000;
+}

--- a/packages/agent-openai/src/prompts.ts
+++ b/packages/agent-openai/src/prompts.ts
@@ -1,0 +1,61 @@
+import type { ReviewContext } from "@ai-conclave/core";
+
+export const SYSTEM_PROMPT = `You are a senior code reviewer on a multi-agent council for Ai-Conclave. The council reviews AI-generated code and design changes before merge.
+
+Your goal: catch real blockers, not style nits. You work alongside other agents (Claude, Gemini, possibly domain-specific specialists). Your reviews are weighed against theirs; spurious blockers hurt your agent score and waste the rework budget.
+
+Rules:
+- Focus on: correctness, security, regression risk, missing tests for non-trivial changes, accessibility + contrast on UI, obvious performance cliffs.
+- Do NOT comment on: style bikeshedding, import order, variable renames that are already consistent, personal formatting preferences.
+- When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
+- Never pad with encouragement ("great work but...") — go straight to the concerns.
+- When the diff is small, low-risk, and has test coverage, approve cleanly. Over-flagging is a bigger sin than missing a nit.
+- You MUST respond in the provided JSON schema. Any field marked nullable uses null when not applicable (do not omit it).`;
+
+export function buildReviewPrompt(ctx: ReviewContext): string {
+  const sections: string[] = [];
+  sections.push(`# Review target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`pull: #${ctx.pullNumber}`);
+  sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
+  sections.push("");
+
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(
+      `These are reviews that led to merged changes on similar code in this repo. Lean on them as a style + quality bar — match their tolerance for what counts as a blocker.`,
+    );
+    sections.push("");
+    for (const entry of ctx.answerKeys.slice(0, 8)) sections.push(`- ${entry}`);
+    sections.push("");
+  }
+
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(
+      `These are patterns that caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
+    );
+    sections.push("");
+    for (const entry of ctx.failureCatalog.slice(0, 8)) sections.push(`- ${entry}`);
+    sections.push("");
+  }
+
+  sections.push(`# Diff`);
+  sections.push("```diff");
+  sections.push(ctx.diff || "(empty diff — respond with verdict=approve, summary noting nothing to review, blockers=[])");
+  sections.push("```");
+  sections.push("");
+  sections.push(`Respond using the conclave_review JSON schema.`);
+  return sections.join("\n");
+}
+
+export function buildCacheablePrefix(ctx: ReviewContext): string {
+  const parts: string[] = [SYSTEM_PROMPT];
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
+  }
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    parts.push("failure-catalog:\n" + ctx.failureCatalog.slice(0, 8).join("\n"));
+  }
+  return parts.join("\n---\n");
+}

--- a/packages/agent-openai/src/review-schema.ts
+++ b/packages/agent-openai/src/review-schema.ts
@@ -1,0 +1,40 @@
+/**
+ * OpenAI strict JSON Schema for the review response.
+ * Per decision #12: "OpenAI strict json_schema via openai-zod-to-json-schema".
+ *
+ * Strict mode requires:
+ *   - `additionalProperties: false` at every level
+ *   - every field in `properties` must be listed in `required`
+ *
+ * The schema mirrors agent-claude's tool_use schema so both agents emit
+ * compatible `ReviewResult` shapes.
+ */
+export const REVIEW_SCHEMA_NAME = "conclave_review";
+
+export const REVIEW_JSON_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    verdict: {
+      type: "string",
+      enum: ["approve", "rework", "reject"],
+    },
+    blockers: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          severity: { type: "string", enum: ["blocker", "major", "minor", "nit"] },
+          category: { type: "string" },
+          message: { type: "string" },
+          file: { type: ["string", "null"] },
+          line: { type: ["number", "null"] },
+        },
+        required: ["severity", "category", "message", "file", "line"],
+      },
+    },
+    summary: { type: "string" },
+  },
+  required: ["verdict", "blockers", "summary"],
+} as const;

--- a/packages/agent-openai/test/openai-agent.test.mjs
+++ b/packages/agent-openai/test/openai-agent.test.mjs
@@ -1,0 +1,181 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EfficiencyGate } from "@ai-conclave/core";
+import { OpenAIAgent } from "../dist/index.js";
+
+function jsonChoice(payload, usage = {}) {
+  return {
+    id: "chatcmpl-test",
+    model: "gpt-5-mini",
+    choices: [
+      {
+        index: 0,
+        finish_reason: "stop",
+        message: {
+          role: "assistant",
+          content: JSON.stringify(payload),
+        },
+      },
+    ],
+    usage: {
+      prompt_tokens: usage.inputTokens ?? 1_000,
+      completion_tokens: usage.outputTokens ?? 100,
+      prompt_tokens_details: usage.cachedInputTokens !== undefined
+        ? { cached_tokens: usage.cachedInputTokens }
+        : undefined,
+    },
+  };
+}
+
+function mockClient(responses) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    chat: {
+      completions: {
+        create: async (params) => {
+          calls.push(params);
+          const r = responses[Math.min(i, responses.length - 1)];
+          i += 1;
+          return r;
+        },
+      },
+    },
+  };
+}
+
+const ctx = {
+  diff: "diff --git a/x b/x\n+added",
+  repo: "acme/x",
+  pullNumber: 3,
+  newSha: "sha-head",
+};
+
+test("OpenAIAgent: parses approve through the gate", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = mockClient([jsonChoice({ verdict: "approve", blockers: [], summary: "LGTM" })]);
+  const agent = new OpenAIAgent({ apiKey: "test", gate, client });
+  const result = await agent.review(ctx);
+  assert.equal(result.agent, "openai");
+  assert.equal(result.verdict, "approve");
+  assert.equal(result.summary, "LGTM");
+  assert.ok(typeof result.costUsd === "number" && result.costUsd > 0);
+});
+
+test("OpenAIAgent: parses rework with structured blockers and ignores malformed items", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = mockClient([
+    jsonChoice({
+      verdict: "rework",
+      blockers: [
+        { severity: "blocker", category: "type-error", message: "ts2345", file: "x.ts", line: 10 },
+        { severity: "minor", category: "dead-code", message: "unused import", file: null, line: null },
+        { invalid: "shape" },
+      ],
+      summary: "1 blocker + 1 minor",
+    }),
+  ]);
+  const agent = new OpenAIAgent({ apiKey: "test", gate, client });
+  const result = await agent.review(ctx);
+  assert.equal(result.verdict, "rework");
+  assert.equal(result.blockers.length, 2);
+  assert.equal(result.blockers[0].file, "x.ts");
+  assert.equal(result.blockers[0].line, 10);
+});
+
+test("OpenAIAgent: wires strict json_schema response_format", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = mockClient([jsonChoice({ verdict: "approve", blockers: [], summary: "" })]);
+  const agent = new OpenAIAgent({ apiKey: "test", gate, client });
+  await agent.review(ctx);
+  const params = client.calls[0];
+  assert.equal(params.response_format?.type, "json_schema");
+  assert.equal(params.response_format?.json_schema.strict, true);
+  assert.equal(params.response_format?.json_schema.name, "conclave_review");
+});
+
+test("OpenAIAgent: applies cached-token discount to actualCost", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const clientCached = mockClient([
+    jsonChoice({ verdict: "approve", blockers: [], summary: "" }, { inputTokens: 10_000, cachedInputTokens: 9_000 }),
+  ]);
+  const clientFresh = mockClient([
+    jsonChoice({ verdict: "approve", blockers: [], summary: "" }, { inputTokens: 10_000 }),
+  ]);
+  const agentCached = new OpenAIAgent({ apiKey: "test", gate: new EfficiencyGate({ perPrUsd: 1 }), client: clientCached });
+  const agentFresh = new OpenAIAgent({ apiKey: "test", gate: new EfficiencyGate({ perPrUsd: 1 }), client: clientFresh });
+  const cached = await agentCached.review(ctx);
+  const fresh = await agentFresh.review(ctx);
+  assert.ok(cached.costUsd < fresh.costUsd, `expected cached cheaper than fresh, got ${cached.costUsd} vs ${fresh.costUsd}`);
+  void gate;
+});
+
+test("OpenAIAgent: refusal throws actionable error", async () => {
+  const client = {
+    calls: [],
+    chat: {
+      completions: {
+        create: async () => ({
+          id: "x",
+          model: "gpt-5-mini",
+          choices: [{ index: 0, finish_reason: "content_filter", message: { role: "assistant", content: null, refusal: "I cannot." } }],
+        }),
+      },
+    },
+  };
+  const agent = new OpenAIAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /model refused/);
+});
+
+test("OpenAIAgent: invalid JSON in content throws", async () => {
+  const client = {
+    calls: [],
+    chat: {
+      completions: {
+        create: async () => ({
+          id: "x",
+          model: "gpt-5-mini",
+          choices: [{ index: 0, finish_reason: "stop", message: { role: "assistant", content: "not json" } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        }),
+      },
+    },
+  };
+  const agent = new OpenAIAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /not valid JSON/);
+});
+
+test("OpenAIAgent: invalid verdict value throws", async () => {
+  const client = mockClient([jsonChoice({ verdict: "yolo", blockers: [], summary: "" })]);
+  const agent = new OpenAIAgent({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => agent.review(ctx), /invalid verdict/);
+});
+
+test("OpenAIAgent: missing API key and no client throws in constructor", () => {
+  const orig = process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  try {
+    assert.throws(() => new OpenAIAgent());
+  } finally {
+    if (orig !== undefined) process.env.OPENAI_API_KEY = orig;
+  }
+});
+
+test("OpenAIAgent: metrics recorded on shared gate", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = mockClient([jsonChoice({ verdict: "approve", blockers: [], summary: "" })]);
+  const agent = new OpenAIAgent({ apiKey: "k", gate, client });
+  await agent.review(ctx);
+  const s = gate.metrics.summary();
+  assert.equal(s.callCount, 1);
+  assert.equal(s.byAgent["openai"].calls, 1);
+});
+
+test("OpenAIAgent: pre-flight budget throw prevents network call", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 0.00001 });
+  const client = mockClient([jsonChoice({ verdict: "approve", blockers: [], summary: "" })]);
+  const agent = new OpenAIAgent({ apiKey: "k", gate, client });
+  await assert.rejects(() => agent.review(ctx), /budget/);
+  assert.equal(client.calls.length, 0);
+});

--- a/packages/agent-openai/test/pricing.test.mjs
+++ b/packages/agent-openai/test/pricing.test.mjs
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { actualCost, estimateCallCost, PRICING } from "../dist/index.js";
+
+test("PRICING: table has primary review models", () => {
+  assert.ok(PRICING["gpt-5-mini"]);
+  assert.ok(PRICING["gpt-5"]);
+  assert.ok(PRICING["gpt-4.1"]);
+});
+
+test("actualCost: baseline gpt-5-mini no cache", () => {
+  // 1000 * 0.5 + 500 * 2.0 = 500 + 1000 = 1500 / 1M = 0.0015
+  const cost = actualCost("gpt-5-mini", { inputTokens: 1_000, outputTokens: 500 });
+  assert.equal(cost.toFixed(4), "0.0015");
+});
+
+test("actualCost: cached input gets discount", () => {
+  const noCache = actualCost("gpt-5", { inputTokens: 10_000, outputTokens: 0 });
+  const cached = actualCost("gpt-5", { inputTokens: 10_000, outputTokens: 0, cachedInputTokens: 10_000 });
+  assert.ok(cached < noCache);
+  // gpt-5: 5 / 2.5 = 50% discount on cached
+  assert.equal((cached / noCache).toFixed(2), "0.50");
+});
+
+test("actualCost: model without cached pricing treats cache at full rate", () => {
+  const model = "o5";
+  const p = PRICING[model];
+  assert.equal(p.cachedInputPerMTok, undefined);
+  const withCache = actualCost(model, { inputTokens: 1_000, outputTokens: 0, cachedInputTokens: 500 });
+  const noCache = actualCost(model, { inputTokens: 1_000, outputTokens: 0 });
+  assert.equal(withCache, noCache);
+});
+
+test("actualCost: throws on unknown model", () => {
+  assert.throws(() => actualCost("gpt-nope", { inputTokens: 1, outputTokens: 1 }));
+});
+
+test("estimateCallCost: deterministic pre-flight", () => {
+  // gpt-5-mini: 5_000 * 0.5/M + 1_000 * 2.0/M = 0.0025 + 0.002 = 0.0045
+  const est = estimateCallCost("gpt-5-mini", 5_000, 1_000);
+  assert.equal(est.toFixed(4), "0.0045");
+});

--- a/packages/agent-openai/tsconfig.json
+++ b/packages/agent-openai/tsconfig.json
@@ -7,8 +7,6 @@
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"],
   "references": [
-    { "path": "../core" },
-    { "path": "../agent-claude" },
-    { "path": "../agent-openai" }
+    { "path": "../core" }
   ]
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,24 @@
+# @ai-conclave/cli
+
+The `conclave` command-line interface for Ai-Conclave.
+
+Skeleton status: `init` and `review` wired end-to-end through the core
+skeleton. Real PR discovery, efficiency gate, memory write-back, and
+notification dispatch land in later PRs.
+
+## Install
+
+```bash
+pnpm add -g @ai-conclave/cli
+# or
+npm install -g @ai-conclave/cli
+```
+
+## Commands
+
+```
+conclave init                Write .conclaverc.json in the current repo
+conclave review [--pr N]     Run a council review (skeleton)
+conclave --help              Show help
+conclave --version           Show version
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "@ai-conclave/agent-claude": "workspace:*",
-    "@ai-conclave/core": "workspace:*"
+    "@ai-conclave/core": "workspace:*",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "@ai-conclave/agent-openai": "workspace:*",
     "@ai-conclave/core": "workspace:*",
     "@ai-conclave/integration-discord": "workspace:*",
+    "@ai-conclave/integration-slack": "workspace:*",
     "@ai-conclave/integration-telegram": "workspace:*",
     "@ai-conclave/observability-langfuse": "workspace:*",
     "@ai-conclave/scm-github": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "@ai-conclave/agent-openai": "workspace:*",
     "@ai-conclave/core": "workspace:*",
     "@ai-conclave/integration-discord": "workspace:*",
+    "@ai-conclave/integration-email": "workspace:*",
     "@ai-conclave/integration-slack": "workspace:*",
     "@ai-conclave/integration-telegram": "workspace:*",
     "@ai-conclave/observability-langfuse": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@ai-conclave/cli",
+  "version": "0.0.0",
+  "description": "Ai-Conclave CLI — the `conclave` binary.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "conclave": "./dist/bin/conclave.js"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@ai-conclave/agent-claude": "workspace:*",
+    "@ai-conclave/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cli/src/bin/conclave.ts
+++ b/packages/cli/src/bin/conclave.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { run } from "../index.js";
+
+run(process.argv.slice(2)).catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`conclave: ${msg}\n`);
+  process.exit(1);
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,32 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const CONFIG_FILENAME = ".conclaverc.json";
+
+const DEFAULT_CONFIG = {
+  version: 1,
+  agents: ["claude"],
+  budget: { perPrUsd: 0.5 },
+  efficiency: { cacheEnabled: true, compactEnabled: true },
+  memory: { answerKeysDir: ".conclave/answer-keys", failureCatalogDir: ".conclave/failure-catalog" },
+};
+
+export async function init(_argv: string[]): Promise<void> {
+  const cwd = process.cwd();
+  const target = path.join(cwd, CONFIG_FILENAME);
+
+  try {
+    await fs.access(target);
+    process.stderr.write(`conclave: ${CONFIG_FILENAME} already exists at ${cwd}. Aborting.\n`);
+    process.exit(1);
+    return;
+  } catch {
+    // does not exist, proceed
+  }
+
+  await fs.writeFile(target, JSON.stringify(DEFAULT_CONFIG, null, 2) + "\n", "utf8");
+  process.stdout.write(
+    `conclave: wrote ${CONFIG_FILENAME}\n` +
+      `Next: set ANTHROPIC_API_KEY, then run \`conclave review\`.\n`,
+  );
+}

--- a/packages/cli/src/commands/poll-outcomes.ts
+++ b/packages/cli/src/commands/poll-outcomes.ts
@@ -1,0 +1,69 @@
+import { FileSystemMemoryStore, OutcomeWriter } from "@ai-conclave/core";
+import { pollOutcomes } from "@ai-conclave/scm-github";
+import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
+
+const HELP = `conclave poll-outcomes — auto-classify pending reviews against GitHub PR state
+
+Usage:
+  conclave poll-outcomes [--quiet]
+
+Scans the memory store for episodic entries with outcome="pending" and
+calls \`gh pr view\` on each. Transitions are classified as:
+  merged PR                      → outcome=merged   → AnswerKey written
+  closed PR (not merged)         → outcome=rejected → FailureEntry per blocker
+  open PR with new head commits  → outcome=reworked → FailureEntry per blocker
+  open PR, head unchanged        → pending (no-op)
+
+Requires 'gh auth login'. Safe to run on a cron.
+`;
+
+function parseArgv(argv: string[]): { quiet: boolean; help: boolean } {
+  return {
+    quiet: argv.includes("--quiet"),
+    help: argv.includes("--help") || argv.includes("-h"),
+  };
+}
+
+export async function pollOutcomesCommand(argv: string[]): Promise<void> {
+  const args = parseArgv(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  const { config, configDir } = await loadConfig();
+  const memoryRoot = resolveMemoryRoot(config, configDir);
+  const store = new FileSystemMemoryStore({ root: memoryRoot });
+  const writer = new OutcomeWriter({ store });
+
+  const summary = await pollOutcomes({ store, writer });
+
+  if (!args.quiet) {
+    process.stdout.write(
+      `conclave poll-outcomes:\n` +
+        `  scanned:    ${summary.scanned}\n` +
+        `  merged:     ${summary.merged}\n` +
+        `  rejected:   ${summary.rejected}\n` +
+        `  reworked:   ${summary.reworked}\n` +
+        `  pending:    ${summary.pending}\n` +
+        `  errors:     ${summary.errors}\n`,
+    );
+    for (const r of summary.results) {
+      if (r.error) {
+        process.stderr.write(`  ${r.episodicId} (${r.repo}#${r.prNumber}): error — ${r.error}\n`);
+      } else if (r.wrote) {
+        process.stdout.write(`  ${r.episodicId} (${r.repo}#${r.prNumber}): ${r.classification}\n`);
+      }
+    }
+  }
+
+  // Exit code: 0 if scan succeeded (errors-per-PR counted separately);
+  // 1 if no episodic entries were found (likely misconfigured).
+  if (summary.scanned === 0) {
+    process.stderr.write(
+      "conclave poll-outcomes: no episodic entries in memory store — run `conclave review` first.\n",
+    );
+    process.exit(1);
+    return;
+  }
+}

--- a/packages/cli/src/commands/record-outcome.ts
+++ b/packages/cli/src/commands/record-outcome.ts
@@ -1,0 +1,62 @@
+import { FileSystemMemoryStore, OutcomeWriter, type OutcomeResult } from "@ai-conclave/core";
+import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
+
+const HELP = `conclave record-outcome — close the self-evolve loop
+
+Usage:
+  conclave record-outcome --id <episodic-id> --result merged|rejected|reworked
+
+On merged PRs, a new answer-key (정답지) is derived from the review summary.
+On rejected / reworked PRs, a failure-catalog entry (오답지) is derived per
+unique blocker (ignoring nits).
+`;
+
+function parseArgv(argv: string[]): { id?: string; result?: OutcomeResult; help: boolean } {
+  const out: { id?: string; result?: OutcomeResult; help: boolean } = { help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--id" && argv[i + 1]) {
+      out.id = argv[i + 1];
+      i += 1;
+    } else if (a === "--result" && argv[i + 1]) {
+      const r = argv[i + 1];
+      if (r === "merged" || r === "rejected" || r === "reworked") out.result = r;
+      i += 1;
+    }
+  }
+  return out;
+}
+
+export async function recordOutcome(argv: string[]): Promise<void> {
+  const args = parseArgv(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  if (!args.id) {
+    process.stderr.write("conclave record-outcome: --id is required\n\n" + HELP);
+    process.exit(2);
+    return;
+  }
+  if (!args.result) {
+    process.stderr.write("conclave record-outcome: --result must be merged|rejected|reworked\n\n" + HELP);
+    process.exit(2);
+    return;
+  }
+
+  const { config, configDir } = await loadConfig();
+  const memoryRoot = resolveMemoryRoot(config, configDir);
+  const store = new FileSystemMemoryStore({ root: memoryRoot });
+  const writer = new OutcomeWriter({ store });
+
+  const output = await writer.recordOutcome({ episodicId: args.id, outcome: args.result });
+
+  process.stdout.write(
+    `conclave record-outcome:\n` +
+      `  episodic:     ${args.id}\n` +
+      `  outcome:      ${args.result}\n` +
+      `  answer-keys:  ${output.answerKeys.length} written\n` +
+      `  failures:     ${output.failures.length} written\n`,
+  );
+}

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -14,6 +14,8 @@ import { ClaudeAgent } from "@ai-conclave/agent-claude";
 import { OpenAIAgent } from "@ai-conclave/agent-openai";
 import { GeminiAgent } from "@ai-conclave/agent-gemini";
 import { LangfuseMetricsSink } from "@ai-conclave/observability-langfuse";
+import { TelegramNotifier } from "@ai-conclave/integration-telegram";
+import type { Notifier } from "@ai-conclave/core";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
 import { renderReview, verdictToExitCode } from "../lib/output.js";
@@ -177,6 +179,48 @@ export async function review(argv: string[]): Promise<void> {
       `  when the PR lands, close the loop with:\n` +
       `    conclave record-outcome --id ${episodic.id} --result merged\n`,
   );
+
+  // 8. Optional integrations — equal-weight per decision #24. Missing
+  //    credentials skip with stderr warning; integration failures never
+  //    kill the review exit code.
+  const notifiers: Notifier[] = [];
+  const tg = config.integrations?.telegram;
+  if (tg?.enabled !== false) {
+    const hasToken = !!process.env["TELEGRAM_BOT_TOKEN"];
+    const hasChat = tg?.chatId !== undefined || !!process.env["TELEGRAM_CHAT_ID"];
+    if (tg?.enabled === true && !hasToken) {
+      process.stderr.write("conclave review: TELEGRAM_BOT_TOKEN not set — skipping Telegram notifier\n");
+    } else if (hasToken && hasChat) {
+      const opts: ConstructorParameters<typeof TelegramNotifier>[0] = {};
+      if (tg?.chatId !== undefined) opts.chatId = tg.chatId;
+      if (tg?.includeActionButtons !== undefined) opts.includeActionButtons = tg.includeActionButtons;
+      try {
+        notifiers.push(new TelegramNotifier(opts));
+      } catch (err) {
+        process.stderr.write(`conclave review: Telegram notifier init failed — ${(err as Error).message}\n`);
+      }
+    }
+  }
+  if (notifiers.length > 0) {
+    const notifyInput = {
+      outcome,
+      ctx: reviewCtx,
+      episodicId: episodic.id,
+      totalCostUsd: gate.metrics.summary().totalCostUsd,
+      ...(loaded.pullNumber && loaded.source === "gh-pr"
+        ? { prUrl: `https://github.com/${loaded.repo}/pull/${loaded.pullNumber}` }
+        : {}),
+    };
+    await Promise.all(
+      notifiers.map(async (n) => {
+        try {
+          await n.notifyReview(notifyInput);
+        } catch (err) {
+          process.stderr.write(`conclave review: ${n.id} notifier failed — ${(err as Error).message}\n`);
+        }
+      }),
+    );
+  }
 
   if (langfuseSink) {
     await langfuseSink.shutdown();

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -3,6 +3,7 @@ import {
   Council,
   EfficiencyGate,
   FileSystemMemoryStore,
+  OutcomeWriter,
   formatAnswerKeyForPrompt,
   formatFailureForPrompt,
   type ReviewContext,
@@ -106,7 +107,17 @@ export async function review(argv: string[]): Promise<void> {
 
   const outcome = await council.deliberate(reviewCtx);
 
-  // 6. Render + exit with a verdict-derived code
+  // 6. Persist the episodic entry (outcome: "pending") so `conclave
+  //    record-outcome` can classify it later into answer-keys / failures.
+  const writer = new OutcomeWriter({ store });
+  const episodic = await writer.writeReview({
+    ctx: reviewCtx,
+    reviews: outcome.results,
+    councilVerdict: outcome.verdict,
+    costUsd: gate.metrics.summary().totalCostUsd,
+  });
+
+  // 7. Render + exit with a verdict-derived code
   process.stdout.write(
     renderReview({
       repo: loaded.repo,
@@ -118,6 +129,11 @@ export async function review(argv: string[]): Promise<void> {
       results: outcome.results,
       metrics: gate.metrics.summary(),
     }),
+  );
+  process.stdout.write(
+    `\nepisodic: ${episodic.id}\n` +
+      `  when the PR lands, close the loop with:\n` +
+      `    conclave record-outcome --id ${episodic.id} --result merged\n`,
   );
 
   process.exit(verdictToExitCode(outcome.verdict));

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -17,6 +17,7 @@ import { LangfuseMetricsSink } from "@ai-conclave/observability-langfuse";
 import { TelegramNotifier } from "@ai-conclave/integration-telegram";
 import { DiscordNotifier } from "@ai-conclave/integration-discord";
 import { SlackNotifier } from "@ai-conclave/integration-slack";
+import { EmailNotifier } from "@ai-conclave/integration-email";
 import type { Notifier } from "@ai-conclave/core";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
@@ -237,6 +238,27 @@ export async function review(argv: string[]): Promise<void> {
         notifiers.push(new SlackNotifier(opts));
       } catch (err) {
         process.stderr.write(`conclave review: Slack notifier init failed — ${(err as Error).message}\n`);
+      }
+    }
+  }
+  const em = config.integrations?.email;
+  if (em?.enabled !== false) {
+    const fromConfigured = !!(em?.from || process.env["CONCLAVE_EMAIL_FROM"]);
+    const toConfigured = !!(em?.to || process.env["CONCLAVE_EMAIL_TO"]);
+    const transportReady = !!process.env["RESEND_API_KEY"];
+    if (em?.enabled === true && (!fromConfigured || !toConfigured || !transportReady)) {
+      process.stderr.write(
+        "conclave review: email integration enabled but missing from / to / RESEND_API_KEY — skipping\n",
+      );
+    } else if (fromConfigured && toConfigured && transportReady) {
+      const opts: ConstructorParameters<typeof EmailNotifier>[0] = {};
+      if (em?.from) opts.from = em.from;
+      if (em?.to) opts.to = em.to;
+      if (em?.subjectOverride) opts.subjectOverride = em.subjectOverride;
+      try {
+        notifiers.push(new EmailNotifier(opts));
+      } catch (err) {
+        process.stderr.write(`conclave review: Email notifier init failed — ${(err as Error).message}\n`);
       }
     }
   }

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -16,6 +16,7 @@ import { GeminiAgent } from "@ai-conclave/agent-gemini";
 import { LangfuseMetricsSink } from "@ai-conclave/observability-langfuse";
 import { TelegramNotifier } from "@ai-conclave/integration-telegram";
 import { DiscordNotifier } from "@ai-conclave/integration-discord";
+import { SlackNotifier } from "@ai-conclave/integration-slack";
 import type { Notifier } from "@ai-conclave/core";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
@@ -218,6 +219,24 @@ export async function review(argv: string[]): Promise<void> {
         notifiers.push(new DiscordNotifier(opts));
       } catch (err) {
         process.stderr.write(`conclave review: Discord notifier init failed — ${(err as Error).message}\n`);
+      }
+    }
+  }
+  const sl = config.integrations?.slack;
+  if (sl?.enabled !== false) {
+    const hasUrl = !!(sl?.webhookUrl || process.env["SLACK_WEBHOOK_URL"]);
+    if (sl?.enabled === true && !hasUrl) {
+      process.stderr.write("conclave review: SLACK_WEBHOOK_URL not set — skipping Slack notifier\n");
+    } else if (hasUrl) {
+      const opts: ConstructorParameters<typeof SlackNotifier>[0] = {};
+      if (sl?.webhookUrl) opts.webhookUrl = sl.webhookUrl;
+      if (sl?.username) opts.username = sl.username;
+      if (sl?.iconUrl) opts.iconUrl = sl.iconUrl;
+      if (sl?.iconEmoji) opts.iconEmoji = sl.iconEmoji;
+      try {
+        notifiers.push(new SlackNotifier(opts));
+      } catch (err) {
+        process.stderr.write(`conclave review: Slack notifier init failed — ${(err as Error).message}\n`);
       }
     }
   }

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -3,14 +3,17 @@ import {
   Council,
   EfficiencyGate,
   FileSystemMemoryStore,
+  MetricsRecorder,
   OutcomeWriter,
   formatAnswerKeyForPrompt,
   formatFailureForPrompt,
+  type MetricsSink,
   type ReviewContext,
 } from "@ai-conclave/core";
 import { ClaudeAgent } from "@ai-conclave/agent-claude";
 import { OpenAIAgent } from "@ai-conclave/agent-openai";
 import { GeminiAgent } from "@ai-conclave/agent-gemini";
+import { LangfuseMetricsSink } from "@ai-conclave/observability-langfuse";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
 import { renderReview, verdictToExitCode } from "../lib/output.js";
@@ -79,12 +82,29 @@ export async function review(argv: string[]): Promise<void> {
   const queryText = `${loaded.repo} ${loaded.diff.slice(0, 4_000)}`;
   const retrieval = await store.retrieve({ query: queryText, repo: loaded.repo, k: 8 });
 
-  // 3. Build the efficiency gate with config-driven budget
+  // 3. Build the efficiency gate with config-driven budget + optional Langfuse sink
   const budget = new BudgetTracker({ perPrUsd: config.budget.perPrUsd });
   budget.onWarning((spent, cap) => {
     process.stderr.write(`conclave review: budget warning — spent $${spent.toFixed(4)} of $${cap.toFixed(2)} cap\n`);
   });
-  const gate = new EfficiencyGate({ budget });
+  let langfuseSink: LangfuseMetricsSink | null = null;
+  const sink: MetricsSink | undefined = (() => {
+    const lf = config.observability?.langfuse;
+    if (!lf?.enabled) return undefined;
+    if (!process.env["LANGFUSE_PUBLIC_KEY"] || !process.env["LANGFUSE_SECRET_KEY"]) {
+      process.stderr.write(
+        "conclave review: langfuse configured but LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set — skipping\n",
+      );
+      return undefined;
+    }
+    const sinkOpts: ConstructorParameters<typeof LangfuseMetricsSink>[0] = {};
+    if (lf.baseUrl) sinkOpts.baseUrl = lf.baseUrl;
+    sinkOpts.traceId = `conclave-${loaded.repo.replace(/\//g, "-")}-${loaded.pullNumber || "local"}-${loaded.newSha.slice(0, 8)}`;
+    langfuseSink = new LangfuseMetricsSink(sinkOpts);
+    return langfuseSink;
+  })();
+  const metrics = sink ? new MetricsRecorder({ sink }) : new MetricsRecorder();
+  const gate = new EfficiencyGate({ budget, metrics });
 
   // 4. Instantiate the council. Agents enabled in config.agents. An agent
   //    is only included if its credentials are available; others are skipped
@@ -157,6 +177,10 @@ export async function review(argv: string[]): Promise<void> {
       `  when the PR lands, close the loop with:\n` +
       `    conclave record-outcome --id ${episodic.id} --result merged\n`,
   );
+
+  if (langfuseSink) {
+    await langfuseSink.shutdown();
+  }
 
   process.exit(verdictToExitCode(outcome.verdict));
 }

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -10,6 +10,7 @@ import {
 } from "@ai-conclave/core";
 import { ClaudeAgent } from "@ai-conclave/agent-claude";
 import { OpenAIAgent } from "@ai-conclave/agent-openai";
+import { GeminiAgent } from "@ai-conclave/agent-gemini";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
 import { renderReview, verdictToExitCode } from "../lib/output.js";
@@ -100,7 +101,12 @@ export async function review(argv: string[]): Promise<void> {
       }
       agents.push(new OpenAIAgent({ gate }));
     } else if (id === "gemini") {
-      process.stderr.write("conclave review: gemini agent not yet implemented — skipping\n");
+      const hasKey = !!(process.env["GOOGLE_API_KEY"] || process.env["GEMINI_API_KEY"]);
+      if (!hasKey) {
+        process.stderr.write("conclave review: GOOGLE_API_KEY / GEMINI_API_KEY not set — skipping Gemini agent\n");
+        continue;
+      }
+      agents.push(new GeminiAgent({ gate }));
     }
   }
   if (agents.length === 0) {

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -15,6 +15,7 @@ import { OpenAIAgent } from "@ai-conclave/agent-openai";
 import { GeminiAgent } from "@ai-conclave/agent-gemini";
 import { LangfuseMetricsSink } from "@ai-conclave/observability-langfuse";
 import { TelegramNotifier } from "@ai-conclave/integration-telegram";
+import { DiscordNotifier } from "@ai-conclave/integration-discord";
 import type { Notifier } from "@ai-conclave/core";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
@@ -198,6 +199,25 @@ export async function review(argv: string[]): Promise<void> {
         notifiers.push(new TelegramNotifier(opts));
       } catch (err) {
         process.stderr.write(`conclave review: Telegram notifier init failed — ${(err as Error).message}\n`);
+      }
+    }
+  }
+  const dc = config.integrations?.discord;
+  if (dc?.enabled !== false) {
+    const hasUrl = !!(dc?.webhookUrl || process.env["DISCORD_WEBHOOK_URL"]);
+    if (dc?.enabled === true && !hasUrl) {
+      process.stderr.write(
+        "conclave review: DISCORD_WEBHOOK_URL not set — skipping Discord notifier\n",
+      );
+    } else if (hasUrl) {
+      const opts: ConstructorParameters<typeof DiscordNotifier>[0] = {};
+      if (dc?.webhookUrl) opts.webhookUrl = dc.webhookUrl;
+      if (dc?.username) opts.username = dc.username;
+      if (dc?.avatarUrl) opts.avatarUrl = dc.avatarUrl;
+      try {
+        notifiers.push(new DiscordNotifier(opts));
+      } catch (err) {
+        process.stderr.write(`conclave review: Discord notifier init failed — ${(err as Error).message}\n`);
       }
     }
   }

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -1,52 +1,124 @@
-import { Council } from "@ai-conclave/core";
+import {
+  BudgetTracker,
+  Council,
+  EfficiencyGate,
+  FileSystemMemoryStore,
+  formatAnswerKeyForPrompt,
+  formatFailureForPrompt,
+  type ReviewContext,
+} from "@ai-conclave/core";
 import { ClaudeAgent } from "@ai-conclave/agent-claude";
+import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
+import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
+import { renderReview, verdictToExitCode } from "../lib/output.js";
 
-/**
- * `conclave review` — skeleton command.
- *
- * Real implementation will:
- *   1. Discover the current PR (git + gh CLI)
- *   2. Load the diff + repo context
- *   3. Route through the efficiency gate (cache / triage / budget)
- *   4. Run the council deliberation across N agents
- *   5. Post consensus back to the PR (GitHub comment + optional Telegram)
- *   6. Write outcome to episodic memory (nightly classifies into
- *      answer-keys / failure-catalog)
- *
- * Current scaffold: spins up a single-Claude council with an empty diff so
- * we can validate the wiring end-to-end.
- */
+function parseArgv(argv: string[]): { pr?: number; diff?: string; base?: string; help: boolean } {
+  const out: { pr?: number; diff?: string; base?: string; help: boolean } = { help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--pr" && argv[i + 1]) {
+      const n = Number.parseInt(argv[i + 1]!, 10);
+      if (!Number.isNaN(n)) out.pr = n;
+      i += 1;
+    } else if (a === "--diff" && argv[i + 1]) {
+      out.diff = argv[i + 1];
+      i += 1;
+    } else if (a === "--base" && argv[i + 1]) {
+      out.base = argv[i + 1];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+const HELP = `conclave review — run a council review on the current branch
+
+Usage:
+  conclave review [--pr N] [--diff <file>] [--base <ref>]
+
+Options:
+  --pr N         Review PR N using gh CLI (preferred — includes repo context).
+  --diff <file>  Review a unified-diff file directly.
+  --base <ref>   Base ref for 'git diff' when neither --pr nor --diff given (default: origin/main).
+
+Environment:
+  ANTHROPIC_API_KEY   required — Claude review call.
+`;
+
 export async function review(argv: string[]): Promise<void> {
-  const prFlag = argv.findIndex((a) => a === "--pr");
-  const prNumber = prFlag >= 0 && argv[prFlag + 1] ? Number.parseInt(argv[prFlag + 1]!, 10) : 0;
-
+  const args = parseArgv(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
   if (!process.env["ANTHROPIC_API_KEY"]) {
-    process.stderr.write(
-      "conclave review: ANTHROPIC_API_KEY not set. Export the key and retry.\n",
-    );
+    process.stderr.write("conclave review: ANTHROPIC_API_KEY not set. Export the key and retry.\n");
     process.exit(1);
     return;
   }
 
-  const council = new Council({ agents: [new ClaudeAgent()] });
+  const { config, configDir } = await loadConfig();
+  const memoryRoot = resolveMemoryRoot(config, configDir);
 
-  process.stdout.write(
-    `conclave review (skeleton):\n` +
-      `  agents: ${council.agentCount}\n` +
-      `  rounds: ${council.roundLimit}\n` +
-      `  pr: ${prNumber || "(none — dry run)"}\n`,
-  );
+  // 1. Load diff
+  let loaded: LoadedDiff;
+  if (args.pr !== undefined) {
+    loaded = await loadPrDiff(args.pr);
+  } else if (args.diff) {
+    loaded = await loadFileDiff(args.diff);
+  } else {
+    loaded = await loadGitDiff(args.base ?? "origin/main");
+  }
 
-  const outcome = await council.deliberate({
-    diff: "",
-    repo: "local/dry-run",
-    pullNumber: prNumber || 0,
-    newSha: "HEAD",
+  if (!loaded.diff.trim()) {
+    process.stderr.write("conclave review: empty diff — nothing to review.\n");
+    process.exit(0);
+    return;
+  }
+
+  // 2. Retrieve RAG context from memory
+  const store = new FileSystemMemoryStore({ root: memoryRoot });
+  const queryText = `${loaded.repo} ${loaded.diff.slice(0, 4_000)}`;
+  const retrieval = await store.retrieve({ query: queryText, repo: loaded.repo, k: 8 });
+
+  // 3. Build the efficiency gate with config-driven budget
+  const budget = new BudgetTracker({ perPrUsd: config.budget.perPrUsd });
+  budget.onWarning((spent, cap) => {
+    process.stderr.write(`conclave review: budget warning — spent $${spent.toFixed(4)} of $${cap.toFixed(2)} cap\n`);
   });
+  const gate = new EfficiencyGate({ budget });
 
+  // 4. Instantiate the council (agent-claude only for now; openai + gemini land in later PRs)
+  const agent = new ClaudeAgent({ gate });
+  const council = new Council({ agents: [agent] });
+
+  // 5. Deliberate
+  const reviewCtx: ReviewContext = {
+    diff: loaded.diff,
+    repo: loaded.repo,
+    pullNumber: loaded.pullNumber,
+    newSha: loaded.newSha,
+    answerKeys: retrieval.answerKeys.map(formatAnswerKeyForPrompt),
+    failureCatalog: retrieval.failures.map(formatFailureForPrompt),
+  };
+  if (loaded.prevSha) reviewCtx.prevSha = loaded.prevSha;
+
+  const outcome = await council.deliberate(reviewCtx);
+
+  // 6. Render + exit with a verdict-derived code
   process.stdout.write(
-    `  verdict: ${outcome.verdict}\n` +
-      `  consensus: ${outcome.consensusReached}\n` +
-      `  results: ${outcome.results.length}\n`,
+    renderReview({
+      repo: loaded.repo,
+      pullNumber: loaded.pullNumber,
+      sha: loaded.newSha,
+      source: loaded.source,
+      councilVerdict: outcome.verdict,
+      consensus: outcome.consensusReached,
+      results: outcome.results,
+      metrics: gate.metrics.summary(),
+    }),
   );
+
+  process.exit(verdictToExitCode(outcome.verdict));
 }

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -1,0 +1,52 @@
+import { Council } from "@ai-conclave/core";
+import { ClaudeAgent } from "@ai-conclave/agent-claude";
+
+/**
+ * `conclave review` — skeleton command.
+ *
+ * Real implementation will:
+ *   1. Discover the current PR (git + gh CLI)
+ *   2. Load the diff + repo context
+ *   3. Route through the efficiency gate (cache / triage / budget)
+ *   4. Run the council deliberation across N agents
+ *   5. Post consensus back to the PR (GitHub comment + optional Telegram)
+ *   6. Write outcome to episodic memory (nightly classifies into
+ *      answer-keys / failure-catalog)
+ *
+ * Current scaffold: spins up a single-Claude council with an empty diff so
+ * we can validate the wiring end-to-end.
+ */
+export async function review(argv: string[]): Promise<void> {
+  const prFlag = argv.findIndex((a) => a === "--pr");
+  const prNumber = prFlag >= 0 && argv[prFlag + 1] ? Number.parseInt(argv[prFlag + 1]!, 10) : 0;
+
+  if (!process.env["ANTHROPIC_API_KEY"]) {
+    process.stderr.write(
+      "conclave review: ANTHROPIC_API_KEY not set. Export the key and retry.\n",
+    );
+    process.exit(1);
+    return;
+  }
+
+  const council = new Council({ agents: [new ClaudeAgent()] });
+
+  process.stdout.write(
+    `conclave review (skeleton):\n` +
+      `  agents: ${council.agentCount}\n` +
+      `  rounds: ${council.roundLimit}\n` +
+      `  pr: ${prNumber || "(none — dry run)"}\n`,
+  );
+
+  const outcome = await council.deliberate({
+    diff: "",
+    repo: "local/dry-run",
+    pullNumber: prNumber || 0,
+    newSha: "HEAD",
+  });
+
+  process.stdout.write(
+    `  verdict: ${outcome.verdict}\n` +
+      `  consensus: ${outcome.consensusReached}\n` +
+      `  results: ${outcome.results.length}\n`,
+  );
+}

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -9,6 +9,7 @@ import {
   type ReviewContext,
 } from "@ai-conclave/core";
 import { ClaudeAgent } from "@ai-conclave/agent-claude";
+import { OpenAIAgent } from "@ai-conclave/agent-openai";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
 import { renderReview, verdictToExitCode } from "../lib/output.js";
@@ -53,12 +54,6 @@ export async function review(argv: string[]): Promise<void> {
     process.stdout.write(HELP);
     return;
   }
-  if (!process.env["ANTHROPIC_API_KEY"]) {
-    process.stderr.write("conclave review: ANTHROPIC_API_KEY not set. Export the key and retry.\n");
-    process.exit(1);
-    return;
-  }
-
   const { config, configDir } = await loadConfig();
   const memoryRoot = resolveMemoryRoot(config, configDir);
 
@@ -90,9 +85,30 @@ export async function review(argv: string[]): Promise<void> {
   });
   const gate = new EfficiencyGate({ budget });
 
-  // 4. Instantiate the council (agent-claude only for now; openai + gemini land in later PRs)
-  const agent = new ClaudeAgent({ gate });
-  const council = new Council({ agents: [agent] });
+  // 4. Instantiate the council. Agents enabled in config.agents. An agent
+  //    is only included if its credentials are available; others are skipped
+  //    with a warning so a missing key doesn't block review.
+  const agents = [];
+  for (const id of config.agents) {
+    if (id === "claude") {
+      if (!process.env["ANTHROPIC_API_KEY"]) continue;
+      agents.push(new ClaudeAgent({ gate }));
+    } else if (id === "openai") {
+      if (!process.env["OPENAI_API_KEY"]) {
+        process.stderr.write("conclave review: OPENAI_API_KEY not set — skipping OpenAI agent\n");
+        continue;
+      }
+      agents.push(new OpenAIAgent({ gate }));
+    } else if (id === "gemini") {
+      process.stderr.write("conclave review: gemini agent not yet implemented — skipping\n");
+    }
+  }
+  if (agents.length === 0) {
+    process.stderr.write("conclave review: no agents available. Set at least ANTHROPIC_API_KEY.\n");
+    process.exit(1);
+    return;
+  }
+  const council = new Council({ agents });
 
   // 5. Deliberate
   const reviewCtx: ReviewContext = {

--- a/packages/cli/src/commands/seed.ts
+++ b/packages/cli/src/commands/seed.ts
@@ -1,0 +1,64 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { FileSystemMemoryStore, seedFromLegacyCatalogPath } from "@ai-conclave/core";
+import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
+
+const HELP = `conclave seed — bootstrap the failure catalog from a legacy source
+
+Usage:
+  conclave seed [--from <path>]
+
+--from <path>   Path to a legacy failure-catalog JSON. Defaults to the
+                bundled solo-cto-agent catalog (decision #18).
+
+Writes one FailureEntry per legacy item into the current .conclave/
+memory store. Categories are normalized to the 11 allowed enum values
+via heuristic matching; a per-category count is printed so Bae can audit.
+`;
+
+function parseArgv(argv: string[]): { from?: string; help: boolean } {
+  const out: { from?: string; help: boolean } = { help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--from" && argv[i + 1]) {
+      out.from = argv[i + 1];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+/** Resolve the bundled legacy catalog path (ships inside @ai-conclave/core). */
+function resolveBundledCatalog(): string {
+  // When bundled via tsc, this file lives at node_modules/@ai-conclave/cli/dist/commands/seed.js.
+  // The catalog ships under node_modules/@ai-conclave/core/dist/memory/seeds/solo-cto-agent-failure-catalog.json
+  // — but we resolve it relative to the core package's module root for portability.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  // Walk up to the workspace root, then dive into core's dist.
+  return path.resolve(here, "..", "..", "..", "core", "dist", "memory", "seeds", "solo-cto-agent-failure-catalog.json");
+}
+
+export async function seed(argv: string[]): Promise<void> {
+  const args = parseArgv(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  const { config, configDir } = await loadConfig();
+  const memoryRoot = resolveMemoryRoot(config, configDir);
+  const store = new FileSystemMemoryStore({ root: memoryRoot });
+
+  const source = args.from ?? resolveBundledCatalog();
+  const result = await seedFromLegacyCatalogPath(source, store, { extraTags: ["legacy", "solo-cto-agent"] });
+
+  process.stdout.write(
+    `conclave seed:\n` +
+      `  source:   ${source}\n` +
+      `  written:  ${result.entries.length} failure-catalog entries → ${memoryRoot}/failure-catalog/code/\n` +
+      `  by category:\n`,
+  );
+  for (const [cat, count] of Object.entries(result.byCategory)) {
+    if (count > 0) process.stdout.write(`    ${cat.padEnd(14)} ${count}\n`);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { init } from "./commands/init.js";
 import { review } from "./commands/review.js";
 import { recordOutcome } from "./commands/record-outcome.js";
+import { pollOutcomesCommand } from "./commands/poll-outcomes.js";
 
 const HELP = `conclave — Ai-Conclave CLI
 
@@ -10,7 +11,8 @@ Usage:
 Commands:
   init                  Set up conclave in the current repo (config + skeleton)
   review                Run a council review on the current branch
-  record-outcome        Record a PR's merge/reject/rework outcome (closes self-evolve loop)
+  record-outcome        Record a PR's merge/reject/rework outcome manually
+  poll-outcomes         Auto-classify pending reviews against live GitHub PR state
   --help, -h            Show this
   --version, -v         Show version
 
@@ -18,6 +20,7 @@ Examples:
   conclave init
   conclave review --pr 42
   conclave record-outcome --id ep-... --result merged
+  conclave poll-outcomes                 # cron-friendly automatic outcome capture
 `;
 
 export async function run(argv: string[]): Promise<void> {
@@ -42,6 +45,9 @@ export async function run(argv: string[]): Promise<void> {
       return;
     case "record-outcome":
       await recordOutcome(rest);
+      return;
+    case "poll-outcomes":
+      await pollOutcomesCommand(rest);
       return;
     default:
       process.stderr.write(`Unknown command: ${cmd}\n\n${HELP}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import { init } from "./commands/init.js";
 import { review } from "./commands/review.js";
 import { recordOutcome } from "./commands/record-outcome.js";
 import { pollOutcomesCommand } from "./commands/poll-outcomes.js";
+import { seed } from "./commands/seed.js";
 
 const HELP = `conclave — Ai-Conclave CLI
 
@@ -13,6 +14,7 @@ Commands:
   review                Run a council review on the current branch
   record-outcome        Record a PR's merge/reject/rework outcome manually
   poll-outcomes         Auto-classify pending reviews against live GitHub PR state
+  seed                  Bootstrap failure-catalog from a legacy source (default: bundled solo-cto-agent)
   --help, -h            Show this
   --version, -v         Show version
 
@@ -21,6 +23,7 @@ Examples:
   conclave review --pr 42
   conclave record-outcome --id ep-... --result merged
   conclave poll-outcomes                 # cron-friendly automatic outcome capture
+  conclave seed                           # one-time bootstrap from the bundled solo-cto-agent catalog
 `;
 
 export async function run(argv: string[]): Promise<void> {
@@ -48,6 +51,9 @@ export async function run(argv: string[]): Promise<void> {
       return;
     case "poll-outcomes":
       await pollOutcomesCommand(rest);
+      return;
+    case "seed":
+      await seed(rest);
       return;
     default:
       process.stderr.write(`Unknown command: ${cmd}\n\n${HELP}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,44 @@
+import { init } from "./commands/init.js";
+import { review } from "./commands/review.js";
+
+const HELP = `conclave — Ai-Conclave CLI (skeleton)
+
+Usage:
+  conclave <command> [options]
+
+Commands:
+  init                  Set up conclave in the current repo (config + skeleton)
+  review                Run a council review on the current branch
+  --help, -h            Show this
+  --version, -v         Show version
+
+Examples:
+  conclave init
+  conclave review --pr 42
+`;
+
+export async function run(argv: string[]): Promise<void> {
+  const [cmd, ...rest] = argv;
+
+  if (!cmd || cmd === "--help" || cmd === "-h" || cmd === "help") {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  if (cmd === "--version" || cmd === "-v") {
+    process.stdout.write("0.0.0\n");
+    return;
+  }
+
+  switch (cmd) {
+    case "init":
+      await init(rest);
+      return;
+    case "review":
+      await review(rest);
+      return;
+    default:
+      process.stderr.write(`Unknown command: ${cmd}\n\n${HELP}`);
+      process.exit(2);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,8 @@
 import { init } from "./commands/init.js";
 import { review } from "./commands/review.js";
+import { recordOutcome } from "./commands/record-outcome.js";
 
-const HELP = `conclave — Ai-Conclave CLI (skeleton)
+const HELP = `conclave — Ai-Conclave CLI
 
 Usage:
   conclave <command> [options]
@@ -9,12 +10,14 @@ Usage:
 Commands:
   init                  Set up conclave in the current repo (config + skeleton)
   review                Run a council review on the current branch
+  record-outcome        Record a PR's merge/reject/rework outcome (closes self-evolve loop)
   --help, -h            Show this
   --version, -v         Show version
 
 Examples:
   conclave init
   conclave review --pr 42
+  conclave record-outcome --id ep-... --result merged
 `;
 
 export async function run(argv: string[]): Promise<void> {
@@ -36,6 +39,9 @@ export async function run(argv: string[]): Promise<void> {
       return;
     case "review":
       await review(rest);
+      return;
+    case "record-outcome":
+      await recordOutcome(rest);
       return;
     default:
       process.stderr.write(`Unknown command: ${cmd}\n\n${HELP}`);

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,0 +1,78 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+
+export const CONFIG_FILENAME = ".conclaverc.json";
+
+export const ConclaveConfigSchema = z.object({
+  version: z.literal(1),
+  agents: z.array(z.enum(["claude", "openai", "gemini"])).default(["claude"]),
+  budget: z
+    .object({
+      perPrUsd: z.number().positive(),
+    })
+    .default({ perPrUsd: 0.5 }),
+  efficiency: z
+    .object({
+      cacheEnabled: z.boolean(),
+      compactEnabled: z.boolean(),
+    })
+    .default({ cacheEnabled: true, compactEnabled: true }),
+  memory: z
+    .object({
+      answerKeysDir: z.string(),
+      failureCatalogDir: z.string(),
+      root: z.string().optional(),
+    })
+    .default({
+      answerKeysDir: ".conclave/answer-keys",
+      failureCatalogDir: ".conclave/failure-catalog",
+    }),
+});
+
+export type ConclaveConfig = z.infer<typeof ConclaveConfigSchema>;
+
+export const DEFAULT_CONFIG: ConclaveConfig = {
+  version: 1,
+  agents: ["claude"],
+  budget: { perPrUsd: 0.5 },
+  efficiency: { cacheEnabled: true, compactEnabled: true },
+  memory: {
+    answerKeysDir: ".conclave/answer-keys",
+    failureCatalogDir: ".conclave/failure-catalog",
+    root: ".conclave",
+  },
+};
+
+/**
+ * Loads .conclaverc.json from `cwd` or any ancestor directory. Returns the
+ * merged+validated config + the directory the config was found in (or
+ * `cwd` if none found). Missing config → DEFAULT_CONFIG with cwd root.
+ */
+export async function loadConfig(cwd: string = process.cwd()): Promise<{
+  config: ConclaveConfig;
+  configDir: string;
+  found: boolean;
+}> {
+  let dir = path.resolve(cwd);
+  while (true) {
+    const candidate = path.join(dir, CONFIG_FILENAME);
+    try {
+      const raw = await fs.readFile(candidate, "utf8");
+      const parsed = ConclaveConfigSchema.parse(JSON.parse(raw));
+      return { config: parsed, configDir: dir, found: true };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") throw err;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return { config: DEFAULT_CONFIG, configDir: cwd, found: false };
+}
+
+export function resolveMemoryRoot(config: ConclaveConfig, configDir: string): string {
+  const root = config.memory.root ?? ".conclave";
+  return path.isAbsolute(root) ? root : path.join(configDir, root);
+}

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -28,6 +28,16 @@ export const ConclaveConfigSchema = z.object({
       answerKeysDir: ".conclave/answer-keys",
       failureCatalogDir: ".conclave/failure-catalog",
     }),
+  observability: z
+    .object({
+      langfuse: z
+        .object({
+          enabled: z.boolean().default(true),
+          baseUrl: z.string().url().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 
 export type ConclaveConfig = z.infer<typeof ConclaveConfigSchema>;

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -38,6 +38,17 @@ export const ConclaveConfigSchema = z.object({
         .optional(),
     })
     .optional(),
+  integrations: z
+    .object({
+      telegram: z
+        .object({
+          enabled: z.boolean().default(true),
+          chatId: z.union([z.number(), z.string()]).optional(),
+          includeActionButtons: z.boolean().default(true),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 
 export type ConclaveConfig = z.infer<typeof ConclaveConfigSchema>;

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -55,6 +55,15 @@ export const ConclaveConfigSchema = z.object({
           avatarUrl: z.string().url().optional(),
         })
         .optional(),
+      slack: z
+        .object({
+          enabled: z.boolean().default(true),
+          webhookUrl: z.string().url().optional(),
+          username: z.string().optional(),
+          iconUrl: z.string().url().optional(),
+          iconEmoji: z.string().optional(),
+        })
+        .optional(),
     })
     .optional(),
 });

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -47,6 +47,14 @@ export const ConclaveConfigSchema = z.object({
           includeActionButtons: z.boolean().default(true),
         })
         .optional(),
+      discord: z
+        .object({
+          enabled: z.boolean().default(true),
+          webhookUrl: z.string().url().optional(),
+          username: z.string().optional(),
+          avatarUrl: z.string().url().optional(),
+        })
+        .optional(),
     })
     .optional(),
 });

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -64,6 +64,16 @@ export const ConclaveConfigSchema = z.object({
           iconEmoji: z.string().optional(),
         })
         .optional(),
+      email: z
+        .object({
+          enabled: z.boolean().default(true),
+          from: z.string().email().optional(),
+          to: z
+            .union([z.string().email(), z.array(z.string().email()).min(1)])
+            .optional(),
+          subjectOverride: z.string().optional(),
+        })
+        .optional(),
     })
     .optional(),
 });

--- a/packages/cli/src/lib/diff-source.ts
+++ b/packages/cli/src/lib/diff-source.ts
@@ -1,0 +1,112 @@
+import { promises as fs } from "node:fs";
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+export interface LoadedDiff {
+  diff: string;
+  repo: string;
+  pullNumber: number;
+  newSha: string;
+  prevSha?: string;
+  source: "gh-pr" | "git-diff" | "file";
+}
+
+export interface DiffSourceDeps {
+  execFile?: (
+    bin: string,
+    args: readonly string[],
+    opts?: { cwd?: string; timeout?: number },
+  ) => Promise<{ stdout: string; stderr?: string }>;
+  readFile?: (path: string) => Promise<string>;
+}
+
+const defaultDeps: Required<DiffSourceDeps> = {
+  execFile: async (bin, args, opts) => {
+    const { stdout, stderr } = await execFile(bin, args as string[], { ...opts, maxBuffer: 20 * 1024 * 1024 });
+    return { stdout, stderr };
+  },
+  readFile: (p) => fs.readFile(p, "utf8"),
+};
+
+/** Load a diff from `gh pr diff N` + `gh pr view N --json ...`. Requires `gh` + repo context. */
+export async function loadPrDiff(prNumber: number, deps: DiffSourceDeps = {}): Promise<LoadedDiff> {
+  const run = deps.execFile ?? defaultDeps.execFile;
+  const prStr = String(prNumber);
+  const [diffRes, viewRes] = await Promise.all([
+    run("gh", ["pr", "diff", prStr]),
+    run("gh", ["pr", "view", prStr, "--json", "headRefOid,baseRefOid,headRepository,headRepositoryOwner,number"]),
+  ]);
+  const view = JSON.parse(viewRes.stdout) as {
+    headRefOid?: string;
+    baseRefOid?: string;
+    headRepository?: { name?: string };
+    headRepositoryOwner?: { login?: string };
+    number?: number;
+  };
+  const repoName = view.headRepository?.name;
+  const repoOwner = view.headRepositoryOwner?.login;
+  if (!repoName || !repoOwner) {
+    throw new Error(`loadPrDiff: gh did not return repo owner/name for PR ${prStr}`);
+  }
+  const headSha = view.headRefOid;
+  if (!headSha) {
+    throw new Error(`loadPrDiff: gh did not return headRefOid for PR ${prStr}`);
+  }
+  const loaded: LoadedDiff = {
+    diff: diffRes.stdout,
+    repo: `${repoOwner}/${repoName}`,
+    pullNumber: view.number ?? prNumber,
+    newSha: headSha,
+    source: "gh-pr",
+  };
+  if (view.baseRefOid) loaded.prevSha = view.baseRefOid;
+  return loaded;
+}
+
+/** Load a diff from `git diff <base>..HEAD`. Uses `origin/main` as the default base. */
+export async function loadGitDiff(base: string = "origin/main", deps: DiffSourceDeps = {}): Promise<LoadedDiff> {
+  const run = deps.execFile ?? defaultDeps.execFile;
+  const [diffRes, shaRes, baseRes, remoteRes] = await Promise.all([
+    run("git", ["diff", `${base}..HEAD`]),
+    run("git", ["rev-parse", "HEAD"]),
+    run("git", ["rev-parse", base]).catch(() => ({ stdout: "" })),
+    run("git", ["remote", "get-url", "origin"]).catch(() => ({ stdout: "" })),
+  ]);
+  const remoteUrl = remoteRes.stdout.trim();
+  const repoSlug = parseRepoSlugFromRemote(remoteUrl) ?? "local/unknown";
+  const loaded: LoadedDiff = {
+    diff: diffRes.stdout,
+    repo: repoSlug,
+    pullNumber: 0,
+    newSha: shaRes.stdout.trim(),
+    source: "git-diff",
+  };
+  const baseSha = baseRes.stdout.trim();
+  if (baseSha) loaded.prevSha = baseSha;
+  return loaded;
+}
+
+/** Load a diff from a local unified-diff file. Useful for replaying failing reviews. */
+export async function loadFileDiff(filePath: string, deps: DiffSourceDeps = {}): Promise<LoadedDiff> {
+  const read = deps.readFile ?? defaultDeps.readFile;
+  const diff = await read(filePath);
+  return {
+    diff,
+    repo: "local/file",
+    pullNumber: 0,
+    newSha: "FILE",
+    source: "file",
+  };
+}
+
+/** Extract "owner/repo" slug from a git remote URL (https or ssh). Returns null if it can't parse. */
+export function parseRepoSlugFromRemote(url: string): string | null {
+  if (!url) return null;
+  const https = url.match(/github\.com[:/]+([^/]+)\/([^/]+?)(?:\.git)?(?:\/)?$/i);
+  if (https) return `${https[1]}/${https[2]}`;
+  const ssh = url.match(/^git@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (ssh) return `${ssh[1]}/${ssh[2]}`;
+  return null;
+}

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -1,0 +1,87 @@
+import type { Blocker, ReviewResult, MetricsSummary } from "@ai-conclave/core";
+
+export interface PrintReviewInput {
+  repo: string;
+  pullNumber: number;
+  sha: string;
+  source: string;
+  councilVerdict: "approve" | "rework" | "reject";
+  consensus: boolean;
+  results: readonly ReviewResult[];
+  metrics: MetricsSummary;
+}
+
+const SEVERITY_ORDER: Record<Blocker["severity"], number> = {
+  blocker: 0,
+  major: 1,
+  minor: 2,
+  nit: 3,
+};
+
+function severityTag(s: Blocker["severity"]): string {
+  switch (s) {
+    case "blocker":
+      return "[BLOCKER]";
+    case "major":
+      return "[MAJOR]  ";
+    case "minor":
+      return "[MINOR]  ";
+    case "nit":
+      return "[NIT]    ";
+  }
+}
+
+function verdictTag(v: "approve" | "rework" | "reject"): string {
+  switch (v) {
+    case "approve":
+      return "APPROVE";
+    case "rework":
+      return "REWORK ";
+    case "reject":
+      return "REJECT ";
+  }
+}
+
+export function renderReview(input: PrintReviewInput): string {
+  const lines: string[] = [];
+  lines.push(`conclave review — ${input.repo}${input.pullNumber ? ` #${input.pullNumber}` : ""}`);
+  lines.push(`  sha:    ${input.sha.slice(0, 12)}`);
+  lines.push(`  source: ${input.source}`);
+  lines.push("");
+  lines.push(`Verdict: ${verdictTag(input.councilVerdict)}${input.consensus ? "" : "  (no consensus)"}`);
+  lines.push("");
+
+  for (const r of input.results) {
+    lines.push(`── ${r.agent} → ${verdictTag(r.verdict)} ──`);
+    if (r.blockers.length === 0) {
+      lines.push("  (no blockers)");
+    } else {
+      const sorted = [...r.blockers].sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+      for (const b of sorted) {
+        const loc = b.file ? `  ${b.file}${b.line ? `:${b.line}` : ""}` : "";
+        lines.push(`  ${severityTag(b.severity)} (${b.category})${loc}`);
+        lines.push(`    ${b.message}`);
+      }
+    }
+    if (r.summary) {
+      lines.push("");
+      lines.push(`  summary: ${r.summary}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("── metrics ──");
+  lines.push(`  calls:      ${input.metrics.callCount}`);
+  lines.push(`  tokens:     in=${input.metrics.totalInputTokens} out=${input.metrics.totalOutputTokens}`);
+  lines.push(`  cost:       $${input.metrics.totalCostUsd.toFixed(4)}`);
+  lines.push(`  latency:    ${input.metrics.totalLatencyMs}ms`);
+  lines.push(`  cache hit:  ${(input.metrics.cacheHitRate * 100).toFixed(1)}%`);
+
+  return lines.join("\n") + "\n";
+}
+
+export function verdictToExitCode(v: "approve" | "rework" | "reject"): number {
+  if (v === "approve") return 0;
+  if (v === "rework") return 1;
+  return 2;
+}

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  DEFAULT_CONFIG,
+  CONFIG_FILENAME,
+  loadConfig,
+  resolveMemoryRoot,
+} from "../dist/lib/config.js";
+
+function mkdirp(p) {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+test("loadConfig: returns DEFAULT_CONFIG when no file is found", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aic-cli-cfg-"));
+  try {
+    const { config, found } = await loadConfig(dir);
+    assert.equal(found, false);
+    assert.deepEqual(config, DEFAULT_CONFIG);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig: reads + validates a real config file", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aic-cli-cfg-"));
+  try {
+    fs.writeFileSync(
+      path.join(dir, CONFIG_FILENAME),
+      JSON.stringify({
+        version: 1,
+        agents: ["claude"],
+        budget: { perPrUsd: 0.25 },
+        efficiency: { cacheEnabled: true, compactEnabled: true },
+        memory: { answerKeysDir: "a", failureCatalogDir: "b" },
+      }),
+    );
+    const { config, configDir, found } = await loadConfig(dir);
+    assert.equal(found, true);
+    assert.equal(configDir, dir);
+    assert.equal(config.budget.perPrUsd, 0.25);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig: walks up to ancestor directory", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aic-cli-cfg-"));
+  try {
+    fs.writeFileSync(
+      path.join(root, CONFIG_FILENAME),
+      JSON.stringify({ version: 1 }),
+    );
+    const nested = path.join(root, "a", "b", "c");
+    mkdirp(nested);
+    const { config, configDir, found } = await loadConfig(nested);
+    assert.equal(found, true);
+    assert.equal(configDir, root);
+    assert.equal(config.version, 1);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig: malformed JSON throws", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aic-cli-cfg-"));
+  try {
+    fs.writeFileSync(path.join(dir, CONFIG_FILENAME), "not json");
+    await assert.rejects(() => loadConfig(dir));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig: schema-invalid config (negative budget) throws", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aic-cli-cfg-"));
+  try {
+    fs.writeFileSync(
+      path.join(dir, CONFIG_FILENAME),
+      JSON.stringify({ version: 1, budget: { perPrUsd: -1 } }),
+    );
+    await assert.rejects(() => loadConfig(dir));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveMemoryRoot: relative path becomes absolute under configDir", () => {
+  const root = resolveMemoryRoot({ ...DEFAULT_CONFIG, memory: { ...DEFAULT_CONFIG.memory, root: "sub/mem" } }, "/tmp/cfg");
+  assert.ok(root.endsWith("sub/mem") || root.endsWith("sub\\mem"));
+});
+
+test("resolveMemoryRoot: absolute path passes through", () => {
+  const abs = path.resolve("/tmp/custom-mem");
+  const root = resolveMemoryRoot({ ...DEFAULT_CONFIG, memory: { ...DEFAULT_CONFIG.memory, root: abs } }, "/other/dir");
+  assert.equal(root, abs);
+});

--- a/packages/cli/test/diff-source.test.mjs
+++ b/packages/cli/test/diff-source.test.mjs
@@ -1,0 +1,109 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseRepoSlugFromRemote,
+  loadPrDiff,
+  loadGitDiff,
+  loadFileDiff,
+} from "../dist/lib/diff-source.js";
+
+test("parseRepoSlugFromRemote: https URL", () => {
+  assert.equal(
+    parseRepoSlugFromRemote("https://github.com/acme/my-app.git"),
+    "acme/my-app",
+  );
+});
+
+test("parseRepoSlugFromRemote: ssh URL", () => {
+  assert.equal(parseRepoSlugFromRemote("git@github.com:acme/my-app.git"), "acme/my-app");
+});
+
+test("parseRepoSlugFromRemote: URL without .git suffix", () => {
+  assert.equal(parseRepoSlugFromRemote("https://github.com/acme/my-app"), "acme/my-app");
+});
+
+test("parseRepoSlugFromRemote: unparseable returns null", () => {
+  assert.equal(parseRepoSlugFromRemote("not a url"), null);
+  assert.equal(parseRepoSlugFromRemote(""), null);
+});
+
+test("loadPrDiff: builds a LoadedDiff from mocked gh output", async () => {
+  const exec = async (bin, args) => {
+    if (bin !== "gh") throw new Error(`unexpected bin ${bin}`);
+    if (args[0] === "pr" && args[1] === "diff") {
+      return { stdout: "diff --git a/x b/x\n+added" };
+    }
+    if (args[0] === "pr" && args[1] === "view") {
+      return {
+        stdout: JSON.stringify({
+          headRefOid: "sha-head",
+          baseRefOid: "sha-base",
+          headRepository: { name: "my-app" },
+          headRepositoryOwner: { login: "acme" },
+          number: 42,
+        }),
+      };
+    }
+    throw new Error(`unexpected args ${args.join(" ")}`);
+  };
+  const loaded = await loadPrDiff(42, { execFile: exec });
+  assert.equal(loaded.source, "gh-pr");
+  assert.equal(loaded.repo, "acme/my-app");
+  assert.equal(loaded.pullNumber, 42);
+  assert.equal(loaded.newSha, "sha-head");
+  assert.equal(loaded.prevSha, "sha-base");
+  assert.match(loaded.diff, /\+added/);
+});
+
+test("loadPrDiff: missing repo owner throws actionable error", async () => {
+  const exec = async (_bin, args) => {
+    if (args[0] === "pr" && args[1] === "diff") return { stdout: "" };
+    if (args[0] === "pr" && args[1] === "view") {
+      return { stdout: JSON.stringify({ headRefOid: "x", number: 1 }) };
+    }
+    throw new Error("unexpected");
+  };
+  await assert.rejects(() => loadPrDiff(1, { execFile: exec }), /did not return repo owner/);
+});
+
+test("loadGitDiff: assembles from mocked git commands", async () => {
+  const exec = async (bin, args) => {
+    if (bin !== "git") throw new Error("unexpected bin");
+    if (args[0] === "diff") return { stdout: "diff --git a/y b/y\n+y" };
+    if (args[0] === "rev-parse" && args[1] === "HEAD") return { stdout: "head-sha\n" };
+    if (args[0] === "rev-parse") return { stdout: "base-sha\n" };
+    if (args[0] === "remote") return { stdout: "https://github.com/acme/widget.git\n" };
+    return { stdout: "" };
+  };
+  const loaded = await loadGitDiff("origin/main", { execFile: exec });
+  assert.equal(loaded.source, "git-diff");
+  assert.equal(loaded.repo, "acme/widget");
+  assert.equal(loaded.newSha, "head-sha");
+  assert.equal(loaded.prevSha, "base-sha");
+});
+
+test("loadGitDiff: missing remote fallbacks to local/unknown", async () => {
+  const exec = async (bin, args) => {
+    if (args[0] === "diff") return { stdout: "diff" };
+    if (args[0] === "rev-parse" && args[1] === "HEAD") return { stdout: "sha\n" };
+    if (args[0] === "remote") {
+      const err = new Error("no remote");
+      throw err;
+    }
+    return { stdout: "" };
+  };
+  const loaded = await loadGitDiff("origin/main", { execFile: exec });
+  assert.equal(loaded.repo, "local/unknown");
+});
+
+test("loadFileDiff: reads diff content from injected readFile", async () => {
+  const loaded = await loadFileDiff("/tmp/x.diff", {
+    readFile: async (p) => {
+      assert.equal(p, "/tmp/x.diff");
+      return "diff --git a/a b/a\n-old\n+new";
+    },
+  });
+  assert.equal(loaded.source, "file");
+  assert.equal(loaded.repo, "local/file");
+  assert.match(loaded.diff, /\+new/);
+});

--- a/packages/cli/test/output.test.mjs
+++ b/packages/cli/test/output.test.mjs
@@ -1,0 +1,97 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { renderReview, verdictToExitCode } from "../dist/lib/output.js";
+
+const baseMetrics = {
+  callCount: 1,
+  totalInputTokens: 1_000,
+  totalOutputTokens: 200,
+  totalCostUsd: 0.015,
+  totalLatencyMs: 900,
+  cacheHitRate: 0.5,
+  byAgent: { claude: { calls: 1, costUsd: 0.015 } },
+  byModel: { "claude-sonnet-4-6": { calls: 1, costUsd: 0.015 } },
+};
+
+test("verdictToExitCode: approve=0, rework=1, reject=2", () => {
+  assert.equal(verdictToExitCode("approve"), 0);
+  assert.equal(verdictToExitCode("rework"), 1);
+  assert.equal(verdictToExitCode("reject"), 2);
+});
+
+test("renderReview: approve + no blockers produces clean output", () => {
+  const out = renderReview({
+    repo: "acme/my-app",
+    pullNumber: 7,
+    sha: "abcdef1234567890",
+    source: "gh-pr",
+    councilVerdict: "approve",
+    consensus: true,
+    results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+    metrics: baseMetrics,
+  });
+  assert.match(out, /Verdict: APPROVE/);
+  assert.match(out, /acme\/my-app #7/);
+  assert.match(out, /no blockers/);
+  assert.match(out, /cache hit:  50.0%/);
+});
+
+test("renderReview: rework with mixed-severity blockers sorts by severity", () => {
+  const out = renderReview({
+    repo: "acme/my-app",
+    pullNumber: 0,
+    sha: "sha",
+    source: "git-diff",
+    councilVerdict: "rework",
+    consensus: false,
+    results: [
+      {
+        agent: "claude",
+        verdict: "rework",
+        blockers: [
+          { severity: "nit", category: "style", message: "unused var" },
+          { severity: "blocker", category: "type-error", message: "ts2345", file: "x.ts", line: 10 },
+          { severity: "major", category: "security", message: "hardcoded secret" },
+        ],
+        summary: "1 blocker + 1 major + 1 nit",
+      },
+    ],
+    metrics: baseMetrics,
+  });
+  const blockerIdx = out.indexOf("[BLOCKER]");
+  const majorIdx = out.indexOf("[MAJOR]");
+  const nitIdx = out.indexOf("[NIT]");
+  assert.ok(blockerIdx < majorIdx, "blocker should come before major");
+  assert.ok(majorIdx < nitIdx, "major should come before nit");
+  assert.match(out, /no consensus/);
+  assert.match(out, /x\.ts:10/);
+});
+
+test("renderReview: reject output tagged", () => {
+  const out = renderReview({
+    repo: "acme/my-app",
+    pullNumber: 1,
+    sha: "sha",
+    source: "gh-pr",
+    councilVerdict: "reject",
+    consensus: true,
+    results: [{ agent: "claude", verdict: "reject", blockers: [], summary: "wrong approach" }],
+    metrics: baseMetrics,
+  });
+  assert.match(out, /Verdict: REJECT/);
+});
+
+test("renderReview: metrics section rendered", () => {
+  const out = renderReview({
+    repo: "acme/my-app",
+    pullNumber: 1,
+    sha: "sha",
+    source: "gh-pr",
+    councilVerdict: "approve",
+    consensus: true,
+    results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "" }],
+    metrics: { ...baseMetrics, totalCostUsd: 0.0345 },
+  });
+  assert.match(out, /\$0\.0345/);
+  assert.match(out, /calls:      1/);
+});

--- a/packages/cli/test/smoke.test.mjs
+++ b/packages/cli/test/smoke.test.mjs
@@ -1,0 +1,22 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { run } from "../dist/index.js";
+
+test("cli: run is exported", () => {
+  assert.equal(typeof run, "function");
+});
+
+test("cli: --version prints 0.0.0 to stdout", async () => {
+  const chunks = [];
+  const origWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (c) => {
+    chunks.push(String(c));
+    return true;
+  };
+  try {
+    await run(["--version"]);
+  } finally {
+    process.stdout.write = origWrite;
+  }
+  assert.match(chunks.join(""), /0\.0\.0/);
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../agent-claude" },
     { "path": "../agent-gemini" },
     { "path": "../agent-openai" },
+    { "path": "../observability-langfuse" },
     { "path": "../scm-github" }
   ]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "../agent-gemini" },
     { "path": "../agent-openai" },
     { "path": "../integration-discord" },
+    { "path": "../integration-slack" },
     { "path": "../integration-telegram" },
     { "path": "../observability-langfuse" },
     { "path": "../scm-github" }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "../agent-gemini" },
     { "path": "../agent-openai" },
     { "path": "../integration-discord" },
+    { "path": "../integration-email" },
     { "path": "../integration-slack" },
     { "path": "../integration-telegram" },
     { "path": "../observability-langfuse" },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../agent-claude" }
+  ]
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../agent-claude" },
     { "path": "../agent-gemini" },
     { "path": "../agent-openai" },
+    { "path": "../integration-discord" },
     { "path": "../integration-telegram" },
     { "path": "../observability-langfuse" },
     { "path": "../scm-github" }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../agent-claude" },
     { "path": "../agent-gemini" },
     { "path": "../agent-openai" },
+    { "path": "../integration-telegram" },
     { "path": "../observability-langfuse" },
     { "path": "../scm-github" }
   ]

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,28 @@
+# @ai-conclave/core
+
+Agent interface, council orchestration, self-evolve substrate, and
+efficiency gate for Ai-Conclave.
+
+Skeleton status: `Agent` / `Council` interfaces + Zod schemas only. Mastra
+graph, memory substrate, and efficiency gate land in subsequent PRs.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { Council, type Agent, type ReviewContext } from "@ai-conclave/core";
+
+const council = new Council({ agents: [claudeAgent, openaiAgent] });
+const ctx: ReviewContext = {
+  diff: "...",
+  repo: "acme/my-app",
+  pullNumber: 42,
+  newSha: "abc123",
+};
+const outcome = await council.deliberate(ctx);
+```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./efficiency": {
+      "types": "./dist/efficiency/index.d.ts",
+      "import": "./dist/efficiency/index.js"
     }
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ai-conclave/core",
+  "version": "0.0.0",
+  "description": "Ai-Conclave core — Agent interface, council orchestration, self-evolve substrate, efficiency gate.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,10 @@
     "./efficiency": {
       "types": "./dist/efficiency/index.d.ts",
       "import": "./dist/efficiency/index.js"
+    },
+    "./memory": {
+      "types": "./dist/memory/index.d.ts",
+      "import": "./dist/memory/index.js"
     }
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,10 +23,11 @@
   "files": [
     "dist",
     "src",
+    "scripts",
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node scripts/copy-seeds.mjs",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node --test --experimental-test-coverage test/*.test.mjs",

--- a/packages/core/scripts/copy-seeds.mjs
+++ b/packages/core/scripts/copy-seeds.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * tsc does not copy non-TS files. Post-build step that mirrors the
+ * seeds/ directory from src/memory/seeds → dist/memory/seeds so the
+ * bundled legacy failure-catalog JSON is available at runtime.
+ */
+import { cpSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, "..");
+const from = path.join(pkgRoot, "src", "memory", "seeds");
+const to = path.join(pkgRoot, "dist", "memory", "seeds");
+
+if (!existsSync(from)) {
+  console.log(`[copy-seeds] nothing to copy (src/memory/seeds not found)`);
+  process.exit(0);
+}
+mkdirSync(path.dirname(to), { recursive: true });
+cpSync(from, to, { recursive: true });
+console.log(`[copy-seeds] copied ${from} → ${to}`);

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -1,0 +1,34 @@
+export type Severity = "blocker" | "major" | "minor" | "nit";
+
+export interface Blocker {
+  severity: Severity;
+  category: string;
+  message: string;
+  file?: string;
+  line?: number;
+}
+
+export interface ReviewContext {
+  diff: string;
+  repo: string;
+  pullNumber: number;
+  prevSha?: string;
+  newSha: string;
+  answerKeys?: string[];
+  failureCatalog?: string[];
+}
+
+export interface ReviewResult {
+  agent: string;
+  verdict: "approve" | "rework" | "reject";
+  blockers: Blocker[];
+  summary: string;
+  tokensUsed?: number;
+  costUsd?: number;
+}
+
+export interface Agent {
+  readonly id: string;
+  readonly displayName: string;
+  review(ctx: ReviewContext): Promise<ReviewResult>;
+}

--- a/packages/core/src/council.ts
+++ b/packages/core/src/council.ts
@@ -1,0 +1,60 @@
+import type { Agent, ReviewContext, ReviewResult } from "./agent.js";
+
+export interface CouncilOptions {
+  agents: Agent[];
+  maxRounds?: number;
+}
+
+export interface CouncilOutcome {
+  verdict: "approve" | "rework" | "reject";
+  rounds: number;
+  results: ReviewResult[];
+  consensusReached: boolean;
+}
+
+/**
+ * Council — orchestrates N agents across up to `maxRounds` of review.
+ *
+ * This is a skeleton. The real Mastra-graph implementation (3-round A/B/C
+ * debate with early-exit on agreement, rework dispatch, efficiency-gate
+ * routing) lands in a subsequent PR. For now, Council runs a single round
+ * and returns each agent's individual verdict.
+ */
+export class Council {
+  private readonly agents: Agent[];
+  private readonly maxRounds: number;
+
+  constructor(opts: CouncilOptions) {
+    if (opts.agents.length === 0) {
+      throw new Error("Council requires at least one agent");
+    }
+    this.agents = opts.agents;
+    this.maxRounds = opts.maxRounds ?? 3;
+  }
+
+  async deliberate(ctx: ReviewContext): Promise<CouncilOutcome> {
+    const results = await Promise.all(this.agents.map((a) => a.review(ctx)));
+    const verdicts = results.map((r) => r.verdict);
+    const allApprove = verdicts.every((v) => v === "approve");
+    const anyReject = verdicts.some((v) => v === "reject");
+    const verdict: CouncilOutcome["verdict"] = anyReject
+      ? "reject"
+      : allApprove
+      ? "approve"
+      : "rework";
+    return {
+      verdict,
+      rounds: 1,
+      results,
+      consensusReached: allApprove || anyReject,
+    };
+  }
+
+  get agentCount(): number {
+    return this.agents.length;
+  }
+
+  get roundLimit(): number {
+    return this.maxRounds;
+  }
+}

--- a/packages/core/src/efficiency/budget.ts
+++ b/packages/core/src/efficiency/budget.ts
@@ -1,0 +1,83 @@
+export interface BudgetOptions {
+  /** Max total USD that may be spent across all LLM calls within this run. */
+  perPrUsd: number;
+  /** Optional soft-warning threshold as a fraction of perPrUsd (0..1). Defaults to 0.8. */
+  warnAt?: number;
+}
+
+/** Thrown when a spend attempt would exceed the per-PR budget cap. */
+export class BudgetExceededError extends Error {
+  readonly attemptedUsd: number;
+  readonly capUsd: number;
+  readonly spentUsd: number;
+
+  constructor(attemptedUsd: number, capUsd: number, spentUsd: number) {
+    super(
+      `budget: attempt to spend $${attemptedUsd.toFixed(4)} would take total to $${(spentUsd + attemptedUsd).toFixed(4)} (cap $${capUsd.toFixed(2)})`,
+    );
+    this.name = "BudgetExceededError";
+    this.attemptedUsd = attemptedUsd;
+    this.capUsd = capUsd;
+    this.spentUsd = spentUsd;
+  }
+}
+
+/** Default per-PR budget per decision #20. User-configurable via opts.perPrUsd. */
+export const DEFAULT_PER_PR_BUDGET_USD = 0.5;
+
+export class BudgetTracker {
+  private readonly capUsd: number;
+  private readonly warnAt: number;
+  private spent = 0;
+  private warned = false;
+  private warningHandler: ((spentUsd: number, capUsd: number) => void) | undefined;
+
+  constructor(opts: BudgetOptions) {
+    if (opts.perPrUsd <= 0) throw new Error("budget: perPrUsd must be > 0");
+    this.capUsd = opts.perPrUsd;
+    this.warnAt = opts.warnAt ?? 0.8;
+    if (this.warnAt < 0 || this.warnAt > 1) {
+      throw new Error("budget: warnAt must be in [0, 1]");
+    }
+  }
+
+  /** Attach a one-shot warning callback that fires when spending crosses the warn threshold. */
+  onWarning(handler: (spentUsd: number, capUsd: number) => void): void {
+    this.warningHandler = handler;
+  }
+
+  /** Throws BudgetExceededError if adding `usd` would exceed the cap. Call BEFORE the LLM call. */
+  reserve(usd: number): void {
+    if (usd < 0) throw new Error("budget: cannot reserve negative USD");
+    if (this.spent + usd > this.capUsd) {
+      throw new BudgetExceededError(usd, this.capUsd, this.spent);
+    }
+  }
+
+  /** Record actual spend after the call lands. No throw — we've already reserved. */
+  commit(usd: number): void {
+    if (usd < 0) throw new Error("budget: cannot commit negative USD");
+    this.spent += usd;
+    if (!this.warned && this.spent / this.capUsd >= this.warnAt) {
+      this.warned = true;
+      this.warningHandler?.(this.spent, this.capUsd);
+    }
+  }
+
+  get spentUsd(): number {
+    return this.spent;
+  }
+
+  get remainingUsd(): number {
+    return Math.max(0, this.capUsd - this.spent);
+  }
+
+  get capacityUsd(): number {
+    return this.capUsd;
+  }
+
+  reset(): void {
+    this.spent = 0;
+    this.warned = false;
+  }
+}

--- a/packages/core/src/efficiency/cache.ts
+++ b/packages/core/src/efficiency/cache.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+
+export interface CacheEntry<T> {
+  value: T;
+  storedAt: number;
+}
+
+export interface CacheOptions {
+  /** Time-to-live in milliseconds. Defaults to Anthropic's 5-minute prompt-cache window. */
+  ttlMs?: number;
+  /** Max entries held in memory. Oldest-first eviction. */
+  maxEntries?: number;
+}
+
+/**
+ * Anthropic prompt-cache 5-minute TTL is the design constraint:
+ * - On a HIT, downstream can signal `cache_control: ephemeral` to the API and save ~90% input cost
+ * - On a MISS within a live window, the request should still mark the large static prefix as `ephemeral`
+ *   so the NEXT identical call within 5 min hits the provider cache.
+ *
+ * PromptCache here tracks our view of whether we've recently issued a matching prefix — it does not
+ * store LLM output. The provider is the source of truth for what's actually cached server-side.
+ */
+export const ANTHROPIC_PROMPT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+export class PromptCache {
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+  private readonly store = new Map<string, CacheEntry<true>>();
+  private hits = 0;
+  private misses = 0;
+
+  constructor(opts: CacheOptions = {}) {
+    this.ttlMs = opts.ttlMs ?? ANTHROPIC_PROMPT_CACHE_TTL_MS;
+    this.maxEntries = opts.maxEntries ?? 1024;
+  }
+
+  /** Stable hash of a prefix string. Exported for tests + debugging. */
+  static key(prefix: string, model: string): string {
+    return createHash("sha256").update(`${model}\u0000${prefix}`).digest("hex");
+  }
+
+  isLive(prefix: string, model: string, now: number = Date.now()): boolean {
+    const k = PromptCache.key(prefix, model);
+    const entry = this.store.get(k);
+    if (!entry) {
+      this.misses += 1;
+      return false;
+    }
+    if (now - entry.storedAt > this.ttlMs) {
+      this.store.delete(k);
+      this.misses += 1;
+      return false;
+    }
+    this.hits += 1;
+    return true;
+  }
+
+  mark(prefix: string, model: string, now: number = Date.now()): void {
+    const k = PromptCache.key(prefix, model);
+    if (!this.store.has(k) && this.store.size >= this.maxEntries) {
+      const oldest = this.store.keys().next().value;
+      if (oldest !== undefined) this.store.delete(oldest);
+    }
+    this.store.set(k, { value: true, storedAt: now });
+  }
+
+  hitRate(): number {
+    const total = this.hits + this.misses;
+    return total === 0 ? 0 : this.hits / total;
+  }
+
+  get stats(): { hits: number; misses: number; size: number } {
+    return { hits: this.hits, misses: this.misses, size: this.store.size };
+  }
+
+  reset(): void {
+    this.store.clear();
+    this.hits = 0;
+    this.misses = 0;
+  }
+}

--- a/packages/core/src/efficiency/compact.ts
+++ b/packages/core/src/efficiency/compact.ts
@@ -1,0 +1,87 @@
+export interface CompactableMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+  /** Tokens for this message (estimate). */
+  tokens: number;
+  /** If true, never compact or drop — used for the current turn's user ask and system prompt. */
+  pin?: boolean;
+}
+
+export interface CompactOptions {
+  /** Target token budget for the conversation after compaction. */
+  targetTokens: number;
+  /** Optional summarizer. If provided, older messages are collapsed into a summary message. */
+  summarize?: (messages: readonly CompactableMessage[]) => Promise<string>;
+}
+
+export interface CompactResult {
+  messages: CompactableMessage[];
+  droppedCount: number;
+  summarizedCount: number;
+  finalTokens: number;
+}
+
+/**
+ * Round-to-round context compression.
+ *
+ * Strategy:
+ *   1. Keep all `pin: true` messages (system prompt, current turn).
+ *   2. Walk remaining messages newest-to-oldest, keeping until budget is hit.
+ *   3. If a `summarize` function is provided, collapse the dropped tail into
+ *      a single assistant-role summary message at the head of unpinned history.
+ *
+ * The real implementation uses Haiku for the summary call — kept as an
+ * injected function so callers can swap in a cached/noop variant for tests.
+ */
+export async function compact(
+  messages: readonly CompactableMessage[],
+  opts: CompactOptions,
+): Promise<CompactResult> {
+  const pinned = messages.filter((m) => m.pin);
+  const unpinned = messages.filter((m) => !m.pin);
+
+  const pinnedTokens = pinned.reduce((sum, m) => sum + m.tokens, 0);
+  const budget = opts.targetTokens - pinnedTokens;
+
+  if (budget <= 0) {
+    return {
+      messages: pinned,
+      droppedCount: unpinned.length,
+      summarizedCount: 0,
+      finalTokens: pinnedTokens,
+    };
+  }
+
+  // Fit newest-first.
+  const kept: CompactableMessage[] = [];
+  let used = 0;
+  for (let i = unpinned.length - 1; i >= 0; i -= 1) {
+    const m = unpinned[i]!;
+    if (used + m.tokens > budget) break;
+    kept.unshift(m);
+    used += m.tokens;
+  }
+  const dropped = unpinned.slice(0, unpinned.length - kept.length);
+
+  let summarized = 0;
+  if (dropped.length > 0 && opts.summarize) {
+    const summaryText = await opts.summarize(dropped);
+    const summaryTokens = Math.ceil(summaryText.length / 4);
+    if (summaryTokens <= budget - used) {
+      kept.unshift({
+        role: "assistant",
+        content: `[compacted summary of ${dropped.length} earlier messages]\n${summaryText}`,
+        tokens: summaryTokens,
+      });
+      used += summaryTokens;
+      summarized = dropped.length;
+    }
+  }
+
+  return {
+    messages: [...pinned, ...kept],
+    droppedCount: dropped.length - summarized,
+    summarizedCount: summarized,
+    finalTokens: pinnedTokens + used,
+  };
+}

--- a/packages/core/src/efficiency/gate.ts
+++ b/packages/core/src/efficiency/gate.ts
@@ -1,0 +1,95 @@
+import { PromptCache } from "./cache.js";
+import { BudgetTracker, DEFAULT_PER_PR_BUDGET_USD } from "./budget.js";
+import { MetricsRecorder, type CallMetric } from "./metrics.js";
+import { selectModel, estimateTokens, type ModelChoice } from "./router.js";
+
+export interface EfficiencyGateOptions {
+  perPrUsd?: number;
+  cache?: PromptCache;
+  budget?: BudgetTracker;
+  metrics?: MetricsRecorder;
+}
+
+export interface GateCallInput {
+  agent: string;
+  /** The prefix that is safe to prompt-cache (system prompt + pinned RAG context). */
+  cacheablePrefix: string;
+  /** The full prompt (prefix + volatile tail). Used for token estimation. */
+  prompt: string;
+  /** Pre-flight cost estimate in USD (caller computes from token budget + model pricing). */
+  estimatedCostUsd: number;
+  /** Override model routing if the caller has a specific requirement. */
+  forceModel?: string;
+}
+
+export interface GateCallOutcome<T> {
+  result: T;
+  metric: CallMetric;
+  modelChoice: ModelChoice;
+}
+
+export interface GateExecuteFn<T> {
+  (args: { model: string; cacheHit: boolean }): Promise<{
+    result: T;
+    inputTokens: number;
+    outputTokens: number;
+    costUsd: number;
+    latencyMs: number;
+  }>;
+}
+
+/**
+ * EfficiencyGate — central orchestrator. Every agent's LLM call MUST route
+ * through `run()` so cache, budget, routing, and metrics are uniform.
+ *
+ * Direct SDK calls outside this gate are a contract violation (decision #22).
+ */
+export class EfficiencyGate {
+  readonly cache: PromptCache;
+  readonly budget: BudgetTracker;
+  readonly metrics: MetricsRecorder;
+
+  constructor(opts: EfficiencyGateOptions = {}) {
+    this.cache = opts.cache ?? new PromptCache();
+    this.budget = opts.budget ?? new BudgetTracker({ perPrUsd: opts.perPrUsd ?? DEFAULT_PER_PR_BUDGET_USD });
+    this.metrics = opts.metrics ?? new MetricsRecorder();
+  }
+
+  async run<T>(input: GateCallInput, execute: GateExecuteFn<T>): Promise<GateCallOutcome<T>> {
+    // 1. Reserve budget BEFORE the call — throws if over cap.
+    this.budget.reserve(input.estimatedCostUsd);
+
+    // 2. Route to a model class.
+    const tokens = estimateTokens(input.prompt);
+    const choice: ModelChoice = input.forceModel
+      ? { model: input.forceModel, class: "sonnet", reason: "forced by caller" }
+      : selectModel(tokens);
+
+    // 3. Check cache liveness for the cacheable prefix.
+    const cacheHit = this.cache.isLive(input.cacheablePrefix, choice.model);
+
+    // 4. Execute.
+    const call = await execute({ model: choice.model, cacheHit });
+
+    // 5. Mark cache so the NEXT identical call within TTL reports a hit.
+    this.cache.mark(input.cacheablePrefix, choice.model);
+
+    // 6. Commit actual spend.
+    this.budget.commit(call.costUsd);
+
+    // 7. Record metric.
+    const metric: CallMetric = {
+      agent: input.agent,
+      model: choice.model,
+      inputTokens: call.inputTokens,
+      outputTokens: call.outputTokens,
+      costUsd: call.costUsd,
+      latencyMs: call.latencyMs,
+      cacheHit,
+      timestamp: Date.now(),
+    };
+    this.metrics.record(metric);
+
+    return { result: call.result, metric, modelChoice: choice };
+  }
+}

--- a/packages/core/src/efficiency/index.ts
+++ b/packages/core/src/efficiency/index.ts
@@ -1,0 +1,32 @@
+export { PromptCache, ANTHROPIC_PROMPT_CACHE_TTL_MS } from "./cache.js";
+export type { CacheEntry, CacheOptions } from "./cache.js";
+
+export { BudgetTracker, BudgetExceededError, DEFAULT_PER_PR_BUDGET_USD } from "./budget.js";
+export type { BudgetOptions } from "./budget.js";
+
+export { MetricsRecorder } from "./metrics.js";
+export type { CallMetric, MetricsSummary, MetricsSink } from "./metrics.js";
+
+export {
+  triageReview,
+  touchesRiskyPath,
+  DEFAULT_RISKY_PATH_PATTERNS,
+} from "./triage.js";
+export type { TriagePath, TriageInput, TriageOptions, TriageOutcome } from "./triage.js";
+
+export { selectModel, estimateTokens, DEFAULT_MODELS } from "./router.js";
+export type { ModelClass, ModelChoice, RouterOptions } from "./router.js";
+
+export { compact } from "./compact.js";
+export type { CompactableMessage, CompactOptions, CompactResult } from "./compact.js";
+
+export { buildRelevanceContext, inferTestPath } from "./relevance.js";
+export type { RelevanceChunk, RelevanceInput, RelevanceOptions } from "./relevance.js";
+
+export { EfficiencyGate } from "./gate.js";
+export type {
+  EfficiencyGateOptions,
+  GateCallInput,
+  GateCallOutcome,
+  GateExecuteFn,
+} from "./gate.js";

--- a/packages/core/src/efficiency/metrics.ts
+++ b/packages/core/src/efficiency/metrics.ts
@@ -1,0 +1,104 @@
+export interface CallMetric {
+  agent: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+  cacheHit: boolean;
+  timestamp: number;
+}
+
+export interface MetricsSummary {
+  callCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+  totalLatencyMs: number;
+  cacheHitRate: number;
+  byAgent: Record<string, { calls: number; costUsd: number }>;
+  byModel: Record<string, { calls: number; costUsd: number }>;
+}
+
+export interface MetricsSink {
+  record(metric: CallMetric): void;
+}
+
+/**
+ * MetricsRecorder — collects per-call metrics in memory and optionally
+ * forwards to an external sink (Langfuse self-hosted planned; stub here).
+ *
+ * Real Langfuse OTLP wiring lands when observability package is added;
+ * until then this is the source of truth for cost/tokens/latency.
+ */
+export class MetricsRecorder {
+  private readonly records: CallMetric[] = [];
+  private readonly sink: MetricsSink | undefined;
+
+  constructor(opts: { sink?: MetricsSink } = {}) {
+    this.sink = opts.sink;
+  }
+
+  record(metric: CallMetric): void {
+    this.records.push(metric);
+    this.sink?.record(metric);
+  }
+
+  all(): readonly CallMetric[] {
+    return this.records;
+  }
+
+  summary(): MetricsSummary {
+    if (this.records.length === 0) {
+      return {
+        callCount: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalCostUsd: 0,
+        totalLatencyMs: 0,
+        cacheHitRate: 0,
+        byAgent: {},
+        byModel: {},
+      };
+    }
+
+    const byAgent: Record<string, { calls: number; costUsd: number }> = {};
+    const byModel: Record<string, { calls: number; costUsd: number }> = {};
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let costUsd = 0;
+    let latencyMs = 0;
+    let cacheHits = 0;
+
+    for (const r of this.records) {
+      inputTokens += r.inputTokens;
+      outputTokens += r.outputTokens;
+      costUsd += r.costUsd;
+      latencyMs += r.latencyMs;
+      if (r.cacheHit) cacheHits += 1;
+      const ag = byAgent[r.agent] ?? { calls: 0, costUsd: 0 };
+      ag.calls += 1;
+      ag.costUsd += r.costUsd;
+      byAgent[r.agent] = ag;
+      const md = byModel[r.model] ?? { calls: 0, costUsd: 0 };
+      md.calls += 1;
+      md.costUsd += r.costUsd;
+      byModel[r.model] = md;
+    }
+
+    return {
+      callCount: this.records.length,
+      totalInputTokens: inputTokens,
+      totalOutputTokens: outputTokens,
+      totalCostUsd: costUsd,
+      totalLatencyMs: latencyMs,
+      cacheHitRate: cacheHits / this.records.length,
+      byAgent,
+      byModel,
+    };
+  }
+
+  reset(): void {
+    this.records.length = 0;
+  }
+}

--- a/packages/core/src/efficiency/relevance.ts
+++ b/packages/core/src/efficiency/relevance.ts
@@ -1,0 +1,104 @@
+export interface RelevanceChunk {
+  path: string;
+  excerpt: string;
+  reason: "diff" | "import-of-diff" | "imported-by-diff" | "test-of-diff";
+  estimatedTokens: number;
+}
+
+export interface RelevanceInput {
+  diff: string;
+  diffPaths: readonly string[];
+  /** Optional resolver: given a path, return its full content (for selective excerpts). */
+  readFile?: (path: string) => Promise<string | null>;
+  /** Optional resolver: given a path, return its direct imports (for graph walk). */
+  importsOf?: (path: string) => Promise<readonly string[]>;
+}
+
+export interface RelevanceOptions {
+  /** Max tokens to spend on the assembled context. Default 20_000. */
+  tokenBudget?: number;
+  /** Depth of import-graph walk. Default 1 (direct imports only). */
+  graphDepth?: number;
+}
+
+/**
+ * Build a relevance context for a review call.
+ *
+ * Priority (in token-budget order):
+ *   1. Full diff (always included; truncated to budget if oversized)
+ *   2. Test files matching diffed paths (critical for missing-coverage checks)
+ *   3. Direct imports of diffed paths (next PR may import these; reviewer needs the interfaces)
+ *   4. Files that import the diffed paths (potential breakage surface)
+ *
+ * The function is deliberately conservative: if `readFile` / `importsOf` are
+ * not provided, it returns just the diff. Scm-github (v2.0) will supply the
+ * real resolvers; for scaffolding we keep this pure.
+ */
+export async function buildRelevanceContext(
+  input: RelevanceInput,
+  opts: RelevanceOptions = {},
+): Promise<{ chunks: RelevanceChunk[]; totalTokens: number }> {
+  const budget = opts.tokenBudget ?? 20_000;
+  const chunks: RelevanceChunk[] = [];
+  let used = 0;
+
+  const diffTokens = Math.ceil(input.diff.length / 4);
+  const diffChunk: RelevanceChunk = {
+    path: "__diff__",
+    excerpt: diffTokens > budget ? input.diff.slice(0, budget * 4) : input.diff,
+    reason: "diff",
+    estimatedTokens: Math.min(diffTokens, budget),
+  };
+  chunks.push(diffChunk);
+  used += diffChunk.estimatedTokens;
+  if (used >= budget) return { chunks, totalTokens: used };
+
+  if (input.readFile) {
+    for (const p of input.diffPaths) {
+      if (used >= budget) break;
+      const testPath = inferTestPath(p);
+      if (!testPath) continue;
+      const content = await input.readFile(testPath);
+      if (!content) continue;
+      const tokens = Math.ceil(content.length / 4);
+      if (used + tokens > budget) continue;
+      chunks.push({ path: testPath, excerpt: content, reason: "test-of-diff", estimatedTokens: tokens });
+      used += tokens;
+    }
+  }
+
+  if (input.importsOf && (opts.graphDepth ?? 1) > 0) {
+    const seen = new Set(input.diffPaths);
+    for (const p of input.diffPaths) {
+      if (used >= budget) break;
+      const imports = await input.importsOf(p);
+      for (const imp of imports) {
+        if (used >= budget) break;
+        if (seen.has(imp)) continue;
+        seen.add(imp);
+        const content = input.readFile ? await input.readFile(imp) : null;
+        if (!content) continue;
+        const tokens = Math.ceil(content.length / 4);
+        if (used + tokens > budget) continue;
+        chunks.push({
+          path: imp,
+          excerpt: content,
+          reason: "import-of-diff",
+          estimatedTokens: tokens,
+        });
+        used += tokens;
+      }
+    }
+  }
+
+  return { chunks, totalTokens: used };
+}
+
+/** Heuristic: map a source file path to its conventional test path. Returns null if none inferable. */
+export function inferTestPath(source: string): string | null {
+  if (/\.(test|spec)\.(ts|tsx|js|mjs)$/.test(source)) return source;
+  const m = source.match(/^(.*)\/([^/]+?)\.(ts|tsx|js|mjs)$/);
+  if (!m) return null;
+  const [, dir, base, ext] = m;
+  return `${dir}/${base}.test.${ext}`;
+}

--- a/packages/core/src/efficiency/router.ts
+++ b/packages/core/src/efficiency/router.ts
@@ -1,0 +1,63 @@
+export type ModelClass = "haiku" | "sonnet" | "opus" | "long-context";
+
+export interface ModelChoice {
+  /** Provider-specific model identifier. */
+  model: string;
+  /** Logical class for metrics grouping. */
+  class: ModelClass;
+  /** Reason text for logs / traces. */
+  reason: string;
+}
+
+export interface RouterOptions {
+  /** Upper bound (input tokens) for Haiku path. Default 8_000. */
+  haikuMax?: number;
+  /** Upper bound (input tokens) for Sonnet path. Default 50_000. */
+  sonnetMax?: number;
+  /** Override default model IDs if needed (e.g. preview releases). */
+  models?: Partial<Record<ModelClass, string>>;
+}
+
+/**
+ * Default model identifiers per 34-decision tech stack (2026-04-19):
+ *   haiku   → fast triage, nightly episodic→catalog classification
+ *   sonnet  → main reviewer workhorse (decision-core default)
+ *   long    → Gemini 2.5 Pro for >50K input tokens (long-context slot)
+ */
+export const DEFAULT_MODELS: Record<ModelClass, string> = {
+  haiku: "claude-haiku-4-5",
+  sonnet: "claude-sonnet-4-6",
+  opus: "claude-opus-4-7",
+  "long-context": "gemini-2.5-pro",
+};
+
+/**
+ * Route by input size. Output-size driven routing is intentionally excluded
+ * for now — output tends to be bounded by the prompt structure, not a
+ * separate routing axis.
+ */
+export function selectModel(
+  inputTokenEstimate: number,
+  opts: RouterOptions = {},
+): ModelChoice {
+  const haikuMax = opts.haikuMax ?? 8_000;
+  const sonnetMax = opts.sonnetMax ?? 50_000;
+  const models = { ...DEFAULT_MODELS, ...opts.models };
+
+  if (inputTokenEstimate <= haikuMax) {
+    return { model: models.haiku, class: "haiku", reason: `input ${inputTokenEstimate} ≤ ${haikuMax}` };
+  }
+  if (inputTokenEstimate <= sonnetMax) {
+    return { model: models.sonnet, class: "sonnet", reason: `input ${inputTokenEstimate} ≤ ${sonnetMax}` };
+  }
+  return {
+    model: models["long-context"],
+    class: "long-context",
+    reason: `input ${inputTokenEstimate} > ${sonnetMax}`,
+  };
+}
+
+/** Rough input-size estimator. Real impl should use tiktoken / Anthropic tokenizer; this is a placeholder. */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}

--- a/packages/core/src/efficiency/triage.ts
+++ b/packages/core/src/efficiency/triage.ts
@@ -1,0 +1,75 @@
+export type TriagePath = "lite" | "full";
+
+export interface TriageInput {
+  /** Net lines changed (adds + deletes). */
+  linesChanged: number;
+  /** Number of files in the diff. */
+  fileCount: number;
+  /** Whether the diff touches any test files. */
+  hasTests: boolean;
+  /** Whether any of the changed files matches a "risky path" pattern (e.g. schema/, migrations/, auth/, payments/). */
+  touchesRiskyPath: boolean;
+  /** Total added/deleted characters (optional, used as a size tiebreaker). */
+  sizeBytes?: number;
+}
+
+export interface TriageOptions {
+  /** Under this many lines of change, a PR is considered lite-eligible. Default 40. */
+  liteLineThreshold?: number;
+  /** Under this many files, a PR is considered lite-eligible. Default 3. */
+  liteFileThreshold?: number;
+}
+
+export interface TriageOutcome {
+  path: TriagePath;
+  /** Human-readable reason the path was chosen. */
+  reason: string;
+}
+
+const DEFAULT_LITE_LINES = 40;
+const DEFAULT_LITE_FILES = 3;
+
+/**
+ * Classifies a review as "lite" (single agent, short review) or "full" (3-round council).
+ *
+ * Rules in priority order:
+ *   1. Risky-path touches always go full — missing a security/schema bug is more expensive than the review cost.
+ *   2. Large PRs (>threshold lines OR >threshold files) go full.
+ *   3. PRs that TOUCH but don't ADD tests for changed logic go full (we want the second agent to catch missing coverage).
+ *   4. Everything else → lite.
+ */
+export function triageReview(input: TriageInput, opts: TriageOptions = {}): TriageOutcome {
+  const lineThreshold = opts.liteLineThreshold ?? DEFAULT_LITE_LINES;
+  const fileThreshold = opts.liteFileThreshold ?? DEFAULT_LITE_FILES;
+
+  if (input.touchesRiskyPath) {
+    return { path: "full", reason: "diff touches a risky path (schema / auth / payment / migration)" };
+  }
+  if (input.linesChanged > lineThreshold) {
+    return { path: "full", reason: `linesChanged ${input.linesChanged} > ${lineThreshold}` };
+  }
+  if (input.fileCount > fileThreshold) {
+    return { path: "full", reason: `fileCount ${input.fileCount} > ${fileThreshold}` };
+  }
+  if (!input.hasTests && input.linesChanged >= 10) {
+    return { path: "full", reason: "non-trivial diff without any test files touched" };
+  }
+  return { path: "lite", reason: "small, low-risk, has test coverage or trivial" };
+}
+
+/** Default patterns that force a full council review when touched. */
+export const DEFAULT_RISKY_PATH_PATTERNS = [
+  /(^|\/)(schema|schemas)\//i,
+  /(^|\/)migrations?\//i,
+  /(^|\/)auth\//i,
+  /(^|\/)(payment|payments|billing)\//i,
+  /\.sql$/i,
+  /prisma\/schema\.prisma$/i,
+] as const;
+
+export function touchesRiskyPath(
+  paths: readonly string[],
+  patterns: readonly RegExp[] = DEFAULT_RISKY_PATH_PATTERNS,
+): boolean {
+  return paths.some((p) => patterns.some((re) => re.test(p)));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,8 @@
 export type { Agent, ReviewContext, ReviewResult, Blocker, Severity } from "./agent.js";
 export { Council } from "./council.js";
+export type { CouncilOutcome } from "./council.js";
 export { ReviewResultSchema, BlockerSchema } from "./schema.js";
+export type { Notifier, NotifyReviewInput } from "./notifier.js";
 
 // Memory substrate (decision #17: 정답지 + 오답지 duality as core primitive).
 // Re-exported here for convenience; dedicated subpath at @ai-conclave/core/memory.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,11 @@ export {
   OutcomeWriter,
   RuleBasedClassifier,
   newEpisodicId,
+  seedFromLegacyCatalog,
+  seedFromLegacyCatalogPath,
+  toFailureEntry,
+  mapLegacyCategory,
+  LegacyCatalogSchema,
 } from "./memory/index.js";
 export type {
   AnswerKey,
@@ -33,6 +38,11 @@ export type {
   Classifier,
   ClassificationOutput,
   OutcomeResult,
+  LegacyEntry,
+  LegacyCatalog,
+  SeedOptions,
+  SeedResult,
+  NewFailureCategory,
 } from "./memory/index.js";
 
 // Efficiency Gate (decision #22: first-class from day 1) — every LLM call

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,44 @@
 export type { Agent, ReviewContext, ReviewResult, Blocker, Severity } from "./agent.js";
 export { Council } from "./council.js";
 export { ReviewResultSchema, BlockerSchema } from "./schema.js";
+
+// Efficiency Gate (decision #22: first-class from day 1) — every LLM call
+// routes through `EfficiencyGate.run(...)`. Re-exported here for convenience;
+// the dedicated subpath export lives at @ai-conclave/core/efficiency.
+export {
+  EfficiencyGate,
+  PromptCache,
+  BudgetTracker,
+  BudgetExceededError,
+  MetricsRecorder,
+  selectModel,
+  estimateTokens,
+  triageReview,
+  touchesRiskyPath,
+  compact,
+  buildRelevanceContext,
+  DEFAULT_PER_PR_BUDGET_USD,
+  DEFAULT_MODELS,
+  ANTHROPIC_PROMPT_CACHE_TTL_MS,
+} from "./efficiency/index.js";
+export type {
+  CallMetric,
+  MetricsSummary,
+  MetricsSink,
+  TriagePath,
+  TriageInput,
+  TriageOutcome,
+  ModelClass,
+  ModelChoice,
+  RouterOptions,
+  CompactableMessage,
+  CompactOptions,
+  CompactResult,
+  RelevanceChunk,
+  RelevanceInput,
+  RelevanceOptions,
+  EfficiencyGateOptions,
+  GateCallInput,
+  GateCallOutcome,
+  GateExecuteFn,
+} from "./efficiency/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,28 @@ export type { Agent, ReviewContext, ReviewResult, Blocker, Severity } from "./ag
 export { Council } from "./council.js";
 export { ReviewResultSchema, BlockerSchema } from "./schema.js";
 
+// Memory substrate (decision #17: 정답지 + 오답지 duality as core primitive).
+// Re-exported here for convenience; dedicated subpath at @ai-conclave/core/memory.
+export {
+  FileSystemMemoryStore,
+  AnswerKeySchema,
+  EpisodicEntrySchema,
+  FailureEntrySchema,
+  SemanticRuleSchema,
+  formatAnswerKeyForPrompt,
+  formatFailureForPrompt,
+} from "./memory/index.js";
+export type {
+  AnswerKey,
+  EpisodicEntry,
+  FailureEntry,
+  SemanticRule,
+  MemoryStore,
+  MemoryReadQuery,
+  MemoryRetrieval,
+  FsStoreOptions,
+} from "./memory/index.js";
+
 // Efficiency Gate (decision #22: first-class from day 1) — every LLM call
 // routes through `EfficiencyGate.run(...)`. Re-exported here for convenience;
 // the dedicated subpath export lives at @ai-conclave/core/efficiency.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,9 @@ export {
   SemanticRuleSchema,
   formatAnswerKeyForPrompt,
   formatFailureForPrompt,
+  OutcomeWriter,
+  RuleBasedClassifier,
+  newEpisodicId,
 } from "./memory/index.js";
 export type {
   AnswerKey,
@@ -22,6 +25,12 @@ export type {
   MemoryReadQuery,
   MemoryRetrieval,
   FsStoreOptions,
+  WriteReviewInput,
+  RecordOutcomeInput,
+  RecordOutcomeOutput,
+  Classifier,
+  ClassificationOutput,
+  OutcomeResult,
 } from "./memory/index.js";
 
 // Efficiency Gate (decision #22: first-class from day 1) — every LLM call

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,3 @@
+export type { Agent, ReviewContext, ReviewResult, Blocker, Severity } from "./agent.js";
+export { Council } from "./council.js";
+export { ReviewResultSchema, BlockerSchema } from "./schema.js";

--- a/packages/core/src/memory/classifier.ts
+++ b/packages/core/src/memory/classifier.ts
@@ -1,0 +1,150 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { EpisodicEntry, AnswerKey, FailureEntry } from "./schema.js";
+import type { Blocker } from "../agent.js";
+
+export type OutcomeResult = "merged" | "rejected" | "reworked";
+
+export interface ClassificationOutput {
+  answerKeys: AnswerKey[];
+  failures: FailureEntry[];
+}
+
+export interface Classifier {
+  classify(episodic: EpisodicEntry, outcome: OutcomeResult): ClassificationOutput;
+}
+
+/**
+ * RuleBasedClassifier — deterministic extraction of answer-keys + failures
+ * from an EpisodicEntry without an LLM call.
+ *
+ * Rules:
+ *   - merged + all agents approved → one `AnswerKey` from the consensus
+ *     summary. Pattern = `by-repo/<repo>`; tags derived from diff file
+ *     extensions + blocker categories that appeared but were fixed.
+ *   - rejected / reworked → one `FailureEntry` per unique (category, severity)
+ *     blocker seen across all agent reviews. Title from blocker.message
+ *     (first sentence), body combines message + file:line context.
+ *
+ * Haiku-backed classifier lands later as a drop-in replacement; interface
+ * is stable.
+ */
+export class RuleBasedClassifier implements Classifier {
+  classify(episodic: EpisodicEntry, outcome: OutcomeResult): ClassificationOutput {
+    if (outcome === "merged") {
+      return { answerKeys: [this.extractAnswerKey(episodic)], failures: [] };
+    }
+    return { answerKeys: [], failures: this.extractFailures(episodic) };
+  }
+
+  private extractAnswerKey(episodic: EpisodicEntry): AnswerKey {
+    const summaries = episodic.reviews
+      .map((r) => r.summary)
+      .filter((s) => s && s.trim().length > 0)
+      .slice(0, 3)
+      .join(" | ");
+    const lesson = summaries || `Merged without blockers — ${episodic.repo} #${episodic.pullNumber}`;
+    const tags = this.deriveTags(episodic);
+    const key: AnswerKey = {
+      id: `ak-${shortHash(episodic.id + ":" + episodic.sha)}`,
+      createdAt: episodic.createdAt,
+      domain: "code",
+      pattern: `by-repo/${episodic.repo}`,
+      lesson,
+      tags,
+      repo: episodic.repo,
+      episodicId: episodic.id,
+    };
+    return key;
+  }
+
+  private extractFailures(episodic: EpisodicEntry): FailureEntry[] {
+    const seen = new Map<string, FailureEntry>();
+    for (const review of episodic.reviews) {
+      for (const blocker of review.blockers) {
+        if (blocker.severity === "nit") continue;
+        const key = `${blocker.category}|${blocker.severity}|${truncate(blocker.message, 80)}`;
+        if (seen.has(key)) continue;
+        seen.set(key, toFailureEntry(blocker, episodic));
+      }
+    }
+    return [...seen.values()];
+  }
+
+  private deriveTags(episodic: EpisodicEntry): string[] {
+    const tags = new Set<string>();
+    for (const review of episodic.reviews) {
+      for (const b of review.blockers) tags.add(b.category);
+    }
+    return [...tags];
+  }
+}
+
+function toFailureEntry(blocker: Blocker, episodic: EpisodicEntry): FailureEntry {
+  const category = mapCategory(blocker.category);
+  const severity: FailureEntry["severity"] =
+    blocker.severity === "blocker" ? "blocker" : blocker.severity === "major" ? "major" : "minor";
+  const file = blocker.file ? `${blocker.file}${blocker.line ? `:${blocker.line}` : ""}` : undefined;
+  const entry: FailureEntry = {
+    id: `fc-${shortHash(episodic.id + ":" + blocker.category + ":" + blocker.message)}`,
+    createdAt: episodic.createdAt,
+    domain: "code",
+    category,
+    severity,
+    title: titleFrom(blocker.message),
+    body: [blocker.message, file ? `at ${file}` : null].filter(Boolean).join(" "),
+    tags: [blocker.category],
+    seedBlocker: blocker,
+    episodicId: episodic.id,
+  };
+  return entry;
+}
+
+const ALLOWED_CATEGORIES: FailureEntry["category"][] = [
+  "type-error",
+  "missing-test",
+  "regression",
+  "security",
+  "accessibility",
+  "contrast",
+  "performance",
+  "dead-code",
+  "api-misuse",
+  "schema-drift",
+  "other",
+];
+
+function mapCategory(raw: string): FailureEntry["category"] {
+  const normalized = raw.toLowerCase().replace(/\s+/g, "-");
+  for (const c of ALLOWED_CATEGORIES) {
+    if (c === normalized) return c;
+  }
+  if (normalized.includes("test")) return "missing-test";
+  if (normalized.includes("type")) return "type-error";
+  if (normalized.includes("security") || normalized.includes("secret")) return "security";
+  if (normalized.includes("a11y") || normalized.includes("accessibility")) return "accessibility";
+  if (normalized.includes("perf")) return "performance";
+  if (normalized.includes("dead") || normalized.includes("unused")) return "dead-code";
+  if (normalized.includes("regress")) return "regression";
+  if (normalized.includes("contrast")) return "contrast";
+  if (normalized.includes("schema") || normalized.includes("migration")) return "schema-drift";
+  if (normalized.includes("api")) return "api-misuse";
+  return "other";
+}
+
+function titleFrom(message: string): string {
+  const firstSentence = message.split(/[.!?]\s/)[0] ?? message;
+  return truncate(firstSentence.trim(), 120);
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}
+
+function shortHash(s: string): string {
+  return createHash("sha256").update(s).digest("hex").slice(0, 12);
+}
+
+/** Factory helper for a new EpisodicEntry id (used by CLI / outcome-writer). */
+export function newEpisodicId(): string {
+  return `ep-${randomUUID()}`;
+}

--- a/packages/core/src/memory/fs-store.ts
+++ b/packages/core/src/memory/fs-store.ts
@@ -163,6 +163,27 @@ export class FileSystemMemoryStore implements MemoryStore {
     return null;
   }
 
+  async listEpisodic(): Promise<EpisodicEntry[]> {
+    const episRoot = path.join(this.root, "episodic");
+    const days = await safeReaddir(episRoot);
+    const out: EpisodicEntry[] = [];
+    for (const day of days) {
+      const dir = path.join(episRoot, day);
+      const files = await safeReaddir(dir);
+      for (const f of files) {
+        if (!f.endsWith(".json")) continue;
+        try {
+          const raw = await fs.readFile(path.join(dir, f), "utf8");
+          const parsed = EpisodicEntrySchema.safeParse(JSON.parse(raw));
+          if (parsed.success) out.push(parsed.data);
+        } catch {
+          continue;
+        }
+      }
+    }
+    return out;
+  }
+
   async listRules(): Promise<SemanticRule[]> {
     const file = path.join(this.root, "semantic", "rules.jsonl");
     try {

--- a/packages/core/src/memory/fs-store.ts
+++ b/packages/core/src/memory/fs-store.ts
@@ -143,6 +143,26 @@ export class FileSystemMemoryStore implements MemoryStore {
     return out;
   }
 
+  async findEpisodic(id: string): Promise<EpisodicEntry | null> {
+    const episRoot = path.join(this.root, "episodic");
+    const days = await safeReaddir(episRoot);
+    for (const day of days) {
+      const dir = path.join(episRoot, day);
+      const files = await safeReaddir(dir);
+      for (const f of files) {
+        if (!f.includes(id) || !f.endsWith(".json")) continue;
+        try {
+          const raw = await fs.readFile(path.join(dir, f), "utf8");
+          const parsed = EpisodicEntrySchema.safeParse(JSON.parse(raw));
+          if (parsed.success && parsed.data.id === id) return parsed.data;
+        } catch {
+          continue;
+        }
+      }
+    }
+    return null;
+  }
+
   async listRules(): Promise<SemanticRule[]> {
     const file = path.join(this.root, "semantic", "rules.jsonl");
     try {

--- a/packages/core/src/memory/fs-store.ts
+++ b/packages/core/src/memory/fs-store.ts
@@ -1,0 +1,171 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  AnswerKeySchema,
+  EpisodicEntrySchema,
+  FailureEntrySchema,
+  SemanticRuleSchema,
+  type AnswerKey,
+  type EpisodicEntry,
+  type FailureEntry,
+  type SemanticRule,
+} from "./schema.js";
+import type { MemoryReadQuery, MemoryRetrieval, MemoryStore } from "./store.js";
+import { retrieve } from "./retrieval.js";
+
+export interface FsStoreOptions {
+  root: string;
+}
+
+/**
+ * FileSystemMemoryStore — JSON-file backend for the self-evolve substrate.
+ *
+ * Layout under `root`:
+ *   episodic/YYYY-MM-DD/pr-{n}.json          (90d TTL — pruning runs out-of-band)
+ *   answer-keys/{domain}/{id}.json
+ *   failure-catalog/{domain}/{id}.json
+ *   semantic/rules.json                       (single JSONL file, appended)
+ *
+ * All paths are created lazily on first write. Reads are glob-less —
+ * we walk only the directories we care about.
+ */
+export class FileSystemMemoryStore implements MemoryStore {
+  private readonly root: string;
+
+  constructor(opts: FsStoreOptions) {
+    this.root = opts.root;
+  }
+
+  async retrieve(q: MemoryReadQuery): Promise<MemoryRetrieval> {
+    const k = q.k ?? 8;
+    const answerKeyCorpus = await this.listAnswerKeys(q.domain);
+    const failureCorpus = await this.listFailures(q.domain);
+    const ruleCorpus = await this.listRules();
+
+    const answerKeys = retrieve(
+      answerKeyCorpus,
+      q.query,
+      {
+        text: (d) => `${d.pattern}\n${d.lesson}\n${d.tags.join(" ")}`,
+        tags: (d) => d.tags,
+        repo: (d) => d.repo,
+      },
+      k,
+      { queryRepo: q.repo },
+    ).map((s) => s.doc);
+
+    const failures = retrieve(
+      failureCorpus,
+      q.query,
+      {
+        text: (d) => `${d.title}\n${d.body}\n${d.category}\n${d.tags.join(" ")}`,
+        tags: (d) => [d.category, ...d.tags],
+      },
+      k,
+    ).map((s) => s.doc);
+
+    const rules = retrieve(
+      ruleCorpus,
+      q.query,
+      {
+        text: (d) => `${d.tag}\n${d.rule}`,
+        tags: (d) => [d.tag],
+      },
+      Math.min(k, 4),
+    ).map((s) => s.doc);
+
+    return { answerKeys, failures, rules };
+  }
+
+  async writeEpisodic(entry: EpisodicEntry): Promise<void> {
+    EpisodicEntrySchema.parse(entry);
+    const day = entry.createdAt.slice(0, 10);
+    const dir = path.join(this.root, "episodic", day);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, `pr-${entry.pullNumber}-${entry.id}.json`),
+      JSON.stringify(entry, null, 2),
+      "utf8",
+    );
+  }
+
+  async writeAnswerKey(key: AnswerKey): Promise<void> {
+    AnswerKeySchema.parse(key);
+    const dir = path.join(this.root, "answer-keys", key.domain);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, `${key.id}.json`), JSON.stringify(key, null, 2), "utf8");
+  }
+
+  async writeFailure(entry: FailureEntry): Promise<void> {
+    FailureEntrySchema.parse(entry);
+    const dir = path.join(this.root, "failure-catalog", entry.domain);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, `${entry.id}.json`), JSON.stringify(entry, null, 2), "utf8");
+  }
+
+  async writeRule(rule: SemanticRule): Promise<void> {
+    SemanticRuleSchema.parse(rule);
+    const dir = path.join(this.root, "semantic");
+    await fs.mkdir(dir, { recursive: true });
+    const file = path.join(dir, "rules.jsonl");
+    await fs.appendFile(file, JSON.stringify(rule) + "\n", "utf8");
+  }
+
+  async listAnswerKeys(domain?: "code" | "design"): Promise<AnswerKey[]> {
+    const domains: Array<"code" | "design"> = domain ? [domain] : ["code", "design"];
+    const out: AnswerKey[] = [];
+    for (const d of domains) {
+      const dir = path.join(this.root, "answer-keys", d);
+      const files = await safeReaddir(dir);
+      for (const f of files) {
+        if (!f.endsWith(".json")) continue;
+        const raw = await fs.readFile(path.join(dir, f), "utf8");
+        const parsed = AnswerKeySchema.safeParse(JSON.parse(raw));
+        if (parsed.success) out.push(parsed.data);
+      }
+    }
+    return out;
+  }
+
+  async listFailures(domain?: "code" | "design"): Promise<FailureEntry[]> {
+    const domains: Array<"code" | "design"> = domain ? [domain] : ["code", "design"];
+    const out: FailureEntry[] = [];
+    for (const d of domains) {
+      const dir = path.join(this.root, "failure-catalog", d);
+      const files = await safeReaddir(dir);
+      for (const f of files) {
+        if (!f.endsWith(".json")) continue;
+        const raw = await fs.readFile(path.join(dir, f), "utf8");
+        const parsed = FailureEntrySchema.safeParse(JSON.parse(raw));
+        if (parsed.success) out.push(parsed.data);
+      }
+    }
+    return out;
+  }
+
+  async listRules(): Promise<SemanticRule[]> {
+    const file = path.join(this.root, "semantic", "rules.jsonl");
+    try {
+      const raw = await fs.readFile(file, "utf8");
+      const out: SemanticRule[] = [];
+      for (const line of raw.split(/\r?\n/)) {
+        if (!line.trim()) continue;
+        const parsed = SemanticRuleSchema.safeParse(JSON.parse(line));
+        if (parsed.success) out.push(parsed.data);
+      }
+      return out;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+  }
+}
+
+async function safeReaddir(dir: string): Promise<string[]> {
+  try {
+    return await fs.readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+}

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -22,3 +22,13 @@ export type { RetrievalFieldExtractor, RetrievalOptions, ScoredDoc } from "./ret
 
 export { FileSystemMemoryStore } from "./fs-store.js";
 export type { FsStoreOptions } from "./fs-store.js";
+
+export { OutcomeWriter } from "./outcome-writer.js";
+export type {
+  WriteReviewInput,
+  RecordOutcomeInput,
+  RecordOutcomeOutput,
+} from "./outcome-writer.js";
+
+export { RuleBasedClassifier, newEpisodicId } from "./classifier.js";
+export type { Classifier, ClassificationOutput, OutcomeResult } from "./classifier.js";

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -32,3 +32,13 @@ export type {
 
 export { RuleBasedClassifier, newEpisodicId } from "./classifier.js";
 export type { Classifier, ClassificationOutput, OutcomeResult } from "./classifier.js";
+
+export {
+  LegacyEntrySchema,
+  LegacyCatalogSchema,
+  mapLegacyCategory,
+  toFailureEntry,
+  seedFromLegacyCatalog,
+  seedFromLegacyCatalogPath,
+} from "./seeder.js";
+export type { LegacyEntry, LegacyCatalog, SeedOptions, SeedResult, NewFailureCategory } from "./seeder.js";

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -1,0 +1,24 @@
+export {
+  AnswerKeySchema,
+  AnswerKeyDomainSchema,
+  EpisodicEntrySchema,
+  FailureEntrySchema,
+  FailureCategorySchema,
+  FailureSeveritySchema,
+  SemanticRuleSchema,
+} from "./schema.js";
+export type {
+  AnswerKey,
+  EpisodicEntry,
+  FailureEntry,
+  SemanticRule,
+} from "./schema.js";
+
+export { formatAnswerKeyForPrompt, formatFailureForPrompt } from "./store.js";
+export type { MemoryStore, MemoryReadQuery, MemoryRetrieval } from "./store.js";
+
+export { retrieve } from "./retrieval.js";
+export type { RetrievalFieldExtractor, RetrievalOptions, ScoredDoc } from "./retrieval.js";
+
+export { FileSystemMemoryStore } from "./fs-store.js";
+export type { FsStoreOptions } from "./fs-store.js";

--- a/packages/core/src/memory/outcome-writer.ts
+++ b/packages/core/src/memory/outcome-writer.ts
@@ -1,0 +1,97 @@
+import { createHash } from "node:crypto";
+import type { EpisodicEntry, AnswerKey, FailureEntry } from "./schema.js";
+import type { MemoryStore } from "./store.js";
+import { RuleBasedClassifier, newEpisodicId, type Classifier, type OutcomeResult } from "./classifier.js";
+import type { ReviewContext, ReviewResult } from "../agent.js";
+
+export interface WriteReviewInput {
+  ctx: ReviewContext;
+  reviews: readonly ReviewResult[];
+  councilVerdict: "approve" | "rework" | "reject";
+  costUsd: number;
+  /** Provide a stable id to make the write idempotent (re-runs update instead of dup). Defaults to a UUID. */
+  episodicId?: string;
+}
+
+export interface RecordOutcomeInput {
+  episodicId: string;
+  outcome: OutcomeResult;
+}
+
+export interface RecordOutcomeOutput {
+  answerKeys: AnswerKey[];
+  failures: FailureEntry[];
+}
+
+/**
+ * OutcomeWriter — closes the self-evolve loop.
+ *
+ * Called from two points in the lifecycle:
+ *   1. `writeReview(...)` — at the end of `conclave review`, persists an
+ *      `EpisodicEntry` with `outcome: "pending"`.
+ *   2. `recordOutcome(...)` — when the PR lands (merged / rejected /
+ *      reworked), updates the stored episodic entry and invokes the
+ *      classifier to produce `AnswerKey` + `FailureEntry` records.
+ *
+ * The classifier is pluggable (decision #17). Default is the rule-based
+ * extractor — no LLM cost. A Haiku-backed classifier will slot in later
+ * as a subtype, behind the same `Classifier` interface.
+ */
+export class OutcomeWriter {
+  private readonly store: MemoryStore;
+  private readonly classifier: Classifier;
+  private readonly episodicIndex: Map<string, EpisodicEntry>;
+
+  constructor(opts: { store: MemoryStore; classifier?: Classifier }) {
+    this.store = opts.store;
+    this.classifier = opts.classifier ?? new RuleBasedClassifier();
+    this.episodicIndex = new Map();
+  }
+
+  async writeReview(input: WriteReviewInput): Promise<EpisodicEntry> {
+    const id = input.episodicId ?? newEpisodicId();
+    const entry: EpisodicEntry = {
+      id,
+      createdAt: new Date().toISOString(),
+      repo: input.ctx.repo,
+      pullNumber: input.ctx.pullNumber,
+      sha: input.ctx.newSha,
+      diffSha256: sha256(input.ctx.diff),
+      reviews: [...input.reviews],
+      councilVerdict: input.councilVerdict,
+      outcome: "pending",
+      costUsd: input.costUsd,
+    };
+    await this.store.writeEpisodic(entry);
+    this.episodicIndex.set(id, entry);
+    return entry;
+  }
+
+  async recordOutcome(input: RecordOutcomeInput): Promise<RecordOutcomeOutput> {
+    const existing = this.episodicIndex.get(input.episodicId) ?? (await this.loadEpisodicFromDisk(input.episodicId));
+    if (!existing) {
+      throw new Error(`OutcomeWriter: no episodic entry found for id ${input.episodicId}`);
+    }
+    const updated: EpisodicEntry = { ...existing, outcome: input.outcome };
+    await this.store.writeEpisodic(updated);
+    this.episodicIndex.set(input.episodicId, updated);
+
+    const classification = this.classifier.classify(updated, input.outcome);
+    for (const key of classification.answerKeys) await this.store.writeAnswerKey(key);
+    for (const entry of classification.failures) await this.store.writeFailure(entry);
+    return classification;
+  }
+
+  private async loadEpisodicFromDisk(id: string): Promise<EpisodicEntry | null> {
+    return this.store.findEpisodic(id);
+  }
+
+  /** Test helper: inject an episodic entry into the in-memory index. */
+  _setEpisodicForTest(entry: EpisodicEntry): void {
+    this.episodicIndex.set(entry.id, entry);
+  }
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}

--- a/packages/core/src/memory/retrieval.ts
+++ b/packages/core/src/memory/retrieval.ts
@@ -1,0 +1,109 @@
+/**
+ * Lightweight BM25-ish retrieval. We avoid a heavy vector DB for the
+ * skeleton — answer-keys and failures are short text, the corpus is O(100s)
+ * per repo, and a keyword-plus-tag ranking is good enough to pilot the
+ * self-evolve loop. Vector embeddings slot in later as a pluggable
+ * scoring backend without breaking the store interface.
+ */
+
+export interface ScoredDoc<T> {
+  doc: T;
+  score: number;
+}
+
+export interface RetrievalFieldExtractor<T> {
+  text(doc: T): string;
+  tags(doc: T): readonly string[];
+  repo?(doc: T): string | undefined;
+}
+
+export interface RetrievalOptions {
+  /** Lexicon boost: when query tokens match doc tags, multiply score by this factor. Default 1.5. */
+  tagBoost?: number;
+  /** Multiply score for docs whose repo matches the query's repo. Default 1.2. */
+  repoBoost?: number;
+  /** Minimum score to retain a doc. Default 0.05. */
+  minScore?: number;
+}
+
+const STOP_WORDS = new Set([
+  "a", "an", "the", "and", "or", "to", "of", "in", "on", "for", "with", "by",
+  "is", "are", "was", "were", "be", "been", "being", "it", "its", "this",
+  "that", "these", "those", "at", "from", "as", "but", "not", "if", "then",
+]);
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣\-]+/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length > 1 && !STOP_WORDS.has(t));
+}
+
+function termFrequencies(tokens: readonly string[]): Map<string, number> {
+  const tf = new Map<string, number>();
+  for (const t of tokens) tf.set(t, (tf.get(t) ?? 0) + 1);
+  return tf;
+}
+
+/**
+ * Score a single document against a query. Returns a scalar in [0, ~n]
+ * where n is the number of query tokens. Uses:
+ *   1. Cosine-ish term overlap (sum of min(tf_q, tf_d) / sqrt(|q|·|d|))
+ *   2. Tag-match boost
+ *   3. Repo-match boost (small, just tie-breaking)
+ */
+function scoreDoc<T>(
+  doc: T,
+  queryTokens: readonly string[],
+  queryRepo: string | undefined,
+  extract: RetrievalFieldExtractor<T>,
+  opts: Required<Pick<RetrievalOptions, "tagBoost" | "repoBoost">>,
+): number {
+  const qTf = termFrequencies(queryTokens);
+  const dTokens = tokenize(extract.text(doc));
+  if (dTokens.length === 0 || queryTokens.length === 0) return 0;
+  const dTf = termFrequencies(dTokens);
+
+  let overlap = 0;
+  for (const [t, qf] of qTf) {
+    const df = dTf.get(t);
+    if (df) overlap += Math.min(qf, df);
+  }
+  let score = overlap / Math.sqrt(queryTokens.length * dTokens.length);
+
+  if (score > 0) {
+    const tagSet = new Set(extract.tags(doc).map((t) => t.toLowerCase()));
+    let tagHits = 0;
+    for (const t of qTf.keys()) if (tagSet.has(t)) tagHits += 1;
+    if (tagHits > 0) score *= opts.tagBoost;
+
+    if (queryRepo && extract.repo) {
+      const r = extract.repo(doc);
+      if (r && r === queryRepo) score *= opts.repoBoost;
+    }
+  }
+
+  return score;
+}
+
+export function retrieve<T>(
+  corpus: readonly T[],
+  queryText: string,
+  extract: RetrievalFieldExtractor<T>,
+  k: number,
+  opts: RetrievalOptions & { queryRepo?: string } = {},
+): ScoredDoc<T>[] {
+  const tokens = tokenize(queryText);
+  if (tokens.length === 0 || corpus.length === 0) return [];
+  const tagBoost = opts.tagBoost ?? 1.5;
+  const repoBoost = opts.repoBoost ?? 1.2;
+  const minScore = opts.minScore ?? 0.05;
+  const scored: ScoredDoc<T>[] = [];
+  for (const doc of corpus) {
+    const score = scoreDoc(doc, tokens, opts.queryRepo, extract, { tagBoost, repoBoost });
+    if (score >= minScore) scored.push({ doc, score });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, k);
+}

--- a/packages/core/src/memory/schema.ts
+++ b/packages/core/src/memory/schema.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+import { BlockerSchema, ReviewResultSchema } from "../schema.js";
+
+/**
+ * EpisodicEntry — raw event log. One record per review cycle.
+ * 90-day TTL per architecture. Nightly Haiku job classifies these into
+ * answer-keys (on merge) + failure-catalog (on reject/rework).
+ */
+export const EpisodicEntrySchema = z.object({
+  id: z.string().min(1),
+  createdAt: z.string().datetime(),
+  repo: z.string().min(1),
+  pullNumber: z.number().int().nonnegative(),
+  sha: z.string().min(1),
+  diffSha256: z.string().length(64),
+  reviews: z.array(ReviewResultSchema),
+  councilVerdict: z.enum(["approve", "rework", "reject"]),
+  outcome: z.enum(["merged", "rejected", "reworked", "pending"]),
+  costUsd: z.number().nonnegative(),
+});
+export type EpisodicEntry = z.infer<typeof EpisodicEntrySchema>;
+
+/**
+ * AnswerKey (정답지) — a SUCCESS PATTERN. Written when a PR merges.
+ * Retrieved at review time so future reviews match the repo's tolerance
+ * for what counts as a blocker and what counts as polish.
+ */
+export const AnswerKeyDomainSchema = z.enum(["code", "design"]);
+export const AnswerKeySchema = z.object({
+  id: z.string().min(1),
+  createdAt: z.string().datetime(),
+  domain: AnswerKeyDomainSchema,
+  /** e.g. "by-pattern/auth-middleware", "by-component/LoginForm". Flat path inside the domain. */
+  pattern: z.string().min(1),
+  repo: z.string().optional(),
+  user: z.string().optional(),
+  /** One-paragraph distillation of what made this PR a good change. */
+  lesson: z.string().min(1),
+  /** Tags for filtered retrieval ("auth", "react", "refactor", "ui"). */
+  tags: z.array(z.string()).default([]),
+  /** Optional pointer back to the episodic entry that produced this answer-key. */
+  episodicId: z.string().optional(),
+});
+export type AnswerKey = z.infer<typeof AnswerKeySchema>;
+
+/**
+ * FailureEntry (오답지) — a FAILURE PATTERN. Written on reject or rework.
+ * Seeded from solo-cto-agent's failure-catalog.json (ERR-001~) per
+ * decision #18 — do not start from zero.
+ */
+export const FailureSeveritySchema = z.enum(["blocker", "major", "minor"]);
+export const FailureCategorySchema = z.enum([
+  "type-error",
+  "missing-test",
+  "regression",
+  "security",
+  "accessibility",
+  "contrast",
+  "performance",
+  "dead-code",
+  "api-misuse",
+  "schema-drift",
+  "other",
+]);
+export const FailureEntrySchema = z.object({
+  id: z.string().min(1),
+  createdAt: z.string().datetime(),
+  domain: AnswerKeyDomainSchema,
+  category: FailureCategorySchema,
+  severity: FailureSeveritySchema,
+  /** Short human-readable title of the pattern. */
+  title: z.string().min(1),
+  /** Details / why it's bad / how to fix — the thing agents read at review time. */
+  body: z.string().min(1),
+  /** Optional small code-or-diff snippet showing the pattern. */
+  snippet: z.string().optional(),
+  tags: z.array(z.string()).default([]),
+  /** Blocker that first surfaced this pattern, if any. */
+  seedBlocker: BlockerSchema.optional(),
+  episodicId: z.string().optional(),
+});
+export type FailureEntry = z.infer<typeof FailureEntrySchema>;
+
+/**
+ * SemanticRule — distilled cross-entry pattern. Weekly Haiku job.
+ * Format kept intentionally narrow so rules are short, actionable, and
+ * indexable by a tag vocabulary.
+ */
+export const SemanticRuleSchema = z.object({
+  id: z.string().min(1),
+  createdAt: z.string().datetime(),
+  tag: z.string().min(1),
+  rule: z.string().min(1),
+  evidence: z.object({
+    answerKeyIds: z.array(z.string()).default([]),
+    failureIds: z.array(z.string()).default([]),
+  }),
+});
+export type SemanticRule = z.infer<typeof SemanticRuleSchema>;

--- a/packages/core/src/memory/seeder.ts
+++ b/packages/core/src/memory/seeder.ts
@@ -1,0 +1,147 @@
+import { promises as fs } from "node:fs";
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import type { FailureEntry } from "./schema.js";
+import type { MemoryStore } from "./store.js";
+
+/**
+ * Legacy shape of solo-cto-agent's failure-catalog.json (ERR-001~).
+ * Decision #18: port directly rather than starting from zero.
+ */
+export const LegacyEntrySchema = z.object({
+  id: z.string().min(1),
+  category: z.string().min(1),
+  pattern: z.string().min(1),
+  description: z.string().min(1),
+  fix: z.string().min(1),
+});
+
+export const LegacyCatalogSchema = z.object({
+  version: z.literal(1),
+  updated_at: z.string(),
+  items: z.array(LegacyEntrySchema),
+});
+
+export type LegacyEntry = z.infer<typeof LegacyEntrySchema>;
+export type LegacyCatalog = z.infer<typeof LegacyCatalogSchema>;
+
+export type NewFailureCategory = FailureEntry["category"];
+
+/**
+ * Map a legacy (category, pattern, description) triple to our canonical
+ * enum. Ordered: most-specific terms first so e.g. "type error" catches
+ * "type" before "module" does.
+ */
+export function mapLegacyCategory(legacy: LegacyEntry): NewFailureCategory {
+  const blob = `${legacy.category} ${legacy.pattern} ${legacy.description}`.toLowerCase();
+  const rules: Array<[RegExp, NewFailureCategory]> = [
+    [/type\s*error|ts\d{4}|type\s*mismatch/i, "type-error"],
+    [/missing\s*test|no\s*test|untested/i, "missing-test"],
+    [/prisma|schema|migration|db\s*connection|sql|database/i, "schema-drift"],
+    [/secret|token|nextauth_url|api\s*key|credential|leak/i, "security"],
+    [/accessibility|a11y|aria/i, "accessibility"],
+    [/contrast/i, "contrast"],
+    [/timeout|memory_?limit|performance|slow|invocation_timeout/i, "performance"],
+    [/dead\s*code|unused\s*import|unused\s*var/i, "dead-code"],
+    [/regression|broke|broken/i, "regression"],
+    [/module\s*not\s*found|cannot\s*find\s*module|import|'use\s*server'|route\s*.*does\s*not\s*match/i, "api-misuse"],
+  ];
+  for (const [re, cat] of rules) {
+    if (re.test(blob)) return cat;
+  }
+  return "other";
+}
+
+export interface SeedOptions {
+  /** Timestamp to attach to each derived FailureEntry. Defaults to catalog.updated_at. */
+  createdAt?: string;
+  /** Default severity. Legacy catalog didn't distinguish — default "major". */
+  severity?: FailureEntry["severity"];
+  /** Extra tags to attach to every derived entry (e.g. ["legacy", "solo-cto-agent"]). */
+  extraTags?: readonly string[];
+  /** If true, write through `store.writeFailure`. If false, just return derived entries. Default true. */
+  write?: boolean;
+}
+
+export interface SeedResult {
+  /** All derived entries (written + any skipped with reason). */
+  entries: FailureEntry[];
+  /** Per-entry category distribution for the caller to print. */
+  byCategory: Record<NewFailureCategory, number>;
+}
+
+/** Convert a legacy entry into our canonical FailureEntry shape. */
+export function toFailureEntry(legacy: LegacyEntry, opts: SeedOptions = {}): FailureEntry {
+  const category = mapLegacyCategory(legacy);
+  const severity = opts.severity ?? "major";
+  const createdAt = opts.createdAt ?? new Date().toISOString();
+  const extra = opts.extraTags ?? ["legacy", "solo-cto-agent"];
+  const id = `fc-legacy-${legacy.id}-${shortHash(legacy.pattern)}`;
+  return {
+    id,
+    createdAt,
+    domain: "code",
+    category,
+    severity,
+    title: legacy.pattern,
+    body: `${legacy.description} Fix: ${legacy.fix}`,
+    tags: [legacy.category, ...extra],
+  };
+}
+
+/** Parse legacy catalog JSON and derive FailureEntry records; optionally write them. */
+export async function seedFromLegacyCatalog(
+  raw: string,
+  store: MemoryStore,
+  opts: SeedOptions = {},
+): Promise<SeedResult> {
+  const parsed = LegacyCatalogSchema.parse(JSON.parse(raw));
+  const createdAt = opts.createdAt ?? ensureIsoDate(parsed.updated_at);
+  const entries: FailureEntry[] = [];
+  const byCategory: Record<NewFailureCategory, number> = initCategoryCounter();
+  for (const legacy of parsed.items) {
+    const seedOpts: SeedOptions = { createdAt };
+    if (opts.severity !== undefined) seedOpts.severity = opts.severity;
+    if (opts.extraTags !== undefined) seedOpts.extraTags = opts.extraTags;
+    const entry = toFailureEntry(legacy, seedOpts);
+    entries.push(entry);
+    byCategory[entry.category] += 1;
+    if (opts.write !== false) await store.writeFailure(entry);
+  }
+  return { entries, byCategory };
+}
+
+export async function seedFromLegacyCatalogPath(
+  filePath: string,
+  store: MemoryStore,
+  opts: SeedOptions = {},
+): Promise<SeedResult> {
+  const raw = await fs.readFile(filePath, "utf8");
+  return seedFromLegacyCatalog(raw, store, opts);
+}
+
+function ensureIsoDate(date: string): string {
+  if (/\d{4}-\d{2}-\d{2}T/.test(date)) return date;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(date)) return `${date}T00:00:00.000Z`;
+  return new Date().toISOString();
+}
+
+function shortHash(s: string): string {
+  return createHash("sha256").update(s).digest("hex").slice(0, 8);
+}
+
+function initCategoryCounter(): Record<NewFailureCategory, number> {
+  return {
+    "type-error": 0,
+    "missing-test": 0,
+    regression: 0,
+    security: 0,
+    accessibility: 0,
+    contrast: 0,
+    performance: 0,
+    "dead-code": 0,
+    "api-misuse": 0,
+    "schema-drift": 0,
+    other: 0,
+  };
+}

--- a/packages/core/src/memory/seeds/solo-cto-agent-failure-catalog.json
+++ b/packages/core/src/memory/seeds/solo-cto-agent-failure-catalog.json
@@ -1,0 +1,111 @@
+{
+  "version": 1,
+  "updated_at": "2026-04-13",
+  "items": [
+    {
+      "id": "ERR-001",
+      "category": "build",
+      "pattern": "Module not found",
+      "description": "Import path missing or dependency not installed.",
+      "fix": "Verify file path or install missing dependency."
+    },
+    {
+      "id": "ERR-002",
+      "category": "build",
+      "pattern": "prisma generate did not create",
+      "description": "Prisma client not generated or output path mismatched.",
+      "fix": "Run prisma generate and confirm output path."
+    },
+    {
+      "id": "ERR-003",
+      "category": "build",
+      "pattern": "@apply unknown utility",
+      "description": "Tailwind config mismatch or wrong version syntax.",
+      "fix": "Verify Tailwind version and update @apply usage."
+    },
+    {
+      "id": "ERR-004",
+      "category": "deploy",
+      "pattern": "Build completed in 14ms",
+      "description": "Wrong root directory or build command skipped real build.",
+      "fix": "Check project root and build command configuration."
+    },
+    {
+      "id": "ERR-005",
+      "category": "deploy",
+      "pattern": "No output directory found",
+      "description": "Build output directory not produced or misconfigured.",
+      "fix": "Confirm framework preset and output directory."
+    },
+    {
+      "id": "ERR-006",
+      "category": "runtime",
+      "pattern": "NEXTAUTH_URL is not set",
+      "description": "Auth runtime missing required environment variable.",
+      "fix": "Set NEXTAUTH_URL and redeploy."
+    },
+    {
+      "id": "ERR-007",
+      "category": "runtime",
+      "pattern": "PrismaClientInitializationError",
+      "description": "DB connection or schema mismatch at runtime.",
+      "fix": "Verify DATABASE_URL and schema compatibility."
+    },
+    {
+      "id": "ERR-008",
+      "category": "runtime",
+      "pattern": "Cannot find module '/var/task'",
+      "description": "Serverless packaging missing build artifacts.",
+      "fix": "Ensure build output is included in deployment."
+    },
+    {
+      "id": "ERR-009",
+      "category": "build",
+      "pattern": "Type error: Route .* does not match",
+      "description": "Next.js App Router page/layout type mismatch after upgrade.",
+      "fix": "Update page component signature to match expected Next.js types."
+    },
+    {
+      "id": "ERR-010",
+      "category": "build",
+      "pattern": "Cannot find module 'next/headers'",
+      "description": "Server-only import used in client component.",
+      "fix": "Add 'use server' directive or move import to server component."
+    },
+    {
+      "id": "ERR-011",
+      "category": "deploy",
+      "pattern": "FUNCTION_INVOCATION_TIMEOUT",
+      "description": "Serverless function exceeded execution time limit.",
+      "fix": "Check for missing await, large DB queries, or increase timeout in vercel.json."
+    },
+    {
+      "id": "ERR-012",
+      "category": "deploy",
+      "pattern": "Edge Runtime is not supported",
+      "description": "Package uses Node.js APIs not available in Edge Runtime.",
+      "fix": "Switch to nodejs runtime in route config or replace incompatible package."
+    },
+    {
+      "id": "ERR-013",
+      "category": "runtime",
+      "pattern": "relation .* does not exist",
+      "description": "Database table missing — migration not applied or wrong schema.",
+      "fix": "Run pending migrations or verify DATABASE_URL points to correct database."
+    },
+    {
+      "id": "ERR-014",
+      "category": "runtime",
+      "pattern": "JWT_SESSION_ERROR",
+      "description": "NextAuth session token invalid or NEXTAUTH_SECRET changed.",
+      "fix": "Verify NEXTAUTH_SECRET matches across environments. Clear cookies if rotated."
+    },
+    {
+      "id": "ERR-015",
+      "category": "build",
+      "pattern": "Conflicting peer dependency",
+      "description": "npm install fails due to incompatible package version requirements.",
+      "fix": "Check which packages conflict, pin compatible versions, or use --legacy-peer-deps as last resort."
+    }
+  ]
+}

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -39,6 +39,8 @@ export interface MemoryStore {
   listAnswerKeys(domain?: "code" | "design"): Promise<AnswerKey[]>;
   listFailures(domain?: "code" | "design"): Promise<FailureEntry[]>;
   listRules(): Promise<SemanticRule[]>;
+  /** Find a single episodic entry by id. Returns null if not found. */
+  findEpisodic(id: string): Promise<EpisodicEntry | null>;
 }
 
 /**

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -41,6 +41,8 @@ export interface MemoryStore {
   listRules(): Promise<SemanticRule[]>;
   /** Find a single episodic entry by id. Returns null if not found. */
   findEpisodic(id: string): Promise<EpisodicEntry | null>;
+  /** List every episodic entry (mostly for outcome polling + admin tools). */
+  listEpisodic(): Promise<EpisodicEntry[]>;
 }
 
 /**

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -1,0 +1,56 @@
+import type { AnswerKey, EpisodicEntry, FailureEntry, SemanticRule } from "./schema.js";
+
+export interface MemoryReadQuery {
+  /** Free-text query. Typically the diff summary + file paths + blocker categories of the PR under review. */
+  query: string;
+  /** Filter by domain (code / design). Null/omitted = both. */
+  domain?: "code" | "design";
+  /** Max results per bucket. Default 8. */
+  k?: number;
+  /** Repo scope — prefer entries tagged for this repo; falls back to global. */
+  repo?: string;
+}
+
+export interface MemoryRetrieval {
+  answerKeys: AnswerKey[];
+  failures: FailureEntry[];
+  rules: SemanticRule[];
+}
+
+/**
+ * MemoryStore — read + write interface for the self-evolve substrate.
+ *
+ * Implementations: `FileSystemMemoryStore` (JSON files under `.conclave/`),
+ * future `PostgresMemoryStore` for shared/team deployments, future
+ * `FederatedReadOnlyStore` for the hash+category baseline fetched from a
+ * shared endpoint (decision #21).
+ *
+ * RAG path (`retrieve(...)`) is read-only and is called once per review.
+ * Write methods are called by the outcome-writer on merge / reject /
+ * rework events (future PR wires this up).
+ */
+export interface MemoryStore {
+  retrieve(query: MemoryReadQuery): Promise<MemoryRetrieval>;
+  writeEpisodic(entry: EpisodicEntry): Promise<void>;
+  writeAnswerKey(key: AnswerKey): Promise<void>;
+  writeFailure(entry: FailureEntry): Promise<void>;
+  writeRule(rule: SemanticRule): Promise<void>;
+  /** Utility — list all answer-keys matching a domain filter. Mostly for tests + admin tools. */
+  listAnswerKeys(domain?: "code" | "design"): Promise<AnswerKey[]>;
+  listFailures(domain?: "code" | "design"): Promise<FailureEntry[]>;
+  listRules(): Promise<SemanticRule[]>;
+}
+
+/**
+ * Distilled summary helpers that convert retrieved entries into the short
+ * string form that ReviewContext.answerKeys / failureCatalog carry. Agents
+ * splice these into prompts (see agent-claude/prompts.ts).
+ */
+export function formatAnswerKeyForPrompt(k: AnswerKey): string {
+  const tags = k.tags.length > 0 ? ` [${k.tags.join(", ")}]` : "";
+  return `(${k.domain}/${k.pattern})${tags} — ${k.lesson}`;
+}
+
+export function formatFailureForPrompt(f: FailureEntry): string {
+  return `(${f.domain}/${f.category}/${f.severity}) ${f.title} — ${f.body}`;
+}

--- a/packages/core/src/notifier.ts
+++ b/packages/core/src/notifier.ts
@@ -1,0 +1,34 @@
+import type { ReviewContext } from "./agent.js";
+import type { CouncilOutcome } from "./council.js";
+
+export interface NotifyReviewInput {
+  outcome: CouncilOutcome;
+  ctx: ReviewContext;
+  episodicId: string;
+  totalCostUsd: number;
+  /** Optional PR URL if the SCM adapter resolved one — lets notifiers link directly. */
+  prUrl?: string;
+}
+
+/**
+ * Notifier — pluggable notification surface.
+ *
+ * Decision #24: Telegram / Discord / Slack / Email are EQUAL-WEIGHT
+ * integrations alongside CLI / Web / IDE. None is the "hero". Any
+ * integration package implements this interface and consumers register
+ * zero-or-more notifiers on the council run.
+ *
+ * Contract:
+ *   - `notifyReview` is called once per completed council deliberation.
+ *   - Implementations are fire-and-forget from the caller's perspective.
+ *     They may throw; the caller is expected to catch + log + continue
+ *     (a failed notification must not kill a review).
+ *   - Implementations should NOT call LLM APIs. If they need
+ *     summarization, take a pre-summarized field on NotifyReviewInput or
+ *     compose the summary from existing `outcome.results[].summary`.
+ */
+export interface Notifier {
+  readonly id: string;
+  readonly displayName: string;
+  notifyReview(input: NotifyReviewInput): Promise<void>;
+}

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const SeveritySchema = z.enum(["blocker", "major", "minor", "nit"]);
+
+export const BlockerSchema = z.object({
+  severity: SeveritySchema,
+  category: z.string().min(1),
+  message: z.string().min(1),
+  file: z.string().optional(),
+  line: z.number().int().positive().optional(),
+});
+
+export const ReviewResultSchema = z.object({
+  agent: z.string().min(1),
+  verdict: z.enum(["approve", "rework", "reject"]),
+  blockers: z.array(BlockerSchema),
+  summary: z.string(),
+  tokensUsed: z.number().int().nonnegative().optional(),
+  costUsd: z.number().nonnegative().optional(),
+});
+
+export type BlockerInput = z.input<typeof BlockerSchema>;
+export type ReviewResultInput = z.input<typeof ReviewResultSchema>;

--- a/packages/core/test/budget.test.mjs
+++ b/packages/core/test/budget.test.mjs
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { BudgetTracker, BudgetExceededError, DEFAULT_PER_PR_BUDGET_USD } from "../dist/index.js";
+
+test("BudgetTracker: happy path reserve + commit", () => {
+  const b = new BudgetTracker({ perPrUsd: 1 });
+  b.reserve(0.2);
+  b.commit(0.15);
+  b.reserve(0.3);
+  b.commit(0.3);
+  assert.equal(b.spentUsd, 0.45);
+  assert.equal(b.remainingUsd, 0.55);
+});
+
+test("BudgetTracker: reserve beyond cap throws BudgetExceededError", () => {
+  const b = new BudgetTracker({ perPrUsd: 1 });
+  b.reserve(0.6);
+  b.commit(0.6);
+  assert.throws(() => b.reserve(0.5), (err) => {
+    assert.ok(err instanceof BudgetExceededError);
+    assert.equal(err.capUsd, 1);
+    assert.equal(err.spentUsd, 0.6);
+    return true;
+  });
+});
+
+test("BudgetTracker: warning handler fires once at threshold", () => {
+  const b = new BudgetTracker({ perPrUsd: 1, warnAt: 0.5 });
+  const events = [];
+  b.onWarning((spent, cap) => events.push({ spent, cap }));
+  b.commit(0.2);
+  assert.equal(events.length, 0);
+  b.commit(0.4); // 0.6 >= 0.5 cap
+  assert.equal(events.length, 1);
+  b.commit(0.3); // already warned — no second fire
+  assert.equal(events.length, 1);
+});
+
+test("BudgetTracker: default perPrUsd exported constant equals 0.5 per decision #20", () => {
+  assert.equal(DEFAULT_PER_PR_BUDGET_USD, 0.5);
+});
+
+test("BudgetTracker: rejects invalid opts", () => {
+  assert.throws(() => new BudgetTracker({ perPrUsd: 0 }));
+  assert.throws(() => new BudgetTracker({ perPrUsd: -1 }));
+  assert.throws(() => new BudgetTracker({ perPrUsd: 1, warnAt: -0.1 }));
+  assert.throws(() => new BudgetTracker({ perPrUsd: 1, warnAt: 1.1 }));
+});

--- a/packages/core/test/cache.test.mjs
+++ b/packages/core/test/cache.test.mjs
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PromptCache, ANTHROPIC_PROMPT_CACHE_TTL_MS } from "../dist/index.js";
+
+test("PromptCache: mark then isLive reports hit", () => {
+  const c = new PromptCache();
+  assert.equal(c.isLive("prefix-A", "claude-sonnet-4-6"), false);
+  c.mark("prefix-A", "claude-sonnet-4-6");
+  assert.equal(c.isLive("prefix-A", "claude-sonnet-4-6"), true);
+});
+
+test("PromptCache: keys are model-scoped", () => {
+  const c = new PromptCache();
+  c.mark("same-prefix", "claude-sonnet-4-6");
+  assert.equal(c.isLive("same-prefix", "claude-haiku-4-5"), false);
+});
+
+test("PromptCache: expires after TTL", () => {
+  const c = new PromptCache({ ttlMs: 100 });
+  c.mark("p", "m", 1_000);
+  assert.equal(c.isLive("p", "m", 1_050), true);
+  assert.equal(c.isLive("p", "m", 1_101), false);
+});
+
+test("PromptCache: hitRate reflects hits + misses", () => {
+  const c = new PromptCache();
+  c.isLive("x", "m"); // miss
+  c.mark("x", "m");
+  c.isLive("x", "m"); // hit
+  c.isLive("y", "m"); // miss
+  assert.equal(c.hitRate().toFixed(3), "0.333");
+});
+
+test("PromptCache: maxEntries evicts oldest", () => {
+  const c = new PromptCache({ maxEntries: 2 });
+  c.mark("a", "m", 1);
+  c.mark("b", "m", 2);
+  c.mark("c", "m", 3); // evicts "a"
+  assert.equal(c.isLive("a", "m", 4), false);
+  assert.equal(c.isLive("b", "m", 4), true);
+  assert.equal(c.isLive("c", "m", 4), true);
+});
+
+test("PromptCache: default TTL matches Anthropic 5-minute window", () => {
+  assert.equal(ANTHROPIC_PROMPT_CACHE_TTL_MS, 300_000);
+});

--- a/packages/core/test/classifier.test.mjs
+++ b/packages/core/test/classifier.test.mjs
@@ -1,0 +1,154 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { RuleBasedClassifier, newEpisodicId } from "../dist/index.js";
+
+const now = () => new Date().toISOString();
+
+function mkEpisodic(reviews, overrides = {}) {
+  return {
+    id: "ep-test",
+    createdAt: now(),
+    repo: "acme/app",
+    pullNumber: 7,
+    sha: "abc1234",
+    diffSha256: "a".repeat(64),
+    reviews,
+    councilVerdict: overrides.councilVerdict ?? "approve",
+    outcome: overrides.outcome ?? "pending",
+    costUsd: 0.01,
+    ...overrides,
+  };
+}
+
+test("newEpisodicId: returns ep-prefixed UUID-shape", () => {
+  const id = newEpisodicId();
+  assert.match(id, /^ep-[0-9a-f-]+$/);
+});
+
+test("classify merged: single answer-key, no failures", () => {
+  const c = new RuleBasedClassifier();
+  const out = c.classify(
+    mkEpisodic([{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }]),
+    "merged",
+  );
+  assert.equal(out.answerKeys.length, 1);
+  assert.equal(out.failures.length, 0);
+  assert.equal(out.answerKeys[0].domain, "code");
+  assert.match(out.answerKeys[0].pattern, /by-repo\/acme\/app/);
+  assert.match(out.answerKeys[0].lesson, /LGTM/);
+});
+
+test("classify merged: empty summary falls back to default lesson", () => {
+  const c = new RuleBasedClassifier();
+  const out = c.classify(
+    mkEpisodic([{ agent: "claude", verdict: "approve", blockers: [], summary: "" }]),
+    "merged",
+  );
+  assert.match(out.answerKeys[0].lesson, /Merged without blockers/);
+});
+
+test("classify rejected: one failure per unique (category, severity, message)", () => {
+  const c = new RuleBasedClassifier();
+  const out = c.classify(
+    mkEpisodic([
+      {
+        agent: "claude",
+        verdict: "reject",
+        blockers: [
+          { severity: "blocker", category: "type-error", message: "ts2345 mismatch", file: "x.ts", line: 10 },
+          { severity: "major", category: "security", message: "secret in source" },
+          { severity: "nit", category: "style", message: "trailing whitespace" },
+        ],
+        summary: "2 blockers + 1 nit",
+      },
+    ]),
+    "rejected",
+  );
+  assert.equal(out.answerKeys.length, 0);
+  assert.equal(out.failures.length, 2); // nit excluded
+  const categories = out.failures.map((f) => f.category);
+  assert.ok(categories.includes("type-error"));
+  assert.ok(categories.includes("security"));
+});
+
+test("classify rejected: dedupes same (category, severity, message) across agents", () => {
+  const c = new RuleBasedClassifier();
+  const sameBlocker = { severity: "blocker", category: "security", message: "same leak" };
+  const out = c.classify(
+    mkEpisodic([
+      { agent: "claude", verdict: "reject", blockers: [sameBlocker], summary: "" },
+      { agent: "openai", verdict: "reject", blockers: [sameBlocker], summary: "" },
+    ]),
+    "rejected",
+  );
+  assert.equal(out.failures.length, 1);
+});
+
+test("classify reworked: behaves like rejected (writes failures)", () => {
+  const c = new RuleBasedClassifier();
+  const out = c.classify(
+    mkEpisodic([
+      {
+        agent: "claude",
+        verdict: "rework",
+        blockers: [{ severity: "major", category: "missing-test", message: "no test for new branch" }],
+        summary: "1 major",
+      },
+    ]),
+    "reworked",
+  );
+  assert.equal(out.answerKeys.length, 0);
+  assert.equal(out.failures.length, 1);
+  assert.equal(out.failures[0].category, "missing-test");
+});
+
+test("category mapping: free-form strings normalize to allowed enum", () => {
+  const c = new RuleBasedClassifier();
+  const { failures } = c.classify(
+    mkEpisodic([
+      {
+        agent: "claude",
+        verdict: "reject",
+        blockers: [
+          { severity: "blocker", category: "Type Error", message: "a" },
+          { severity: "blocker", category: "UNUSED IMPORT", message: "b" },
+          { severity: "blocker", category: "a11y", message: "c" },
+          { severity: "blocker", category: "weird-custom", message: "d" },
+        ],
+        summary: "",
+      },
+    ]),
+    "rejected",
+  );
+  const cats = failures.map((f) => f.category);
+  assert.ok(cats.includes("type-error"));
+  assert.ok(cats.includes("dead-code"));
+  assert.ok(cats.includes("accessibility"));
+  assert.ok(cats.includes("other"));
+});
+
+test("classify merged: tags derived from categories seen in review", () => {
+  const c = new RuleBasedClassifier();
+  const { answerKeys } = c.classify(
+    mkEpisodic([
+      {
+        agent: "claude",
+        verdict: "approve",
+        blockers: [{ severity: "minor", category: "unused-imports", message: "ok" }],
+        summary: "all fine after rework",
+      },
+    ]),
+    "merged",
+  );
+  assert.ok(answerKeys[0].tags.includes("unused-imports"));
+});
+
+test("classify: ids are stable for the same input", () => {
+  const c = new RuleBasedClassifier();
+  const ep = mkEpisodic([
+    { agent: "claude", verdict: "reject", blockers: [{ severity: "blocker", category: "security", message: "leak" }], summary: "" },
+  ]);
+  const a = c.classify(ep, "rejected");
+  const b = c.classify(ep, "rejected");
+  assert.equal(a.failures[0].id, b.failures[0].id);
+});

--- a/packages/core/test/compact.test.mjs
+++ b/packages/core/test/compact.test.mjs
@@ -1,0 +1,65 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { compact } from "../dist/index.js";
+
+function msg(role, content, tokens, pin = false) {
+  return { role, content, tokens, pin };
+}
+
+test("compact: all messages fit under budget → no drops", async () => {
+  const messages = [
+    msg("system", "you are a reviewer", 10, true),
+    msg("user", "here is the diff", 20),
+    msg("assistant", "looks fine", 15),
+  ];
+  const out = await compact(messages, { targetTokens: 100 });
+  assert.equal(out.droppedCount, 0);
+  assert.equal(out.summarizedCount, 0);
+  assert.equal(out.messages.length, 3);
+});
+
+test("compact: pinned messages are always kept", async () => {
+  const messages = [
+    msg("system", "pinned system", 80, true),
+    msg("user", "ancient user msg", 50),
+    msg("user", "recent user msg", 10),
+  ];
+  const out = await compact(messages, { targetTokens: 100 });
+  assert.ok(out.messages.some((m) => m.content === "pinned system"));
+});
+
+test("compact: newest-first fits under budget, older dropped", async () => {
+  const messages = [
+    msg("user", "oldest", 40),
+    msg("user", "middle", 40),
+    msg("user", "newest", 40),
+  ];
+  const out = await compact(messages, { targetTokens: 80 });
+  assert.equal(out.droppedCount, 1);
+  const kept = out.messages.map((m) => m.content);
+  assert.deepEqual(kept, ["middle", "newest"]);
+});
+
+test("compact: summarizer collapses dropped tail", async () => {
+  const messages = [
+    msg("user", "oldest", 40),
+    msg("user", "middle", 40),
+    msg("user", "newest", 40),
+  ];
+  const out = await compact(messages, {
+    targetTokens: 90, // enough for newest + small summary
+    summarize: async (dropped) => `summary of ${dropped.length}`,
+  });
+  assert.equal(out.summarizedCount, 2);
+  assert.ok(out.messages[0].content.startsWith("[compacted summary of 2 earlier messages]"));
+});
+
+test("compact: returns only pinned when pinned already consume budget", async () => {
+  const messages = [
+    msg("system", "huge pinned prompt", 1_000, true),
+    msg("user", "will not fit", 50),
+  ];
+  const out = await compact(messages, { targetTokens: 500 });
+  assert.equal(out.messages.length, 1);
+  assert.equal(out.droppedCount, 1);
+});

--- a/packages/core/test/council.test.mjs
+++ b/packages/core/test/council.test.mjs
@@ -1,0 +1,66 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Council } from "../dist/index.js";
+
+function fakeAgent(id, verdict) {
+  return {
+    id,
+    displayName: id,
+    review: async () => ({
+      agent: id,
+      verdict,
+      blockers: [],
+      summary: `${id} says ${verdict}`,
+    }),
+  };
+}
+
+const ctx = { diff: "", repo: "acme/x", pullNumber: 1, newSha: "HEAD" };
+
+test("Council: empty agents throws", () => {
+  assert.throws(() => new Council({ agents: [] }));
+});
+
+test("Council: single approve → approve + consensus", async () => {
+  const council = new Council({ agents: [fakeAgent("claude", "approve")] });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.verdict, "approve");
+  assert.equal(outcome.consensusReached, true);
+  assert.equal(outcome.results.length, 1);
+});
+
+test("Council: all approve → approve", async () => {
+  const council = new Council({
+    agents: [fakeAgent("claude", "approve"), fakeAgent("openai", "approve")],
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.verdict, "approve");
+  assert.equal(outcome.consensusReached, true);
+});
+
+test("Council: any reject → reject (consensus)", async () => {
+  const council = new Council({
+    agents: [fakeAgent("claude", "approve"), fakeAgent("openai", "reject")],
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.verdict, "reject");
+  assert.equal(outcome.consensusReached, true);
+});
+
+test("Council: mixed approve + rework → rework (no consensus)", async () => {
+  const council = new Council({
+    agents: [fakeAgent("claude", "approve"), fakeAgent("openai", "rework")],
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.verdict, "rework");
+  assert.equal(outcome.consensusReached, false);
+});
+
+test("Council: exposes config", async () => {
+  const council = new Council({
+    agents: [fakeAgent("a", "approve"), fakeAgent("b", "approve")],
+    maxRounds: 5,
+  });
+  assert.equal(council.agentCount, 2);
+  assert.equal(council.roundLimit, 5);
+});

--- a/packages/core/test/gate.test.mjs
+++ b/packages/core/test/gate.test.mjs
@@ -1,0 +1,95 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EfficiencyGate, BudgetExceededError } from "../dist/index.js";
+
+async function fakeExecute(spec) {
+  return async ({ model, cacheHit }) => ({
+    result: { ok: true, model, cacheHit },
+    inputTokens: spec.inputTokens ?? 1_000,
+    outputTokens: spec.outputTokens ?? 200,
+    costUsd: spec.costUsd ?? 0.015,
+    latencyMs: spec.latencyMs ?? 1_100,
+  });
+}
+
+test("EfficiencyGate.run: happy path routes, executes, records", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const { result, metric, modelChoice } = await gate.run(
+    {
+      agent: "claude",
+      cacheablePrefix: "system + pinned RAG",
+      prompt: "some prompt",
+      estimatedCostUsd: 0.02,
+    },
+    await fakeExecute({ costUsd: 0.017 }),
+  );
+  assert.equal(result.ok, true);
+  assert.equal(metric.costUsd, 0.017);
+  assert.equal(metric.agent, "claude");
+  assert.equal(modelChoice.class, "haiku");
+  assert.equal(gate.budget.spentUsd, 0.017);
+});
+
+test("EfficiencyGate.run: second identical call sees cacheHit = true", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const input = {
+    agent: "claude",
+    cacheablePrefix: "identical prefix",
+    prompt: "p",
+    estimatedCostUsd: 0.01,
+  };
+  const first = await gate.run(input, await fakeExecute({ costUsd: 0.005 }));
+  assert.equal(first.result.cacheHit, false);
+  const second = await gate.run(input, await fakeExecute({ costUsd: 0.001 }));
+  assert.equal(second.result.cacheHit, true);
+});
+
+test("EfficiencyGate.run: reserve throws BudgetExceededError before execute runs", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 0.1 });
+  let executed = false;
+  await assert.rejects(
+    () =>
+      gate.run(
+        {
+          agent: "claude",
+          cacheablePrefix: "x",
+          prompt: "p",
+          estimatedCostUsd: 0.5, // blows the cap
+        },
+        async () => {
+          executed = true;
+          throw new Error("should not run");
+        },
+      ),
+    (err) => err instanceof BudgetExceededError,
+  );
+  assert.equal(executed, false);
+});
+
+test("EfficiencyGate.run: forceModel honored", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const { modelChoice } = await gate.run(
+    {
+      agent: "claude",
+      cacheablePrefix: "p",
+      prompt: "p",
+      estimatedCostUsd: 0.01,
+      forceModel: "claude-opus-4-7",
+    },
+    await fakeExecute({ costUsd: 0.01 }),
+  );
+  assert.equal(modelChoice.model, "claude-opus-4-7");
+});
+
+test("EfficiencyGate.run: multiple calls aggregate metrics", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  for (let i = 0; i < 3; i += 1) {
+    await gate.run(
+      { agent: "claude", cacheablePrefix: `p${i}`, prompt: "p", estimatedCostUsd: 0.01 },
+      await fakeExecute({ costUsd: 0.01 }),
+    );
+  }
+  const s = gate.metrics.summary();
+  assert.equal(s.callCount, 3);
+  assert.equal(s.totalCostUsd.toFixed(3), "0.030");
+});

--- a/packages/core/test/memory-fs-store.test.mjs
+++ b/packages/core/test/memory-fs-store.test.mjs
@@ -1,0 +1,179 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FileSystemMemoryStore } from "../dist/index.js";
+
+function freshStore() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aic-mem-"));
+  return { store: new FileSystemMemoryStore({ root }), root };
+}
+
+function cleanup(root) {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+const now = () => new Date().toISOString();
+
+test("FileSystemMemoryStore: write + list answer-keys round-trip", async () => {
+  const { store, root } = freshStore();
+  try {
+    await store.writeAnswerKey({
+      id: "ak-001",
+      createdAt: now(),
+      domain: "code",
+      pattern: "by-pattern/auth",
+      lesson: "stateless middleware composes",
+      tags: ["auth"],
+    });
+    const out = await store.listAnswerKeys("code");
+    assert.equal(out.length, 1);
+    assert.equal(out[0].id, "ak-001");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: list returns [] when dir missing", async () => {
+  const { store, root } = freshStore();
+  try {
+    assert.deepEqual(await store.listAnswerKeys(), []);
+    assert.deepEqual(await store.listFailures(), []);
+    assert.deepEqual(await store.listRules(), []);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: write failure + retrieve surfaces it", async () => {
+  const { store, root } = freshStore();
+  try {
+    await store.writeFailure({
+      id: "fc-001",
+      createdAt: now(),
+      domain: "code",
+      category: "security",
+      severity: "blocker",
+      title: "JWT logged in full",
+      body: "Truncate JWTs to first/last 4 chars before log.",
+      tags: ["auth", "logging"],
+    });
+    const result = await store.retrieve({ query: "JWT auth logging truncate", domain: "code", k: 5 });
+    assert.equal(result.failures.length, 1);
+    assert.equal(result.failures[0].id, "fc-001");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: domain filter excludes other-domain entries", async () => {
+  const { store, root } = freshStore();
+  try {
+    await store.writeAnswerKey({
+      id: "ak-code",
+      createdAt: now(),
+      domain: "code",
+      pattern: "by-pattern/x",
+      lesson: "code lesson",
+      tags: [],
+    });
+    await store.writeAnswerKey({
+      id: "ak-design",
+      createdAt: now(),
+      domain: "design",
+      pattern: "by-component/Button",
+      lesson: "design lesson",
+      tags: [],
+    });
+    const code = await store.listAnswerKeys("code");
+    const design = await store.listAnswerKeys("design");
+    assert.equal(code.length, 1);
+    assert.equal(design.length, 1);
+    assert.equal(code[0].id, "ak-code");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: retrieve returns empty buckets on empty corpus", async () => {
+  const { store, root } = freshStore();
+  try {
+    const result = await store.retrieve({ query: "anything at all" });
+    assert.deepEqual(result.answerKeys, []);
+    assert.deepEqual(result.failures, []);
+    assert.deepEqual(result.rules, []);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: writeRule appends JSONL", async () => {
+  const { store, root } = freshStore();
+  try {
+    await store.writeRule({
+      id: "r1",
+      createdAt: now(),
+      tag: "auth",
+      rule: "never log raw JWTs",
+      evidence: { answerKeyIds: [], failureIds: ["fc-001"] },
+    });
+    await store.writeRule({
+      id: "r2",
+      createdAt: now(),
+      tag: "a11y",
+      rule: "contrast at least AA",
+      evidence: { answerKeyIds: [], failureIds: [] },
+    });
+    const rules = await store.listRules();
+    assert.equal(rules.length, 2);
+    assert.equal(rules[0].id, "r1");
+    assert.equal(rules[1].id, "r2");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: writeEpisodic organizes by day + PR", async () => {
+  const { store, root } = freshStore();
+  try {
+    const createdAt = "2026-04-19T12:00:00.000Z";
+    await store.writeEpisodic({
+      id: "ep-1",
+      createdAt,
+      repo: "acme/demo",
+      pullNumber: 42,
+      sha: "abc",
+      diffSha256: "a".repeat(64),
+      reviews: [{ agent: "claude", verdict: "approve", blockers: [], summary: "ok" }],
+      councilVerdict: "approve",
+      outcome: "merged",
+      costUsd: 0.01,
+    });
+    const dayDir = path.join(root, "episodic", "2026-04-19");
+    const files = fs.readdirSync(dayDir);
+    assert.ok(files.some((f) => f.startsWith("pr-42")));
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("FileSystemMemoryStore: retrieve k defaults to 8", async () => {
+  const { store, root } = freshStore();
+  try {
+    for (let i = 0; i < 12; i += 1) {
+      await store.writeAnswerKey({
+        id: `ak-${i}`,
+        createdAt: now(),
+        domain: "code",
+        pattern: `by-pattern/x${i}`,
+        lesson: "auth middleware stateless composition",
+        tags: ["auth"],
+      });
+    }
+    const r = await store.retrieve({ query: "auth middleware stateless" });
+    assert.ok(r.answerKeys.length <= 8, `expected ≤ 8, got ${r.answerKeys.length}`);
+  } finally {
+    cleanup(root);
+  }
+});

--- a/packages/core/test/memory-retrieval.test.mjs
+++ b/packages/core/test/memory-retrieval.test.mjs
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { retrieve } from "../dist/index.js";
+
+const corpus = [
+  { id: "1", text: "authentication middleware should validate JWT signatures", tags: ["auth", "security"], repo: "acme/app" },
+  { id: "2", text: "React components must handle empty cart state gracefully", tags: ["ui", "react"], repo: "acme/shop" },
+  { id: "3", text: "database migrations require backwards compatibility", tags: ["db", "migration"], repo: "acme/app" },
+  { id: "4", text: "accessibility contrast ratio must hit AA minimum", tags: ["a11y"], repo: "acme/shop" },
+];
+
+const extract = {
+  text: (d) => d.text,
+  tags: (d) => d.tags,
+  repo: (d) => d.repo,
+};
+
+test("retrieve: query matches content", () => {
+  const hits = retrieve(corpus, "empty cart state in React", extract, 3);
+  assert.ok(hits.length > 0);
+  assert.equal(hits[0].doc.id, "2");
+});
+
+test("retrieve: tag boost promotes tag-matching docs", () => {
+  const hits = retrieve(corpus, "auth security", extract, 3);
+  assert.equal(hits[0].doc.id, "1");
+});
+
+test("retrieve: repo boost promotes same-repo docs", () => {
+  const sameRepo = [
+    { id: "a", text: "generic observation", tags: [], repo: "acme/target" },
+    { id: "b", text: "generic observation", tags: [], repo: "acme/other" },
+  ];
+  const hits = retrieve(sameRepo, "generic observation", extract, 2, { queryRepo: "acme/target" });
+  assert.equal(hits[0].doc.id, "a");
+});
+
+test("retrieve: respects k", () => {
+  const hits = retrieve(corpus, "state ui component auth migration contrast", extract, 2);
+  assert.ok(hits.length <= 2);
+});
+
+test("retrieve: empty query returns nothing", () => {
+  const hits = retrieve(corpus, "", extract, 5);
+  assert.deepEqual(hits, []);
+});
+
+test("retrieve: no-match returns empty", () => {
+  const hits = retrieve(corpus, "xylophone concatenate helicopter", extract, 5);
+  assert.deepEqual(hits, []);
+});
+
+test("retrieve: stop words are ignored", () => {
+  const onlyStops = retrieve(corpus, "the and or to of in on for", extract, 5);
+  assert.deepEqual(onlyStops, []);
+});
+
+test("retrieve: Korean tokens survive tokenizer", () => {
+  const kCorpus = [{ id: "k1", text: "인증 미들웨어는 상태가 없어야 한다", tags: ["auth"], repo: "x" }];
+  const hits = retrieve(kCorpus, "인증 미들웨어", extract, 3);
+  assert.ok(hits.length > 0);
+});

--- a/packages/core/test/memory-schema.test.mjs
+++ b/packages/core/test/memory-schema.test.mjs
@@ -1,0 +1,94 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  AnswerKeySchema,
+  EpisodicEntrySchema,
+  FailureEntrySchema,
+  SemanticRuleSchema,
+} from "../dist/index.js";
+
+test("AnswerKeySchema: minimal valid shape passes", () => {
+  const parsed = AnswerKeySchema.parse({
+    id: "ak-1",
+    createdAt: new Date().toISOString(),
+    domain: "code",
+    pattern: "by-pattern/auth-middleware",
+    lesson: "middleware should be stateless and compose left-to-right",
+    tags: ["auth", "middleware"],
+  });
+  assert.equal(parsed.pattern, "by-pattern/auth-middleware");
+});
+
+test("AnswerKeySchema: rejects invalid domain", () => {
+  assert.throws(() =>
+    AnswerKeySchema.parse({
+      id: "ak-1",
+      createdAt: new Date().toISOString(),
+      domain: "infra", // not in enum
+      pattern: "x",
+      lesson: "y",
+    }),
+  );
+});
+
+test("FailureEntrySchema: minimal valid shape passes", () => {
+  const parsed = FailureEntrySchema.parse({
+    id: "fc-1",
+    createdAt: new Date().toISOString(),
+    domain: "code",
+    category: "type-error",
+    severity: "blocker",
+    title: "Unsafe any",
+    body: "Do not add `as any` to work around strict typing.",
+  });
+  assert.equal(parsed.category, "type-error");
+});
+
+test("FailureEntrySchema: rejects unknown category", () => {
+  assert.throws(() =>
+    FailureEntrySchema.parse({
+      id: "x",
+      createdAt: new Date().toISOString(),
+      domain: "code",
+      category: "telepathy", // not in enum
+      severity: "blocker",
+      title: "t",
+      body: "b",
+    }),
+  );
+});
+
+test("EpisodicEntrySchema: accepts a full council outcome shape", () => {
+  const parsed = EpisodicEntrySchema.parse({
+    id: "ep-1",
+    createdAt: new Date().toISOString(),
+    repo: "acme/demo",
+    pullNumber: 42,
+    sha: "abc123",
+    diffSha256: "a".repeat(64),
+    reviews: [
+      {
+        agent: "claude",
+        verdict: "approve",
+        blockers: [],
+        summary: "LGTM",
+      },
+    ],
+    councilVerdict: "approve",
+    outcome: "merged",
+    costUsd: 0.012,
+  });
+  assert.equal(parsed.reviews.length, 1);
+});
+
+test("SemanticRuleSchema: default evidence arrays", () => {
+  const parsed = SemanticRuleSchema.parse({
+    id: "r-1",
+    createdAt: new Date().toISOString(),
+    tag: "auth",
+    rule: "never log the full JWT — truncate to first/last 4 chars",
+    evidence: {},
+  });
+  assert.deepEqual(parsed.evidence.answerKeyIds, []);
+  assert.deepEqual(parsed.evidence.failureIds, []);
+});

--- a/packages/core/test/metrics.test.mjs
+++ b/packages/core/test/metrics.test.mjs
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MetricsRecorder } from "../dist/index.js";
+
+function mkMetric(overrides = {}) {
+  return {
+    agent: "claude",
+    model: "claude-sonnet-4-6",
+    inputTokens: 1_000,
+    outputTokens: 200,
+    costUsd: 0.015,
+    latencyMs: 1_200,
+    cacheHit: false,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+test("MetricsRecorder: empty summary", () => {
+  const r = new MetricsRecorder();
+  const s = r.summary();
+  assert.equal(s.callCount, 0);
+  assert.equal(s.totalCostUsd, 0);
+  assert.equal(s.cacheHitRate, 0);
+});
+
+test("MetricsRecorder: aggregates by agent and model", () => {
+  const r = new MetricsRecorder();
+  r.record(mkMetric({ agent: "claude", model: "claude-sonnet-4-6", costUsd: 0.02 }));
+  r.record(mkMetric({ agent: "claude", model: "claude-haiku-4-5", costUsd: 0.005 }));
+  r.record(mkMetric({ agent: "openai", model: "gpt-4.1", costUsd: 0.03 }));
+  const s = r.summary();
+  assert.equal(s.callCount, 3);
+  assert.equal(s.totalCostUsd.toFixed(3), "0.055");
+  assert.equal(s.byAgent["claude"].calls, 2);
+  assert.equal(s.byAgent["openai"].calls, 1);
+  assert.equal(s.byModel["claude-sonnet-4-6"].costUsd, 0.02);
+});
+
+test("MetricsRecorder: cache hit rate", () => {
+  const r = new MetricsRecorder();
+  r.record(mkMetric({ cacheHit: true }));
+  r.record(mkMetric({ cacheHit: true }));
+  r.record(mkMetric({ cacheHit: false }));
+  r.record(mkMetric({ cacheHit: false }));
+  assert.equal(r.summary().cacheHitRate, 0.5);
+});
+
+test("MetricsRecorder: forwards to external sink", () => {
+  const forwarded = [];
+  const r = new MetricsRecorder({ sink: { record: (m) => forwarded.push(m) } });
+  r.record(mkMetric({ agent: "claude" }));
+  assert.equal(forwarded.length, 1);
+  assert.equal(forwarded[0].agent, "claude");
+});
+
+test("MetricsRecorder: reset clears state", () => {
+  const r = new MetricsRecorder();
+  r.record(mkMetric());
+  r.reset();
+  assert.equal(r.summary().callCount, 0);
+});

--- a/packages/core/test/outcome-writer.test.mjs
+++ b/packages/core/test/outcome-writer.test.mjs
@@ -1,0 +1,160 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FileSystemMemoryStore, OutcomeWriter } from "../dist/index.js";
+
+function freshFs() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aic-outcome-"));
+  return { store: new FileSystemMemoryStore({ root }), root };
+}
+function cleanup(root) {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+const baseCtx = { diff: "diff --git a/x b/x\n+added", repo: "acme/app", pullNumber: 42, newSha: "sha-head" };
+const approveReview = { agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" };
+const rejectReview = {
+  agent: "claude",
+  verdict: "reject",
+  blockers: [{ severity: "blocker", category: "security", message: "hardcoded key" }],
+  summary: "blocker",
+};
+
+test("writeReview: persists an episodic entry with outcome=pending", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const entry = await writer.writeReview({
+      ctx: baseCtx,
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.02,
+    });
+    assert.equal(entry.outcome, "pending");
+    assert.equal(entry.reviews.length, 1);
+    // Round-trip: the file exists and is findable.
+    const found = await store.findEpisodic(entry.id);
+    assert.ok(found);
+    assert.equal(found.id, entry.id);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("recordOutcome merged: writes one answer-key", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const ep = await writer.writeReview({
+      ctx: baseCtx,
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+    });
+    const out = await writer.recordOutcome({ episodicId: ep.id, outcome: "merged" });
+    assert.equal(out.answerKeys.length, 1);
+    assert.equal(out.failures.length, 0);
+    const aks = await store.listAnswerKeys();
+    assert.equal(aks.length, 1);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("recordOutcome rejected: writes failures from each blocker", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const ep = await writer.writeReview({
+      ctx: baseCtx,
+      reviews: [rejectReview],
+      councilVerdict: "reject",
+      costUsd: 0.03,
+    });
+    const out = await writer.recordOutcome({ episodicId: ep.id, outcome: "rejected" });
+    assert.equal(out.failures.length, 1);
+    const failures = await store.listFailures();
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].category, "security");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("recordOutcome: updates episodic outcome field from pending → merged/rejected/reworked", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const ep = await writer.writeReview({
+      ctx: baseCtx,
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+    });
+    await writer.recordOutcome({ episodicId: ep.id, outcome: "merged" });
+    const after = await store.findEpisodic(ep.id);
+    assert.equal(after.outcome, "merged");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("recordOutcome: reconstructs episodic from disk if in-memory index is cold", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writerA = new OutcomeWriter({ store });
+    const ep = await writerA.writeReview({
+      ctx: baseCtx,
+      reviews: [rejectReview],
+      councilVerdict: "reject",
+      costUsd: 0.01,
+    });
+    // Simulate a fresh process: new OutcomeWriter without the id in its index.
+    const writerB = new OutcomeWriter({ store });
+    const out = await writerB.recordOutcome({ episodicId: ep.id, outcome: "rejected" });
+    assert.equal(out.failures.length, 1);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("recordOutcome: unknown episodic id throws actionable error", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    await assert.rejects(
+      () => writer.recordOutcome({ episodicId: "ep-does-not-exist", outcome: "merged" }),
+      /no episodic entry found/,
+    );
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("writeReview: caller-provided episodicId makes the write idempotent", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const id = "ep-stable-1";
+    await writer.writeReview({
+      ctx: baseCtx,
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+      episodicId: id,
+    });
+    await writer.writeReview({
+      ctx: { ...baseCtx, newSha: "sha-newer" },
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.02,
+      episodicId: id,
+    });
+    const found = await store.findEpisodic(id);
+    assert.equal(found.sha, "sha-newer"); // latest write wins
+  } finally {
+    cleanup(root);
+  }
+});

--- a/packages/core/test/relevance.test.mjs
+++ b/packages/core/test/relevance.test.mjs
@@ -1,0 +1,63 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildRelevanceContext, inferTestPath } from "../dist/index.js";
+
+test("buildRelevanceContext: diff only when no readFile provided", async () => {
+  const out = await buildRelevanceContext({
+    diff: "diff --git a/foo.ts b/foo.ts\n+added line",
+    diffPaths: ["foo.ts"],
+  });
+  assert.equal(out.chunks.length, 1);
+  assert.equal(out.chunks[0].reason, "diff");
+});
+
+test("buildRelevanceContext: appends test file when discoverable", async () => {
+  const out = await buildRelevanceContext({
+    diff: "diff of foo.ts",
+    diffPaths: ["src/foo.ts"],
+    readFile: async (p) => (p === "src/foo.test.ts" ? "// test body" : null),
+  });
+  const testChunk = out.chunks.find((c) => c.reason === "test-of-diff");
+  assert.ok(testChunk, "expected test chunk");
+  assert.equal(testChunk.path, "src/foo.test.ts");
+});
+
+test("buildRelevanceContext: walks direct imports when graphDepth >= 1", async () => {
+  const files = new Map([
+    ["src/foo.ts", "// foo"],
+    ["src/bar.ts", "// bar"],
+  ]);
+  const out = await buildRelevanceContext(
+    {
+      diff: "diff",
+      diffPaths: ["src/foo.ts"],
+      readFile: async (p) => files.get(p) ?? null,
+      importsOf: async (p) => (p === "src/foo.ts" ? ["src/bar.ts"] : []),
+    },
+    { graphDepth: 1 },
+  );
+  const imp = out.chunks.find((c) => c.reason === "import-of-diff");
+  assert.ok(imp);
+  assert.equal(imp.path, "src/bar.ts");
+});
+
+test("buildRelevanceContext: respects tokenBudget", async () => {
+  const out = await buildRelevanceContext(
+    {
+      diff: "x".repeat(10_000),
+      diffPaths: ["huge.ts"],
+    },
+    { tokenBudget: 500 },
+  );
+  assert.ok(out.totalTokens <= 500);
+});
+
+test("inferTestPath: maps source → test path by convention", () => {
+  assert.equal(inferTestPath("src/foo.ts"), "src/foo.test.ts");
+  assert.equal(inferTestPath("src/a/b/c.tsx"), "src/a/b/c.test.tsx");
+  assert.equal(inferTestPath("pkg/mod.js"), "pkg/mod.test.js");
+  // Already a test file — returns itself so caller doesn't recurse.
+  assert.equal(inferTestPath("src/foo.test.ts"), "src/foo.test.ts");
+  assert.equal(inferTestPath("src/foo.spec.js"), "src/foo.spec.js");
+  assert.equal(inferTestPath("no-extension"), null);
+});

--- a/packages/core/test/router.test.mjs
+++ b/packages/core/test/router.test.mjs
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { selectModel, estimateTokens, DEFAULT_MODELS } from "../dist/index.js";
+
+test("selectModel: small input → haiku", () => {
+  const choice = selectModel(5_000);
+  assert.equal(choice.class, "haiku");
+  assert.equal(choice.model, DEFAULT_MODELS.haiku);
+});
+
+test("selectModel: medium input → sonnet", () => {
+  const choice = selectModel(20_000);
+  assert.equal(choice.class, "sonnet");
+  assert.equal(choice.model, DEFAULT_MODELS.sonnet);
+});
+
+test("selectModel: large input → long-context (gemini)", () => {
+  const choice = selectModel(100_000);
+  assert.equal(choice.class, "long-context");
+  assert.equal(choice.model, DEFAULT_MODELS["long-context"]);
+});
+
+test("selectModel: boundary at haikuMax is inclusive of haiku", () => {
+  const choice = selectModel(8_000);
+  assert.equal(choice.class, "haiku");
+});
+
+test("selectModel: custom thresholds honored", () => {
+  const choice = selectModel(2_000, { haikuMax: 1_000, sonnetMax: 5_000 });
+  assert.equal(choice.class, "sonnet");
+});
+
+test("selectModel: model override via opts.models", () => {
+  const choice = selectModel(5_000, { models: { haiku: "custom-haiku" } });
+  assert.equal(choice.model, "custom-haiku");
+});
+
+test("estimateTokens: ~4 chars per token heuristic", () => {
+  assert.equal(estimateTokens("a".repeat(40)), 10);
+  assert.equal(estimateTokens(""), 0);
+  assert.equal(estimateTokens("abc"), 1);
+});

--- a/packages/core/test/seeder.test.mjs
+++ b/packages/core/test/seeder.test.mjs
@@ -1,0 +1,251 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  FileSystemMemoryStore,
+  LegacyCatalogSchema,
+  mapLegacyCategory,
+  seedFromLegacyCatalog,
+  toFailureEntry,
+} from "../dist/index.js";
+
+function freshStore() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aic-seed-"));
+  return { store: new FileSystemMemoryStore({ root }), root };
+}
+function cleanup(root) {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+test("mapLegacyCategory: type error → type-error", () => {
+  const e = {
+    id: "ERR-009",
+    category: "build",
+    pattern: "Type error: Route does not match",
+    description: "Next.js type mismatch",
+    fix: "Update signature",
+  };
+  assert.equal(mapLegacyCategory(e), "type-error");
+});
+
+test("mapLegacyCategory: prisma / schema → schema-drift", () => {
+  assert.equal(
+    mapLegacyCategory({
+      id: "x",
+      category: "build",
+      pattern: "prisma generate did not create",
+      description: "Prisma client not generated",
+      fix: "Run prisma generate",
+    }),
+    "schema-drift",
+  );
+});
+
+test("mapLegacyCategory: timeout → performance", () => {
+  assert.equal(
+    mapLegacyCategory({
+      id: "x",
+      category: "deploy",
+      pattern: "FUNCTION_INVOCATION_TIMEOUT",
+      description: "Serverless function exceeded time limit",
+      fix: "Investigate",
+    }),
+    "performance",
+  );
+});
+
+test("mapLegacyCategory: unused import → dead-code", () => {
+  assert.equal(
+    mapLegacyCategory({
+      id: "x",
+      category: "build",
+      pattern: "unused import lint",
+      description: "ESLint flagged unused import",
+      fix: "Remove the import",
+    }),
+    "dead-code",
+  );
+});
+
+test("mapLegacyCategory: nextauth / secret → security", () => {
+  assert.equal(
+    mapLegacyCategory({
+      id: "x",
+      category: "runtime",
+      pattern: "NEXTAUTH_URL is not set",
+      description: "Auth env missing",
+      fix: "Set NEXTAUTH_URL",
+    }),
+    "security",
+  );
+});
+
+test("mapLegacyCategory: module not found → api-misuse", () => {
+  assert.equal(
+    mapLegacyCategory({
+      id: "x",
+      category: "build",
+      pattern: "Cannot find module 'next/headers'",
+      description: "Server-only import used in client component",
+      fix: "Add 'use server' directive",
+    }),
+    "api-misuse",
+  );
+});
+
+test("mapLegacyCategory: unknown falls back to other", () => {
+  assert.equal(
+    mapLegacyCategory({
+      id: "x",
+      category: "misc",
+      pattern: "Something unusual",
+      description: "No recognizable keywords at all here",
+      fix: "Manual triage",
+    }),
+    "other",
+  );
+});
+
+test("toFailureEntry: deterministic id (stable across calls)", () => {
+  const legacy = {
+    id: "ERR-001",
+    category: "build",
+    pattern: "Module not found",
+    description: "x",
+    fix: "y",
+  };
+  const a = toFailureEntry(legacy, { createdAt: "2026-04-19T00:00:00.000Z" });
+  const b = toFailureEntry(legacy, { createdAt: "2026-04-19T00:00:00.000Z" });
+  assert.equal(a.id, b.id);
+  assert.match(a.id, /^fc-legacy-ERR-001-/);
+});
+
+test("toFailureEntry: tags merge legacy category + extras + defaults", () => {
+  const entry = toFailureEntry(
+    { id: "x", category: "runtime", pattern: "p", description: "d", fix: "f" },
+    { extraTags: ["legacy", "solo-cto-agent"] },
+  );
+  assert.ok(entry.tags.includes("runtime"));
+  assert.ok(entry.tags.includes("legacy"));
+  assert.ok(entry.tags.includes("solo-cto-agent"));
+});
+
+test("toFailureEntry: body is description + 'Fix: ' + fix", () => {
+  const entry = toFailureEntry({
+    id: "x",
+    category: "build",
+    pattern: "p",
+    description: "short desc",
+    fix: "do the thing",
+  });
+  assert.match(entry.body, /short desc.*Fix: do the thing/);
+});
+
+test("LegacyCatalogSchema: accepts solo-cto-agent shape", () => {
+  const parsed = LegacyCatalogSchema.parse({
+    version: 1,
+    updated_at: "2026-04-13",
+    items: [
+      { id: "ERR-001", category: "build", pattern: "p", description: "d", fix: "f" },
+    ],
+  });
+  assert.equal(parsed.items.length, 1);
+});
+
+test("LegacyCatalogSchema: rejects wrong version", () => {
+  assert.throws(() =>
+    LegacyCatalogSchema.parse({
+      version: 2,
+      updated_at: "2026-04-13",
+      items: [],
+    }),
+  );
+});
+
+test("seedFromLegacyCatalog: writes derived failures + returns byCategory", async () => {
+  const { store, root } = freshStore();
+  try {
+    const raw = JSON.stringify({
+      version: 1,
+      updated_at: "2026-04-13",
+      items: [
+        { id: "ERR-A", category: "build", pattern: "Type error", description: "ts", fix: "fix" },
+        { id: "ERR-B", category: "build", pattern: "prisma client", description: "schema", fix: "run" },
+        { id: "ERR-C", category: "deploy", pattern: "timeout", description: "slow", fix: "bump" },
+        { id: "ERR-D", category: "build", pattern: "Type error", description: "ts2", fix: "fix" },
+      ],
+    });
+    const result = await seedFromLegacyCatalog(raw, store);
+    assert.equal(result.entries.length, 4);
+    assert.equal(result.byCategory["type-error"], 2);
+    assert.equal(result.byCategory["schema-drift"], 1);
+    assert.equal(result.byCategory["performance"], 1);
+    const written = await store.listFailures();
+    assert.equal(written.length, 4);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("seedFromLegacyCatalog: { write: false } returns entries without touching store", async () => {
+  const { store, root } = freshStore();
+  try {
+    const raw = JSON.stringify({
+      version: 1,
+      updated_at: "2026-04-13",
+      items: [{ id: "ERR-A", category: "build", pattern: "Type error", description: "t", fix: "f" }],
+    });
+    const result = await seedFromLegacyCatalog(raw, store, { write: false });
+    assert.equal(result.entries.length, 1);
+    const written = await store.listFailures();
+    assert.equal(written.length, 0);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("seedFromLegacyCatalog: createdAt inherits YYYY-MM-DD with midnight UTC", async () => {
+  const { store, root } = freshStore();
+  try {
+    const raw = JSON.stringify({
+      version: 1,
+      updated_at: "2026-04-13",
+      items: [{ id: "x", category: "build", pattern: "p", description: "d", fix: "f" }],
+    });
+    const result = await seedFromLegacyCatalog(raw, store, { write: false });
+    assert.match(result.entries[0].createdAt, /^2026-04-13T00:00:00/);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("seedFromLegacyCatalog: bundled solo-cto-agent catalog writes 15 entries", async () => {
+  const { store, root } = freshStore();
+  try {
+    const bundled = path.resolve(
+      process.cwd(),
+      "dist",
+      "memory",
+      "seeds",
+      "solo-cto-agent-failure-catalog.json",
+    );
+    if (!fs.existsSync(bundled)) {
+      // Run from monorepo root or per-package context — this test is a
+      // smoke against the copied seed file. Skip if copy-seeds hasn't run
+      // yet in this environment.
+      console.log("  (skipped: bundled seed not found at " + bundled + ")");
+      return;
+    }
+    const raw = fs.readFileSync(bundled, "utf8");
+    const result = await seedFromLegacyCatalog(raw, store);
+    assert.equal(result.entries.length, 15);
+    // every derived entry tagged "solo-cto-agent"
+    for (const e of result.entries) {
+      assert.ok(e.tags.includes("solo-cto-agent"));
+    }
+  } finally {
+    cleanup(root);
+  }
+});

--- a/packages/core/test/smoke.test.mjs
+++ b/packages/core/test/smoke.test.mjs
@@ -1,0 +1,11 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Council } from "../dist/index.js";
+
+test("core: Council is exported from @ai-conclave/core", () => {
+  assert.equal(typeof Council, "function");
+});
+
+test("core: Council empty agents throws", () => {
+  assert.throws(() => new Council({ agents: [] }), /at least one agent/);
+});

--- a/packages/core/test/triage.test.mjs
+++ b/packages/core/test/triage.test.mjs
@@ -1,0 +1,77 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { triageReview, touchesRiskyPath } from "../dist/index.js";
+
+test("triageReview: risky path forces full regardless of size", () => {
+  const out = triageReview({
+    linesChanged: 1,
+    fileCount: 1,
+    hasTests: true,
+    touchesRiskyPath: true,
+  });
+  assert.equal(out.path, "full");
+  assert.match(out.reason, /risky/i);
+});
+
+test("triageReview: small + tests + not risky → lite", () => {
+  const out = triageReview({
+    linesChanged: 20,
+    fileCount: 2,
+    hasTests: true,
+    touchesRiskyPath: false,
+  });
+  assert.equal(out.path, "lite");
+});
+
+test("triageReview: large lines → full", () => {
+  const out = triageReview({
+    linesChanged: 500,
+    fileCount: 1,
+    hasTests: true,
+    touchesRiskyPath: false,
+  });
+  assert.equal(out.path, "full");
+  assert.match(out.reason, /linesChanged/);
+});
+
+test("triageReview: many files → full", () => {
+  const out = triageReview({
+    linesChanged: 10,
+    fileCount: 10,
+    hasTests: true,
+    touchesRiskyPath: false,
+  });
+  assert.equal(out.path, "full");
+  assert.match(out.reason, /fileCount/);
+});
+
+test("triageReview: non-trivial diff without tests → full", () => {
+  const out = triageReview({
+    linesChanged: 30,
+    fileCount: 2,
+    hasTests: false,
+    touchesRiskyPath: false,
+  });
+  assert.equal(out.path, "full");
+  assert.match(out.reason, /without any test/);
+});
+
+test("triageReview: trivial diff without tests still lite (not worth full council)", () => {
+  const out = triageReview({
+    linesChanged: 5,
+    fileCount: 1,
+    hasTests: false,
+    touchesRiskyPath: false,
+  });
+  assert.equal(out.path, "lite");
+});
+
+test("touchesRiskyPath: schema / migrations / auth / payments / .sql / prisma schema match", () => {
+  assert.equal(touchesRiskyPath(["src/auth/login.ts"]), true);
+  assert.equal(touchesRiskyPath(["db/migrations/001_init.sql"]), true);
+  assert.equal(touchesRiskyPath(["payments/stripe.ts"]), true);
+  assert.equal(touchesRiskyPath(["prisma/schema.prisma"]), true);
+  assert.equal(touchesRiskyPath(["sql/analytics.sql"]), true);
+  assert.equal(touchesRiskyPath(["src/components/Button.tsx"]), false);
+  assert.equal(touchesRiskyPath([]), false);
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/packages/integration-discord/README.md
+++ b/packages/integration-discord/README.md
@@ -1,0 +1,51 @@
+# @ai-conclave/integration-discord
+
+Discord notifier for Ai-Conclave council reviews. Implements the
+`Notifier` interface from `@ai-conclave/core`.
+
+Decision #24: equal-weight integration alongside Telegram / Slack /
+Email / CLI. No hero surface.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/integration-discord @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { DiscordNotifier } from "@ai-conclave/integration-discord";
+
+const discord = new DiscordNotifier({
+  webhookUrl: process.env.DISCORD_WEBHOOK_URL,
+});
+
+await discord.notifyReview({
+  outcome,
+  ctx,
+  episodicId: episodic.id,
+  totalCostUsd: gate.metrics.summary().totalCostUsd,
+  prUrl: "https://github.com/acme/app/pull/42",
+});
+```
+
+## Setup
+
+1. In your Discord server → channel → Settings → Integrations → **Webhooks** → New Webhook
+2. Copy the webhook URL
+3. `export DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/…'`
+
+No bot token or OAuth setup needed — webhooks are the simplest path and
+match the write-only contract of this notifier.
+
+## Message shape
+
+Single embed:
+- Color-coded title: ✅ green (approve) / 🔧 amber (rework) / ❌ red (reject)
+- Title links to the PR URL when supplied
+- Per-agent fields: verdict + top-3 severity-sorted blockers + summary
+- Footer: total cost + episodic id
+
+Inbound interactivity (button clicks, slash commands) is not in scope
+here — use a separate Discord bot package if / when needed.

--- a/packages/integration-discord/package.json
+++ b/packages/integration-discord/package.json
@@ -1,13 +1,16 @@
 {
-  "name": "@ai-conclave/cli",
+  "name": "@ai-conclave/integration-discord",
   "version": "0.0.0",
-  "description": "Ai-Conclave CLI — the `conclave` binary.",
+  "description": "Ai-Conclave Discord notifier — posts review outcomes to a Discord channel via incoming webhook.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "conclave": "./dist/bin/conclave.js"
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",
@@ -22,15 +25,7 @@
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {
-    "@ai-conclave/agent-claude": "workspace:*",
-    "@ai-conclave/agent-gemini": "workspace:*",
-    "@ai-conclave/agent-openai": "workspace:*",
-    "@ai-conclave/core": "workspace:*",
-    "@ai-conclave/integration-discord": "workspace:*",
-    "@ai-conclave/integration-telegram": "workspace:*",
-    "@ai-conclave/observability-langfuse": "workspace:*",
-    "@ai-conclave/scm-github": "workspace:*",
-    "zod": "^3.24.0"
+    "@ai-conclave/core": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/packages/integration-discord/src/format.ts
+++ b/packages/integration-discord/src/format.ts
@@ -1,0 +1,101 @@
+import type { NotifyReviewInput } from "@ai-conclave/core";
+
+const VERDICT_COLOR: Record<"approve" | "rework" | "reject", number> = {
+  approve: 0x22c55e, // green-500
+  rework: 0xf59e0b, // amber-500
+  reject: 0xef4444, // red-500
+};
+
+const VERDICT_EMOJI: Record<"approve" | "rework" | "reject", string> = {
+  approve: "✅",
+  rework: "🔧",
+  reject: "❌",
+};
+
+const SEVERITY_EMOJI: Record<"blocker" | "major" | "minor" | "nit", string> = {
+  blocker: "🛑",
+  major: "⚠️",
+  minor: "🔹",
+  nit: "💬",
+};
+
+export interface DiscordEmbed {
+  title: string;
+  url?: string;
+  description?: string;
+  color: number;
+  fields: Array<{ name: string; value: string; inline?: boolean }>;
+  footer?: { text: string };
+  timestamp?: string;
+}
+
+export interface DiscordWebhookPayload {
+  username?: string;
+  avatar_url?: string;
+  content?: string;
+  embeds: DiscordEmbed[];
+}
+
+/**
+ * Render a NotifyReviewInput as a Discord webhook payload. One embed per
+ * review with color-coded verdict + per-agent fields.
+ *
+ * Discord embed limits (truncated automatically):
+ *   - title ≤ 256 chars
+ *   - description ≤ 4096 chars
+ *   - field.name ≤ 256, field.value ≤ 1024
+ *   - max 25 fields
+ *   - total embed size ≤ 6000 chars
+ */
+export function formatReviewForDiscord(input: NotifyReviewInput): DiscordWebhookPayload {
+  const { outcome, ctx, totalCostUsd, prUrl, episodicId } = input;
+  const title = trunc(
+    `${VERDICT_EMOJI[outcome.verdict]} ${outcome.verdict.toUpperCase()} — ${ctx.repo}${ctx.pullNumber ? ` #${ctx.pullNumber}` : ""}`,
+    256,
+  );
+  const descriptionParts: string[] = [];
+  if (!outcome.consensusReached) descriptionParts.push("*no consensus reached*");
+  if (descriptionParts.length === 0) descriptionParts.push(`sha \`${ctx.newSha.slice(0, 12)}\``);
+
+  const fields: DiscordEmbed["fields"] = [];
+  for (const r of outcome.results) {
+    if (fields.length >= 24) break; // leave 1 slot for footer-like info
+    const header = `${VERDICT_EMOJI[r.verdict]} ${r.agent}`;
+    const lines: string[] = [];
+    if (r.blockers.length === 0) {
+      lines.push("_(no blockers)_");
+    } else {
+      const sorted = [...r.blockers]
+        .sort((a, b) => severityOrder(a.severity) - severityOrder(b.severity))
+        .slice(0, 3);
+      for (const b of sorted) {
+        const where = b.file ? ` \`${b.file}${b.line ? `:${b.line}` : ""}\`` : "";
+        lines.push(`${SEVERITY_EMOJI[b.severity]} **${b.severity}** (${b.category})${where}`);
+        lines.push(`    ${b.message}`);
+      }
+      if (r.blockers.length > 3) lines.push(`… +${r.blockers.length - 3} more`);
+    }
+    if (r.summary) lines.push(`_${trunc(r.summary, 400)}_`);
+    fields.push({ name: header, value: trunc(lines.join("\n"), 1024), inline: false });
+  }
+
+  const footerText = `cost $${totalCostUsd.toFixed(4)} · episodic ${episodicId}`;
+  const embed: DiscordEmbed = {
+    title,
+    description: trunc(descriptionParts.join("\n"), 4096),
+    color: VERDICT_COLOR[outcome.verdict],
+    fields,
+    footer: { text: trunc(footerText, 2048) },
+    timestamp: new Date().toISOString(),
+  };
+  if (prUrl) embed.url = prUrl;
+  return { embeds: [embed] };
+}
+
+function severityOrder(s: "blocker" | "major" | "minor" | "nit"): number {
+  return { blocker: 0, major: 1, minor: 2, nit: 3 }[s];
+}
+
+function trunc(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}

--- a/packages/integration-discord/src/index.ts
+++ b/packages/integration-discord/src/index.ts
@@ -1,0 +1,4 @@
+export { DiscordNotifier } from "./notifier.js";
+export type { DiscordNotifierOptions, HttpFetch } from "./notifier.js";
+export { formatReviewForDiscord } from "./format.js";
+export type { DiscordEmbed, DiscordWebhookPayload } from "./format.js";

--- a/packages/integration-discord/src/notifier.ts
+++ b/packages/integration-discord/src/notifier.ts
@@ -1,0 +1,77 @@
+import type { Notifier, NotifyReviewInput } from "@ai-conclave/core";
+import { formatReviewForDiscord } from "./format.js";
+
+export interface HttpFetch {
+  (url: string, init: { method: string; headers: Record<string, string>; body: string }): Promise<{
+    ok: boolean;
+    status: number;
+    text: () => Promise<string>;
+  }>;
+}
+
+export interface DiscordNotifierOptions {
+  /** Incoming webhook URL (or set via DISCORD_WEBHOOK_URL env). */
+  webhookUrl?: string;
+  /** Override display username on the message. */
+  username?: string;
+  /** Override avatar URL on the message. */
+  avatarUrl?: string;
+  /** Inject fetch for tests. */
+  fetch?: HttpFetch;
+}
+
+const DEFAULT_USERNAME = "Ai-Conclave";
+
+/**
+ * DiscordNotifier — posts review outcomes to a Discord channel via
+ * incoming webhook.
+ *
+ * Discord webhooks are much simpler than bot API (no token, no chat id,
+ * just the webhook URL). We use a single-embed payload with color-coded
+ * verdict. If inbound interactivity is later required (slash commands,
+ * button clicks), a separate bot package can be added.
+ */
+export class DiscordNotifier implements Notifier {
+  readonly id = "discord";
+  readonly displayName = "Discord";
+
+  private readonly webhookUrl: string;
+  private readonly username: string;
+  private readonly avatarUrl: string | undefined;
+  private readonly fetchFn: HttpFetch;
+
+  constructor(opts: DiscordNotifierOptions = {}) {
+    const url = opts.webhookUrl ?? process.env["DISCORD_WEBHOOK_URL"] ?? "";
+    if (!url) {
+      throw new Error("DiscordNotifier: DISCORD_WEBHOOK_URL not set (pass opts.webhookUrl or env)");
+    }
+    if (!/^https:\/\/(discord|discordapp)\.com\/api\/webhooks\//i.test(url)) {
+      throw new Error(
+        "DiscordNotifier: webhookUrl must be an https://discord.com/api/webhooks/... URL",
+      );
+    }
+    this.webhookUrl = url;
+    this.username = opts.username ?? DEFAULT_USERNAME;
+    this.avatarUrl = opts.avatarUrl;
+    this.fetchFn =
+      opts.fetch ?? ((...args) => fetch(...(args as Parameters<typeof fetch>)) as ReturnType<HttpFetch>);
+  }
+
+  async notifyReview(input: NotifyReviewInput): Promise<void> {
+    const payload = formatReviewForDiscord(input);
+    payload.username = this.username;
+    if (this.avatarUrl) payload.avatar_url = this.avatarUrl;
+
+    const res = await this.fetchFn(this.webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `DiscordNotifier: webhook POST failed (status ${res.status}): ${text.slice(0, 200)}`,
+      );
+    }
+  }
+}

--- a/packages/integration-discord/test/format.test.mjs
+++ b/packages/integration-discord/test/format.test.mjs
@@ -1,0 +1,160 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatReviewForDiscord } from "../dist/index.js";
+
+function mkInput(overrides = {}) {
+  return {
+    outcome: {
+      verdict: "approve",
+      rounds: 1,
+      consensusReached: true,
+      results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+    },
+    ctx: { diff: "", repo: "acme/app", pullNumber: 42, newSha: "abcdef1234567890" },
+    episodicId: "ep-disc-1",
+    totalCostUsd: 0.0153,
+    ...overrides,
+  };
+}
+
+test("formatReviewForDiscord: approve embed is green", () => {
+  const payload = formatReviewForDiscord(mkInput());
+  const embed = payload.embeds[0];
+  assert.equal(embed.color, 0x22c55e);
+  assert.match(embed.title, /✅ APPROVE/);
+});
+
+test("formatReviewForDiscord: reject embed is red", () => {
+  const payload = formatReviewForDiscord(
+    mkInput({
+      outcome: {
+        verdict: "reject",
+        rounds: 1,
+        consensusReached: true,
+        results: [{ agent: "claude", verdict: "reject", blockers: [], summary: "wrong" }],
+      },
+    }),
+  );
+  assert.equal(payload.embeds[0].color, 0xef4444);
+});
+
+test("formatReviewForDiscord: rework embed is amber", () => {
+  const payload = formatReviewForDiscord(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: true,
+        results: [{ agent: "claude", verdict: "rework", blockers: [], summary: "" }],
+      },
+    }),
+  );
+  assert.equal(payload.embeds[0].color, 0xf59e0b);
+});
+
+test("formatReviewForDiscord: embed links to prUrl when supplied", () => {
+  const payload = formatReviewForDiscord(mkInput({ prUrl: "https://github.com/acme/app/pull/42" }));
+  assert.equal(payload.embeds[0].url, "https://github.com/acme/app/pull/42");
+});
+
+test("formatReviewForDiscord: no consensus tag in description", () => {
+  const payload = formatReviewForDiscord(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: false,
+        results: [{ agent: "claude", verdict: "rework", blockers: [], summary: "" }],
+      },
+    }),
+  );
+  assert.match(payload.embeds[0].description, /no consensus/);
+});
+
+test("formatReviewForDiscord: per-agent field with severity-sorted top-3 blockers", () => {
+  const blockers = [
+    { severity: "nit", category: "style", message: "nit 1" },
+    { severity: "blocker", category: "security", message: "block 1", file: "x.ts", line: 4 },
+    { severity: "minor", category: "dead-code", message: "minor 1" },
+    { severity: "major", category: "regression", message: "major 1" },
+    { severity: "blocker", category: "type-error", message: "block 2" },
+  ];
+  const payload = formatReviewForDiscord(
+    mkInput({
+      outcome: {
+        verdict: "reject",
+        rounds: 1,
+        consensusReached: true,
+        results: [{ agent: "claude", verdict: "reject", blockers, summary: "5 blockers" }],
+      },
+    }),
+  );
+  const field = payload.embeds[0].fields[0];
+  assert.match(field.name, /❌ claude/);
+  // Blockers, then block 2, then major 1 should appear in order
+  const blockerIdx = field.value.indexOf("block 1");
+  const block2Idx = field.value.indexOf("block 2");
+  const majorIdx = field.value.indexOf("major 1");
+  assert.ok(blockerIdx < block2Idx);
+  assert.ok(block2Idx < majorIdx);
+  // ...and "+2 more" since 5 blockers - 3 shown
+  assert.match(field.value, /\+2 more/);
+  // file:line rendered
+  assert.match(field.value, /x\.ts:4/);
+});
+
+test("formatReviewForDiscord: field value truncates at 1024 chars", () => {
+  const huge = "x".repeat(3000);
+  const payload = formatReviewForDiscord(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: true,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [{ severity: "blocker", category: "security", message: huge }],
+            summary: "",
+          },
+        ],
+      },
+    }),
+  );
+  assert.ok(payload.embeds[0].fields[0].value.length <= 1024);
+});
+
+test("formatReviewForDiscord: footer includes cost + episodic id", () => {
+  const payload = formatReviewForDiscord(mkInput({ totalCostUsd: 0.0345, episodicId: "ep-xyz" }));
+  assert.match(payload.embeds[0].footer.text, /\$0\.0345/);
+  assert.match(payload.embeds[0].footer.text, /ep-xyz/);
+});
+
+test("formatReviewForDiscord: timestamp is ISO and recent", () => {
+  const payload = formatReviewForDiscord(mkInput());
+  assert.match(payload.embeds[0].timestamp, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("formatReviewForDiscord: (no blockers) placeholder per agent", () => {
+  const payload = formatReviewForDiscord(mkInput());
+  assert.match(payload.embeds[0].fields[0].value, /no blockers/);
+});
+
+test("formatReviewForDiscord: caps at 24 per-agent fields", () => {
+  const manyResults = [];
+  for (let i = 0; i < 30; i += 1) {
+    manyResults.push({ agent: `agent-${i}`, verdict: "approve", blockers: [], summary: "" });
+  }
+  const payload = formatReviewForDiscord(
+    mkInput({
+      outcome: {
+        verdict: "approve",
+        rounds: 1,
+        consensusReached: true,
+        results: manyResults,
+      },
+    }),
+  );
+  assert.ok(payload.embeds[0].fields.length <= 24);
+});

--- a/packages/integration-discord/test/notifier.test.mjs
+++ b/packages/integration-discord/test/notifier.test.mjs
@@ -1,0 +1,120 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { DiscordNotifier } from "../dist/index.js";
+
+function mockFetch(response = { ok: true, status: 204, text: "" }) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init, body: JSON.parse(init.body) });
+    return {
+      ok: response.ok,
+      status: response.status,
+      text: async () => response.text,
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const baseInput = {
+  outcome: {
+    verdict: "approve",
+    rounds: 1,
+    consensusReached: true,
+    results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+  },
+  ctx: { diff: "", repo: "acme/app", pullNumber: 42, newSha: "abc" },
+  episodicId: "ep-d",
+  totalCostUsd: 0.01,
+};
+
+const GOOD_WEBHOOK = "https://discord.com/api/webhooks/123/abc";
+
+test("DiscordNotifier: rejects missing webhook URL", () => {
+  const orig = process.env.DISCORD_WEBHOOK_URL;
+  delete process.env.DISCORD_WEBHOOK_URL;
+  try {
+    assert.throws(() => new DiscordNotifier());
+  } finally {
+    if (orig !== undefined) process.env.DISCORD_WEBHOOK_URL = orig;
+  }
+});
+
+test("DiscordNotifier: rejects non-Discord URL", () => {
+  assert.throws(() => new DiscordNotifier({ webhookUrl: "https://evil.example.com/webhook" }));
+});
+
+test("DiscordNotifier: accepts both discord.com and discordapp.com hosts", () => {
+  const f = mockFetch();
+  const n1 = new DiscordNotifier({
+    webhookUrl: "https://discord.com/api/webhooks/1/x",
+    fetch: f,
+  });
+  const n2 = new DiscordNotifier({
+    webhookUrl: "https://discordapp.com/api/webhooks/1/x",
+    fetch: f,
+  });
+  assert.ok(n1 && n2);
+});
+
+test("DiscordNotifier: notifyReview POSTs to webhook URL with JSON body", async () => {
+  const f = mockFetch();
+  const n = new DiscordNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: f });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls.length, 1);
+  assert.equal(f.calls[0].url, GOOD_WEBHOOK);
+  assert.equal(f.calls[0].init.method, "POST");
+  assert.equal(f.calls[0].init.headers["content-type"], "application/json");
+});
+
+test("DiscordNotifier: default username = Ai-Conclave", async () => {
+  const f = mockFetch();
+  const n = new DiscordNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: f });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.username, "Ai-Conclave");
+});
+
+test("DiscordNotifier: username override is honored", async () => {
+  const f = mockFetch();
+  const n = new DiscordNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: f, username: "Conclave Bot" });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.username, "Conclave Bot");
+});
+
+test("DiscordNotifier: avatarUrl propagates when supplied", async () => {
+  const f = mockFetch();
+  const n = new DiscordNotifier({
+    webhookUrl: GOOD_WEBHOOK,
+    fetch: f,
+    avatarUrl: "https://example.com/avatar.png",
+  });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.avatar_url, "https://example.com/avatar.png");
+});
+
+test("DiscordNotifier: non-200 response throws with status + snippet", async () => {
+  const f = mockFetch({ ok: false, status: 400, text: "bad request: invalid embed" });
+  const n = new DiscordNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: f });
+  await assert.rejects(() => n.notifyReview(baseInput), /status 400.*bad request/);
+});
+
+test("DiscordNotifier: env fallback for DISCORD_WEBHOOK_URL", async () => {
+  const orig = process.env.DISCORD_WEBHOOK_URL;
+  process.env.DISCORD_WEBHOOK_URL = GOOD_WEBHOOK;
+  const f = mockFetch();
+  try {
+    const n = new DiscordNotifier({ fetch: f });
+    await n.notifyReview(baseInput);
+    assert.equal(f.calls[0].url, GOOD_WEBHOOK);
+  } finally {
+    if (orig !== undefined) process.env.DISCORD_WEBHOOK_URL = orig;
+    else delete process.env.DISCORD_WEBHOOK_URL;
+  }
+});
+
+test("DiscordNotifier: conforms to Notifier interface", () => {
+  const n = new DiscordNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: async () => ({ ok: true, status: 204, text: async () => "" }) });
+  assert.equal(n.id, "discord");
+  assert.equal(n.displayName, "Discord");
+  assert.equal(typeof n.notifyReview, "function");
+});

--- a/packages/integration-discord/tsconfig.json
+++ b/packages/integration-discord/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/integration-email/README.md
+++ b/packages/integration-email/README.md
@@ -1,0 +1,61 @@
+# @ai-conclave/integration-email
+
+Email notifier for Ai-Conclave council reviews. Implements the
+`Notifier` interface from `@ai-conclave/core`.
+
+Decision #24: equal-weight integration alongside Telegram / Discord /
+Slack / CLI.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/integration-email @ai-conclave/core
+```
+
+## Default transport — Resend
+
+```ts
+import { EmailNotifier } from "@ai-conclave/integration-email";
+
+const email = new EmailNotifier({
+  from: "conclave@yourdomain.com",
+  to: "you@yourdomain.com",
+  // RESEND_API_KEY is read from env automatically
+});
+```
+
+No Resend SDK dependency — a single `fetch` call to the REST API.
+
+## Swapping transports
+
+`EmailNotifier` accepts any object implementing `EmailTransport`
+(`{ id, send(msg) }`). Drop-in examples:
+
+```ts
+// nodemailer SMTP
+import nodemailer from "nodemailer";
+const smtp = nodemailer.createTransport({ host, port, auth });
+const transport = {
+  id: "smtp",
+  send: (m) => smtp.sendMail(m).then(() => undefined),
+};
+new EmailNotifier({ from, to, transport });
+
+// @aws-sdk/client-ses — similar wrapper
+// postmark / sendgrid / mailgun — implement send() the same way
+```
+
+## Env
+
+| Var | Purpose |
+|---|---|
+| `RESEND_API_KEY` | Default transport (Resend API) |
+| `CONCLAVE_EMAIL_FROM` | From address fallback |
+| `CONCLAVE_EMAIL_TO` | Comma-separated recipient list fallback |
+
+## Message shape
+
+- Subject: `[conclave] VERDICT — repo #N` (override via `subjectOverride`)
+- Plaintext body + HTML body; both rendered from the same source
+- HTML is self-contained (inline styles, email-client safe)
+- Cost + episodic id in footer

--- a/packages/integration-email/package.json
+++ b/packages/integration-email/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ai-conclave/integration-email",
+  "version": "0.0.0",
+  "description": "Ai-Conclave email notifier — pluggable transport (Resend default; SMTP/SES/nodemailer drop-ins).",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@ai-conclave/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/integration-email/src/format.ts
+++ b/packages/integration-email/src/format.ts
@@ -1,0 +1,113 @@
+import type { NotifyReviewInput } from "@ai-conclave/core";
+
+const VERDICT_LABEL: Record<"approve" | "rework" | "reject", string> = {
+  approve: "APPROVE",
+  rework: "REWORK",
+  reject: "REJECT",
+};
+
+const VERDICT_COLOR: Record<"approve" | "rework" | "reject", string> = {
+  approve: "#16a34a",
+  rework: "#d97706",
+  reject: "#dc2626",
+};
+
+export interface RenderedEmail {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+/** Escape HTML-special chars for the html body. */
+function h(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function severityOrder(s: "blocker" | "major" | "minor" | "nit"): number {
+  return { blocker: 0, major: 1, minor: 2, nit: 3 }[s];
+}
+
+/** Render a NotifyReviewInput to plaintext + HTML email bodies. */
+export function renderEmail(input: NotifyReviewInput): RenderedEmail {
+  const { outcome, ctx, totalCostUsd, prUrl, episodicId } = input;
+  const subject = `[conclave] ${VERDICT_LABEL[outcome.verdict]} — ${ctx.repo}${ctx.pullNumber ? ` #${ctx.pullNumber}` : ""}`;
+
+  const textLines: string[] = [];
+  textLines.push(
+    `Verdict: ${VERDICT_LABEL[outcome.verdict]}${outcome.consensusReached ? "" : " (no consensus reached)"}`,
+  );
+  textLines.push(`Repo:    ${ctx.repo}${ctx.pullNumber ? ` #${ctx.pullNumber}` : ""}`);
+  textLines.push(`SHA:     ${ctx.newSha.slice(0, 12)}`);
+  if (prUrl) textLines.push(`PR:      ${prUrl}`);
+  textLines.push("");
+  for (const r of outcome.results) {
+    textLines.push(`── ${r.agent} → ${VERDICT_LABEL[r.verdict]} ──`);
+    if (r.blockers.length === 0) textLines.push("  (no blockers)");
+    else {
+      const sorted = [...r.blockers]
+        .sort((a, b) => severityOrder(a.severity) - severityOrder(b.severity))
+        .slice(0, 5);
+      for (const b of sorted) {
+        const where = b.file ? `  ${b.file}${b.line ? `:${b.line}` : ""}` : "";
+        textLines.push(`  [${b.severity.toUpperCase()}] (${b.category})${where}`);
+        textLines.push(`    ${b.message}`);
+      }
+      if (r.blockers.length > 5) textLines.push(`  ... +${r.blockers.length - 5} more`);
+    }
+    if (r.summary) textLines.push(`  summary: ${r.summary}`);
+    textLines.push("");
+  }
+  textLines.push(`cost: $${totalCostUsd.toFixed(4)} · episodic: ${episodicId}`);
+  const text = textLines.join("\n");
+
+  // HTML rendering — self-contained, no external CSS, email-safe.
+  const htmlSections: string[] = [];
+  htmlSections.push(
+    `<div style="font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;color:#111;max-width:640px;margin:0 auto;padding:16px;">`,
+  );
+  htmlSections.push(
+    `<h2 style="margin:0 0 8px 0;color:${VERDICT_COLOR[outcome.verdict]}">${h(VERDICT_LABEL[outcome.verdict])} — ${h(ctx.repo)}${ctx.pullNumber ? ` #${ctx.pullNumber}` : ""}</h2>`,
+  );
+  if (!outcome.consensusReached) htmlSections.push(`<p style="color:#555;margin:0 0 8px 0"><em>no consensus reached</em></p>`);
+  if (prUrl) {
+    htmlSections.push(
+      `<p style="margin:0 0 16px 0"><a href="${h(prUrl)}" style="color:#2563eb">${h(prUrl)}</a></p>`,
+    );
+  }
+  for (const r of outcome.results) {
+    htmlSections.push(
+      `<h3 style="margin:16px 0 4px 0">${h(r.agent)} → <span style="color:${VERDICT_COLOR[r.verdict]}">${h(VERDICT_LABEL[r.verdict])}</span></h3>`,
+    );
+    if (r.blockers.length === 0) {
+      htmlSections.push(`<p style="color:#666;margin:0"><em>(no blockers)</em></p>`);
+    } else {
+      const sorted = [...r.blockers]
+        .sort((a, b) => severityOrder(a.severity) - severityOrder(b.severity))
+        .slice(0, 5);
+      htmlSections.push(`<ul style="margin:4px 0 0 0;padding-left:20px">`);
+      for (const b of sorted) {
+        const where = b.file ? ` <code style="background:#f3f4f6;padding:2px 4px">${h(b.file)}${b.line ? `:${b.line}` : ""}</code>` : "";
+        htmlSections.push(
+          `<li><strong>${h(b.severity)}</strong> (${h(b.category)})${where}<br/>${h(b.message)}</li>`,
+        );
+      }
+      if (r.blockers.length > 5) htmlSections.push(`<li><em>+${r.blockers.length - 5} more</em></li>`);
+      htmlSections.push(`</ul>`);
+    }
+    if (r.summary) {
+      htmlSections.push(
+        `<p style="color:#444;margin:8px 0 0 0"><em>${h(r.summary)}</em></p>`,
+      );
+    }
+  }
+  htmlSections.push(
+    `<hr style="border:none;border-top:1px solid #e5e7eb;margin:16px 0"/>` +
+      `<p style="color:#6b7280;font-size:12px;margin:0">` +
+      `cost $${totalCostUsd.toFixed(4)} · episodic <code>${h(episodicId)}</code>` +
+      `</p>` +
+      `</div>`,
+  );
+  const html = htmlSections.join("");
+
+  return { subject, text, html };
+}

--- a/packages/integration-email/src/index.ts
+++ b/packages/integration-email/src/index.ts
@@ -1,0 +1,11 @@
+export { EmailNotifier } from "./notifier.js";
+export type { EmailNotifierOptions } from "./notifier.js";
+export { ResendTransport } from "./transport.js";
+export type {
+  EmailTransport,
+  EmailMessage,
+  ResendTransportOptions,
+  HttpFetch,
+} from "./transport.js";
+export { renderEmail } from "./format.js";
+export type { RenderedEmail } from "./format.js";

--- a/packages/integration-email/src/notifier.ts
+++ b/packages/integration-email/src/notifier.ts
@@ -1,0 +1,70 @@
+import type { Notifier, NotifyReviewInput } from "@ai-conclave/core";
+import { renderEmail } from "./format.js";
+import { ResendTransport, type EmailTransport, type HttpFetch } from "./transport.js";
+
+export interface EmailNotifierOptions {
+  /** From address (or set via CONCLAVE_EMAIL_FROM). */
+  from?: string;
+  /** Recipient(s). Comma-split CONCLAVE_EMAIL_TO env when omitted. */
+  to?: string | readonly string[];
+  /** Override subject template. Default: "[conclave] VERDICT — repo #N". */
+  subjectOverride?: string;
+  /** Injected transport. Default: ResendTransport. */
+  transport?: EmailTransport;
+  /** Fetch injection for the default transport. */
+  fetch?: HttpFetch;
+  /** Only used when constructing default Resend transport. */
+  resendApiKey?: string;
+}
+
+/**
+ * EmailNotifier — implements `Notifier` using a pluggable transport.
+ *
+ * Decision #24: equal-weight integration. Email rounds out the
+ * write-only notification family alongside Telegram / Discord / Slack.
+ *
+ * Transport defaults to `ResendTransport` (minimal, no SDK dep). Swap
+ * via `opts.transport` for SMTP / SES / Postmark / SendGrid / etc.
+ */
+export class EmailNotifier implements Notifier {
+  readonly id = "email";
+  readonly displayName = "Email";
+
+  private readonly from: string;
+  private readonly to: readonly string[];
+  private readonly subjectOverride: string | undefined;
+  private readonly transport: EmailTransport;
+
+  constructor(opts: EmailNotifierOptions = {}) {
+    const from = opts.from ?? process.env["CONCLAVE_EMAIL_FROM"] ?? "";
+    const rawTo =
+      opts.to !== undefined
+        ? opts.to
+        : (process.env["CONCLAVE_EMAIL_TO"] ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+    const to = Array.isArray(rawTo) ? [...rawTo] : [rawTo as string];
+    if (!from) throw new Error("EmailNotifier: from address not set (pass opts.from or CONCLAVE_EMAIL_FROM)");
+    if (to.length === 0) throw new Error("EmailNotifier: to recipient(s) not set (pass opts.to or CONCLAVE_EMAIL_TO)");
+    this.from = from;
+    this.to = to;
+    this.subjectOverride = opts.subjectOverride;
+    if (opts.transport) {
+      this.transport = opts.transport;
+    } else {
+      const transOpts: ConstructorParameters<typeof ResendTransport>[0] = {};
+      if (opts.resendApiKey) transOpts.apiKey = opts.resendApiKey;
+      if (opts.fetch) transOpts.fetch = opts.fetch;
+      this.transport = new ResendTransport(transOpts);
+    }
+  }
+
+  async notifyReview(input: NotifyReviewInput): Promise<void> {
+    const rendered = renderEmail(input);
+    await this.transport.send({
+      from: this.from,
+      to: this.to,
+      subject: this.subjectOverride ?? rendered.subject,
+      text: rendered.text,
+      html: rendered.html,
+    });
+  }
+}

--- a/packages/integration-email/src/transport.ts
+++ b/packages/integration-email/src/transport.ts
@@ -1,0 +1,86 @@
+export interface EmailMessage {
+  from: string;
+  to: string | readonly string[];
+  subject: string;
+  text: string;
+  html?: string;
+}
+
+/**
+ * EmailTransport — send one email. Pluggable so callers can swap the
+ * default `ResendTransport` (HTTP, no SDK dep) for SMTP, SES, Postmark,
+ * or any other provider via a thin adapter.
+ */
+export interface EmailTransport {
+  readonly id: string;
+  send(msg: EmailMessage): Promise<void>;
+}
+
+export interface HttpFetch {
+  (url: string, init: { method: string; headers: Record<string, string>; body: string }): Promise<{
+    ok: boolean;
+    status: number;
+    text: () => Promise<string>;
+  }>;
+}
+
+export interface ResendTransportOptions {
+  apiKey?: string;
+  /** Injectable fetch for tests. */
+  fetch?: HttpFetch;
+  /** Base URL override (tests). Defaults to Resend API. */
+  baseUrl?: string;
+}
+
+/**
+ * ResendTransport — default transport. Uses Resend's REST API
+ * (https://resend.com/docs/api-reference/emails/send-email). Single
+ * POST call; no SDK dependency. Bearer-token auth via `RESEND_API_KEY`
+ * env.
+ *
+ * To use a different provider:
+ *   - SMTP: implement `EmailTransport` with nodemailer
+ *   - SES: implement with @aws-sdk/client-ses
+ *   - Postmark / SendGrid / Mailgun: implement with native fetch
+ *
+ * Pass your transport to `EmailNotifier` via `opts.transport`.
+ */
+export class ResendTransport implements EmailTransport {
+  readonly id = "resend";
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly fetchFn: HttpFetch;
+
+  constructor(opts: ResendTransportOptions = {}) {
+    const key = opts.apiKey ?? process.env["RESEND_API_KEY"] ?? "";
+    if (!key) throw new Error("ResendTransport: RESEND_API_KEY not set");
+    this.apiKey = key;
+    this.baseUrl = opts.baseUrl ?? "https://api.resend.com";
+    this.fetchFn = opts.fetch ?? ((...args) => fetch(...(args as Parameters<typeof fetch>)) as ReturnType<HttpFetch>);
+  }
+
+  async send(msg: EmailMessage): Promise<void> {
+    const to = Array.isArray(msg.to) ? [...msg.to] : [msg.to];
+    const body: Record<string, unknown> = {
+      from: msg.from,
+      to,
+      subject: msg.subject,
+      text: msg.text,
+    };
+    if (msg.html) body["html"] = msg.html;
+    const res = await this.fetchFn(`${this.baseUrl}/emails`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${this.apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `ResendTransport: send failed (status ${res.status}): ${text.slice(0, 200)}`,
+      );
+    }
+  }
+}

--- a/packages/integration-email/test/format.test.mjs
+++ b/packages/integration-email/test/format.test.mjs
@@ -1,0 +1,144 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { renderEmail } from "../dist/index.js";
+
+function mkInput(overrides = {}) {
+  return {
+    outcome: {
+      verdict: "approve",
+      rounds: 1,
+      consensusReached: true,
+      results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+    },
+    ctx: { diff: "", repo: "acme/app", pullNumber: 42, newSha: "abc123def" },
+    episodicId: "ep-mail-1",
+    totalCostUsd: 0.021,
+    ...overrides,
+  };
+}
+
+test("renderEmail: subject contains verdict + repo + pr", () => {
+  const { subject } = renderEmail(mkInput());
+  assert.match(subject, /\[conclave\] APPROVE — acme\/app #42/);
+});
+
+test("renderEmail: subject no PR when pullNumber is 0", () => {
+  const { subject } = renderEmail(mkInput({ ctx: { diff: "", repo: "acme/app", pullNumber: 0, newSha: "x" } }));
+  assert.equal(subject, "[conclave] APPROVE — acme/app");
+});
+
+test("renderEmail: text body has verdict/repo/sha lines and per-agent section", () => {
+  const { text } = renderEmail(mkInput());
+  assert.match(text, /Verdict: APPROVE/);
+  assert.match(text, /Repo:\s+acme\/app #42/);
+  assert.match(text, /SHA:\s+abc123def/);
+  assert.match(text, /claude → APPROVE/);
+  assert.match(text, /LGTM/);
+});
+
+test("renderEmail: text body has 'no consensus' tag when applicable", () => {
+  const { text } = renderEmail(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: false,
+        results: [{ agent: "claude", verdict: "rework", blockers: [], summary: "" }],
+      },
+    }),
+  );
+  assert.match(text, /no consensus reached/);
+});
+
+test("renderEmail: text body severity-sorts up to 5 blockers", () => {
+  const blockers = [
+    { severity: "nit", category: "style", message: "nit one" },
+    { severity: "blocker", category: "security", message: "block one", file: "x.ts", line: 3 },
+    { severity: "minor", category: "dead-code", message: "minor one" },
+    { severity: "major", category: "regression", message: "major one" },
+    { severity: "blocker", category: "type-error", message: "block two" },
+    { severity: "nit", category: "style", message: "nit two" },
+    { severity: "minor", category: "dead-code", message: "minor two" },
+  ];
+  const { text } = renderEmail(
+    mkInput({
+      outcome: {
+        verdict: "reject",
+        rounds: 1,
+        consensusReached: true,
+        results: [{ agent: "claude", verdict: "reject", blockers, summary: "" }],
+      },
+    }),
+  );
+  const i1 = text.indexOf("block one");
+  const i2 = text.indexOf("block two");
+  const i3 = text.indexOf("major one");
+  assert.ok(i1 < i2);
+  assert.ok(i2 < i3);
+  assert.match(text, /\+2 more/); // 7 - 5 = 2
+  assert.match(text, /x\.ts:3/);
+});
+
+test("renderEmail: text footer includes cost + episodic id", () => {
+  const { text } = renderEmail(mkInput({ totalCostUsd: 0.0345, episodicId: "ep-xyz" }));
+  assert.match(text, /\$0\.0345/);
+  assert.match(text, /ep-xyz/);
+});
+
+test("renderEmail: HTML body uses inline styles only (email-safe)", () => {
+  const { html } = renderEmail(mkInput());
+  assert.match(html, /<h2 style=/);
+  assert.match(html, /<div style=/);
+  assert.ok(!html.includes("<style>"), "no <style> blocks allowed (unreliable in email clients)");
+  assert.ok(!html.includes("<link"), "no external stylesheets allowed");
+});
+
+test("renderEmail: HTML escapes <, >, &, \"", () => {
+  const { html } = renderEmail(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: true,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [{ severity: "blocker", category: "type-error", message: `got <never> "expected"` }],
+            summary: "a & b",
+          },
+        ],
+      },
+    }),
+  );
+  assert.match(html, /&lt;never&gt;/);
+  assert.match(html, /&quot;expected&quot;/);
+  assert.match(html, /a &amp; b/);
+});
+
+test("renderEmail: HTML links to prUrl", () => {
+  const { html } = renderEmail(mkInput({ prUrl: "https://github.com/acme/app/pull/42" }));
+  assert.match(html, /<a href="https:\/\/github\.com\/acme\/app\/pull\/42"/);
+});
+
+test("renderEmail: HTML has color-coded verdict headline", () => {
+  const approve = renderEmail(mkInput());
+  assert.match(approve.html, /#16a34a/);
+  const reject = renderEmail(
+    mkInput({
+      outcome: {
+        verdict: "reject",
+        rounds: 1,
+        consensusReached: true,
+        results: [{ agent: "claude", verdict: "reject", blockers: [], summary: "" }],
+      },
+    }),
+  );
+  assert.match(reject.html, /#dc2626/);
+});
+
+test("renderEmail: (no blockers) placeholder per agent in both text + html", () => {
+  const { text, html } = renderEmail(mkInput());
+  assert.match(text, /no blockers/);
+  assert.match(html, /no blockers/);
+});

--- a/packages/integration-email/test/notifier.test.mjs
+++ b/packages/integration-email/test/notifier.test.mjs
@@ -1,0 +1,177 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EmailNotifier, ResendTransport } from "../dist/index.js";
+
+function mockFetch(response = { ok: true, status: 200, text: "{}" }) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init, body: JSON.parse(init.body) });
+    return {
+      ok: response.ok,
+      status: response.status,
+      text: async () => response.text,
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const baseInput = {
+  outcome: {
+    verdict: "approve",
+    rounds: 1,
+    consensusReached: true,
+    results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+  },
+  ctx: { diff: "", repo: "acme/app", pullNumber: 42, newSha: "abc" },
+  episodicId: "ep-e",
+  totalCostUsd: 0.01,
+};
+
+// ── ResendTransport ──────────────────────────────────────────────
+
+test("ResendTransport: missing API key throws", () => {
+  const orig = process.env.RESEND_API_KEY;
+  delete process.env.RESEND_API_KEY;
+  try {
+    assert.throws(() => new ResendTransport());
+  } finally {
+    if (orig !== undefined) process.env.RESEND_API_KEY = orig;
+  }
+});
+
+test("ResendTransport: send POSTs to /emails with bearer + JSON body", async () => {
+  const f = mockFetch();
+  const t = new ResendTransport({ apiKey: "re_test", fetch: f });
+  await t.send({ from: "a@x.com", to: "b@x.com", subject: "s", text: "hi", html: "<b>hi</b>" });
+  assert.equal(f.calls.length, 1);
+  assert.ok(f.calls[0].url.endsWith("/emails"));
+  assert.equal(f.calls[0].init.method, "POST");
+  assert.equal(f.calls[0].init.headers.authorization, "Bearer re_test");
+  assert.equal(f.calls[0].init.headers["content-type"], "application/json");
+  assert.deepEqual(f.calls[0].body.to, ["b@x.com"]);
+  assert.equal(f.calls[0].body.html, "<b>hi</b>");
+});
+
+test("ResendTransport: `to` array passed through", async () => {
+  const f = mockFetch();
+  const t = new ResendTransport({ apiKey: "k", fetch: f });
+  await t.send({ from: "a@x.com", to: ["b@x.com", "c@x.com"], subject: "s", text: "t" });
+  assert.deepEqual(f.calls[0].body.to, ["b@x.com", "c@x.com"]);
+});
+
+test("ResendTransport: non-200 throws with status + snippet", async () => {
+  const f = mockFetch({ ok: false, status: 422, text: "invalid from" });
+  const t = new ResendTransport({ apiKey: "k", fetch: f });
+  await assert.rejects(
+    () => t.send({ from: "bad", to: "a@x.com", subject: "s", text: "t" }),
+    /status 422.*invalid from/,
+  );
+});
+
+// ── EmailNotifier ────────────────────────────────────────────────
+
+test("EmailNotifier: rejects missing from", () => {
+  const origF = process.env.CONCLAVE_EMAIL_FROM;
+  const origT = process.env.CONCLAVE_EMAIL_TO;
+  delete process.env.CONCLAVE_EMAIL_FROM;
+  process.env.CONCLAVE_EMAIL_TO = "a@x.com";
+  try {
+    assert.throws(() => new EmailNotifier({ to: "a@x.com", transport: { id: "mock", send: async () => {} } }));
+  } finally {
+    if (origF !== undefined) process.env.CONCLAVE_EMAIL_FROM = origF;
+    if (origT !== undefined) process.env.CONCLAVE_EMAIL_TO = origT;
+    else delete process.env.CONCLAVE_EMAIL_TO;
+  }
+});
+
+test("EmailNotifier: rejects missing to", () => {
+  const origF = process.env.CONCLAVE_EMAIL_FROM;
+  const origT = process.env.CONCLAVE_EMAIL_TO;
+  process.env.CONCLAVE_EMAIL_FROM = "a@x.com";
+  delete process.env.CONCLAVE_EMAIL_TO;
+  try {
+    assert.throws(
+      () => new EmailNotifier({ from: "a@x.com", transport: { id: "mock", send: async () => {} } }),
+    );
+  } finally {
+    if (origF !== undefined) process.env.CONCLAVE_EMAIL_FROM = origF;
+    else delete process.env.CONCLAVE_EMAIL_FROM;
+    if (origT !== undefined) process.env.CONCLAVE_EMAIL_TO = origT;
+  }
+});
+
+test("EmailNotifier: comma-separated CONCLAVE_EMAIL_TO env → array", async () => {
+  const origF = process.env.CONCLAVE_EMAIL_FROM;
+  const origT = process.env.CONCLAVE_EMAIL_TO;
+  process.env.CONCLAVE_EMAIL_FROM = "a@x.com";
+  process.env.CONCLAVE_EMAIL_TO = "b@x.com, c@x.com";
+  try {
+    const sent = [];
+    const transport = { id: "mock", send: async (m) => sent.push(m) };
+    const n = new EmailNotifier({ transport });
+    await n.notifyReview(baseInput);
+    assert.equal(sent.length, 1);
+    assert.deepEqual(sent[0].to, ["b@x.com", "c@x.com"]);
+  } finally {
+    if (origF !== undefined) process.env.CONCLAVE_EMAIL_FROM = origF;
+    else delete process.env.CONCLAVE_EMAIL_FROM;
+    if (origT !== undefined) process.env.CONCLAVE_EMAIL_TO = origT;
+    else delete process.env.CONCLAVE_EMAIL_TO;
+  }
+});
+
+test("EmailNotifier: subjectOverride wins over rendered subject", async () => {
+  const sent = [];
+  const transport = { id: "mock", send: async (m) => sent.push(m) };
+  const n = new EmailNotifier({
+    from: "a@x.com",
+    to: "b@x.com",
+    subjectOverride: "custom subject",
+    transport,
+  });
+  await n.notifyReview(baseInput);
+  assert.equal(sent[0].subject, "custom subject");
+});
+
+test("EmailNotifier: uses rendered subject by default", async () => {
+  const sent = [];
+  const transport = { id: "mock", send: async (m) => sent.push(m) };
+  const n = new EmailNotifier({ from: "a@x.com", to: "b@x.com", transport });
+  await n.notifyReview(baseInput);
+  assert.match(sent[0].subject, /\[conclave\] APPROVE/);
+});
+
+test("EmailNotifier: text + html both sent", async () => {
+  const sent = [];
+  const transport = { id: "mock", send: async (m) => sent.push(m) };
+  const n = new EmailNotifier({ from: "a@x.com", to: "b@x.com", transport });
+  await n.notifyReview(baseInput);
+  assert.ok(sent[0].text && sent[0].text.length > 0);
+  assert.ok(sent[0].html && sent[0].html.length > 0);
+  assert.ok(sent[0].html.includes("<div"));
+});
+
+test("EmailNotifier: custom transport plugs in cleanly", async () => {
+  const calls = [];
+  const transport = {
+    id: "custom-smtp",
+    send: async (m) => {
+      calls.push(m);
+    },
+  };
+  const n = new EmailNotifier({ from: "a@x.com", to: "b@x.com", transport });
+  await n.notifyReview(baseInput);
+  assert.equal(calls.length, 1);
+});
+
+test("EmailNotifier: Notifier interface conformance", () => {
+  const n = new EmailNotifier({
+    from: "a@x.com",
+    to: "b@x.com",
+    transport: { id: "mock", send: async () => {} },
+  });
+  assert.equal(n.id, "email");
+  assert.equal(n.displayName, "Email");
+  assert.equal(typeof n.notifyReview, "function");
+});

--- a/packages/integration-email/tsconfig.json
+++ b/packages/integration-email/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/integration-slack/README.md
+++ b/packages/integration-slack/README.md
@@ -1,0 +1,51 @@
+# @ai-conclave/integration-slack
+
+Slack notifier for Ai-Conclave council reviews. Implements the
+`Notifier` interface from `@ai-conclave/core`.
+
+Decision #24: equal-weight integration alongside Telegram / Discord /
+Email / CLI.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/integration-slack @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { SlackNotifier } from "@ai-conclave/integration-slack";
+
+const slack = new SlackNotifier({
+  webhookUrl: process.env.SLACK_WEBHOOK_URL,
+});
+
+await slack.notifyReview({
+  outcome,
+  ctx,
+  episodicId: episodic.id,
+  totalCostUsd: gate.metrics.summary().totalCostUsd,
+  prUrl: "https://github.com/acme/app/pull/42",
+});
+```
+
+## Setup
+
+1. https://api.slack.com/apps → Create App → From scratch
+2. **Incoming Webhooks** → toggle on → **Add New Webhook to Workspace**
+3. Pick a channel, copy the URL
+4. `export SLACK_WEBHOOK_URL='https://hooks.slack.com/services/…'`
+
+## Message shape
+
+- Block Kit body (sections + context + dividers)
+- Verdict header with emoji, links to PR URL when supplied
+- Per-agent section: top-3 severity-sorted blockers + summary
+- Footer context block: cost + episodic id
+- Fallback `text` field for mobile push notifications
+
+## Inbound interactivity
+
+Not supported here (webhooks are write-only). For slash commands or
+button clicks, add a separate Slack app with OAuth + event subscriptions.

--- a/packages/integration-slack/package.json
+++ b/packages/integration-slack/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ai-conclave/integration-slack",
+  "version": "0.0.0",
+  "description": "Ai-Conclave Slack notifier — posts review outcomes to a Slack channel via incoming webhook.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@ai-conclave/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/integration-slack/src/format.ts
+++ b/packages/integration-slack/src/format.ts
@@ -1,0 +1,117 @@
+import type { NotifyReviewInput } from "@ai-conclave/core";
+
+const VERDICT_EMOJI: Record<"approve" | "rework" | "reject", string> = {
+  approve: ":white_check_mark:",
+  rework: ":wrench:",
+  reject: ":x:",
+};
+
+const SEVERITY_EMOJI: Record<"blocker" | "major" | "minor" | "nit", string> = {
+  blocker: ":no_entry:",
+  major: ":warning:",
+  minor: ":small_blue_diamond:",
+  nit: ":speech_balloon:",
+};
+
+export interface SlackBlock {
+  type: string;
+  text?: { type: "mrkdwn" | "plain_text"; text: string; emoji?: boolean };
+  fields?: Array<{ type: "mrkdwn" | "plain_text"; text: string }>;
+  elements?: Array<{ type: "mrkdwn"; text: string }>;
+}
+
+export interface SlackWebhookPayload {
+  text: string;
+  username?: string;
+  icon_url?: string;
+  icon_emoji?: string;
+  blocks: SlackBlock[];
+}
+
+/**
+ * Render a NotifyReviewInput as a Slack incoming-webhook payload.
+ *
+ * Uses Block Kit (blocks[]) for the rich body; `text` is a fallback for
+ * notifications (mobile banner, push digest). The fallback mirrors the
+ * verdict + repo so notifications are meaningful even when the full
+ * layout doesn't render.
+ *
+ * Slack limits:
+ *   - top-level `text` ≤ 40_000 chars (soft); we truncate at 1_000.
+ *   - each block's text ≤ 3_000 chars; we truncate at 2_900 to leave
+ *     room for wrappers.
+ *   - ≤ 50 blocks per message; we cap on per-agent section count.
+ */
+export function formatReviewForSlack(input: NotifyReviewInput): SlackWebhookPayload {
+  const { outcome, ctx, totalCostUsd, prUrl, episodicId } = input;
+  const verdictTag = `${VERDICT_EMOJI[outcome.verdict]} *${outcome.verdict.toUpperCase()}*`;
+  const title = `${verdictTag} — ${ctx.repo}${ctx.pullNumber ? ` #${ctx.pullNumber}` : ""}`;
+
+  const blocks: SlackBlock[] = [];
+
+  const headerText = prUrl
+    ? `${verdictTag} — <${prUrl}|${escapeText(ctx.repo)} #${ctx.pullNumber}>`
+    : title;
+  blocks.push({ type: "section", text: { type: "mrkdwn", text: trunc(headerText, 2900) } });
+  if (!outcome.consensusReached) {
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: "_no consensus reached_" }],
+    });
+  }
+  blocks.push({ type: "divider" });
+
+  for (const r of outcome.results) {
+    if (blocks.length >= 46) break; // leave slack for divider + footer
+    const header = `${VERDICT_EMOJI[r.verdict]} *${r.agent}* — _${r.verdict}_`;
+    const lines: string[] = [header];
+    if (r.blockers.length === 0) {
+      lines.push("_(no blockers)_");
+    } else {
+      const sorted = [...r.blockers]
+        .sort((a, b) => severityOrder(a.severity) - severityOrder(b.severity))
+        .slice(0, 3);
+      for (const b of sorted) {
+        const where = b.file ? ` \`${b.file}${b.line ? `:${b.line}` : ""}\`` : "";
+        lines.push(`${SEVERITY_EMOJI[b.severity]} *${b.severity}* (${b.category})${where}`);
+        lines.push(`    ${escapeText(b.message)}`);
+      }
+      if (r.blockers.length > 3) lines.push(`_… +${r.blockers.length - 3} more_`);
+    }
+    if (r.summary) lines.push(`_${escapeText(trunc(r.summary, 400))}_`);
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: trunc(lines.join("\n"), 2900) },
+    });
+  }
+
+  blocks.push({ type: "divider" });
+  blocks.push({
+    type: "context",
+    elements: [
+      { type: "mrkdwn", text: `cost \`$${totalCostUsd.toFixed(4)}\` · episodic \`${episodicId}\`` },
+    ],
+  });
+
+  return {
+    text: trunc(title, 1000),
+    blocks,
+  };
+}
+
+function severityOrder(s: "blocker" | "major" | "minor" | "nit"): number {
+  return { blocker: 0, major: 1, minor: 2, nit: 3 }[s];
+}
+
+function trunc(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}
+
+/**
+ * Slack mrkdwn requires escaping `<`, `>`, `&` to avoid entity parsing.
+ * Code fences (backticks) are safe, so blocker `file:line` paths are
+ * wrapped in backticks upstream rather than escaped.
+ */
+function escapeText(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/packages/integration-slack/src/index.ts
+++ b/packages/integration-slack/src/index.ts
@@ -1,0 +1,4 @@
+export { SlackNotifier } from "./notifier.js";
+export type { SlackNotifierOptions, HttpFetch } from "./notifier.js";
+export { formatReviewForSlack } from "./format.js";
+export type { SlackBlock, SlackWebhookPayload } from "./format.js";

--- a/packages/integration-slack/src/notifier.ts
+++ b/packages/integration-slack/src/notifier.ts
@@ -1,0 +1,75 @@
+import type { Notifier, NotifyReviewInput } from "@ai-conclave/core";
+import { formatReviewForSlack } from "./format.js";
+
+export interface HttpFetch {
+  (url: string, init: { method: string; headers: Record<string, string>; body: string }): Promise<{
+    ok: boolean;
+    status: number;
+    text: () => Promise<string>;
+  }>;
+}
+
+export interface SlackNotifierOptions {
+  /** Incoming webhook URL (or set via SLACK_WEBHOOK_URL env). */
+  webhookUrl?: string;
+  /** Override display username. */
+  username?: string;
+  /** Override icon URL or emoji. At most one used; url wins if both set. */
+  iconUrl?: string;
+  iconEmoji?: string;
+  /** Inject fetch for tests. */
+  fetch?: HttpFetch;
+}
+
+const DEFAULT_USERNAME = "Ai-Conclave";
+
+/**
+ * SlackNotifier — posts review outcomes to a Slack channel via incoming
+ * webhook. Same pattern as `@ai-conclave/integration-discord` — write-only,
+ * no OAuth.
+ */
+export class SlackNotifier implements Notifier {
+  readonly id = "slack";
+  readonly displayName = "Slack";
+
+  private readonly webhookUrl: string;
+  private readonly username: string;
+  private readonly iconUrl: string | undefined;
+  private readonly iconEmoji: string | undefined;
+  private readonly fetchFn: HttpFetch;
+
+  constructor(opts: SlackNotifierOptions = {}) {
+    const url = opts.webhookUrl ?? process.env["SLACK_WEBHOOK_URL"] ?? "";
+    if (!url) {
+      throw new Error("SlackNotifier: SLACK_WEBHOOK_URL not set (pass opts.webhookUrl or env)");
+    }
+    if (!/^https:\/\/hooks\.slack\.com\/services\//i.test(url)) {
+      throw new Error("SlackNotifier: webhookUrl must be an https://hooks.slack.com/services/... URL");
+    }
+    this.webhookUrl = url;
+    this.username = opts.username ?? DEFAULT_USERNAME;
+    this.iconUrl = opts.iconUrl;
+    this.iconEmoji = opts.iconEmoji;
+    this.fetchFn =
+      opts.fetch ?? ((...args) => fetch(...(args as Parameters<typeof fetch>)) as ReturnType<HttpFetch>);
+  }
+
+  async notifyReview(input: NotifyReviewInput): Promise<void> {
+    const payload = formatReviewForSlack(input);
+    payload.username = this.username;
+    if (this.iconUrl) payload.icon_url = this.iconUrl;
+    else if (this.iconEmoji) payload.icon_emoji = this.iconEmoji;
+
+    const res = await this.fetchFn(this.webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `SlackNotifier: webhook POST failed (status ${res.status}): ${text.slice(0, 200)}`,
+      );
+    }
+  }
+}

--- a/packages/integration-slack/test/format.test.mjs
+++ b/packages/integration-slack/test/format.test.mjs
@@ -1,0 +1,159 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatReviewForSlack } from "../dist/index.js";
+
+function mkInput(overrides = {}) {
+  return {
+    outcome: {
+      verdict: "approve",
+      rounds: 1,
+      consensusReached: true,
+      results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+    },
+    ctx: { diff: "", repo: "acme/app", pullNumber: 42, newSha: "sha-head" },
+    episodicId: "ep-slack-1",
+    totalCostUsd: 0.0123,
+    ...overrides,
+  };
+}
+
+test("formatReviewForSlack: top-level text fallback summarizes verdict + repo", () => {
+  const p = formatReviewForSlack(mkInput());
+  assert.match(p.text, /APPROVE/);
+  assert.match(p.text, /acme\/app #42/);
+});
+
+test("formatReviewForSlack: header section uses slack mrkdwn link when prUrl supplied", () => {
+  const p = formatReviewForSlack(mkInput({ prUrl: "https://github.com/acme/app/pull/42" }));
+  const first = p.blocks.find((b) => b.type === "section");
+  assert.match(first.text.text, /<https:\/\/github\.com\/acme\/app\/pull\/42\|/);
+});
+
+test("formatReviewForSlack: no-consensus context block", () => {
+  const p = formatReviewForSlack(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: false,
+        results: [{ agent: "claude", verdict: "rework", blockers: [], summary: "" }],
+      },
+    }),
+  );
+  const ctx = p.blocks.find((b) => b.type === "context" && b.elements?.[0]?.text?.includes("consensus"));
+  assert.ok(ctx);
+});
+
+test("formatReviewForSlack: escapes slack-special chars (< > &)", () => {
+  const p = formatReviewForSlack(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: true,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [{ severity: "blocker", category: "type-error", message: "got <never> expected" }],
+            summary: "a & b",
+          },
+        ],
+      },
+    }),
+  );
+  const agentSection = p.blocks.find((b) => b.type === "section" && b.text?.text?.includes("claude"));
+  assert.ok(agentSection);
+  assert.match(agentSection.text.text, /&lt;never&gt;/);
+  assert.match(agentSection.text.text, /a &amp; b/);
+});
+
+test("formatReviewForSlack: severity-sorted top-3 + overflow count", () => {
+  const blockers = [
+    { severity: "nit", category: "style", message: "nit one" },
+    { severity: "blocker", category: "security", message: "block one" },
+    { severity: "minor", category: "dead-code", message: "minor one" },
+    { severity: "major", category: "regression", message: "major one" },
+    { severity: "blocker", category: "type-error", message: "block two" },
+  ];
+  const p = formatReviewForSlack(
+    mkInput({
+      outcome: {
+        verdict: "reject",
+        rounds: 1,
+        consensusReached: true,
+        results: [{ agent: "claude", verdict: "reject", blockers, summary: "" }],
+      },
+    }),
+  );
+  const section = p.blocks.find((b) => b.type === "section" && b.text?.text?.includes("claude"));
+  const txt = section.text.text;
+  const i1 = txt.indexOf("block one");
+  const i2 = txt.indexOf("block two");
+  const i3 = txt.indexOf("major one");
+  assert.ok(i1 < i2);
+  assert.ok(i2 < i3);
+  assert.match(txt, /\+2 more/);
+});
+
+test("formatReviewForSlack: footer context block has cost + episodic id", () => {
+  const p = formatReviewForSlack(mkInput({ totalCostUsd: 0.0345, episodicId: "ep-z" }));
+  const footer = p.blocks[p.blocks.length - 1];
+  assert.equal(footer.type, "context");
+  assert.match(footer.elements[0].text, /\$0\.0345/);
+  assert.match(footer.elements[0].text, /ep-z/);
+});
+
+test("formatReviewForSlack: dividers bracket the per-agent sections", () => {
+  const p = formatReviewForSlack(mkInput());
+  const dividers = p.blocks.filter((b) => b.type === "divider");
+  assert.equal(dividers.length, 2);
+});
+
+test("formatReviewForSlack: caps total blocks under 50", () => {
+  const many = [];
+  for (let i = 0; i < 60; i += 1) {
+    many.push({ agent: `a-${i}`, verdict: "approve", blockers: [], summary: "" });
+  }
+  const p = formatReviewForSlack(
+    mkInput({
+      outcome: {
+        verdict: "approve",
+        rounds: 1,
+        consensusReached: true,
+        results: many,
+      },
+    }),
+  );
+  assert.ok(p.blocks.length <= 50);
+});
+
+test("formatReviewForSlack: (no blockers) placeholder per agent", () => {
+  const p = formatReviewForSlack(mkInput());
+  const section = p.blocks.find((b) => b.type === "section" && b.text?.text?.includes("claude"));
+  assert.match(section.text.text, /no blockers/);
+});
+
+test("formatReviewForSlack: truncates section text at 2900 chars", () => {
+  const huge = "x".repeat(10_000);
+  const p = formatReviewForSlack(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: true,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [{ severity: "blocker", category: "security", message: huge }],
+            summary: "",
+          },
+        ],
+      },
+    }),
+  );
+  for (const b of p.blocks) {
+    if (b.text) assert.ok(b.text.text.length <= 2900, `block text too long: ${b.text.text.length}`);
+  }
+});

--- a/packages/integration-slack/test/notifier.test.mjs
+++ b/packages/integration-slack/test/notifier.test.mjs
@@ -1,0 +1,115 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { SlackNotifier } from "../dist/index.js";
+
+function mockFetch(response = { ok: true, status: 200, text: "ok" }) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init, body: JSON.parse(init.body) });
+    return {
+      ok: response.ok,
+      status: response.status,
+      text: async () => response.text,
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const baseInput = {
+  outcome: {
+    verdict: "approve",
+    rounds: 1,
+    consensusReached: true,
+    results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+  },
+  ctx: { diff: "", repo: "acme/app", pullNumber: 42, newSha: "abc" },
+  episodicId: "ep-s",
+  totalCostUsd: 0.01,
+};
+
+const GOOD_WEBHOOK = "https://hooks.slack.com/services/T000/B000/xxxx";
+
+test("SlackNotifier: missing webhook URL throws", () => {
+  const orig = process.env.SLACK_WEBHOOK_URL;
+  delete process.env.SLACK_WEBHOOK_URL;
+  try {
+    assert.throws(() => new SlackNotifier());
+  } finally {
+    if (orig !== undefined) process.env.SLACK_WEBHOOK_URL = orig;
+  }
+});
+
+test("SlackNotifier: non-hooks.slack.com URL throws", () => {
+  assert.throws(() => new SlackNotifier({ webhookUrl: "https://evil.example.com/wh" }));
+});
+
+test("SlackNotifier: POST + JSON body", async () => {
+  const f = mockFetch();
+  const n = new SlackNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: f });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls.length, 1);
+  assert.equal(f.calls[0].url, GOOD_WEBHOOK);
+  assert.equal(f.calls[0].init.method, "POST");
+  assert.equal(f.calls[0].init.headers["content-type"], "application/json");
+});
+
+test("SlackNotifier: default username + iconEmoji/iconUrl behavior", async () => {
+  const f = mockFetch();
+  const n = new SlackNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: f });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.username, "Ai-Conclave");
+  assert.equal(f.calls[0].body.icon_url, undefined);
+  assert.equal(f.calls[0].body.icon_emoji, undefined);
+});
+
+test("SlackNotifier: iconUrl wins over iconEmoji when both supplied", async () => {
+  const f = mockFetch();
+  const n = new SlackNotifier({
+    webhookUrl: GOOD_WEBHOOK,
+    fetch: f,
+    iconUrl: "https://example.com/img.png",
+    iconEmoji: ":robot_face:",
+  });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.icon_url, "https://example.com/img.png");
+  assert.equal(f.calls[0].body.icon_emoji, undefined);
+});
+
+test("SlackNotifier: iconEmoji used when iconUrl absent", async () => {
+  const f = mockFetch();
+  const n = new SlackNotifier({
+    webhookUrl: GOOD_WEBHOOK,
+    fetch: f,
+    iconEmoji: ":robot_face:",
+  });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.icon_emoji, ":robot_face:");
+});
+
+test("SlackNotifier: non-200 throws with status + body snippet", async () => {
+  const f = mockFetch({ ok: false, status: 400, text: "invalid_payload" });
+  const n = new SlackNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: f });
+  await assert.rejects(() => n.notifyReview(baseInput), /status 400.*invalid_payload/);
+});
+
+test("SlackNotifier: SLACK_WEBHOOK_URL env fallback", async () => {
+  const orig = process.env.SLACK_WEBHOOK_URL;
+  process.env.SLACK_WEBHOOK_URL = GOOD_WEBHOOK;
+  const f = mockFetch();
+  try {
+    const n = new SlackNotifier({ fetch: f });
+    await n.notifyReview(baseInput);
+    assert.equal(f.calls[0].url, GOOD_WEBHOOK);
+  } finally {
+    if (orig !== undefined) process.env.SLACK_WEBHOOK_URL = orig;
+    else delete process.env.SLACK_WEBHOOK_URL;
+  }
+});
+
+test("SlackNotifier: Notifier interface conformance", () => {
+  const n = new SlackNotifier({ webhookUrl: GOOD_WEBHOOK, fetch: async () => ({ ok: true, status: 200, text: async () => "" }) });
+  assert.equal(n.id, "slack");
+  assert.equal(n.displayName, "Slack");
+  assert.equal(typeof n.notifyReview, "function");
+});

--- a/packages/integration-slack/tsconfig.json
+++ b/packages/integration-slack/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/integration-telegram/README.md
+++ b/packages/integration-telegram/README.md
@@ -1,0 +1,56 @@
+# @ai-conclave/integration-telegram
+
+Telegram notifier for Ai-Conclave council reviews. Implements the
+`Notifier` interface from `@ai-conclave/core`.
+
+Decision #24: equal-weight integration alongside Discord / Slack / Email
+/ CLI. No hero surface.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/integration-telegram @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { TelegramNotifier } from "@ai-conclave/integration-telegram";
+
+const telegram = new TelegramNotifier({
+  token: process.env.TELEGRAM_BOT_TOKEN,
+  chatId: process.env.TELEGRAM_CHAT_ID,
+});
+
+// After Council.deliberate:
+await telegram.notifyReview({
+  outcome,
+  ctx,
+  episodicId: episodic.id,
+  totalCostUsd: gate.metrics.summary().totalCostUsd,
+  prUrl: "https://github.com/acme/app/pull/42",
+});
+```
+
+## Setup
+
+1. Create a bot via [@BotFather](https://t.me/BotFather) and save the token
+2. Open a chat with the bot OR add it to a group
+3. Get your chat id:
+   ```bash
+   curl "https://api.telegram.org/bot<TOKEN>/getUpdates"
+   ```
+   (Send a message to the bot first, then the chat id appears in the result.)
+4. Set `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in your env.
+
+## What's in the message
+
+- Header: verdict emoji + repo + PR link (if supplied)
+- Per-agent verdict + top-3 blockers by severity
+- Summary per agent
+- Footer: total cost + episodic id (for later `conclave record-outcome`)
+- Inline action buttons: ✅ Approve / 🔧 Rework / ❌ Reject
+
+Inline buttons emit `callback_data = "ep:<episodicId>:<outcome>"` — a
+callback handler in a future package can close the loop by invoking
+`OutcomeWriter.recordOutcome` directly.

--- a/packages/integration-telegram/package.json
+++ b/packages/integration-telegram/package.json
@@ -1,13 +1,16 @@
 {
-  "name": "@ai-conclave/cli",
+  "name": "@ai-conclave/integration-telegram",
   "version": "0.0.0",
-  "description": "Ai-Conclave CLI — the `conclave` binary.",
+  "description": "Ai-Conclave Telegram notifier — posts review outcomes to a Telegram chat via Bot API.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "conclave": "./dist/bin/conclave.js"
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",
@@ -22,14 +25,7 @@
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {
-    "@ai-conclave/agent-claude": "workspace:*",
-    "@ai-conclave/agent-gemini": "workspace:*",
-    "@ai-conclave/agent-openai": "workspace:*",
-    "@ai-conclave/core": "workspace:*",
-    "@ai-conclave/integration-telegram": "workspace:*",
-    "@ai-conclave/observability-langfuse": "workspace:*",
-    "@ai-conclave/scm-github": "workspace:*",
-    "zod": "^3.24.0"
+    "@ai-conclave/core": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/packages/integration-telegram/src/client.ts
+++ b/packages/integration-telegram/src/client.ts
@@ -1,0 +1,80 @@
+export interface TelegramSendMessageParams {
+  chat_id: number | string;
+  text: string;
+  parse_mode?: "HTML" | "MarkdownV2";
+  disable_web_page_preview?: boolean;
+  reply_markup?: TelegramInlineKeyboard;
+}
+
+export interface TelegramInlineKeyboard {
+  inline_keyboard: TelegramInlineKeyboardButton[][];
+}
+
+export interface TelegramInlineKeyboardButton {
+  text: string;
+  callback_data?: string;
+  url?: string;
+}
+
+export interface TelegramResponse<T> {
+  ok: boolean;
+  result?: T;
+  description?: string;
+  error_code?: number;
+}
+
+export interface HttpFetch {
+  (url: string, init: { method: string; headers: Record<string, string>; body: string }): Promise<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+    text: () => Promise<string>;
+  }>;
+}
+
+/**
+ * Thin Telegram Bot API wrapper. Uses native fetch (Node 20+) by default;
+ * accepts an injected `HttpFetch` for tests.
+ *
+ * Intentionally limited to the methods the notifier needs — any expansion
+ * stays under ~200 lines to keep dep surface thin. Full bot command-loop
+ * + webhook listener lives in a separate package if/when Bae wants it.
+ */
+export class TelegramClient {
+  private readonly token: string;
+  private readonly baseUrl: string;
+  private readonly fetchFn: HttpFetch;
+
+  constructor(opts: { token: string; baseUrl?: string; fetch?: HttpFetch }) {
+    if (!opts.token) throw new Error("TelegramClient: token is required");
+    this.token = opts.token;
+    this.baseUrl = opts.baseUrl ?? "https://api.telegram.org";
+    this.fetchFn = opts.fetch ?? ((...args) => fetch(...(args as Parameters<typeof fetch>)) as ReturnType<HttpFetch>);
+  }
+
+  async sendMessage(params: TelegramSendMessageParams): Promise<TelegramResponse<unknown>> {
+    return this.call("sendMessage", params);
+  }
+
+  private async call<T>(method: string, body: unknown): Promise<TelegramResponse<T>> {
+    const url = `${this.baseUrl}/bot${this.token}/${method}`;
+    const res = await this.fetchFn(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    let data: TelegramResponse<T>;
+    try {
+      data = (await res.json()) as TelegramResponse<T>;
+    } catch {
+      const text = await res.text();
+      throw new Error(`TelegramClient: ${method} returned non-JSON (status ${res.status}): ${text.slice(0, 200)}`);
+    }
+    if (!data.ok) {
+      throw new Error(
+        `TelegramClient: ${method} failed — ${data.description ?? "no description"} (code ${data.error_code ?? "?"})`,
+      );
+    }
+    return data;
+  }
+}

--- a/packages/integration-telegram/src/format.ts
+++ b/packages/integration-telegram/src/format.ts
@@ -1,0 +1,77 @@
+import type { NotifyReviewInput } from "@ai-conclave/core";
+
+const VERDICT_EMOJI: Record<"approve" | "rework" | "reject", string> = {
+  approve: "✅",
+  rework: "🔧",
+  reject: "❌",
+};
+
+const SEVERITY_EMOJI: Record<"blocker" | "major" | "minor" | "nit", string> = {
+  blocker: "🛑",
+  major: "⚠️",
+  minor: "🔹",
+  nit: "💬",
+};
+
+/** Telegram HTML mode allows <b>, <i>, <code>, <pre>, <a href>. Escape &, <, >. */
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Render a NotifyReviewInput into a Telegram HTML-mode message body.
+ *
+ * Contract:
+ *   - Max length 4096 chars per Telegram (longer → truncated with ellipsis).
+ *   - Per-agent sections, each capped to the top-3 blockers by severity.
+ *   - Repo + PR link line at the top if `prUrl` is set.
+ *   - Cost + episodic id in a footer for ops visibility.
+ */
+export function formatReviewForTelegram(input: NotifyReviewInput): string {
+  const { outcome, ctx, totalCostUsd, prUrl, episodicId } = input;
+  const lines: string[] = [];
+
+  const verdictBadge = `${VERDICT_EMOJI[outcome.verdict]} <b>${outcome.verdict.toUpperCase()}</b>`;
+  const header = prUrl
+    ? `${verdictBadge} — <a href="${esc(prUrl)}">${esc(ctx.repo)} #${ctx.pullNumber}</a>`
+    : `${verdictBadge} — <b>${esc(ctx.repo)}${ctx.pullNumber ? ` #${ctx.pullNumber}` : ""}</b>`;
+  lines.push(header);
+  if (!outcome.consensusReached) lines.push("<i>no consensus reached</i>");
+  lines.push("");
+
+  for (const result of outcome.results) {
+    lines.push(
+      `<b>${esc(result.agent)}</b> → ${VERDICT_EMOJI[result.verdict]} <i>${result.verdict}</i>`,
+    );
+    if (result.blockers.length === 0) {
+      lines.push("  (no blockers)");
+    } else {
+      const sorted = [...result.blockers]
+        .sort((a, b) => severityOrder(a.severity) - severityOrder(b.severity))
+        .slice(0, 3);
+      for (const b of sorted) {
+        const where = b.file ? ` <code>${esc(b.file)}${b.line ? `:${b.line}` : ""}</code>` : "";
+        lines.push(
+          `  ${SEVERITY_EMOJI[b.severity]} <b>${b.severity}</b> (${esc(b.category)})${where}`,
+        );
+        lines.push(`    ${esc(b.message)}`);
+      }
+      if (result.blockers.length > 3) lines.push(`  … +${result.blockers.length - 3} more`);
+    }
+    if (result.summary) lines.push(`  <i>${esc(truncate(result.summary, 240))}</i>`);
+    lines.push("");
+  }
+
+  lines.push(`<i>cost: $${totalCostUsd.toFixed(4)} · episodic: <code>${esc(episodicId)}</code></i>`);
+
+  const message = lines.join("\n");
+  return message.length <= 4090 ? message : message.slice(0, 4085) + "\n…";
+}
+
+function severityOrder(s: "blocker" | "major" | "minor" | "nit"): number {
+  return { blocker: 0, major: 1, minor: 2, nit: 3 }[s];
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}

--- a/packages/integration-telegram/src/index.ts
+++ b/packages/integration-telegram/src/index.ts
@@ -1,0 +1,11 @@
+export { TelegramClient } from "./client.js";
+export type {
+  TelegramSendMessageParams,
+  TelegramInlineKeyboard,
+  TelegramInlineKeyboardButton,
+  TelegramResponse,
+  HttpFetch,
+} from "./client.js";
+export { TelegramNotifier } from "./notifier.js";
+export type { TelegramNotifierOptions } from "./notifier.js";
+export { formatReviewForTelegram } from "./format.js";

--- a/packages/integration-telegram/src/notifier.ts
+++ b/packages/integration-telegram/src/notifier.ts
@@ -1,0 +1,84 @@
+import type { Notifier, NotifyReviewInput } from "@ai-conclave/core";
+import { TelegramClient, type HttpFetch, type TelegramInlineKeyboard } from "./client.js";
+import { formatReviewForTelegram } from "./format.js";
+
+export interface TelegramNotifierOptions {
+  /** Bot token from BotFather. If omitted, read from TELEGRAM_BOT_TOKEN env. */
+  token?: string;
+  /** Chat id (user or group). If omitted, read from TELEGRAM_CHAT_ID env. */
+  chatId?: number | string;
+  /** Pre-built client (tests). */
+  client?: TelegramClient;
+  /** Inject fetch for tests. */
+  fetch?: HttpFetch;
+  /** Base URL override (tests or self-hosted bot API). */
+  baseUrl?: string;
+  /** If true, attaches inline buttons (approve/reject/rework) to the message. Default true. */
+  includeActionButtons?: boolean;
+}
+
+/**
+ * TelegramNotifier — posts review outcomes to a Telegram chat.
+ *
+ * Decision #24: Telegram is an equal-weight integration alongside
+ * Discord / Slack / Email / CLI. No "hero" surface. This notifier is
+ * intentionally minimal — sendMessage + optional action buttons.
+ * Inbound bot command handling (approve via button, /status, etc.) lives
+ * in a separate command-surface package if/when added.
+ */
+export class TelegramNotifier implements Notifier {
+  readonly id = "telegram";
+  readonly displayName = "Telegram";
+
+  private readonly chatId: number | string;
+  private readonly client: TelegramClient;
+  private readonly includeActionButtons: boolean;
+
+  constructor(opts: TelegramNotifierOptions = {}) {
+    const token = opts.token ?? process.env["TELEGRAM_BOT_TOKEN"] ?? "";
+    const chatRaw = opts.chatId ?? process.env["TELEGRAM_CHAT_ID"] ?? "";
+    if (!token && !opts.client) {
+      throw new Error("TelegramNotifier: TELEGRAM_BOT_TOKEN not set (pass opts.token, opts.client, or env)");
+    }
+    if (!chatRaw) {
+      throw new Error("TelegramNotifier: TELEGRAM_CHAT_ID not set (pass opts.chatId or env)");
+    }
+    this.chatId = typeof chatRaw === "string" && /^-?\d+$/.test(chatRaw) ? Number(chatRaw) : chatRaw;
+    if (opts.client) {
+      this.client = opts.client;
+    } else {
+      const clientOpts: ConstructorParameters<typeof TelegramClient>[0] = { token };
+      if (opts.fetch) clientOpts.fetch = opts.fetch;
+      if (opts.baseUrl) clientOpts.baseUrl = opts.baseUrl;
+      this.client = new TelegramClient(clientOpts);
+    }
+    this.includeActionButtons = opts.includeActionButtons ?? true;
+  }
+
+  async notifyReview(input: NotifyReviewInput): Promise<void> {
+    const text = formatReviewForTelegram(input);
+    const sendParams: Parameters<TelegramClient["sendMessage"]>[0] = {
+      chat_id: this.chatId,
+      text,
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+    };
+    if (this.includeActionButtons) {
+      sendParams.reply_markup = buildActionKeyboard(input);
+    }
+    await this.client.sendMessage(sendParams);
+  }
+}
+
+function buildActionKeyboard(input: NotifyReviewInput): TelegramInlineKeyboard {
+  // callback_data is constrained to 64 bytes by Telegram — keep it compact.
+  const id = input.episodicId;
+  const row = [
+    { text: "✅ Approve", callback_data: `ep:${id}:merged` },
+    { text: "🔧 Rework", callback_data: `ep:${id}:reworked` },
+    { text: "❌ Reject", callback_data: `ep:${id}:rejected` },
+  ];
+  // If the button callback_data is too long, drop it. Episodic ids are
+  // ~40 chars so `ep:${id}:merged` ≈ 50 chars — within 64-byte limit.
+  return { inline_keyboard: [row] };
+}

--- a/packages/integration-telegram/test/client.test.mjs
+++ b/packages/integration-telegram/test/client.test.mjs
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { TelegramClient } from "../dist/index.js";
+
+function mockFetch(responses) {
+  let i = 0;
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: async () => r.json,
+      text: async () => r.text ?? JSON.stringify(r.json),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+test("TelegramClient: rejects empty token", () => {
+  assert.throws(() => new TelegramClient({ token: "" }));
+});
+
+test("TelegramClient: sendMessage issues POST to /botTOKEN/sendMessage", async () => {
+  const f = mockFetch([{ json: { ok: true, result: { message_id: 1 } } }]);
+  const client = new TelegramClient({ token: "test-token", fetch: f });
+  await client.sendMessage({ chat_id: 123, text: "hi" });
+  assert.equal(f.calls.length, 1);
+  assert.equal(f.calls[0].url, "https://api.telegram.org/bottest-token/sendMessage");
+  assert.equal(f.calls[0].init.method, "POST");
+  assert.equal(f.calls[0].init.headers["content-type"], "application/json");
+  assert.match(f.calls[0].init.body, /"chat_id":123/);
+});
+
+test("TelegramClient: throws on ok=false with Telegram description", async () => {
+  const f = mockFetch([
+    { json: { ok: false, description: "chat not found", error_code: 400 } },
+  ]);
+  const client = new TelegramClient({ token: "t", fetch: f });
+  await assert.rejects(
+    () => client.sendMessage({ chat_id: 0, text: "x" }),
+    /chat not found.*code 400/,
+  );
+});
+
+test("TelegramClient: throws on non-JSON response with status + snippet", async () => {
+  const f = async () => ({
+    ok: false,
+    status: 502,
+    json: async () => {
+      throw new Error("invalid json");
+    },
+    text: async () => "upstream error page".repeat(50),
+  });
+  const client = new TelegramClient({ token: "t", fetch: f });
+  await assert.rejects(() => client.sendMessage({ chat_id: 0, text: "x" }), /non-JSON.*status 502/);
+});
+
+test("TelegramClient: honors baseUrl override", async () => {
+  const f = mockFetch([{ json: { ok: true, result: {} } }]);
+  const client = new TelegramClient({ token: "t", fetch: f, baseUrl: "https://telegram.local" });
+  await client.sendMessage({ chat_id: 1, text: "hi" });
+  assert.ok(f.calls[0].url.startsWith("https://telegram.local/"));
+});

--- a/packages/integration-telegram/test/format.test.mjs
+++ b/packages/integration-telegram/test/format.test.mjs
@@ -1,0 +1,137 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatReviewForTelegram } from "../dist/index.js";
+
+function mkInput(overrides = {}) {
+  return {
+    outcome: {
+      verdict: "approve",
+      rounds: 1,
+      results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+      consensusReached: true,
+    },
+    ctx: {
+      diff: "",
+      repo: "acme/app",
+      pullNumber: 42,
+      newSha: "abc123",
+    },
+    episodicId: "ep-test-1",
+    totalCostUsd: 0.0153,
+    ...overrides,
+  };
+}
+
+test("formatReviewForTelegram: approve with HTML emoji header", () => {
+  const msg = formatReviewForTelegram(mkInput());
+  assert.match(msg, /✅ <b>APPROVE<\/b>/);
+  assert.match(msg, /acme\/app.*#42/);
+  assert.match(msg, /LGTM/);
+});
+
+test("formatReviewForTelegram: link to prUrl when supplied", () => {
+  const msg = formatReviewForTelegram(mkInput({ prUrl: "https://github.com/acme/app/pull/42" }));
+  assert.match(msg, /<a href="https:\/\/github\.com\/acme\/app\/pull\/42">/);
+});
+
+test("formatReviewForTelegram: escapes HTML-special chars in content", () => {
+  const msg = formatReviewForTelegram(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: true,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [
+              { severity: "blocker", category: "type-error", message: "got <never> expected <string>", file: "x<.ts" },
+            ],
+            summary: "a & b",
+          },
+        ],
+      },
+    }),
+  );
+  assert.ok(!msg.includes("<never>"), "raw angle brackets must be escaped");
+  assert.match(msg, /&lt;never&gt;/);
+  assert.match(msg, /a &amp; b/);
+});
+
+test("formatReviewForTelegram: severity-sorts blockers and caps at 3", () => {
+  const blockers = [
+    { severity: "nit", category: "style", message: "nit 1" },
+    { severity: "blocker", category: "security", message: "block 1" },
+    { severity: "minor", category: "dead-code", message: "minor 1" },
+    { severity: "major", category: "regression", message: "major 1" },
+    { severity: "blocker", category: "type-error", message: "block 2" },
+  ];
+  const msg = formatReviewForTelegram(
+    mkInput({
+      outcome: {
+        verdict: "reject",
+        rounds: 1,
+        consensusReached: true,
+        results: [{ agent: "claude", verdict: "reject", blockers, summary: "" }],
+      },
+    }),
+  );
+  // Top-3 by severity: block 1, block 2, major 1
+  const order = ["block 1", "block 2", "major 1"];
+  let lastIdx = -1;
+  for (const label of order) {
+    const idx = msg.indexOf(label);
+    assert.ok(idx > lastIdx, `expected "${label}" to appear in order`);
+    lastIdx = idx;
+  }
+  assert.match(msg, /\+2 more/); // 5 blockers minus 3 shown = 2 more
+});
+
+test("formatReviewForTelegram: no-consensus tag", () => {
+  const msg = formatReviewForTelegram(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: false,
+        results: [{ agent: "claude", verdict: "rework", blockers: [], summary: "" }],
+      },
+    }),
+  );
+  assert.match(msg, /no consensus/);
+});
+
+test("formatReviewForTelegram: footer includes cost + episodic id", () => {
+  const msg = formatReviewForTelegram(mkInput({ totalCostUsd: 0.0345, episodicId: "ep-xyz" }));
+  assert.match(msg, /\$0\.0345/);
+  assert.match(msg, /ep-xyz/);
+});
+
+test("formatReviewForTelegram: truncates if longer than 4096 chars", () => {
+  const huge = "x".repeat(12_000);
+  const msg = formatReviewForTelegram(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: true,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [{ severity: "blocker", category: "security", message: huge }],
+            summary: "",
+          },
+        ],
+      },
+    }),
+  );
+  assert.ok(msg.length <= 4096, `expected ≤ 4096 chars, got ${msg.length}`);
+  assert.ok(msg.endsWith("…"));
+});
+
+test("formatReviewForTelegram: (no blockers) placeholder when empty", () => {
+  const msg = formatReviewForTelegram(mkInput());
+  assert.match(msg, /no blockers/);
+});

--- a/packages/integration-telegram/test/notifier.test.mjs
+++ b/packages/integration-telegram/test/notifier.test.mjs
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { TelegramNotifier } from "../dist/index.js";
+
+function mockFetch(response = { ok: true, result: { message_id: 1 } }) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init, body: JSON.parse(init.body) });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => response,
+      text: async () => JSON.stringify(response),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const baseInput = {
+  outcome: {
+    verdict: "approve",
+    rounds: 1,
+    consensusReached: true,
+    results: [{ agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" }],
+  },
+  ctx: { diff: "", repo: "acme/app", pullNumber: 42, newSha: "abc" },
+  episodicId: "ep-test",
+  totalCostUsd: 0.01,
+};
+
+test("TelegramNotifier: constructor throws on missing token", () => {
+  const orig = process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  try {
+    assert.throws(() => new TelegramNotifier({ chatId: 1 }));
+  } finally {
+    if (orig !== undefined) process.env.TELEGRAM_BOT_TOKEN = orig;
+  }
+});
+
+test("TelegramNotifier: constructor throws on missing chatId", () => {
+  const orig = process.env.TELEGRAM_CHAT_ID;
+  delete process.env.TELEGRAM_CHAT_ID;
+  try {
+    assert.throws(() => new TelegramNotifier({ token: "t" }));
+  } finally {
+    if (orig !== undefined) process.env.TELEGRAM_CHAT_ID = orig;
+  }
+});
+
+test("TelegramNotifier: numeric-string chat id is coerced to number", async () => {
+  const f = mockFetch();
+  const n = new TelegramNotifier({ token: "t", chatId: "-100123", fetch: f });
+  await n.notifyReview(baseInput);
+  assert.equal(typeof f.calls[0].body.chat_id, "number");
+  assert.equal(f.calls[0].body.chat_id, -100123);
+});
+
+test("TelegramNotifier: notifyReview posts HTML + disable_web_page_preview", async () => {
+  const f = mockFetch();
+  const n = new TelegramNotifier({ token: "t", chatId: 999, fetch: f });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.parse_mode, "HTML");
+  assert.equal(f.calls[0].body.disable_web_page_preview, true);
+  assert.match(f.calls[0].body.text, /APPROVE/);
+});
+
+test("TelegramNotifier: includes inline action keyboard by default", async () => {
+  const f = mockFetch();
+  const n = new TelegramNotifier({ token: "t", chatId: 999, fetch: f });
+  await n.notifyReview(baseInput);
+  const kb = f.calls[0].body.reply_markup?.inline_keyboard;
+  assert.ok(Array.isArray(kb));
+  assert.equal(kb[0].length, 3);
+  const callbacks = kb[0].map((b) => b.callback_data);
+  assert.ok(callbacks[0].startsWith("ep:ep-test:merged"));
+  assert.ok(callbacks[1].startsWith("ep:ep-test:reworked"));
+  assert.ok(callbacks[2].startsWith("ep:ep-test:rejected"));
+});
+
+test("TelegramNotifier: includeActionButtons:false omits reply_markup", async () => {
+  const f = mockFetch();
+  const n = new TelegramNotifier({ token: "t", chatId: 999, fetch: f, includeActionButtons: false });
+  await n.notifyReview(baseInput);
+  assert.equal(f.calls[0].body.reply_markup, undefined);
+});
+
+test("TelegramNotifier: uses TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID env fallback", async () => {
+  const origT = process.env.TELEGRAM_BOT_TOKEN;
+  const origC = process.env.TELEGRAM_CHAT_ID;
+  process.env.TELEGRAM_BOT_TOKEN = "env-token";
+  process.env.TELEGRAM_CHAT_ID = "555";
+  const f = mockFetch();
+  try {
+    const n = new TelegramNotifier({ fetch: f });
+    await n.notifyReview(baseInput);
+    assert.ok(f.calls[0].url.includes("env-token"));
+    assert.equal(f.calls[0].body.chat_id, 555);
+  } finally {
+    if (origT !== undefined) process.env.TELEGRAM_BOT_TOKEN = origT;
+    else delete process.env.TELEGRAM_BOT_TOKEN;
+    if (origC !== undefined) process.env.TELEGRAM_CHAT_ID = origC;
+    else delete process.env.TELEGRAM_CHAT_ID;
+  }
+});
+
+test("TelegramNotifier: conforms to Notifier interface", () => {
+  const n = new TelegramNotifier({ token: "t", chatId: 1, fetch: async () => ({ ok: true, status: 200, json: async () => ({ ok: true, result: {} }), text: async () => "" }) });
+  assert.equal(n.id, "telegram");
+  assert.equal(n.displayName, "Telegram");
+  assert.equal(typeof n.notifyReview, "function");
+});

--- a/packages/integration-telegram/tsconfig.json
+++ b/packages/integration-telegram/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -1,0 +1,41 @@
+# @ai-conclave/observability-langfuse
+
+Langfuse sink for Ai-Conclave's efficiency-gate metrics. Forwards every
+LLM call's cost / tokens / latency / cache-hit to Langfuse for trace
+inspection.
+
+Self-hosted is the intended deployment target per decision #13. Cloud
+works identically — pass the cloud base URL.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/observability-langfuse @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { EfficiencyGate, MetricsRecorder } from "@ai-conclave/core";
+import { LangfuseMetricsSink } from "@ai-conclave/observability-langfuse";
+
+const sink = new LangfuseMetricsSink({
+  publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+  secretKey: process.env.LANGFUSE_SECRET_KEY,
+  baseUrl: process.env.LANGFUSE_BASEURL, // self-hosted URL (optional for cloud)
+});
+
+const gate = new EfficiencyGate({
+  metrics: new MetricsRecorder({ sink }),
+});
+```
+
+Call `sink.shutdown()` at process exit to flush pending events.
+
+## Env variables
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `LANGFUSE_PUBLIC_KEY` | ✓ | Public key from your Langfuse project |
+| `LANGFUSE_SECRET_KEY` | ✓ | Secret key from your Langfuse project |
+| `LANGFUSE_BASEURL` | optional | Self-hosted URL (defaults to Langfuse cloud) |

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -1,13 +1,16 @@
 {
-  "name": "@ai-conclave/cli",
+  "name": "@ai-conclave/observability-langfuse",
   "version": "0.0.0",
-  "description": "Ai-Conclave CLI — the `conclave` binary.",
+  "description": "Ai-Conclave observability sink — forwards efficiency-gate metrics to Langfuse (self-hosted per decision #13).",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "conclave": "./dist/bin/conclave.js"
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",
@@ -22,13 +25,8 @@
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {
-    "@ai-conclave/agent-claude": "workspace:*",
-    "@ai-conclave/agent-gemini": "workspace:*",
-    "@ai-conclave/agent-openai": "workspace:*",
     "@ai-conclave/core": "workspace:*",
-    "@ai-conclave/observability-langfuse": "workspace:*",
-    "@ai-conclave/scm-github": "workspace:*",
-    "zod": "^3.24.0"
+    "langfuse": "^3.30.0"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/packages/observability-langfuse/src/index.ts
+++ b/packages/observability-langfuse/src/index.ts
@@ -1,0 +1,7 @@
+export { LangfuseMetricsSink } from "./sink.js";
+export type {
+  LangfuseLike,
+  LangfuseGenerationParams,
+  LangfuseGenerationHandle,
+  LangfuseSinkOptions,
+} from "./sink.js";

--- a/packages/observability-langfuse/src/sink.ts
+++ b/packages/observability-langfuse/src/sink.ts
@@ -1,0 +1,162 @@
+import type { CallMetric, MetricsSink } from "@ai-conclave/core";
+
+/**
+ * Minimal subset of the Langfuse SDK surface the sink consumes. Typed
+ * narrowly so tests never instantiate the real client and SDK minor
+ * version bumps don't break the build.
+ */
+export interface LangfuseLike {
+  generation(params: LangfuseGenerationParams): LangfuseGenerationHandle;
+  flushAsync(): Promise<void>;
+  shutdownAsync?(): Promise<void>;
+}
+
+export interface LangfuseGenerationParams {
+  name: string;
+  model: string;
+  startTime?: Date;
+  endTime?: Date;
+  input?: unknown;
+  output?: unknown;
+  metadata?: Record<string, unknown>;
+  usage?: {
+    input?: number;
+    output?: number;
+    total?: number;
+    unit?: "TOKENS" | "CHARACTERS";
+    inputCost?: number;
+    outputCost?: number;
+    totalCost?: number;
+  };
+  traceId?: string;
+}
+
+export interface LangfuseGenerationHandle {
+  end(update?: Partial<LangfuseGenerationParams>): void;
+}
+
+export interface LangfuseSinkOptions {
+  /** Pre-built Langfuse client. Used by tests + callers who want shared state. */
+  client?: LangfuseLike;
+  /** Factory invoked when `client` is not supplied. Defaults to lazy import of `langfuse`. */
+  clientFactory?: () => Promise<LangfuseLike>;
+  /** Host override for self-hosted (decision #13). Defaults to env LANGFUSE_BASEURL. */
+  baseUrl?: string;
+  publicKey?: string;
+  secretKey?: string;
+  /** Optional trace id so all metrics in a single review share a parent span. */
+  traceId?: string;
+}
+
+async function defaultClientFactory(opts: LangfuseSinkOptions): Promise<LangfuseLike> {
+  const publicKey = opts.publicKey ?? process.env["LANGFUSE_PUBLIC_KEY"];
+  const secretKey = opts.secretKey ?? process.env["LANGFUSE_SECRET_KEY"];
+  const baseUrl = opts.baseUrl ?? process.env["LANGFUSE_BASEURL"];
+  if (!publicKey || !secretKey) {
+    throw new Error("LangfuseMetricsSink: LANGFUSE_PUBLIC_KEY + LANGFUSE_SECRET_KEY required");
+  }
+  const mod = (await import("langfuse")) as unknown as {
+    Langfuse: new (opts: {
+      publicKey: string;
+      secretKey: string;
+      baseUrl?: string;
+    }) => LangfuseLike;
+  };
+  const ctorOpts: { publicKey: string; secretKey: string; baseUrl?: string } = {
+    publicKey,
+    secretKey,
+  };
+  if (baseUrl) ctorOpts.baseUrl = baseUrl;
+  return new mod.Langfuse(ctorOpts);
+}
+
+/**
+ * LangfuseMetricsSink — drops in as the `sink` on `MetricsRecorder`.
+ * Every per-call metric becomes a Langfuse `generation` (the SDK's model
+ * for a single LLM invocation).
+ *
+ * The sink is fire-and-forget on the record() path (synchronous per
+ * MetricsSink contract); actual HTTP is Langfuse's internal queue. Call
+ * `shutdown()` at process exit to flush pending events.
+ *
+ * Self-hosted Langfuse is the deployment target per decision #13. Cloud
+ * works identically (`baseUrl` omitted or set to the cloud URL).
+ */
+export class LangfuseMetricsSink implements MetricsSink {
+  private readonly opts: LangfuseSinkOptions;
+  private readonly clientFactory: () => Promise<LangfuseLike>;
+  private clientPromise: Promise<LangfuseLike> | null;
+  private clientReady: LangfuseLike | null;
+  private traceId: string | undefined;
+
+  constructor(opts: LangfuseSinkOptions = {}) {
+    this.opts = opts;
+    this.clientFactory = opts.clientFactory ?? (() => defaultClientFactory(opts));
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+    this.clientReady = opts.client ?? null;
+    this.traceId = opts.traceId;
+  }
+
+  setTraceId(id: string | undefined): void {
+    this.traceId = id;
+  }
+
+  /**
+   * MetricsSink.record is synchronous — we kick off the Langfuse call and
+   * let the SDK queue handle delivery. Errors are swallowed to stderr so
+   * observability failure never kills a running review.
+   */
+  record(metric: CallMetric): void {
+    this.submit(metric).catch((err) => {
+      process.stderr.write(
+        `[langfuse] failed to record metric for ${metric.agent}/${metric.model}: ${(err as Error).message}\n`,
+      );
+    });
+  }
+
+  private async submit(metric: CallMetric): Promise<void> {
+    const client = await this.getClient();
+    const startTime = new Date(metric.timestamp - metric.latencyMs);
+    const endTime = new Date(metric.timestamp);
+    const params: LangfuseGenerationParams = {
+      name: `review.${metric.agent}`,
+      model: metric.model,
+      startTime,
+      endTime,
+      usage: {
+        input: metric.inputTokens,
+        output: metric.outputTokens,
+        total: metric.inputTokens + metric.outputTokens,
+        unit: "TOKENS",
+        totalCost: metric.costUsd,
+      },
+      metadata: {
+        cacheHit: metric.cacheHit,
+        latencyMs: metric.latencyMs,
+      },
+    };
+    if (this.traceId) params.traceId = this.traceId;
+    const gen = client.generation(params);
+    // Generations in the Langfuse SDK expect an `end()` call to finalize.
+    gen.end();
+  }
+
+  private async getClient(): Promise<LangfuseLike> {
+    if (!this.clientPromise) this.clientPromise = this.clientFactory();
+    if (!this.clientReady) this.clientReady = await this.clientPromise;
+    return this.clientReady;
+  }
+
+  async flush(): Promise<void> {
+    if (!this.clientPromise) return;
+    const client = await this.clientPromise;
+    await client.flushAsync();
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.clientPromise) return;
+    const client = await this.clientPromise;
+    if (client.shutdownAsync) await client.shutdownAsync();
+    else await client.flushAsync();
+  }
+}

--- a/packages/observability-langfuse/test/sink.test.mjs
+++ b/packages/observability-langfuse/test/sink.test.mjs
@@ -1,0 +1,189 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { LangfuseMetricsSink } from "../dist/index.js";
+
+function mockClient() {
+  const generated = [];
+  const ended = [];
+  let flushes = 0;
+  let shutdowns = 0;
+  return {
+    generated,
+    ended,
+    get flushes() {
+      return flushes;
+    },
+    get shutdowns() {
+      return shutdowns;
+    },
+    generation: (params) => {
+      generated.push(params);
+      return {
+        end: (update) => {
+          ended.push({ params, update });
+        },
+      };
+    },
+    flushAsync: async () => {
+      flushes += 1;
+    },
+    shutdownAsync: async () => {
+      shutdowns += 1;
+    },
+  };
+}
+
+function mkMetric(overrides = {}) {
+  return {
+    agent: "claude",
+    model: "claude-sonnet-4-6",
+    inputTokens: 1_000,
+    outputTokens: 200,
+    costUsd: 0.015,
+    latencyMs: 1_200,
+    cacheHit: false,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+async function tick() {
+  // Allow queued microtasks from record() to resolve.
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+test("LangfuseMetricsSink: record() creates a generation with mapped usage", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  sink.record(mkMetric({ inputTokens: 500, outputTokens: 100, costUsd: 0.01 }));
+  await tick();
+  assert.equal(client.generated.length, 1);
+  const g = client.generated[0];
+  assert.equal(g.name, "review.claude");
+  assert.equal(g.model, "claude-sonnet-4-6");
+  assert.equal(g.usage.input, 500);
+  assert.equal(g.usage.output, 100);
+  assert.equal(g.usage.total, 600);
+  assert.equal(g.usage.totalCost, 0.01);
+  assert.equal(g.usage.unit, "TOKENS");
+  assert.equal(client.ended.length, 1);
+});
+
+test("LangfuseMetricsSink: metadata carries cacheHit + latencyMs", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  sink.record(mkMetric({ cacheHit: true, latencyMs: 850 }));
+  await tick();
+  const g = client.generated[0];
+  assert.equal(g.metadata.cacheHit, true);
+  assert.equal(g.metadata.latencyMs, 850);
+});
+
+test("LangfuseMetricsSink: startTime / endTime derived from timestamp + latency", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  const now = 1_700_000_000_000;
+  sink.record(mkMetric({ timestamp: now, latencyMs: 1_000 }));
+  await tick();
+  const g = client.generated[0];
+  assert.equal(g.endTime.getTime(), now);
+  assert.equal(g.startTime.getTime(), now - 1_000);
+});
+
+test("LangfuseMetricsSink: traceId propagates when set", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client, traceId: "trace-123" });
+  sink.record(mkMetric());
+  await tick();
+  assert.equal(client.generated[0].traceId, "trace-123");
+});
+
+test("LangfuseMetricsSink: setTraceId updates for subsequent records", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  sink.setTraceId("first");
+  sink.record(mkMetric());
+  sink.setTraceId("second");
+  sink.record(mkMetric());
+  await tick();
+  assert.equal(client.generated[0].traceId, "first");
+  assert.equal(client.generated[1].traceId, "second");
+});
+
+test("LangfuseMetricsSink: client errors are swallowed to stderr, not thrown", async () => {
+  const client = {
+    generation: () => {
+      throw new Error("langfuse down");
+    },
+    flushAsync: async () => {},
+  };
+  const sink = new LangfuseMetricsSink({ client });
+  // Capture stderr writes
+  const origStderr = process.stderr.write.bind(process.stderr);
+  const chunks = [];
+  process.stderr.write = (c) => {
+    chunks.push(String(c));
+    return true;
+  };
+  try {
+    sink.record(mkMetric()); // must not throw
+    await tick();
+  } finally {
+    process.stderr.write = origStderr;
+  }
+  assert.match(chunks.join(""), /langfuse.*failed to record/i);
+});
+
+test("LangfuseMetricsSink: flush awaits client.flushAsync", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  sink.record(mkMetric());
+  await tick();
+  await sink.flush();
+  assert.equal(client.flushes, 1);
+});
+
+test("LangfuseMetricsSink: shutdown prefers shutdownAsync over flushAsync", async () => {
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({ client });
+  sink.record(mkMetric());
+  await tick();
+  await sink.shutdown();
+  assert.equal(client.shutdowns, 1);
+  assert.equal(client.flushes, 0);
+});
+
+test("LangfuseMetricsSink: shutdown falls back to flushAsync when shutdownAsync absent", async () => {
+  const client = {
+    generation: () => ({ end: () => {} }),
+    flushAsync: async () => {},
+  };
+  let flushed = 0;
+  client.flushAsync = async () => {
+    flushed += 1;
+  };
+  const sink = new LangfuseMetricsSink({ client });
+  sink.record(mkMetric());
+  await tick();
+  await sink.shutdown();
+  assert.equal(flushed, 1);
+});
+
+test("LangfuseMetricsSink: lazy client init — no client request until first record()", async () => {
+  let factoryCalls = 0;
+  const client = mockClient();
+  const sink = new LangfuseMetricsSink({
+    clientFactory: async () => {
+      factoryCalls += 1;
+      return client;
+    },
+  });
+  assert.equal(factoryCalls, 0);
+  sink.record(mkMetric());
+  await tick();
+  assert.equal(factoryCalls, 1);
+  sink.record(mkMetric());
+  await tick();
+  assert.equal(factoryCalls, 1, "factory should only be called once");
+});

--- a/packages/observability-langfuse/tsconfig.json
+++ b/packages/observability-langfuse/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/scm-github/README.md
+++ b/packages/scm-github/README.md
@@ -1,0 +1,39 @@
+# @ai-conclave/scm-github
+
+GitHub SCM adapter for Ai-Conclave. Resolves PR state for automatic
+outcome capture — closes the gap where users previously had to run
+`conclave record-outcome` manually after every PR landed.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/scm-github @ai-conclave/core
+```
+
+## Usage
+
+```ts
+import { FileSystemMemoryStore, OutcomeWriter } from "@ai-conclave/core";
+import { pollOutcomes } from "@ai-conclave/scm-github";
+
+const store = new FileSystemMemoryStore({ root: ".conclave" });
+const writer = new OutcomeWriter({ store });
+
+const summary = await pollOutcomes({ store, writer });
+console.log(`merged=${summary.merged} rejected=${summary.rejected} reworked=${summary.reworked}`);
+```
+
+## Dependency
+
+Uses the `gh` CLI for auth + network. Same dependency as
+`@ai-conclave/cli` already requires for `conclave review --pr N`, so
+there is no new auth setup — `gh auth login` once is enough.
+
+## Transition rules
+
+| Past observation | Current state | Classified outcome |
+|---|---|---|
+| any | merged | `merged` |
+| any | closed without merge | `rejected` |
+| any | open, head moved since review | `reworked` |
+| any | open, head unchanged | `pending` (no-op) |

--- a/packages/scm-github/package.json
+++ b/packages/scm-github/package.json
@@ -1,13 +1,16 @@
 {
-  "name": "@ai-conclave/cli",
+  "name": "@ai-conclave/scm-github",
   "version": "0.0.0",
-  "description": "Ai-Conclave CLI — the `conclave` binary.",
+  "description": "Ai-Conclave SCM adapter for GitHub — resolve PR state for automatic outcome capture.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "conclave": "./dist/bin/conclave.js"
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",
@@ -22,12 +25,7 @@
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {
-    "@ai-conclave/agent-claude": "workspace:*",
-    "@ai-conclave/agent-gemini": "workspace:*",
-    "@ai-conclave/agent-openai": "workspace:*",
-    "@ai-conclave/core": "workspace:*",
-    "@ai-conclave/scm-github": "workspace:*",
-    "zod": "^3.24.0"
+    "@ai-conclave/core": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/packages/scm-github/src/index.ts
+++ b/packages/scm-github/src/index.ts
@@ -1,0 +1,5 @@
+export { fetchPrState, classifyTransition } from "./pr-state.js";
+export type { PrState, OutcomeForPr, PullRequestState, GhRunner } from "./pr-state.js";
+
+export { pollOutcomes, listPendingEpisodics } from "./poll-runner.js";
+export type { PollRunnerOptions, PollResult, PollSummary } from "./poll-runner.js";

--- a/packages/scm-github/src/poll-runner.ts
+++ b/packages/scm-github/src/poll-runner.ts
@@ -1,0 +1,141 @@
+import type { EpisodicEntry, MemoryStore, OutcomeWriter } from "@ai-conclave/core";
+import {
+  fetchPrState,
+  classifyTransition,
+  type GhRunner,
+  type OutcomeForPr,
+  type PullRequestState,
+} from "./pr-state.js";
+
+export interface PollRunnerOptions {
+  store: MemoryStore;
+  writer: OutcomeWriter;
+  /** Optional test hook: replaces the gh CLI invocation path. */
+  run?: GhRunner;
+}
+
+export interface PollResult {
+  episodicId: string;
+  repo: string;
+  prNumber: number;
+  classification: OutcomeForPr;
+  wrote: boolean;
+  error?: string;
+}
+
+export interface PollSummary {
+  scanned: number;
+  merged: number;
+  rejected: number;
+  reworked: number;
+  pending: number;
+  errors: number;
+  results: PollResult[];
+}
+
+/**
+ * Scan the memory store for episodic entries in `outcome: "pending"` and,
+ * for each one whose PR number is valid, poll GitHub for the current PR
+ * state. Any pending→merged / pending→rejected / pending→reworked
+ * transition is recorded through the OutcomeWriter (which classifies +
+ * writes AnswerKey / FailureEntry records).
+ *
+ * This is the "pull" alternative to a webhook listener. Users can run
+ * `conclave poll-outcomes` on a cron or manually after a batch of
+ * reviews settles. Webhook listener (which needs a hosted server) lands
+ * in a later package if / when Bae wants it.
+ */
+export async function pollOutcomes(opts: PollRunnerOptions): Promise<PollSummary> {
+  const pending = await listPendingEpisodics(opts.store);
+  const summary: PollSummary = {
+    scanned: 0,
+    merged: 0,
+    rejected: 0,
+    reworked: 0,
+    pending: 0,
+    errors: 0,
+    results: [],
+  };
+
+  for (const ep of pending) {
+    summary.scanned += 1;
+    if (!ep.pullNumber || ep.pullNumber <= 0) {
+      // Local / file reviews (pullNumber = 0) have no GitHub state to poll.
+      summary.pending += 1;
+      summary.results.push({
+        episodicId: ep.id,
+        repo: ep.repo,
+        prNumber: ep.pullNumber,
+        classification: "pending",
+        wrote: false,
+      });
+      continue;
+    }
+    try {
+      const state = await fetchPrState(ep.repo, ep.pullNumber, { run: opts.run });
+      const classification = classifyTransition(state, ep.sha);
+      const wrote = await applyClassification(opts.writer, ep.id, classification);
+      tally(summary, classification, wrote);
+      summary.results.push({
+        episodicId: ep.id,
+        repo: ep.repo,
+        prNumber: ep.pullNumber,
+        classification,
+        wrote,
+      });
+    } catch (err) {
+      summary.errors += 1;
+      summary.results.push({
+        episodicId: ep.id,
+        repo: ep.repo,
+        prNumber: ep.pullNumber,
+        classification: "pending",
+        wrote: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return summary;
+}
+
+async function applyClassification(
+  writer: OutcomeWriter,
+  episodicId: string,
+  classification: OutcomeForPr,
+): Promise<boolean> {
+  if (classification === "pending") return false;
+  await writer.recordOutcome({ episodicId, outcome: classification });
+  return true;
+}
+
+function tally(summary: PollSummary, classification: OutcomeForPr, wrote: boolean): void {
+  if (classification === "merged" && wrote) summary.merged += 1;
+  else if (classification === "rejected" && wrote) summary.rejected += 1;
+  else if (classification === "reworked" && wrote) summary.reworked += 1;
+  else summary.pending += 1;
+}
+
+/**
+ * Walk the MemoryStore for episodic entries still in `outcome: "pending"`.
+ * For FS stores this is a one-shot directory walk; for DB stores it would
+ * be a filtered query. We depend only on `findEpisodic` + a walker — any
+ * MemoryStore can implement this path.
+ *
+ * Current implementation probes the store by walking an incrementing
+ * depth-2 directory tree if available. For interfaces without a list
+ * method, we accept that callers pass a list explicitly via a higher-
+ * level helper. For now this helper lives here so the CLI can call it
+ * against the default FS store.
+ */
+export async function listPendingEpisodics(store: MemoryStore): Promise<EpisodicEntry[]> {
+  // Duck-type: FileSystemMemoryStore exposes `_listEpisodic` when present.
+  const duck = store as unknown as { listEpisodic?: () => Promise<EpisodicEntry[]> };
+  if (typeof duck.listEpisodic === "function") {
+    const all = await duck.listEpisodic();
+    return all.filter((e) => e.outcome === "pending");
+  }
+  return [];
+}
+
+export { listPendingEpisodics as _listPendingEpisodics };

--- a/packages/scm-github/src/pr-state.ts
+++ b/packages/scm-github/src/pr-state.ts
@@ -1,0 +1,110 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+export type PrState = "open" | "merged" | "closed";
+export type OutcomeForPr = "merged" | "rejected" | "reworked" | "pending";
+
+export interface PullRequestState {
+  repo: string;
+  prNumber: number;
+  state: PrState;
+  /** If merged: the merge commit SHA. */
+  mergeCommitSha?: string;
+  /** Head commit SHA at the last observation. Used to detect reworks. */
+  headSha: string;
+  /** ISO timestamp of the last state transition observed. */
+  updatedAt: string;
+}
+
+export interface GhRunner {
+  (bin: string, args: readonly string[], opts?: { cwd?: string; timeout?: number }): Promise<{
+    stdout: string;
+    stderr?: string;
+  }>;
+}
+
+const defaultRunner: GhRunner = async (bin, args, opts) => {
+  const { stdout, stderr } = await execFile(bin, args as string[], {
+    ...opts,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return { stdout, stderr };
+};
+
+/**
+ * Fetch a PR's current state via `gh pr view`. Uses the gh CLI for auth +
+ * network — same dependency as @ai-conclave/cli already requires for
+ * `conclave review --pr N`. No GitHub token needs to live in conclave's
+ * config.
+ */
+export async function fetchPrState(
+  repo: string,
+  prNumber: number,
+  deps: { run?: GhRunner } = {},
+): Promise<PullRequestState> {
+  const run = deps.run ?? defaultRunner;
+  const { stdout } = await run("gh", [
+    "pr",
+    "view",
+    String(prNumber),
+    "--repo",
+    repo,
+    "--json",
+    "state,mergeCommit,headRefOid,updatedAt",
+  ]);
+  const raw = JSON.parse(stdout) as {
+    state?: string;
+    mergeCommit?: { oid?: string };
+    headRefOid?: string;
+    updatedAt?: string;
+  };
+  if (!raw.headRefOid) {
+    throw new Error(`scm-github: missing headRefOid for ${repo} #${prNumber}`);
+  }
+  const state = normalizeState(raw.state);
+  const out: PullRequestState = {
+    repo,
+    prNumber,
+    state,
+    headSha: raw.headRefOid,
+    updatedAt: raw.updatedAt ?? new Date().toISOString(),
+  };
+  if (state === "merged" && raw.mergeCommit?.oid) out.mergeCommitSha = raw.mergeCommit.oid;
+  return out;
+}
+
+function normalizeState(raw: string | undefined): PrState {
+  switch ((raw ?? "").toUpperCase()) {
+    case "OPEN":
+      return "open";
+    case "MERGED":
+      return "merged";
+    case "CLOSED":
+      return "closed";
+    default:
+      throw new Error(`scm-github: unknown PR state "${String(raw)}"`);
+  }
+}
+
+/**
+ * Classify the transition from a past PR observation into the outcome
+ * vocabulary used by `OutcomeWriter.recordOutcome`.
+ *
+ * Rules:
+ *   - merged                 → "merged"
+ *   - closed without merge   → "rejected"
+ *   - still open, but head advanced since the review's observation SHA →
+ *     "reworked" (new commits landed on the PR branch)
+ *   - otherwise               → "pending" (nothing to record yet)
+ */
+export function classifyTransition(
+  current: PullRequestState,
+  reviewedSha: string,
+): OutcomeForPr {
+  if (current.state === "merged") return "merged";
+  if (current.state === "closed") return "rejected";
+  if (current.state === "open" && current.headSha !== reviewedSha) return "reworked";
+  return "pending";
+}

--- a/packages/scm-github/test/poll-runner.test.mjs
+++ b/packages/scm-github/test/poll-runner.test.mjs
@@ -1,0 +1,240 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FileSystemMemoryStore, OutcomeWriter } from "@ai-conclave/core";
+import { pollOutcomes, listPendingEpisodics } from "../dist/index.js";
+
+function freshFs() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aic-poll-"));
+  return { store: new FileSystemMemoryStore({ root }), root };
+}
+function cleanup(root) {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+const approveCtx = {
+  diff: "+change",
+  repo: "acme/app",
+  pullNumber: 42,
+  newSha: "head-sha",
+};
+const approveReview = { agent: "claude", verdict: "approve", blockers: [], summary: "LGTM" };
+const rejectReview = {
+  agent: "claude",
+  verdict: "reject",
+  blockers: [{ severity: "blocker", category: "security", message: "leak" }],
+  summary: "blocker",
+};
+
+function runner(responses) {
+  let i = 0;
+  return async (_bin, _args) => {
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    if (typeof r === "function") return { stdout: r() };
+    return { stdout: JSON.stringify(r) };
+  };
+}
+
+test("pollOutcomes: empty store → scanned 0", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const summary = await pollOutcomes({ store, writer, run: runner([]) });
+    assert.equal(summary.scanned, 0);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("pollOutcomes: merged PR writes AnswerKey", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    await writer.writeReview({
+      ctx: approveCtx,
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+    });
+    const summary = await pollOutcomes({
+      store,
+      writer,
+      run: runner([{ state: "MERGED", headRefOid: "head-sha", mergeCommit: { oid: "m" }, updatedAt: "2026-04-19T00:00:00Z" }]),
+    });
+    assert.equal(summary.merged, 1);
+    assert.equal(summary.scanned, 1);
+    assert.equal(summary.results[0].wrote, true);
+    assert.equal((await store.listAnswerKeys()).length, 1);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("pollOutcomes: closed PR → rejected + FailureEntry", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    await writer.writeReview({
+      ctx: approveCtx,
+      reviews: [rejectReview],
+      councilVerdict: "reject",
+      costUsd: 0.01,
+    });
+    const summary = await pollOutcomes({
+      store,
+      writer,
+      run: runner([{ state: "CLOSED", headRefOid: "head-sha", updatedAt: "2026-04-19T00:00:00Z" }]),
+    });
+    assert.equal(summary.rejected, 1);
+    assert.equal((await store.listFailures()).length, 1);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("pollOutcomes: open with advanced head → reworked + FailureEntry", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    await writer.writeReview({
+      ctx: approveCtx,
+      reviews: [rejectReview],
+      councilVerdict: "reject",
+      costUsd: 0.01,
+    });
+    const summary = await pollOutcomes({
+      store,
+      writer,
+      run: runner([{ state: "OPEN", headRefOid: "different-sha", updatedAt: "2026-04-19T00:00:00Z" }]),
+    });
+    assert.equal(summary.reworked, 1);
+    assert.equal((await store.listFailures()).length, 1);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("pollOutcomes: open with same head → pending (no write)", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    await writer.writeReview({
+      ctx: approveCtx,
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+    });
+    const summary = await pollOutcomes({
+      store,
+      writer,
+      run: runner([{ state: "OPEN", headRefOid: "head-sha", updatedAt: "2026-04-19T00:00:00Z" }]),
+    });
+    assert.equal(summary.merged + summary.rejected + summary.reworked, 0);
+    assert.equal(summary.pending, 1);
+    assert.equal((await store.listAnswerKeys()).length, 0);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("pollOutcomes: pullNumber=0 (local review) → pending, no gh call", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    await writer.writeReview({
+      ctx: { ...approveCtx, pullNumber: 0 },
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+    });
+    let called = false;
+    const run = async () => {
+      called = true;
+      return { stdout: "{}" };
+    };
+    const summary = await pollOutcomes({ store, writer, run });
+    assert.equal(called, false);
+    assert.equal(summary.pending, 1);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("pollOutcomes: gh errors counted, scan continues", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    await writer.writeReview({
+      ctx: { ...approveCtx, pullNumber: 1 },
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+    });
+    await writer.writeReview({
+      ctx: { ...approveCtx, pullNumber: 2 },
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+    });
+    let call = 0;
+    const run = async () => {
+      call += 1;
+      if (call === 1) throw new Error("gh boom");
+      return { stdout: JSON.stringify({ state: "MERGED", headRefOid: "head-sha", mergeCommit: { oid: "m" }, updatedAt: "2026-04-19T00:00:00Z" }) };
+    };
+    const summary = await pollOutcomes({ store, writer, run });
+    assert.equal(summary.errors, 1);
+    assert.equal(summary.merged, 1);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("pollOutcomes: only pending entries polled (merged ones skipped)", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const ep1 = await writer.writeReview({ ctx: approveCtx, reviews: [approveReview], councilVerdict: "approve", costUsd: 0.01 });
+    // Already resolved earlier — should not be re-polled.
+    await writer.recordOutcome({ episodicId: ep1.id, outcome: "merged" });
+    await writer.writeReview({
+      ctx: { ...approveCtx, pullNumber: 99 },
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+    });
+    let callCount = 0;
+    const run = async () => {
+      callCount += 1;
+      return { stdout: JSON.stringify({ state: "OPEN", headRefOid: "head-sha", updatedAt: "2026-04-19T00:00:00Z" }) };
+    };
+    const summary = await pollOutcomes({ store, writer, run });
+    assert.equal(summary.scanned, 1);
+    assert.equal(callCount, 1);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("listPendingEpisodics: returns only pending entries", async () => {
+  const { store, root } = freshFs();
+  try {
+    const writer = new OutcomeWriter({ store });
+    const epA = await writer.writeReview({ ctx: approveCtx, reviews: [approveReview], councilVerdict: "approve", costUsd: 0.01 });
+    await writer.recordOutcome({ episodicId: epA.id, outcome: "merged" });
+    await writer.writeReview({
+      ctx: { ...approveCtx, pullNumber: 77 },
+      reviews: [approveReview],
+      councilVerdict: "approve",
+      costUsd: 0.01,
+    });
+    const pending = await listPendingEpisodics(store);
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].pullNumber, 77);
+  } finally {
+    cleanup(root);
+  }
+});

--- a/packages/scm-github/test/pr-state.test.mjs
+++ b/packages/scm-github/test/pr-state.test.mjs
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fetchPrState, classifyTransition } from "../dist/index.js";
+
+function mockRun(response) {
+  const calls = [];
+  const run = async (bin, args) => {
+    calls.push({ bin, args: [...args] });
+    return { stdout: typeof response === "function" ? response(bin, args) : response };
+  };
+  run.calls = calls;
+  return run;
+}
+
+test("fetchPrState: open PR maps to state=open + headSha", async () => {
+  const run = mockRun(
+    JSON.stringify({
+      state: "OPEN",
+      headRefOid: "sha-head",
+      updatedAt: "2026-04-19T10:00:00Z",
+    }),
+  );
+  const state = await fetchPrState("acme/app", 42, { run });
+  assert.equal(state.state, "open");
+  assert.equal(state.headSha, "sha-head");
+  assert.equal(state.repo, "acme/app");
+  assert.equal(state.prNumber, 42);
+  assert.equal(state.mergeCommitSha, undefined);
+});
+
+test("fetchPrState: merged PR includes mergeCommitSha", async () => {
+  const run = mockRun(
+    JSON.stringify({
+      state: "MERGED",
+      headRefOid: "sha-head",
+      mergeCommit: { oid: "sha-merge" },
+      updatedAt: "2026-04-19T12:00:00Z",
+    }),
+  );
+  const state = await fetchPrState("acme/app", 7, { run });
+  assert.equal(state.state, "merged");
+  assert.equal(state.mergeCommitSha, "sha-merge");
+});
+
+test("fetchPrState: closed PR maps to state=closed", async () => {
+  const run = mockRun(
+    JSON.stringify({
+      state: "CLOSED",
+      headRefOid: "sha-head",
+      updatedAt: "2026-04-19T09:00:00Z",
+    }),
+  );
+  const state = await fetchPrState("acme/app", 99, { run });
+  assert.equal(state.state, "closed");
+});
+
+test("fetchPrState: unknown state string throws", async () => {
+  const run = mockRun(JSON.stringify({ state: "WEIRD", headRefOid: "s" }));
+  await assert.rejects(() => fetchPrState("acme/app", 1, { run }), /unknown PR state/);
+});
+
+test("fetchPrState: missing headRefOid throws", async () => {
+  const run = mockRun(JSON.stringify({ state: "OPEN" }));
+  await assert.rejects(() => fetchPrState("acme/app", 1, { run }), /missing headRefOid/);
+});
+
+test("fetchPrState: invokes gh with --repo + --json flags", async () => {
+  const run = mockRun(
+    JSON.stringify({ state: "OPEN", headRefOid: "s", updatedAt: "2026-04-19T00:00:00Z" }),
+  );
+  await fetchPrState("acme/app", 3, { run });
+  assert.deepEqual(run.calls[0].args, [
+    "pr",
+    "view",
+    "3",
+    "--repo",
+    "acme/app",
+    "--json",
+    "state,mergeCommit,headRefOid,updatedAt",
+  ]);
+});
+
+test("classifyTransition: merged → merged", () => {
+  const out = classifyTransition(
+    { repo: "a/b", prNumber: 1, state: "merged", headSha: "x", updatedAt: "" },
+    "reviewed-sha",
+  );
+  assert.equal(out, "merged");
+});
+
+test("classifyTransition: closed without merge → rejected", () => {
+  const out = classifyTransition(
+    { repo: "a/b", prNumber: 1, state: "closed", headSha: "x", updatedAt: "" },
+    "reviewed-sha",
+  );
+  assert.equal(out, "rejected");
+});
+
+test("classifyTransition: open with advanced head → reworked", () => {
+  const out = classifyTransition(
+    { repo: "a/b", prNumber: 1, state: "open", headSha: "new-sha", updatedAt: "" },
+    "old-sha",
+  );
+  assert.equal(out, "reworked");
+});
+
+test("classifyTransition: open with same head → pending", () => {
+  const out = classifyTransition(
+    { repo: "a/b", prNumber: 1, state: "open", headSha: "same-sha", updatedAt: "" },
+    "same-sha",
+  );
+  assert.equal(out, "pending");
+});

--- a/packages/scm-github/tsconfig.json
+++ b/packages/scm-github/tsconfig.json
@@ -7,10 +7,6 @@
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"],
   "references": [
-    { "path": "../core" },
-    { "path": "../agent-claude" },
-    { "path": "../agent-gemini" },
-    { "path": "../agent-openai" },
-    { "path": "../scm-github" }
+    { "path": "../core" }
   ]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "packages/*"
+  - "apps/*"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "incremental": true
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "ui": "stream",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "*.tsbuildinfo"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fourth `Notifier` — completes decision #24's equal-weight set: **CLI + Telegram + Discord + Slack + Email**. Last of the write-only notification surfaces.

Stacked on [#14](https://github.com/seunghunbae-3svs/ai-conclave/pull/14). Base = `scaffold/integration-slack`.

## Pluggable transport

```ts
interface EmailTransport {
  readonly id: string;
  send(msg: { from, to, subject, text, html }): Promise<void>;
}
```

Default = **`ResendTransport`** (Resend REST API, native fetch, no SDK dep). Swap in:

- **SMTP**: `nodemailer.createTransport()` wrapped in a `send()` adapter
- **SES**: `@aws-sdk/client-ses`
- **Postmark / SendGrid / Mailgun**: native fetch to their respective endpoints

Keeps `@ai-conclave/integration-email` dep-light (just `@ai-conclave/core`).

## Bodies

Both plaintext AND HTML rendered from the same source:

- Subject: `[conclave] VERDICT — repo #N` (override via `subjectOverride`)
- HTML: inline styles only, no `<style>` blocks, no external CSS. Email-client safe across Gmail / Outlook / Apple Mail.
- Color-coded verdict headline (green `#16a34a` / amber `#d97706` / red `#dc2626`).
- HTML escapes `< > & "`.
- Severity-sorted top-5 blockers per agent (5, not 3 — email has more real estate than chat).

## Config

```json
{
  "integrations": {
    "email": {
      "enabled": true,
      "from": "conclave@yourdomain.com",
      "to": ["you@yourdomain.com", "alerts@yourdomain.com"],
      "subjectOverride": "[PROD] review ready"
    }
  }
}
```

Env fallbacks: `RESEND_API_KEY`, `CONCLAVE_EMAIL_FROM`, `CONCLAVE_EMAIL_TO` (comma-separated).

## Tests — 21 cases

### `format.test.mjs` (11)
Subject with + without PR number, text body structure, no-consensus tag, severity-sorted top-5 + `+N more`, footer cost + id, **HTML inline-styles-only enforcement** (no `<style>`, no `<link>`), special-char escape, PR link, color-coded verdict, no-blockers placeholder in both bodies.

### `notifier.test.mjs` (10)
ResendTransport: missing key throws, POST /emails with bearer + JSON shape, `to` array passthrough, non-200 throw.
EmailNotifier: missing from + missing to throws, comma-separated env → array, subjectOverride wins over rendered, default rendered subject used, custom transport plugs in, text + html both sent, Notifier interface conformance.

## Decision #24 — status

| Surface | PR |
|---|---|
| ✅ CLI | #5 |
| ✅ Telegram | #11 |
| ✅ Discord | #13 |
| ✅ Slack | #14 |
| ✅ Email | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)