### PR TITLE
feat: platform-cloudflare + platform-deployment-status (decision #31 v2.0 complete minus Railway)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 ## Unreleased
 
 ### Added
+- **`@ai-conclave/platform-cloudflare`** — Cloudflare Pages adapter via
+  `GET /accounts/{id}/pages/projects/{name}/deployments`. Filters
+  client-side by `deployment_trigger.metadata.commit_hash`; picks newest
+  `latest_stage.status: "success"`. URL-encodes project name for
+  projects with spaces. API `success: false` → throw with first error
+  message. Env: `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` +
+  `CLOUDFLARE_PROJECT_NAME`.
+- **`@ai-conclave/platform-deployment-status`** — generic GitHub
+  Deployments API adapter. Works with **any** host that posts back to
+  GitHub (Render / Fly / Railway / Replit / Docker / custom CI) without
+  a dedicated package. Uses `gh api /repos/{repo}/deployments?sha=<sha>`
+  then resolves each candidate's status. Picks newest in an accepted
+  state (default `["success"]`). URL fallback chain:
+  `environment_url` → `target_url`. Optional `environment` filter.
+  Intended LAST in platform chain — dedicated adapters come first.
+- 19 test cases across Cloudflare + deployment-status covering env
+  validation, commit matching, state filtering, URL fallback, newest-
+  wins, error surfaces, URL encoding, empty results.
 - **`@ai-conclave/visual-review`** — before/after visual diff package
   (decision #15 partial — pixelmatch default; odiff for v2.x speed
   upgrade):

--- a/packages/platform-cloudflare/README.md
+++ b/packages/platform-cloudflare/README.md
@@ -1,0 +1,17 @@
+# @ai-conclave/platform-cloudflare
+
+Cloudflare Pages adapter. Mirrors `@ai-conclave/platform-vercel` /
+`platform-netlify` contracts.
+
+## Env
+
+| Var | Required |
+|---|---|
+| `CLOUDFLARE_API_TOKEN` | ✓ (Pages:Edit permission) |
+| `CLOUDFLARE_ACCOUNT_ID` | ✓ |
+| `CLOUDFLARE_PROJECT_NAME` | ✓ |
+
+```ts
+import { CloudflarePlatform } from "@ai-conclave/platform-cloudflare";
+const cf = new CloudflarePlatform();  // reads env
+```

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ai-conclave/platform-cloudflare",
+  "version": "0.0.0",
+  "description": "Ai-Conclave Cloudflare Pages adapter — resolve preview URL for a commit SHA via Cloudflare API.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@ai-conclave/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -1,0 +1,132 @@
+import type { Platform, PreviewResolution, ResolvePreviewInput } from "@ai-conclave/core";
+
+export interface HttpFetch {
+  (url: string, init: { method: string; headers: Record<string, string> }): Promise<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+    text: () => Promise<string>;
+  }>;
+}
+
+export interface CloudflareAdapterOptions {
+  apiToken?: string;
+  accountId?: string;
+  projectName?: string;
+  baseUrl?: string;
+  waitSeconds?: number;
+  fetch?: HttpFetch;
+}
+
+interface CfDeployment {
+  id?: string;
+  url?: string;
+  latest_stage?: { status?: string };
+  deployment_trigger?: { metadata?: { commit_hash?: string } };
+  created_on?: string;
+}
+
+interface CfPageResponse {
+  success?: boolean;
+  errors?: Array<{ code?: number; message?: string }>;
+  result?: CfDeployment[];
+}
+
+/**
+ * CloudflarePlatform — resolves preview URL for (repo, sha) via
+ * Cloudflare Pages' REST API:
+ * `GET /accounts/{account}/pages/projects/{project}/deployments`
+ *
+ * Cloudflare Pages does not filter server-side by commit; we fetch
+ * recent deployments and filter client-side by `deployment_trigger.
+ * metadata.commit_hash`. Picks the newest with `latest_stage.status:
+ * "success"`.
+ *
+ * Env:
+ *   CLOUDFLARE_API_TOKEN    — required (Pages:Edit permission)
+ *   CLOUDFLARE_ACCOUNT_ID   — required
+ *   CLOUDFLARE_PROJECT_NAME — required
+ */
+export class CloudflarePlatform implements Platform {
+  readonly id = "cloudflare-pages";
+  readonly displayName = "Cloudflare Pages";
+
+  private readonly apiToken: string;
+  private readonly accountId: string;
+  private readonly projectName: string;
+  private readonly baseUrl: string;
+  private readonly waitSeconds: number;
+  private readonly fetchFn: HttpFetch;
+
+  constructor(opts: CloudflareAdapterOptions = {}) {
+    const token = opts.apiToken ?? process.env["CLOUDFLARE_API_TOKEN"] ?? "";
+    const account = opts.accountId ?? process.env["CLOUDFLARE_ACCOUNT_ID"] ?? "";
+    const project = opts.projectName ?? process.env["CLOUDFLARE_PROJECT_NAME"] ?? "";
+    if (!token) throw new Error("CloudflarePlatform: CLOUDFLARE_API_TOKEN not set");
+    if (!account) throw new Error("CloudflarePlatform: CLOUDFLARE_ACCOUNT_ID not set");
+    if (!project) throw new Error("CloudflarePlatform: CLOUDFLARE_PROJECT_NAME not set");
+    this.apiToken = token;
+    this.accountId = account;
+    this.projectName = project;
+    this.baseUrl = opts.baseUrl ?? "https://api.cloudflare.com/client/v4";
+    this.waitSeconds = opts.waitSeconds ?? 0;
+    this.fetchFn = opts.fetch ?? ((...args) => fetch(...(args as Parameters<typeof fetch>)) as ReturnType<HttpFetch>);
+  }
+
+  async resolve(input: ResolvePreviewInput): Promise<PreviewResolution | null> {
+    const wait = input.waitSeconds ?? this.waitSeconds;
+    const deadline = Date.now() + wait * 1_000;
+    while (true) {
+      const match = await this.pollOnce(input.sha);
+      if (match) return match;
+      if (Date.now() >= deadline) return null;
+      await sleep(Math.min(3_000, Math.max(500, deadline - Date.now())));
+    }
+  }
+
+  private async pollOnce(sha: string): Promise<PreviewResolution | null> {
+    const url = `${this.baseUrl}/accounts/${this.accountId}/pages/projects/${encodeURIComponent(this.projectName)}/deployments`;
+    const res = await this.fetchFn(url, {
+      method: "GET",
+      headers: { authorization: `Bearer ${this.apiToken}` },
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status === 401 || res.status === 403) {
+        throw new Error(`CloudflarePlatform: auth failed (status ${res.status})`);
+      }
+      if (res.status >= 500) {
+        const text = await res.text();
+        throw new Error(`CloudflarePlatform: server error ${res.status}: ${text.slice(0, 200)}`);
+      }
+      return null;
+    }
+    const data = (await res.json()) as CfPageResponse;
+    if (data.success === false) {
+      const msg = data.errors?.[0]?.message ?? "unknown";
+      throw new Error(`CloudflarePlatform: API returned success=false — ${msg}`);
+    }
+    const deployments = data.result ?? [];
+    const matching = deployments
+      .filter(
+        (d) =>
+          d.deployment_trigger?.metadata?.commit_hash === sha &&
+          (d.latest_stage?.status ?? "").toLowerCase() === "success",
+      )
+      .sort((a, b) => (b.created_on ?? "").localeCompare(a.created_on ?? ""));
+    const best = matching[0];
+    if (!best || !best.url) return null;
+    const out: PreviewResolution = {
+      url: best.url.startsWith("http") ? best.url : `https://${best.url}`,
+      provider: "cloudflare-pages",
+      sha,
+    };
+    if (best.id) out.deploymentId = best.id;
+    if (best.created_on) out.createdAt = best.created_on;
+    return out;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/packages/platform-cloudflare/test/cloudflare.test.mjs
+++ b/packages/platform-cloudflare/test/cloudflare.test.mjs
@@ -1,0 +1,162 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CloudflarePlatform } from "../dist/index.js";
+
+function mockFetch(responses) {
+  let i = 0;
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: async () => r.json,
+      text: async () => r.text ?? JSON.stringify(r.json),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const BASE_OPTS = {
+  apiToken: "tok",
+  accountId: "acc",
+  projectName: "proj",
+};
+
+test("CloudflarePlatform: missing token / account / project throws", () => {
+  const origT = process.env.CLOUDFLARE_API_TOKEN;
+  const origA = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const origP = process.env.CLOUDFLARE_PROJECT_NAME;
+  delete process.env.CLOUDFLARE_API_TOKEN;
+  delete process.env.CLOUDFLARE_ACCOUNT_ID;
+  delete process.env.CLOUDFLARE_PROJECT_NAME;
+  try {
+    assert.throws(() => new CloudflarePlatform());
+    assert.throws(() => new CloudflarePlatform({ apiToken: "t" }));
+    assert.throws(() => new CloudflarePlatform({ apiToken: "t", accountId: "a" }));
+  } finally {
+    if (origT !== undefined) process.env.CLOUDFLARE_API_TOKEN = origT;
+    if (origA !== undefined) process.env.CLOUDFLARE_ACCOUNT_ID = origA;
+    if (origP !== undefined) process.env.CLOUDFLARE_PROJECT_NAME = origP;
+  }
+});
+
+test("CloudflarePlatform: newest success deployment matching commit wins", async () => {
+  const f = mockFetch([
+    {
+      json: {
+        success: true,
+        result: [
+          {
+            id: "cf-older",
+            url: "https://old.pages.dev",
+            latest_stage: { status: "success" },
+            deployment_trigger: { metadata: { commit_hash: "sha-head" } },
+            created_on: "2026-04-19T10:00:00Z",
+          },
+          {
+            id: "cf-newer",
+            url: "https://new.pages.dev",
+            latest_stage: { status: "success" },
+            deployment_trigger: { metadata: { commit_hash: "sha-head" } },
+            created_on: "2026-04-19T11:00:00Z",
+          },
+        ],
+      },
+    },
+  ]);
+  const p = new CloudflarePlatform({ ...BASE_OPTS, fetch: f });
+  const out = await p.resolve({ repo: "a/b", sha: "sha-head" });
+  assert.ok(out);
+  assert.equal(out.url, "https://new.pages.dev");
+  assert.equal(out.deploymentId, "cf-newer");
+});
+
+test("CloudflarePlatform: non-matching commit filtered", async () => {
+  const f = mockFetch([
+    {
+      json: {
+        success: true,
+        result: [
+          {
+            id: "d1",
+            url: "https://x.pages.dev",
+            latest_stage: { status: "success" },
+            deployment_trigger: { metadata: { commit_hash: "other-sha" } },
+            created_on: "2026-04-19T10:00:00Z",
+          },
+        ],
+      },
+    },
+  ]);
+  const p = new CloudflarePlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "sha-head" }), null);
+});
+
+test("CloudflarePlatform: non-success stage filtered", async () => {
+  const f = mockFetch([
+    {
+      json: {
+        success: true,
+        result: [
+          {
+            id: "d1",
+            url: "https://x.pages.dev",
+            latest_stage: { status: "building" },
+            deployment_trigger: { metadata: { commit_hash: "sha-head" } },
+            created_on: "2026-04-19T10:00:00Z",
+          },
+        ],
+      },
+    },
+  ]);
+  const p = new CloudflarePlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "sha-head" }), null);
+});
+
+test("CloudflarePlatform: API success=false throws", async () => {
+  const f = mockFetch([
+    {
+      json: {
+        success: false,
+        errors: [{ code: 7003, message: "Could not route to /projects" }],
+        result: [],
+      },
+    },
+  ]);
+  const p = new CloudflarePlatform({ ...BASE_OPTS, fetch: f });
+  await assert.rejects(
+    () => p.resolve({ repo: "a/b", sha: "sha-head" }),
+    /Could not route/,
+  );
+});
+
+test("CloudflarePlatform: bearer auth + correct URL path", async () => {
+  const f = mockFetch([{ json: { success: true, result: [] } }]);
+  const p = new CloudflarePlatform({ ...BASE_OPTS, fetch: f });
+  await p.resolve({ repo: "a/b", sha: "x" });
+  assert.equal(f.calls[0].init.headers.authorization, "Bearer tok");
+  assert.match(f.calls[0].url, /\/accounts\/acc\/pages\/projects\/proj\/deployments$/);
+});
+
+test("CloudflarePlatform: 401 → auth error throw", async () => {
+  const f = mockFetch([{ ok: false, status: 401, json: {}, text: "unauthorized" }]);
+  const p = new CloudflarePlatform({ ...BASE_OPTS, fetch: f });
+  await assert.rejects(() => p.resolve({ repo: "a/b", sha: "x" }), /auth failed/);
+});
+
+test("CloudflarePlatform: 404 → null", async () => {
+  const f = mockFetch([{ ok: false, status: 404, json: {}, text: "not found" }]);
+  const p = new CloudflarePlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "x" }), null);
+});
+
+test("CloudflarePlatform: project name with spaces gets URL-encoded", async () => {
+  const f = mockFetch([{ json: { success: true, result: [] } }]);
+  const p = new CloudflarePlatform({ ...BASE_OPTS, projectName: "my project", fetch: f });
+  await p.resolve({ repo: "a/b", sha: "x" });
+  assert.match(f.calls[0].url, /pages\/projects\/my%20project\/deployments$/);
+});

