### PR TITLE
feat: @ai-conclave/visual-review — Playwright + pixelmatch before/after diff (decision #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,51 @@
 ## Unreleased
 
 ### Added
+- **`@ai-conclave/visual-review`** — before/after visual diff package
+  (decision #15 partial — pixelmatch default; odiff for v2.x speed
+  upgrade):
+  - `ScreenshotCapture` interface + `PlaywrightCapture` default
+    implementation. Reuses a single Chromium across captures in the
+    same process; fresh context per capture for isolation. Playwright
+    is an OPTIONAL peer dep — users who never run visual review don't
+    pay the ~300MB Chromium cost.
+  - `VisualDiff` interface + `PixelmatchDiff` default implementation
+    (pure JS, no native binary). `classifyDiffRatio(ratio)` maps into
+    5 severity bands: identical / minor / significant / major /
+    total-rewrite. Swap in an `odiff` adapter for 6–8× speed.
+  - Size-mismatched images pad to max dimensions instead of throwing.
+    Diff PNG shares inputs' dimensions; changed pixels highlighted red
+    (configurable).
+  - `runVisualReview({ platforms, repo, beforeSha, afterSha, … })`
+    orchestrator:
+    - Resolves before + after preview URLs via the Platform adapters
+      from PR #17 (Vercel / Netlify / …). Walks platforms first-non-
+      null-wins.
+    - Captures both URLs sequentially via the configured capture
+      engine.
+    - Diffs via the configured diff engine.
+    - Writes `before.png` / `after.png` / `diff.png` to
+      `<outputDir>/` (default `.conclave/visual/<afterSha>/`).
+    - Returns structured result: before/after PreviewResolution,
+      paths, capture metadata, diff metrics + severity.
+    - Missing before URL → throws with `beforeSha=...`. Missing after
+      → throws with `afterSha=...`. Caller catches + logs + skips —
+      visual failure never poisons the code review verdict.
+    - Closes the default-created `PlaywrightCapture` in a `finally`
+      block. User-supplied captures are the caller's responsibility.
+  - 25 test cases across `diff` (identical → 0, completely different
+    → 1, half-half ≈ 0.5, size-mismatch pads instead of throws, diff
+    image dims, threshold sensitivity, classifyDiffRatio boundaries),
+    `capture` (single launch across captures, viewport + DSF wiring,
+    extraHTTPHeaders propagation, fullPage default + override,
+    waitForSelector triggered, postLoadDelayMs=0 skips wait, finalUrl
+    + viewport returned, close() + re-launch), and `orchestrator`
+    (happy path 3 PNGs written, identical severity, missing before
+    throws with actionable sha, missing after throws, default
+    outputDir `.conclave/visual/<sha>`, user-supplied capture NOT
+    closed by orchestrator, PreviewResolution metadata surfaced).
+
+### Added
 - **`Platform` interface in `@ai-conclave/core`** (decision #31: v2.0
   platform set). Contract: `resolve({ repo, sha, waitSeconds? })` →
   `{ url, provider, sha, deploymentId?, createdAt? } | null`. Missing

--- a/packages/visual-review/README.md
+++ b/packages/visual-review/README.md
@@ -1,0 +1,70 @@
+# @ai-conclave/visual-review
+
+Before/after visual review for Ai-Conclave. Captures PNG screenshots of
+a PR's deployed preview (before SHA + after SHA), runs pixel diff, saves
+all three PNGs + metadata to disk.
+
+Decision #15: odiff is the intended fast path for v2.x; pixelmatch
+(pure JS) ships as the default for a simple install.
+
+## Install
+
+```bash
+pnpm add @ai-conclave/visual-review @ai-conclave/core
+pnpm add playwright           # peer dep; install chromium separately
+npx playwright install chromium
+```
+
+## Usage
+
+```ts
+import { runVisualReview } from "@ai-conclave/visual-review";
+import { VercelPlatform } from "@ai-conclave/platform-vercel";
+import { NetlifyPlatform } from "@ai-conclave/platform-netlify";
+
+const result = await runVisualReview({
+  repo: "acme/app",
+  beforeSha: "abc123",
+  afterSha: "def456",
+  platforms: [new VercelPlatform(), new NetlifyPlatform()],
+  captureOptions: { width: 1440, height: 900, fullPage: true },
+  diffOptions: { threshold: 0.1 },
+  waitSeconds: 120, // allow deploy to finish building
+});
+
+console.log(result.severity);           // "minor" | "significant" | "major" | ...
+console.log(result.diff.diffRatio);     // 0.0023
+console.log(result.paths.diff);         // .conclave/visual/def456/diff.png
+```
+
+## Severity bands
+
+| Ratio | Label | Meaning |
+|---|---|---|
+| < 0.05% | `identical` | noise-only change |
+| < 1% | `minor` | small area touched (a button, an icon) |
+| < 10% | `significant` | a section reworked |
+| < 50% | `major` | bulk change across the page |
+| ≥ 50% | `total-rewrite` | different page entirely |
+
+## Pluggable engines
+
+```ts
+// Swap in odiff for 6-8× speed
+runVisualReview({ …, diff: new OdiffAdapter() });
+
+// Swap in Puppeteer if Playwright isn't available
+runVisualReview({ …, capture: new PuppeteerCapture() });
+```
+
+Both `ScreenshotCapture` and `VisualDiff` are interfaces — any
+implementation works.
+
+## Output
+
+```
+.conclave/visual/<afterSha>/
+├── before.png   # full-page screenshot at beforeSha
+├── after.png    # full-page screenshot at afterSha
+└── diff.png     # pixelmatch output (red = changed)
+```

--- a/packages/visual-review/package.json
+++ b/packages/visual-review/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@ai-conclave/visual-review",
+  "version": "0.0.0",
+  "description": "Ai-Conclave visual review — Playwright screenshots + pixel diff for before/after design review.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@ai-conclave/core": "workspace:*",
+    "pixelmatch": "^6.0.0",
+    "pngjs": "^7.0.0"
+  },
+  "peerDependencies": {
+    "playwright": "^1.49.0"
+  },
+  "peerDependenciesMeta": {
+    "playwright": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/pngjs": "^6.0.5",
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/visual-review/src/capture.ts
+++ b/packages/visual-review/src/capture.ts
@@ -1,0 +1,163 @@
+export interface CaptureOptions {
+  /** Viewport width. Default 1280. */
+  width?: number;
+  /** Viewport height. Default 800. */
+  height?: number;
+  /** Device scale factor for retina-like output. Default 1. */
+  deviceScaleFactor?: number;
+  /** Full-page screenshot (scroll + stitch) vs viewport only. Default true. */
+  fullPage?: boolean;
+  /** Navigation timeout (ms). Default 30_000. */
+  timeoutMs?: number;
+  /** Wait-for selector before screenshotting. */
+  waitForSelector?: string;
+  /** Extra delay after page load (ms). Default 500 for network settle. */
+  postLoadDelayMs?: number;
+  /** HTTP headers (e.g. auth) forwarded to the request. */
+  extraHTTPHeaders?: Record<string, string>;
+}
+
+export interface CaptureResult {
+  /** PNG image bytes. */
+  png: Uint8Array;
+  /** Final URL after redirects. */
+  finalUrl: string;
+  /** Viewport used. */
+  viewport: { width: number; height: number; deviceScaleFactor: number };
+}
+
+/**
+ * ScreenshotCapture — pluggable capture interface. Default impl below
+ * uses Playwright; users who already have Puppeteer / browser-instance
+ * of their choice can swap via `opts.capture` on the orchestrator.
+ */
+export interface ScreenshotCapture {
+  readonly id: string;
+  capture(url: string, opts?: CaptureOptions): Promise<CaptureResult>;
+  close(): Promise<void>;
+}
+
+/** Minimal Playwright subset we rely on — typed narrowly for test mocking. */
+export interface PlaywrightLike {
+  chromium: {
+    launch(opts?: { headless?: boolean }): Promise<PlaywrightBrowser>;
+  };
+}
+
+export interface PlaywrightBrowser {
+  newContext(opts?: {
+    viewport?: { width: number; height: number };
+    deviceScaleFactor?: number;
+    extraHTTPHeaders?: Record<string, string>;
+  }): Promise<PlaywrightContext>;
+  close(): Promise<void>;
+}
+
+export interface PlaywrightContext {
+  newPage(): Promise<PlaywrightPage>;
+  close(): Promise<void>;
+}
+
+export interface PlaywrightPage {
+  goto(url: string, opts?: { timeout?: number; waitUntil?: string }): Promise<{ url: () => string } | null>;
+  url(): string;
+  waitForSelector(selector: string, opts?: { timeout?: number }): Promise<unknown>;
+  waitForTimeout(ms: number): Promise<void>;
+  screenshot(opts?: { fullPage?: boolean }): Promise<Uint8Array | Buffer>;
+  close(): Promise<void>;
+}
+
+const DEFAULT_WIDTH = 1280;
+const DEFAULT_HEIGHT = 800;
+const DEFAULT_DELAY = 500;
+const DEFAULT_TIMEOUT = 30_000;
+
+export interface PlaywrightCaptureOptions {
+  /** Pre-launched Playwright module (tests). */
+  playwright?: PlaywrightLike;
+  /** Factory invoked when `playwright` is not supplied. Defaults to dynamic `import("playwright")`. */
+  playwrightFactory?: () => Promise<PlaywrightLike>;
+  /** Run browser with visible UI (debugging). Default headless. */
+  headless?: boolean;
+}
+
+/**
+ * PlaywrightCapture — launches one Chromium, reuses context across
+ * captures in the same process, closes on explicit `close()`.
+ *
+ * Playwright is declared as an optional peer dependency so installers
+ * that never run visual review don't pay the ~300MB Chromium cost.
+ * `opts.playwright` injection lets tests avoid the real SDK entirely.
+ */
+export class PlaywrightCapture implements ScreenshotCapture {
+  readonly id = "playwright";
+
+  private readonly factory: () => Promise<PlaywrightLike>;
+  private readonly headless: boolean;
+  private browserPromise: Promise<PlaywrightBrowser> | null = null;
+
+  constructor(opts: PlaywrightCaptureOptions = {}) {
+    this.headless = opts.headless ?? true;
+    this.factory =
+      opts.playwrightFactory ??
+      (async () => {
+        if (opts.playwright) return opts.playwright;
+        try {
+          return (await import("playwright")) as unknown as PlaywrightLike;
+        } catch (err) {
+          throw new Error(
+            "PlaywrightCapture: playwright not installed. Run `pnpm add playwright && npx playwright install chromium`.",
+          );
+        }
+      });
+  }
+
+  private async getBrowser(): Promise<PlaywrightBrowser> {
+    if (!this.browserPromise) {
+      this.browserPromise = (async () => {
+        const pw = await this.factory();
+        return pw.chromium.launch({ headless: this.headless });
+      })();
+    }
+    return this.browserPromise;
+  }
+
+  async capture(url: string, opts: CaptureOptions = {}): Promise<CaptureResult> {
+    const width = opts.width ?? DEFAULT_WIDTH;
+    const height = opts.height ?? DEFAULT_HEIGHT;
+    const deviceScaleFactor = opts.deviceScaleFactor ?? 1;
+    const fullPage = opts.fullPage ?? true;
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT;
+    const postLoadDelayMs = opts.postLoadDelayMs ?? DEFAULT_DELAY;
+
+    const browser = await this.getBrowser();
+    const contextOpts: Parameters<PlaywrightBrowser["newContext"]>[0] = {
+      viewport: { width, height },
+      deviceScaleFactor,
+    };
+    if (opts.extraHTTPHeaders) contextOpts.extraHTTPHeaders = opts.extraHTTPHeaders;
+    const context = await browser.newContext(contextOpts);
+    try {
+      const page = await context.newPage();
+      await page.goto(url, { timeout: timeoutMs, waitUntil: "networkidle" });
+      if (opts.waitForSelector) {
+        await page.waitForSelector(opts.waitForSelector, { timeout: timeoutMs });
+      }
+      if (postLoadDelayMs > 0) await page.waitForTimeout(postLoadDelayMs);
+      const raw = await page.screenshot({ fullPage });
+      const png = raw instanceof Uint8Array ? raw : new Uint8Array(raw as ArrayBuffer);
+      const finalUrl = page.url();
+      await page.close();
+      return { png, finalUrl, viewport: { width, height, deviceScaleFactor } };
+    } finally {
+      await context.close();
+    }
+  }
+
+  async close(): Promise<void> {
+    if (!this.browserPromise) return;
+    const browser = await this.browserPromise;
+    await browser.close();
+    this.browserPromise = null;
+  }
+}

--- a/packages/visual-review/src/diff.ts
+++ b/packages/visual-review/src/diff.ts
@@ -1,0 +1,120 @@
+import { PNG } from "pngjs";
+import pixelmatch from "pixelmatch";
+
+export interface DiffOptions {
+  /** Pixelmatch threshold (0..1). Lower = stricter. Default 0.1. */
+  threshold?: number;
+  /** If true, anti-aliased pixels are ignored. Default true. */
+  ignoreAntialiasing?: boolean;
+  /** Alpha for unchanged pixels in diff image (0..1). Default 0.3. */
+  alpha?: number;
+  /** Color of different pixels in diff image [R, G, B]. Default [255, 0, 0]. */
+  diffColor?: [number, number, number];
+}
+
+export interface DiffResult {
+  /** Diff PNG image bytes (same dimensions as inputs). */
+  diffPng: Uint8Array;
+  /** Number of pixels that differ. */
+  diffPixels: number;
+  /** Total pixels (width × height). */
+  totalPixels: number;
+  /** diffPixels / totalPixels, 0..1. */
+  diffRatio: number;
+  /** Resolved dimensions. */
+  width: number;
+  height: number;
+}
+
+export interface VisualDiff {
+  readonly id: string;
+  diff(before: Uint8Array, after: Uint8Array, opts?: DiffOptions): Promise<DiffResult>;
+}
+
+/**
+ * PixelmatchDiff — pure-JS pixel comparison using `pixelmatch` + `pngjs`.
+ *
+ * Handles size mismatch gracefully: canvas padded to the larger of the
+ * two with transparent pixels so the diff is computable instead of
+ * throwing. Callers inspect `diffRatio` to classify "identical / minor /
+ * significant / total rewrite".
+ *
+ * For Zig/SIMD speed (~6-8×) swap in an `odiff` impl behind this
+ * interface — the `VisualDiff` contract stays the same.
+ */
+export class PixelmatchDiff implements VisualDiff {
+  readonly id = "pixelmatch";
+
+  async diff(before: Uint8Array, after: Uint8Array, opts: DiffOptions = {}): Promise<DiffResult> {
+    const beforePng = PNG.sync.read(Buffer.from(before));
+    const afterPng = PNG.sync.read(Buffer.from(after));
+
+    const width = Math.max(beforePng.width, afterPng.width);
+    const height = Math.max(beforePng.height, afterPng.height);
+
+    const beforeCanvas = padToSize(beforePng, width, height);
+    const afterCanvas = padToSize(afterPng, width, height);
+    const diffCanvas = new PNG({ width, height });
+
+    const threshold = opts.threshold ?? 0.1;
+    const ignoreAntialiasing = opts.ignoreAntialiasing ?? true;
+    const alpha = opts.alpha ?? 0.3;
+    const diffColor = opts.diffColor ?? [255, 0, 0];
+
+    const diffPixels = pixelmatch(
+      beforeCanvas.data,
+      afterCanvas.data,
+      diffCanvas.data,
+      width,
+      height,
+      {
+        threshold,
+        includeAA: !ignoreAntialiasing,
+        alpha,
+        diffColor,
+      },
+    );
+
+    const diffPngBuf = PNG.sync.write(diffCanvas);
+    const totalPixels = width * height;
+    return {
+      diffPng: new Uint8Array(diffPngBuf),
+      diffPixels,
+      totalPixels,
+      diffRatio: totalPixels === 0 ? 0 : diffPixels / totalPixels,
+      width,
+      height,
+    };
+  }
+}
+
+function padToSize(source: PNG, targetWidth: number, targetHeight: number): PNG {
+  if (source.width === targetWidth && source.height === targetHeight) return source;
+  const padded = new PNG({ width: targetWidth, height: targetHeight });
+  // Fill with transparent black; pixelmatch will see it as "different".
+  padded.data.fill(0);
+  for (let y = 0; y < source.height; y += 1) {
+    for (let x = 0; x < source.width; x += 1) {
+      const sIdx = (source.width * y + x) << 2;
+      const dIdx = (targetWidth * y + x) << 2;
+      padded.data[dIdx] = source.data[sIdx] ?? 0;
+      padded.data[dIdx + 1] = source.data[sIdx + 1] ?? 0;
+      padded.data[dIdx + 2] = source.data[sIdx + 2] ?? 0;
+      padded.data[dIdx + 3] = source.data[sIdx + 3] ?? 0;
+    }
+  }
+  return padded;
+}
+
+/**
+ * Classify a diff ratio into a coarse severity label — used by the
+ * orchestrator to decide whether to surface the visual change in the
+ * review output or ignore it.
+ */
+export function classifyDiffRatio(ratio: number): "identical" | "minor" | "significant" | "major" | "total-rewrite" {
+  if (ratio < 0.0005) return "identical";       // <0.05% changed
+  if (ratio < 0.01) return "minor";              // <1%
+  if (ratio < 0.10) return "significant";        // <10%
+  if (ratio < 0.50) return "major";              // <50%
+  return "total-rewrite";
+}

--- a/packages/visual-review/src/index.ts
+++ b/packages/visual-review/src/index.ts
@@ -1,0 +1,17 @@
+export { PlaywrightCapture } from "./capture.js";
+export type {
+  CaptureOptions,
+  CaptureResult,
+  ScreenshotCapture,
+  PlaywrightLike,
+  PlaywrightBrowser,
+  PlaywrightContext,
+  PlaywrightPage,
+  PlaywrightCaptureOptions,
+} from "./capture.js";
+
+export { PixelmatchDiff, classifyDiffRatio } from "./diff.js";
+export type { DiffOptions, DiffResult, VisualDiff } from "./diff.js";
+
+export { runVisualReview } from "./orchestrator.js";
+export type { VisualReviewInput, VisualReviewResult } from "./orchestrator.js";

--- a/packages/visual-review/src/orchestrator.ts
+++ b/packages/visual-review/src/orchestrator.ts
@@ -1,0 +1,113 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { Platform, PreviewResolution } from "@ai-conclave/core";
+import { resolveFirstPreview } from "@ai-conclave/core";
+import {
+  PlaywrightCapture,
+  type CaptureOptions,
+  type CaptureResult,
+  type ScreenshotCapture,
+} from "./capture.js";
+import { PixelmatchDiff, classifyDiffRatio, type DiffOptions, type DiffResult, type VisualDiff } from "./diff.js";
+
+export interface VisualReviewInput {
+  repo: string;
+  beforeSha: string;
+  afterSha: string;
+  /** Ordered platforms to try for URL resolution. First non-null wins. */
+  platforms: readonly Platform[];
+  /** Directory to write PNGs under. Defaults to `.conclave/visual/<afterSha>/`. */
+  outputDir?: string;
+  /** Override capture + diff engines. */
+  capture?: ScreenshotCapture;
+  diff?: VisualDiff;
+  /** Capture options (viewport / timeouts / etc.). */
+  captureOptions?: CaptureOptions;
+  /** Diff options (threshold / anti-alias handling). */
+  diffOptions?: DiffOptions;
+  /** Poll preview URL resolution up to N seconds. Default 0 (single try per platform). */
+  waitSeconds?: number;
+}
+
+export interface VisualReviewResult {
+  /** Resolved preview URLs + provider metadata. */
+  before: PreviewResolution;
+  after: PreviewResolution;
+  /** Local paths (absolute) to the saved PNGs. */
+  paths: { before: string; after: string; diff: string };
+  /** Captured viewport + final URLs after redirect. */
+  captures: { before: CaptureResult; after: CaptureResult };
+  /** Raw diff metrics. */
+  diff: DiffResult;
+  /** Coarse severity label. */
+  severity: ReturnType<typeof classifyDiffRatio>;
+}
+
+/**
+ * Run a full visual review — resolve URLs for both SHAs, capture both,
+ * diff them, write PNGs to disk. Returns structured result for the
+ * caller (CLI review command, Telegram/Discord notifier, etc.).
+ *
+ * Design:
+ *   - Platform resolution is best-effort. If EITHER before or after URL
+ *     can't be resolved, the whole review throws a specific error —
+ *     the caller is expected to log + skip, not propagate blame onto
+ *     the code review.
+ *   - Captures are sequential (single browser instance, two pages).
+ *     Fresh context per capture for isolation.
+ *   - Diff runs after both captures land. Size-mismatched images pad to
+ *     the larger dimensions (see `diff.ts`) — no throw.
+ *   - PNGs written to `<outputDir>/(before|after|diff).png`.
+ */
+export async function runVisualReview(input: VisualReviewInput): Promise<VisualReviewResult> {
+  const beforeRes = await resolveFirstPreview(input.platforms, {
+    repo: input.repo,
+    sha: input.beforeSha,
+    waitSeconds: input.waitSeconds ?? 0,
+  });
+  if (!beforeRes) {
+    throw new Error(
+      `visual-review: no preview URL found for beforeSha=${input.beforeSha} across ${input.platforms.length} platform(s)`,
+    );
+  }
+  const afterRes = await resolveFirstPreview(input.platforms, {
+    repo: input.repo,
+    sha: input.afterSha,
+    waitSeconds: input.waitSeconds ?? 0,
+  });
+  if (!afterRes) {
+    throw new Error(
+      `visual-review: no preview URL found for afterSha=${input.afterSha} across ${input.platforms.length} platform(s)`,
+    );
+  }
+
+  const capture = input.capture ?? new PlaywrightCapture();
+  try {
+    const beforeCap = await capture.capture(beforeRes.url, input.captureOptions);
+    const afterCap = await capture.capture(afterRes.url, input.captureOptions);
+
+    const diff = input.diff ?? new PixelmatchDiff();
+    const diffResult = await diff.diff(beforeCap.png, afterCap.png, input.diffOptions);
+
+    const outDir = path.resolve(input.outputDir ?? path.join(".conclave", "visual", input.afterSha));
+    await fs.mkdir(outDir, { recursive: true });
+    const beforePath = path.join(outDir, "before.png");
+    const afterPath = path.join(outDir, "after.png");
+    const diffPath = path.join(outDir, "diff.png");
+    await fs.writeFile(beforePath, beforeCap.png);
+    await fs.writeFile(afterPath, afterCap.png);
+    await fs.writeFile(diffPath, diffResult.diffPng);
+
+    return {
+      before: beforeRes,
+      after: afterRes,
+      paths: { before: beforePath, after: afterPath, diff: diffPath },
+      captures: { before: beforeCap, after: afterCap },
+      diff: diffResult,
+      severity: classifyDiffRatio(diffResult.diffRatio),
+    };
+  } finally {
+    // Close only if WE created the capture; user-supplied instances are their responsibility.
+    if (!input.capture) await capture.close();
+  }
+}

--- a/packages/visual-review/test/capture.test.mjs
+++ b/packages/visual-review/test/capture.test.mjs
@@ -1,0 +1,165 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PNG } from "pngjs";
+import { PlaywrightCapture } from "../dist/index.js";
+
+function solidPng(width, height) {
+  const png = new PNG({ width, height });
+  for (let i = 0; i < png.data.length; i += 4) {
+    png.data[i] = 180;
+    png.data[i + 1] = 180;
+    png.data[i + 2] = 180;
+    png.data[i + 3] = 255;
+  }
+  return new Uint8Array(PNG.sync.write(png));
+}
+
+function mockPlaywright({ navigations = [], screenshots = [] } = {}) {
+  const calls = {
+    launch: 0,
+    newContext: [],
+    goto: [],
+    waitForSelector: [],
+    waitForTimeout: [],
+    screenshot: [],
+  };
+  let navI = 0;
+  let shotI = 0;
+
+  const makePage = () => ({
+    goto: async (url, opts) => {
+      calls.goto.push({ url, opts });
+      const nav = navigations[Math.min(navI, Math.max(0, navigations.length - 1))];
+      navI += 1;
+      return nav ? { url: () => nav } : null;
+    },
+    url: () => {
+      const nav = navigations[Math.max(0, navI - 1)];
+      return nav ?? "";
+    },
+    waitForSelector: async (selector, opts) => {
+      calls.waitForSelector.push({ selector, opts });
+    },
+    waitForTimeout: async (ms) => {
+      calls.waitForTimeout.push(ms);
+    },
+    screenshot: async (opts) => {
+      calls.screenshot.push(opts);
+      const buf = screenshots[Math.min(shotI, Math.max(0, screenshots.length - 1))] ?? solidPng(40, 40);
+      shotI += 1;
+      return buf;
+    },
+    close: async () => {},
+  });
+
+  const browser = {
+    newContext: async (opts) => {
+      calls.newContext.push(opts);
+      return {
+        newPage: async () => makePage(),
+        close: async () => {},
+      };
+    },
+    close: async () => {},
+  };
+
+  const pw = {
+    chromium: {
+      launch: async () => {
+        calls.launch += 1;
+        return browser;
+      },
+    },
+    _calls: calls,
+  };
+  return pw;
+}
+
+test("PlaywrightCapture: launches chromium once across multiple captures", async () => {
+  const pw = mockPlaywright({ navigations: ["https://a", "https://b"] });
+  const c = new PlaywrightCapture({ playwright: pw });
+  await c.capture("https://a");
+  await c.capture("https://b");
+  assert.equal(pw._calls.launch, 1);
+  await c.close();
+});
+
+test("PlaywrightCapture: viewport + deviceScaleFactor wired to context", async () => {
+  const pw = mockPlaywright({ navigations: ["https://a"] });
+  const c = new PlaywrightCapture({ playwright: pw });
+  await c.capture("https://a", { width: 1600, height: 1000, deviceScaleFactor: 2 });
+  const ctx = pw._calls.newContext[0];
+  assert.deepEqual(ctx.viewport, { width: 1600, height: 1000 });
+  assert.equal(ctx.deviceScaleFactor, 2);
+  await c.close();
+});
+
+test("PlaywrightCapture: extraHTTPHeaders propagate", async () => {
+  const pw = mockPlaywright({ navigations: ["https://a"] });
+  const c = new PlaywrightCapture({ playwright: pw });
+  await c.capture("https://a", { extraHTTPHeaders: { "x-secret": "token" } });
+  assert.deepEqual(pw._calls.newContext[0].extraHTTPHeaders, { "x-secret": "token" });
+  await c.close();
+});
+
+test("PlaywrightCapture: fullPage default true", async () => {
+  const pw = mockPlaywright({ navigations: ["https://a"] });
+  const c = new PlaywrightCapture({ playwright: pw });
+  await c.capture("https://a");
+  assert.equal(pw._calls.screenshot[0].fullPage, true);
+  await c.close();
+});
+
+test("PlaywrightCapture: fullPage: false honored", async () => {
+  const pw = mockPlaywright({ navigations: ["https://a"] });
+  const c = new PlaywrightCapture({ playwright: pw });
+  await c.capture("https://a", { fullPage: false });
+  assert.equal(pw._calls.screenshot[0].fullPage, false);
+  await c.close();
+});
+
+test("PlaywrightCapture: waitForSelector called when option set", async () => {
+  const pw = mockPlaywright({ navigations: ["https://a"] });
+  const c = new PlaywrightCapture({ playwright: pw });
+  await c.capture("https://a", { waitForSelector: ".ready" });
+  assert.equal(pw._calls.waitForSelector.length, 1);
+  assert.equal(pw._calls.waitForSelector[0].selector, ".ready");
+  await c.close();
+});
+
+test("PlaywrightCapture: postLoadDelayMs = 0 skips waitForTimeout", async () => {
+  const pw = mockPlaywright({ navigations: ["https://a"] });
+  const c = new PlaywrightCapture({ playwright: pw });
+  await c.capture("https://a", { postLoadDelayMs: 0 });
+  assert.equal(pw._calls.waitForTimeout.length, 0);
+  await c.close();
+});
+
+test("PlaywrightCapture: postLoadDelayMs > 0 invokes waitForTimeout", async () => {
+  const pw = mockPlaywright({ navigations: ["https://a"] });
+  const c = new PlaywrightCapture({ playwright: pw });
+  await c.capture("https://a", { postLoadDelayMs: 1500 });
+  assert.deepEqual(pw._calls.waitForTimeout, [1500]);
+  await c.close();
+});
+
+test("PlaywrightCapture: CaptureResult surfaces final URL + viewport", async () => {
+  const pw = mockPlaywright({ navigations: ["https://a-final"] });
+  const c = new PlaywrightCapture({ playwright: pw });
+  const out = await c.capture("https://a-requested", { width: 800, height: 600 });
+  assert.equal(out.finalUrl, "https://a-final");
+  assert.equal(out.viewport.width, 800);
+  assert.equal(out.viewport.height, 600);
+  assert.ok(out.png instanceof Uint8Array);
+  await c.close();
+});
+
+test("PlaywrightCapture: close() releases browser + subsequent capture relaunches", async () => {
+  const pw = mockPlaywright({ navigations: ["https://a", "https://b"] });
+  const c = new PlaywrightCapture({ playwright: pw });
+  await c.capture("https://a");
+  await c.close();
+  await c.capture("https://b");
+  assert.equal(pw._calls.launch, 2);
+  await c.close();
+});

