### PR TITLE
docs: broaden persona to include Base44 + Manus AI (three concentric circles)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,9 +13,15 @@ truth for scaffolding.
 - **Tagline**: *A multi-agent council reviews your AI-generated code and
   design, debates issues, auto-fixes blockers, and learns your preferences
   over time. Built for solo makers who ship with AI.*
-- **Target persona**: users of Cursor / Claude Code / Windsurf / v0 /
-  Lovable / Bolt whose AI-generated output is mediocre, off-style, or
-  needs human polish. Not seasoned engineers polishing their own code.
+- **Target persona**: anyone shipping AI-generated output without a
+  dedicated reviewer. Three concentric circles:
+  1. **AI coding assistants** (Cursor / Claude Code / Windsurf /
+     Copilot) — review AI-written diffs alongside human-written ones.
+  2. **App-from-prompt builders** (v0 / Lovable / Bolt / Base44) —
+     the output is an entire app; council reviews each generated PR.
+  3. **Autonomous agents** (Manus AI / Devin / general task-runners) —
+     the output is a task result with code + config side-effects.
+  Not seasoned engineers polishing their own code.
 
 ## 7-Layer Architecture
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ learns your preferences over time. Built for solo makers who ship with AI.
 
 ## Who this is for
 
-Users of Cursor, Claude Code, Windsurf, v0, Lovable, or Bolt whose
-AI-generated output is mediocre, off-style, or needs human polish — but
-who don't want to hire a reviewer.
+Anyone who ships AI-generated code or AI-built apps but doesn't want
+to hire a reviewer. Concretely:
+
+- **AI coding assistants** — Cursor, Claude Code, Windsurf, Copilot
+- **App-from-prompt builders** — v0, Lovable, Bolt, Base44
+- **Autonomous agents** — Manus AI, Devin, Cognition-style task runners
+
+If the output is often mediocre, off-style, or needs human polish — and
+the reviewer's job is "catch the blockers, ignore the nits" — the
+council sits in that seat.
 
 This is **not** a tool for seasoned engineers polishing code they wrote
 themselves. It is a council for code that came out of an AI.


### PR DESCRIPTION
## Summary

The original persona list (Cursor / Claude Code / Windsurf / v0 / Lovable / Bolt) captured one slice of the AI-generated-code surface. As of 2026 it's wider. This PR names the **three concentric circles** explicitly in both README and ARCHITECTURE.md.

1. **AI coding assistants** — Cursor, Claude Code, Windsurf, Copilot. Review AI-written diffs alongside human ones.
2. **App-from-prompt builders** — v0, Lovable, Bolt, **Base44** (added). Output is a whole app.
3. **Autonomous agents** — **Manus AI**, Devin, general task-runners (added category). Output is a task result with code + config side-effects.

All three land in the same review surface because they share the same pain: the output is a complete artifact and the user is downstream of its quality — not its author.

No code change. No new dep. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)