--- a/packages/platform-cloudflare/tsconfig.json
+++ b/packages/platform-cloudflare/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/platform-deployment-status/README.md
+++ b/packages/platform-deployment-status/README.md
@@ -1,0 +1,48 @@
+# @ai-conclave/platform-deployment-status
+
+Generic GitHub-Deployments-API adapter. Works with **any** host that
+reports deployments back to GitHub via the standard
+`deployment_status` event (Vercel / Netlify / Render / Fly / Railway /
+Replit / Cloudflare / custom CI workflows — if the host follows
+GitHub's standard deploy-status protocol, this adapter resolves its
+preview URL).
+
+## Why
+
+The long tail of hosts (Render / Fly / Railway / Replit / self-hosted
+Docker) doesn't warrant a dedicated adapter package each. This single
+adapter covers them all by reading GitHub as the source of truth —
+same way humans audit deploys via the PR's "Deployments" tab.
+
+## Setup
+
+Uses `gh api` — same auth as `@ai-conclave/scm-github`. No separate
+token. `gh auth login` once is enough.
+
+## Usage
+
+```ts
+import { DeploymentStatusPlatform } from "@ai-conclave/platform-deployment-status";
+
+const generic = new DeploymentStatusPlatform({
+  environment: "preview",          // optional filter
+  acceptedStates: ["success"],     // default
+});
+```
+
+## Fallback placement
+
+Put this adapter LAST in your `platforms` array. Dedicated adapters
+(Vercel, Netlify, Cloudflare) are faster (direct API) and more
+reliable (no dependency on the host posting back to GitHub
+correctly). The generic adapter is a safety net for hosts without a
+dedicated package.
+
+```ts
+const platforms = [
+  new VercelPlatform(),
+  new NetlifyPlatform(),
+  new CloudflarePlatform(),
+  new DeploymentStatusPlatform(),  // ← fallback
+];
+```