--- a/packages/visual-review/test/diff.test.mjs
+++ b/packages/visual-review/test/diff.test.mjs
@@ -1,0 +1,109 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PNG } from "pngjs";
+import { PixelmatchDiff, classifyDiffRatio } from "../dist/index.js";
+
+function solidPng(width, height, [r, g, b, a]) {
+  const png = new PNG({ width, height });
+  for (let i = 0; i < png.data.length; i += 4) {
+    png.data[i] = r;
+    png.data[i + 1] = g;
+    png.data[i + 2] = b;
+    png.data[i + 3] = a;
+  }
+  return new Uint8Array(PNG.sync.write(png));
+}
+
+function halfHalfPng(width, height, colorA, colorB) {
+  const png = new PNG({ width, height });
+  const split = Math.floor(width / 2);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const i = (y * width + x) * 4;
+      const c = x < split ? colorA : colorB;
+      png.data[i] = c[0];
+      png.data[i + 1] = c[1];
+      png.data[i + 2] = c[2];
+      png.data[i + 3] = c[3];
+    }
+  }
+  return new Uint8Array(PNG.sync.write(png));
+}
+
+test("PixelmatchDiff: identical images → diffRatio = 0", async () => {
+  const a = solidPng(40, 40, [255, 255, 255, 255]);
+  const b = solidPng(40, 40, [255, 255, 255, 255]);
+  const d = new PixelmatchDiff();
+  const out = await d.diff(a, b);
+  assert.equal(out.diffPixels, 0);
+  assert.equal(out.diffRatio, 0);
+  assert.equal(out.width, 40);
+  assert.equal(out.height, 40);
+});
+
+test("PixelmatchDiff: completely different → diffRatio = 1", async () => {
+  const a = solidPng(20, 20, [0, 0, 0, 255]);
+  const b = solidPng(20, 20, [255, 255, 255, 255]);
+  const d = new PixelmatchDiff();
+  const out = await d.diff(a, b);
+  assert.equal(out.diffRatio, 1);
+});
+
+test("PixelmatchDiff: half-half → diffRatio ≈ 0.5", async () => {
+  const white = [255, 255, 255, 255];
+  const black = [0, 0, 0, 255];
+  const a = halfHalfPng(40, 40, white, white);
+  const b = halfHalfPng(40, 40, white, black);
+  const d = new PixelmatchDiff();
+  const out = await d.diff(a, b);
+  assert.ok(out.diffRatio > 0.45 && out.diffRatio < 0.55, `expected ~0.5, got ${out.diffRatio}`);
+});
+
+test("PixelmatchDiff: size-mismatched images pad to max dims instead of throwing", async () => {
+  const small = solidPng(10, 10, [255, 255, 255, 255]);
+  const big = solidPng(40, 40, [255, 255, 255, 255]);
+  const d = new PixelmatchDiff();
+  const out = await d.diff(small, big);
+  assert.equal(out.width, 40);
+  assert.equal(out.height, 40);
+  // Inner 10x10 matches, outer ring (padded transparent vs white) differs
+  const inner = 10 * 10;
+  const total = 40 * 40;
+  assert.ok(out.diffPixels >= total - inner - 1); // allow 1 px antialiasing slack
+});
+
+test("PixelmatchDiff: diff image has same dimensions as inputs", async () => {
+  const a = solidPng(50, 30, [0, 0, 0, 255]);
+  const b = solidPng(50, 30, [255, 255, 255, 255]);
+  const d = new PixelmatchDiff();
+  const out = await d.diff(a, b);
+  const diffPng = PNG.sync.read(Buffer.from(out.diffPng));
+  assert.equal(diffPng.width, 50);
+  assert.equal(diffPng.height, 30);
+});
+
+test("PixelmatchDiff: threshold controls sensitivity", async () => {
+  // Two near-identical colors: #fefefe vs #ffffff
+  const a = solidPng(30, 30, [254, 254, 254, 255]);
+  const b = solidPng(30, 30, [255, 255, 255, 255]);
+  const d = new PixelmatchDiff();
+  const strict = await d.diff(a, b, { threshold: 0.0 });
+  const lenient = await d.diff(a, b, { threshold: 0.3 });
+  assert.ok(strict.diffPixels >= lenient.diffPixels);
+});
+
+test("classifyDiffRatio: bands", () => {
+  assert.equal(classifyDiffRatio(0), "identical");
+  assert.equal(classifyDiffRatio(0.0001), "identical");
+  assert.equal(classifyDiffRatio(0.005), "minor");
+  assert.equal(classifyDiffRatio(0.05), "significant");
+  assert.equal(classifyDiffRatio(0.25), "major");
+  assert.equal(classifyDiffRatio(0.8), "total-rewrite");
+});
+
+test("classifyDiffRatio: boundary exactness", () => {
+  assert.equal(classifyDiffRatio(0.0005), "minor"); // boundary of identical/minor
+  assert.equal(classifyDiffRatio(0.01), "significant");
+  assert.equal(classifyDiffRatio(0.10), "major");
+  assert.equal(classifyDiffRatio(0.50), "total-rewrite");
+});

--- a/packages/visual-review/test/orchestrator.test.mjs
+++ b/packages/visual-review/test/orchestrator.test.mjs
@@ -1,0 +1,209 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PNG } from "pngjs";
+import { runVisualReview } from "../dist/index.js";
+
+function solidPng(w, h, c = [200, 200, 200, 255]) {
+  const png = new PNG({ width: w, height: h });
+  for (let i = 0; i < png.data.length; i += 4) {
+    png.data[i] = c[0];
+    png.data[i + 1] = c[1];
+    png.data[i + 2] = c[2];
+    png.data[i + 3] = c[3];
+  }
+  return new Uint8Array(PNG.sync.write(png));
+}
+
+function fixedPlatform(id, result) {
+  return { id, displayName: id, resolve: async () => result };
+}
+
+function stubCapture(screenshots) {
+  let i = 0;
+  return {
+    id: "stub",
+    capture: async (url) => ({
+      png: screenshots[Math.min(i++, screenshots.length - 1)],
+      finalUrl: url,
+      viewport: { width: 40, height: 40, deviceScaleFactor: 1 },
+    }),
+    close: async () => {},
+  };
+}
+
+const before = solidPng(40, 40, [255, 255, 255, 255]);
+const after = solidPng(40, 40, [0, 0, 0, 255]);
+
+function freshOut() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "aic-vr-"));
+}
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+test("runVisualReview: happy path writes 3 PNGs + returns severity", async () => {
+  const outDir = freshOut();
+  try {
+    const result = await runVisualReview({
+      repo: "acme/app",
+      beforeSha: "sha-before",
+      afterSha: "sha-after",
+      platforms: [
+        fixedPlatform("vercel", { url: "https://before.preview", provider: "vercel", sha: "sha-before" }),
+        fixedPlatform("vercel", { url: "https://after.preview", provider: "vercel", sha: "sha-after" }),
+      ],
+      outputDir: outDir,
+      capture: stubCapture([before, after]),
+    });
+    assert.equal(result.severity, "total-rewrite"); // 100% different
+    assert.ok(fs.existsSync(result.paths.before));
+    assert.ok(fs.existsSync(result.paths.after));
+    assert.ok(fs.existsSync(result.paths.diff));
+    assert.equal(result.diff.diffRatio, 1);
+  } finally {
+    cleanup(outDir);
+  }
+});
+
+test("runVisualReview: identical captures → severity = identical", async () => {
+  const outDir = freshOut();
+  try {
+    const result = await runVisualReview({
+      repo: "acme/app",
+      beforeSha: "s1",
+      afterSha: "s2",
+      platforms: [
+        fixedPlatform("vercel", { url: "https://x", provider: "vercel", sha: "s1" }),
+        fixedPlatform("vercel", { url: "https://y", provider: "vercel", sha: "s2" }),
+      ],
+      outputDir: outDir,
+      capture: stubCapture([before, before]),
+    });
+    assert.equal(result.severity, "identical");
+    assert.equal(result.diff.diffRatio, 0);
+  } finally {
+    cleanup(outDir);
+  }
+});
+
+test("runVisualReview: before URL not found throws with before-sha message", async () => {
+  // Platform resolves per-call sha; the walker calls resolve() for each sha.
+  // First call (before) returns null, second would return a URL but we never get there.
+  const firstNull = fixedPlatform("noop", null);
+  await assert.rejects(
+    () =>
+      runVisualReview({
+        repo: "acme/app",
+        beforeSha: "missing-before",
+        afterSha: "sha-after",
+        platforms: [firstNull],
+        capture: stubCapture([before, after]),
+      }),
+    /beforeSha=missing-before/,
+  );
+});
+
+test("runVisualReview: after URL not found throws with after-sha message", async () => {
+  let call = 0;
+  const platform = {
+    id: "partial",
+    displayName: "partial",
+    resolve: async (input) => {
+      call += 1;
+      if (input.sha === "missing-after") return null;
+      return { url: "https://before.preview", provider: "partial", sha: input.sha };
+    },
+  };
+  await assert.rejects(
+    () =>
+      runVisualReview({
+        repo: "acme/app",
+        beforeSha: "sha-before",
+        afterSha: "missing-after",
+        platforms: [platform],
+        capture: stubCapture([before, after]),
+      }),
+    /afterSha=missing-after/,
+  );
+  assert.ok(call >= 2);
+});
+
+test("runVisualReview: writes to default outputDir .conclave/visual/<afterSha>", async () => {
+  const cwdBefore = process.cwd();
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "aic-vr-cwd-"));
+  process.chdir(tmp);
+  try {
+    const result = await runVisualReview({
+      repo: "acme/app",
+      beforeSha: "b",
+      afterSha: "mysha",
+      platforms: [
+        fixedPlatform("p", { url: "https://b", provider: "p", sha: "b" }),
+        fixedPlatform("p", { url: "https://a", provider: "p", sha: "mysha" }),
+      ],
+      capture: stubCapture([before, before]),
+    });
+    assert.match(result.paths.diff, /\.conclave[\\/]+visual[\\/]+mysha[\\/]+diff\.png$/);
+  } finally {
+    process.chdir(cwdBefore);
+    cleanup(tmp);
+  }
+});
+
+test("runVisualReview: user-supplied capture is NOT closed by orchestrator", async () => {
+  const outDir = freshOut();
+  try {
+    let closed = 0;
+    const capture = {
+      id: "stub",
+      capture: async (url) => ({
+        png: before,
+        finalUrl: url,
+        viewport: { width: 40, height: 40, deviceScaleFactor: 1 },
+      }),
+      close: async () => {
+        closed += 1;
+      },
+    };
+    await runVisualReview({
+      repo: "acme/app",
+      beforeSha: "a",
+      afterSha: "b",
+      platforms: [
+        fixedPlatform("p", { url: "https://a", provider: "p", sha: "a" }),
+        fixedPlatform("p", { url: "https://b", provider: "p", sha: "b" }),
+      ],
+      outputDir: outDir,
+      capture,
+    });
+    assert.equal(closed, 0, "user-supplied capture should be closed by the user, not the orchestrator");
+  } finally {
+    cleanup(outDir);
+  }
+});
+
+test("runVisualReview: result surfaces resolved preview metadata", async () => {
+  const outDir = freshOut();
+  try {
+    const result = await runVisualReview({
+      repo: "acme/app",
+      beforeSha: "b-sha",
+      afterSha: "a-sha",
+      platforms: [
+        fixedPlatform("vercel", { url: "https://b-preview", provider: "vercel", sha: "b-sha", deploymentId: "dep-b" }),
+        fixedPlatform("vercel", { url: "https://a-preview", provider: "vercel", sha: "a-sha", deploymentId: "dep-a" }),
+      ],
+      outputDir: outDir,
+      capture: stubCapture([before, after]),
+    });
+    assert.equal(result.before.url, "https://b-preview");
+    assert.equal(result.before.deploymentId, "dep-b");
+    assert.equal(result.after.url, "https://a-preview");
+    assert.equal(result.after.deploymentId, "dep-a");
+  } finally {
+    cleanup(outDir);
+  }
+});