--- a/packages/platform-deployment-status/package.json
+++ b/packages/platform-deployment-status/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ai-conclave/platform-deployment-status",
+  "version": "0.0.0",
+  "description": "Ai-Conclave generic platform adapter — resolves preview URL via GitHub Deployments API, works with any host that reports back.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@ai-conclave/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/platform-deployment-status/src/index.ts
+++ b/packages/platform-deployment-status/src/index.ts
@@ -1,0 +1,137 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import type { Platform, PreviewResolution, ResolvePreviewInput } from "@ai-conclave/core";
+
+const execFile = promisify(execFileCallback);
+
+export interface GhRunner {
+  (bin: string, args: readonly string[]): Promise<{ stdout: string; stderr?: string }>;
+}
+
+export interface DeploymentStatusAdapterOptions {
+  /** Filter to deployments in a specific environment. e.g. "preview" or "production". */
+  environment?: string;
+  /** Require the deployment status state to be one of these. Default ["success"]. */
+  acceptedStates?: readonly string[];
+  waitSeconds?: number;
+  run?: GhRunner;
+}
+
+interface GhDeployment {
+  id?: number;
+  sha?: string;
+  environment?: string;
+  statuses_url?: string;
+  created_at?: string;
+}
+
+interface GhDeploymentStatus {
+  state?: string;
+  environment_url?: string;
+  target_url?: string;
+  created_at?: string;
+}
+
+/**
+ * DeploymentStatusPlatform — generic GitHub-based adapter. Works with
+ * ANY host that reports deployments back to GitHub via the
+ * Deployments API (Vercel / Netlify / Render / Fly / Railway / Docker
+ * + custom CI workflows — if they post a `deployment_status` event
+ * with an environment_url, we can resolve it).
+ *
+ * Uses `gh api` — same dependency as @ai-conclave/scm-github. No
+ * separate token setup; `gh auth login` is the single credential.
+ *
+ * Why this exists:
+ *   - One adapter handles the long tail of hosts (Render / Fly /
+ *     Railway / Replit / self-hosted Docker) without a dedicated
+ *     package per host.
+ *   - Reads GitHub as the source of truth — matches how humans already
+ *     audit deploys (PR view → "Deployments" tab).
+ *   - Only requires the hosting platform to follow GitHub's standard
+ *     deployment-status protocol. Any modern host does.
+ */
+export class DeploymentStatusPlatform implements Platform {
+  readonly id = "deployment-status";
+  readonly displayName = "GitHub Deployment Status";
+
+  private readonly environment: string | undefined;
+  private readonly acceptedStates: readonly string[];
+  private readonly waitSeconds: number;
+  private readonly run: GhRunner;
+
+  constructor(opts: DeploymentStatusAdapterOptions = {}) {
+    this.environment = opts.environment;
+    this.acceptedStates = opts.acceptedStates ?? ["success"];
+    this.waitSeconds = opts.waitSeconds ?? 0;
+    this.run =
+      opts.run ??
+      (async (bin, args) => {
+        const { stdout, stderr } = await execFile(bin, args as string[], {
+          maxBuffer: 10 * 1024 * 1024,
+        });
+        return { stdout, stderr };
+      });
+  }
+
+  async resolve(input: ResolvePreviewInput): Promise<PreviewResolution | null> {
+    const wait = input.waitSeconds ?? this.waitSeconds;
+    const deadline = Date.now() + wait * 1_000;
+    while (true) {
+      const match = await this.pollOnce(input);
+      if (match) return match;
+      if (Date.now() >= deadline) return null;
+      await sleep(Math.min(3_000, Math.max(500, deadline - Date.now())));
+    }
+  }
+
+  private async pollOnce(input: ResolvePreviewInput): Promise<PreviewResolution | null> {
+    const query = `/repos/${input.repo}/deployments?sha=${encodeURIComponent(input.sha)}&per_page=20`;
+    let deployments: GhDeployment[] = [];
+    try {
+      const { stdout } = await this.run("gh", ["api", query]);
+      deployments = JSON.parse(stdout) as GhDeployment[];
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (/authentication|401|403/i.test(msg)) {
+        throw new Error(`DeploymentStatusPlatform: gh auth failed — ${msg}`);
+      }
+      if (/404|not found/i.test(msg)) return null;
+      throw err;
+    }
+
+    const candidateDeployments = deployments
+      .filter((d) => !this.environment || d.environment === this.environment)
+      .sort((a, b) => (b.created_at ?? "").localeCompare(a.created_at ?? ""));
+
+    for (const dep of candidateDeployments) {
+      if (!dep.id) continue;
+      const status = await this.resolveBestStatus(input.repo, dep.id);
+      if (!status) continue;
+      if (!this.acceptedStates.includes((status.state ?? "").toLowerCase())) continue;
+      const url = status.environment_url ?? status.target_url;
+      if (!url) continue;
+      const out: PreviewResolution = {
+        url: url.startsWith("http") ? url : `https://${url}`,
+        provider: "deployment-status",
+        sha: input.sha,
+      };
+      if (dep.id !== undefined) out.deploymentId = String(dep.id);
+      if (status.created_at) out.createdAt = status.created_at;
+      return out;
+    }
+    return null;
+  }
+
+  private async resolveBestStatus(repo: string, deploymentId: number): Promise<GhDeploymentStatus | null> {
+    const query = `/repos/${repo}/deployments/${deploymentId}/statuses?per_page=20`;
+    const { stdout } = await this.run("gh", ["api", query]);
+    const statuses = JSON.parse(stdout) as GhDeploymentStatus[];
+    if (statuses.length === 0) return null;
+    return statuses.sort((a, b) => (b.created_at ?? "").localeCompare(a.created_at ?? ""))[0] ?? null;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/packages/platform-deployment-status/test/deployment-status.test.mjs
+++ b/packages/platform-deployment-status/test/deployment-status.test.mjs
@@ -1,0 +1,173 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { DeploymentStatusPlatform } from "../dist/index.js";
+
+function mockRunner(endpoints) {
+  const calls = [];
+  const fn = async (bin, args) => {
+    assert.equal(bin, "gh");
+    const endpoint = args[1]; // ["api", "<endpoint>"]
+    calls.push(endpoint);
+    const match = endpoints.find((e) => endpoint.includes(e.match));
+    if (!match) throw new Error(`unexpected endpoint: ${endpoint}`);
+    if (match.throw) throw new Error(match.throw);
+    return { stdout: JSON.stringify(match.json) };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+test("DeploymentStatusPlatform: happy path — success state + environment_url", async () => {
+  const run = mockRunner([
+    {
+      match: "/deployments?sha=",
+      json: [
+        { id: 77, sha: "sha-head", environment: "preview", created_at: "2026-04-19T10:00:00Z" },
+      ],
+    },
+    {
+      match: "/deployments/77/statuses",
+      json: [
+        {
+          state: "success",
+          environment_url: "https://preview.example.com/sha-head",
+          created_at: "2026-04-19T10:05:00Z",
+        },
+      ],
+    },
+  ]);
+  const p = new DeploymentStatusPlatform({ run });
+  const out = await p.resolve({ repo: "acme/app", sha: "sha-head" });
+  assert.ok(out);
+  assert.equal(out.url, "https://preview.example.com/sha-head");
+  assert.equal(out.deploymentId, "77");
+  assert.equal(out.provider, "deployment-status");
+});
+
+test("DeploymentStatusPlatform: environment filter keeps matching, drops others", async () => {
+  const run = mockRunner([
+    {
+      match: "/deployments?sha=",
+      json: [
+        { id: 10, sha: "sha-head", environment: "production", created_at: "2026-04-19T12:00:00Z" },
+        { id: 11, sha: "sha-head", environment: "preview", created_at: "2026-04-19T10:00:00Z" },
+      ],
+    },
+    {
+      match: "/deployments/11/statuses",
+      json: [
+        {
+          state: "success",
+          environment_url: "https://preview.example.com/match",
+          created_at: "2026-04-19T10:05:00Z",
+        },
+      ],
+    },
+  ]);
+  const p = new DeploymentStatusPlatform({ environment: "preview", run });
+  const out = await p.resolve({ repo: "acme/app", sha: "sha-head" });
+  assert.equal(out.url, "https://preview.example.com/match");
+  assert.equal(out.deploymentId, "11");
+});
+
+test("DeploymentStatusPlatform: non-accepted state skipped", async () => {
+  const run = mockRunner([
+    {
+      match: "/deployments?sha=",
+      json: [{ id: 1, sha: "sha-head", environment: "preview", created_at: "2026-04-19T10:00:00Z" }],
+    },
+    {
+      match: "/deployments/1/statuses",
+      json: [
+        {
+          state: "failure",
+          environment_url: "https://broken.example.com",
+          created_at: "2026-04-19T10:05:00Z",
+        },
+      ],
+    },
+  ]);
+  const p = new DeploymentStatusPlatform({ run });
+  assert.equal(await p.resolve({ repo: "acme/app", sha: "sha-head" }), null);
+});
+
+test("DeploymentStatusPlatform: falls back to target_url when environment_url absent", async () => {
+  const run = mockRunner([
+    {
+      match: "/deployments?sha=",
+      json: [{ id: 1, sha: "sha-head", environment: "preview", created_at: "2026-04-19T10:00:00Z" }],
+    },
+    {
+      match: "/deployments/1/statuses",
+      json: [
+        { state: "success", target_url: "https://fallback.example.com", created_at: "2026-04-19T10:05:00Z" },
+      ],
+    },
+  ]);
+  const p = new DeploymentStatusPlatform({ run });
+  const out = await p.resolve({ repo: "acme/app", sha: "sha-head" });
+  assert.equal(out.url, "https://fallback.example.com");
+});
+
+test("DeploymentStatusPlatform: picks newest status when multiple present", async () => {
+  const run = mockRunner([
+    {
+      match: "/deployments?sha=",
+      json: [{ id: 1, sha: "sha-head", environment: "preview", created_at: "2026-04-19T10:00:00Z" }],
+    },
+    {
+      match: "/deployments/1/statuses",
+      json: [
+        { state: "in_progress", target_url: "https://ignored", created_at: "2026-04-19T10:03:00Z" },
+        { state: "success", environment_url: "https://newest.example.com", created_at: "2026-04-19T10:07:00Z" },
+        { state: "pending", target_url: "https://older", created_at: "2026-04-19T10:01:00Z" },
+      ],
+    },
+  ]);
+  const p = new DeploymentStatusPlatform({ run });
+  const out = await p.resolve({ repo: "acme/app", sha: "sha-head" });
+  assert.equal(out.url, "https://newest.example.com");
+});
+
+test("DeploymentStatusPlatform: acceptedStates override", async () => {
+  const run = mockRunner([
+    {
+      match: "/deployments?sha=",
+      json: [{ id: 1, sha: "sha-head", environment: "preview", created_at: "2026-04-19T10:00:00Z" }],
+    },
+    {
+      match: "/deployments/1/statuses",
+      json: [
+        { state: "queued", environment_url: "https://queued.example.com", created_at: "2026-04-19T10:05:00Z" },
+      ],
+    },
+  ]);
+  const p = new DeploymentStatusPlatform({ run, acceptedStates: ["queued", "success"] });
+  const out = await p.resolve({ repo: "acme/app", sha: "sha-head" });
+  assert.equal(out.url, "https://queued.example.com");
+});
+
+test("DeploymentStatusPlatform: empty deployments returns null", async () => {
+  const run = mockRunner([{ match: "/deployments?sha=", json: [] }]);
+  const p = new DeploymentStatusPlatform({ run });
+  assert.equal(await p.resolve({ repo: "acme/app", sha: "missing" }), null);
+});
+
+test("DeploymentStatusPlatform: gh auth error surfaces as actionable message", async () => {
+  const run = mockRunner([{ match: "/deployments?sha=", throw: "HTTP 401: Bad credentials" }]);
+  const p = new DeploymentStatusPlatform({ run });
+  await assert.rejects(() => p.resolve({ repo: "acme/app", sha: "x" }), /gh auth failed/);
+});
+
+test("DeploymentStatusPlatform: gh 404 returns null (not thrown)", async () => {
+  const run = mockRunner([{ match: "/deployments?sha=", throw: "HTTP 404: Not Found" }]);
+  const p = new DeploymentStatusPlatform({ run });
+  assert.equal(await p.resolve({ repo: "acme/app", sha: "x" }), null);
+});
+
+test("DeploymentStatusPlatform: URL-encodes SHA in query string", async () => {
+  const run = mockRunner([{ match: "/deployments?sha=sha%2Fwith%2Fslashes&", json: [] }]);
+  const p = new DeploymentStatusPlatform({ run });
+  await p.resolve({ repo: "acme/app", sha: "sha/with/slashes" });
+  assert.ok(run.calls[0].includes("sha%2Fwith%2Fslashes"));
+});

--- a/packages/platform-deployment-status/tsconfig.json
+++ b/packages/platform-deployment-status/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}


### PR DESCRIPTION
## Summary

Completes decision #31's v2.0 platform set (Vercel + Netlify + now **Cloudflare** + **deployment-status generic**). Railway is the one remaining v2.0 slot — deferred to its own follow-up because it uses GraphQL rather than REST.

## Adapters

### CloudflarePlatform
- REST: `GET /accounts/{id}/pages/projects/{name}/deployments`
- No server-side commit filter → client-filters by `deployment_trigger.metadata.commit_hash`
- Picks newest `latest_stage.status: "success"`
- API `success: false` surfaces the error message (typical cause: token scope missing Pages:Edit)
- URL-encodes project name with spaces
- Env: `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_PROJECT_NAME`

### DeploymentStatusPlatform (generic)
- Uses `gh api /repos/{repo}/deployments?sha=<sha>` + `/deployments/{id}/statuses`
- No dedicated host auth — reuses `gh auth login` from scm-github
- Works with **any** GitHub-integrated host: Render / Fly / Railway / Replit / Docker / custom CI
- URL preference: `environment_url` → `target_url`
- Optional environment filter (`"preview"`, `"production"`)
- `acceptedStates` override (default `["success"]`)
- Designed to sit LAST in the platform chain as a long-tail fallback

## Recommended chain

```ts
const platforms = [
  new VercelPlatform(),           // dedicated — fastest
  new NetlifyPlatform(),
  new CloudflarePlatform(),
  new DeploymentStatusPlatform(), // catches everything else
];
```

## Tests — 19 cases

### `cloudflare.test.mjs` (9)
Missing env (each of 3) throws, newest success wins, non-matching commit filtered, non-success stage filtered, API `success:false` throw with error message, bearer + URL path assertion, 401 auth throw, 404 null, URL-encoded project name with spaces.

### `deployment-status.test.mjs` (10)
Happy path with environment_url, environment filter keeps matching / drops others, non-accepted state skipped, target_url fallback when environment_url absent, newest-status-wins among multiple, `acceptedStates` override accepts non-default state, empty deployments → null, gh auth error → actionable message, gh 404 → null (not thrown), URL-encodes slashes in SHA query.

## Out of scope

- `platform-railway` (GraphQL) — follow-up
- v2.1 platforms (Render / Fly / Replit / Vertex / Docker-local) — decision #32, after launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)