--- a/packages/visual-review/tsconfig.json
+++ b/packages/visual-review/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}


### PR DESCRIPTION
## Summary

Lands the **design-review half** of ai-conclave's value proposition: for every PR, capture the deployed-preview BEFORE state + AFTER state, diff them pixel-wise, surface severity. Uses the Platform adapters from PR #17 for URL resolution.

Decision #15 locks `odiff` as the fast path for v2.x. This PR ships the pluggable pattern with `pixelmatch` (pure JS, no native binary) as the day-1 default — odiff slots in as a drop-in `VisualDiff` adapter later.

## Architecture

```
runVisualReview({ platforms, repo, beforeSha, afterSha, ... })
  │
  ├─ resolveFirstPreview(platforms, beforeSha)  ← from @ai-conclave/core
  ├─ resolveFirstPreview(platforms, afterSha)
  ├─ ScreenshotCapture.capture(beforeUrl)       ← default: PlaywrightCapture
  ├─ ScreenshotCapture.capture(afterUrl)
  ├─ VisualDiff.diff(beforePng, afterPng)       ← default: PixelmatchDiff
  ├─ writeFile(before.png, after.png, diff.png) ← .conclave/visual/<afterSha>/
  └─ return { before, after, paths, captures, diff, severity }
```

## Severity bands

| Ratio | Label |
|---|---|
| < 0.05% | `identical` |
| < 1% | `minor` |
| < 10% | `significant` |
| < 50% | `major` |
| ≥ 50% | `total-rewrite` |

## Install

Playwright is an **optional peer dep** so users who never run visual review don't pay the ~300MB Chromium cost:

```bash
pnpm add @ai-conclave/visual-review @ai-conclave/core
pnpm add playwright
npx playwright install chromium
```

## Pluggable engines

- Capture: swap `PlaywrightCapture` → `PuppeteerCapture` / custom by implementing `ScreenshotCapture`.
- Diff: swap `PixelmatchDiff` → `OdiffAdapter` (6-8× faster) / custom by implementing `VisualDiff`.

Same orchestrator, same result shape.

## Tests — 25 cases

### `diff.test.mjs` (8)
identical → 0 ratio, completely different → 1, half-half ≈ 0.5, size-mismatch pads instead of throws (outer-ring diff), diff image dims match inputs, threshold sensitivity monotonic, classifyDiffRatio label bands + exact boundaries.

### `capture.test.mjs` (10)
Chromium launched once across multiple captures, viewport + DSF wired to context, extraHTTPHeaders propagated, fullPage default true + override, waitForSelector only when set, postLoadDelayMs=0 skips wait / >0 invokes, finalUrl + viewport surfaced, close() + re-capture re-launches.

### `orchestrator.test.mjs` (7)
Happy path writes 3 PNGs + severity label, identical captures → `identical`, missing-before throws with `beforeSha=...`, missing-after throws with `afterSha=...`, default outputDir `.conclave/visual/<afterSha>/`, user-supplied capture NOT closed by orchestrator, PreviewResolution metadata (deploymentId etc.) on result.

## Deferred

- **Vision-model semantic judgment** (is this a regression or an intentional redesign?) — next PR, rides on existing Claude/OpenAI/Gemini agents with image input.
- **odiff** native-binary adapter.
- **CLI `--visual` flag** on `conclave review` — next PR wires this into the default review flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)