### PR TITLE
feat(cli): --visual / --no-visual flags wire visual-review into review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## Unreleased
 
 ### Added
+- **CLI `--visual` / `--no-visual` on `conclave review`** — completes the
+  visual-diff story end-to-end from the CLI.
+  - Config block `visual.{enabled, platforms[], width, height, fullPage,
+    waitSeconds, diffThreshold}` in `.conclaverc.json`.
+  - Flags override config for the run.
+  - `buildPlatforms(ids)` factory lazy-imports adapters; missing env →
+    skipped with stderr warning, never fatal. `deployment-status`
+    always resolves (gh auth only).
+  - Output block appended: severity / diff ratio / before+after URLs /
+    local paths to the 3 PNGs.
+  - Failure-tolerant: visual errors never affect the verdict exit code.
+  - 6 platform-factory test cases.
 - **`@ai-conclave/platform-cloudflare`** — Cloudflare Pages adapter via
   `GET /accounts/{id}/pages/projects/{name}/deployments`. Filters
   client-side by `deployment_trigger.metadata.commit_hash`; picks newest

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,11 @@
     "@ai-conclave/integration-email": "workspace:*",
     "@ai-conclave/integration-slack": "workspace:*",
     "@ai-conclave/integration-telegram": "workspace:*",
+    "@ai-conclave/platform-cloudflare": "workspace:*",
+    "@ai-conclave/platform-deployment-status": "workspace:*",
+    "@ai-conclave/platform-netlify": "workspace:*",
+    "@ai-conclave/platform-vercel": "workspace:*",
+    "@ai-conclave/visual-review": "workspace:*",
     "@ai-conclave/observability-langfuse": "workspace:*",
     "@ai-conclave/scm-github": "workspace:*",
     "zod": "^3.24.0"

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -22,12 +22,29 @@ import type { Notifier } from "@ai-conclave/core";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
 import { renderReview, verdictToExitCode } from "../lib/output.js";
+import { buildPlatforms, type PlatformId } from "../lib/platform-factory.js";
 
-function parseArgv(argv: string[]): { pr?: number; diff?: string; base?: string; help: boolean } {
-  const out: { pr?: number; diff?: string; base?: string; help: boolean } = { help: false };
+function parseArgv(argv: string[]): {
+  pr?: number;
+  diff?: string;
+  base?: string;
+  visual: boolean;
+  noVisual: boolean;
+  help: boolean;
+} {
+  const out: {
+    pr?: number;
+    diff?: string;
+    base?: string;
+    visual: boolean;
+    noVisual: boolean;
+    help: boolean;
+  } = { help: false, visual: false, noVisual: false };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--visual") out.visual = true;
+    else if (a === "--no-visual") out.noVisual = true;
     else if (a === "--pr" && argv[i + 1]) {
       const n = Number.parseInt(argv[i + 1]!, 10);
       if (!Number.isNaN(n)) out.pr = n;
@@ -46,15 +63,21 @@ function parseArgv(argv: string[]): { pr?: number; diff?: string; base?: string;
 const HELP = `conclave review — run a council review on the current branch
 
 Usage:
-  conclave review [--pr N] [--diff <file>] [--base <ref>]
+  conclave review [--pr N] [--diff <file>] [--base <ref>] [--visual|--no-visual]
 
 Options:
   --pr N         Review PR N using gh CLI (preferred — includes repo context).
   --diff <file>  Review a unified-diff file directly.
   --base <ref>   Base ref for 'git diff' when neither --pr nor --diff given (default: origin/main).
+  --visual       Force-enable before/after visual diff (needs platform tokens + playwright).
+  --no-visual    Force-disable visual diff for this run (overrides .conclaverc.json).
 
 Environment:
   ANTHROPIC_API_KEY   required — Claude review call.
+
+Visual review reads platform tokens from env: VERCEL_TOKEN, NETLIFY_TOKEN,
+CLOUDFLARE_API_TOKEN + account/project, or falls back to gh CLI via the
+deployment-status adapter.
 `;
 
 export async function review(argv: string[]): Promise<void> {
@@ -281,6 +304,60 @@ export async function review(argv: string[]): Promise<void> {
         }
       }),
     );
+  }
+
+  // 9. Optional visual diff (before/after preview screenshots). CLI flag
+  //    overrides config. Failures are logged but never fail the review —
+  //    code review verdict always wins.
+  const visualFromConfig = config.visual?.enabled ?? false;
+  const visualEnabled = args.noVisual ? false : args.visual || visualFromConfig;
+  if (visualEnabled) {
+    if (!loaded.prevSha) {
+      process.stderr.write(
+        "conclave review: --visual set but no base SHA available (pullNumber=0 or git diff had no base) — skipping\n",
+      );
+    } else {
+      try {
+        const platformIds: PlatformId[] =
+          config.visual?.platforms ?? ["vercel", "netlify", "cloudflare", "deployment-status"];
+        const { platforms, skipped } = await buildPlatforms(platformIds);
+        for (const sk of skipped) {
+          process.stderr.write(`conclave review: visual platform "${sk.id}" skipped — ${sk.reason}\n`);
+        }
+        if (platforms.length === 0) {
+          process.stderr.write("conclave review: visual enabled but no platforms available — skipping\n");
+        } else {
+          const { runVisualReview } = await import("@ai-conclave/visual-review");
+          const vResult = await runVisualReview({
+            repo: loaded.repo,
+            beforeSha: loaded.prevSha,
+            afterSha: loaded.newSha,
+            platforms,
+            captureOptions: {
+              width: config.visual?.width ?? 1280,
+              height: config.visual?.height ?? 800,
+              fullPage: config.visual?.fullPage ?? true,
+            },
+            diffOptions: { threshold: config.visual?.diffThreshold ?? 0.1 },
+            waitSeconds: config.visual?.waitSeconds ?? 60,
+          });
+          process.stdout.write(
+            `\n── visual review ──\n` +
+              `  severity:   ${vResult.severity}\n` +
+              `  diff ratio: ${(vResult.diff.diffRatio * 100).toFixed(2)}% ` +
+              `(${vResult.diff.diffPixels.toLocaleString()} / ${vResult.diff.totalPixels.toLocaleString()} px)\n` +
+              `  before url: ${vResult.before.url} (${vResult.before.provider})\n` +
+              `  after url:  ${vResult.after.url} (${vResult.after.provider})\n` +
+              `  paths:\n` +
+              `    before:   ${vResult.paths.before}\n` +
+              `    after:    ${vResult.paths.after}\n` +
+              `    diff:     ${vResult.paths.diff}\n`,
+          );
+        }
+      } catch (err) {
+        process.stderr.write(`conclave review: visual diff failed — ${(err as Error).message}\n`);
+      }
+    }
   }
 
   if (langfuseSink) {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -76,6 +76,19 @@ export const ConclaveConfigSchema = z.object({
         .optional(),
     })
     .optional(),
+  visual: z
+    .object({
+      enabled: z.boolean().default(false),
+      platforms: z
+        .array(z.enum(["vercel", "netlify", "cloudflare", "deployment-status"]))
+        .default(["vercel", "netlify", "cloudflare", "deployment-status"]),
+      width: z.number().int().positive().default(1280),
+      height: z.number().int().positive().default(800),
+      fullPage: z.boolean().default(true),
+      waitSeconds: z.number().int().nonnegative().default(60),
+      diffThreshold: z.number().min(0).max(1).default(0.1),
+    })
+    .optional(),
 });
 
 export type ConclaveConfig = z.infer<typeof ConclaveConfigSchema>;

--- a/packages/cli/src/lib/platform-factory.ts
+++ b/packages/cli/src/lib/platform-factory.ts
@@ -1,0 +1,83 @@
+import type { Platform } from "@ai-conclave/core";
+
+export type PlatformId = "vercel" | "netlify" | "cloudflare" | "deployment-status";
+
+export interface PlatformFactoryResult {
+  platforms: Platform[];
+  skipped: Array<{ id: PlatformId; reason: string }>;
+}
+
+/**
+ * Instantiate platform adapters in the order given, skipping any whose
+ * credentials are missing rather than throwing. Returns the live
+ * platforms + a list of skipped ones for caller-side reporting.
+ *
+ * Isolated in its own module so review.ts can import + test it without
+ * dragging the whole review command into the unit tests.
+ */
+export async function buildPlatforms(
+  ids: readonly PlatformId[],
+): Promise<PlatformFactoryResult> {
+  const platforms: Platform[] = [];
+  const skipped: PlatformFactoryResult["skipped"] = [];
+
+  for (const id of ids) {
+    switch (id) {
+      case "vercel": {
+        if (!process.env["VERCEL_TOKEN"]) {
+          skipped.push({ id, reason: "VERCEL_TOKEN not set" });
+          continue;
+        }
+        const mod = await import("@ai-conclave/platform-vercel");
+        try {
+          platforms.push(new mod.VercelPlatform());
+        } catch (err) {
+          skipped.push({ id, reason: (err as Error).message });
+        }
+        break;
+      }
+      case "netlify": {
+        if (!process.env["NETLIFY_TOKEN"] || !process.env["NETLIFY_SITE_ID"]) {
+          skipped.push({ id, reason: "NETLIFY_TOKEN or NETLIFY_SITE_ID not set" });
+          continue;
+        }
+        const mod = await import("@ai-conclave/platform-netlify");
+        try {
+          platforms.push(new mod.NetlifyPlatform());
+        } catch (err) {
+          skipped.push({ id, reason: (err as Error).message });
+        }
+        break;
+      }
+      case "cloudflare": {
+        if (
+          !process.env["CLOUDFLARE_API_TOKEN"] ||
+          !process.env["CLOUDFLARE_ACCOUNT_ID"] ||
+          !process.env["CLOUDFLARE_PROJECT_NAME"]
+        ) {
+          skipped.push({ id, reason: "CLOUDFLARE_API_TOKEN / ACCOUNT_ID / PROJECT_NAME not set" });
+          continue;
+        }
+        const mod = await import("@ai-conclave/platform-cloudflare");
+        try {
+          platforms.push(new mod.CloudflarePlatform());
+        } catch (err) {
+          skipped.push({ id, reason: (err as Error).message });
+        }
+        break;
+      }
+      case "deployment-status": {
+        // No env vars — uses gh CLI auth. Always try to add.
+        const mod = await import("@ai-conclave/platform-deployment-status");
+        try {
+          platforms.push(new mod.DeploymentStatusPlatform());
+        } catch (err) {
+          skipped.push({ id, reason: (err as Error).message });
+        }
+        break;
+      }
+    }
+  }
+
+  return { platforms, skipped };
+}

--- a/packages/cli/test/platform-factory.test.mjs
+++ b/packages/cli/test/platform-factory.test.mjs
@@ -1,0 +1,125 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildPlatforms } from "../dist/lib/platform-factory.js";
+
+function withEnv(patch, fn) {
+  const saved = {};
+  for (const [k, v] of Object.entries(patch)) {
+    saved[k] = process.env[k];
+    if (v === null) delete process.env[k];
+    else process.env[k] = v;
+  }
+  return Promise.resolve(fn()).finally(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+}
+
+test("buildPlatforms: no env → all platforms except deployment-status skipped", async () => {
+  await withEnv(
+    {
+      VERCEL_TOKEN: null,
+      NETLIFY_TOKEN: null,
+      NETLIFY_SITE_ID: null,
+      CLOUDFLARE_API_TOKEN: null,
+      CLOUDFLARE_ACCOUNT_ID: null,
+      CLOUDFLARE_PROJECT_NAME: null,
+    },
+    async () => {
+      const out = await buildPlatforms(["vercel", "netlify", "cloudflare", "deployment-status"]);
+      // deployment-status has no env requirement — always resolves
+      assert.equal(out.platforms.length, 1);
+      assert.equal(out.platforms[0].id, "deployment-status");
+      assert.equal(out.skipped.length, 3);
+      const skippedIds = out.skipped.map((s) => s.id);
+      assert.deepEqual(skippedIds.sort(), ["cloudflare", "netlify", "vercel"]);
+    },
+  );
+});
+
+test("buildPlatforms: Vercel instantiated when VERCEL_TOKEN set", async () => {
+  await withEnv(
+    {
+      VERCEL_TOKEN: "fake-token",
+      NETLIFY_TOKEN: null,
+      CLOUDFLARE_API_TOKEN: null,
+    },
+    async () => {
+      const out = await buildPlatforms(["vercel"]);
+      assert.equal(out.platforms.length, 1);
+      assert.equal(out.platforms[0].id, "vercel");
+      assert.equal(out.skipped.length, 0);
+    },
+  );
+});
+
+test("buildPlatforms: Netlify needs BOTH token + siteId", async () => {
+  await withEnv({ NETLIFY_TOKEN: "t", NETLIFY_SITE_ID: null }, async () => {
+    const out = await buildPlatforms(["netlify"]);
+    assert.equal(out.platforms.length, 0);
+    assert.equal(out.skipped.length, 1);
+    assert.match(out.skipped[0].reason, /SITE_ID/);
+  });
+  await withEnv({ NETLIFY_TOKEN: "t", NETLIFY_SITE_ID: "s" }, async () => {
+    const out = await buildPlatforms(["netlify"]);
+    assert.equal(out.platforms.length, 1);
+  });
+});
+
+test("buildPlatforms: Cloudflare needs all three envs", async () => {
+  await withEnv(
+    {
+      CLOUDFLARE_API_TOKEN: "t",
+      CLOUDFLARE_ACCOUNT_ID: "a",
+      CLOUDFLARE_PROJECT_NAME: null,
+    },
+    async () => {
+      const out = await buildPlatforms(["cloudflare"]);
+      assert.equal(out.platforms.length, 0);
+      assert.equal(out.skipped.length, 1);
+    },
+  );
+  await withEnv(
+    {
+      CLOUDFLARE_API_TOKEN: "t",
+      CLOUDFLARE_ACCOUNT_ID: "a",
+      CLOUDFLARE_PROJECT_NAME: "proj",
+    },
+    async () => {
+      const out = await buildPlatforms(["cloudflare"]);
+      assert.equal(out.platforms.length, 1);
+    },
+  );
+});
+
+test("buildPlatforms: deployment-status has no env requirement", async () => {
+  await withEnv(
+    {
+      VERCEL_TOKEN: null,
+      NETLIFY_TOKEN: null,
+      CLOUDFLARE_API_TOKEN: null,
+    },
+    async () => {
+      const out = await buildPlatforms(["deployment-status"]);
+      assert.equal(out.platforms.length, 1);
+      assert.equal(out.platforms[0].id, "deployment-status");
+    },
+  );
+});
+
+test("buildPlatforms: preserves order of input ids", async () => {
+  await withEnv(
+    {
+      VERCEL_TOKEN: "t",
+      NETLIFY_TOKEN: "t",
+      NETLIFY_SITE_ID: "s",
+    },
+    async () => {
+      const out = await buildPlatforms(["netlify", "vercel", "deployment-status"]);
+      const ids = out.platforms.map((p) => p.id);
+      assert.deepEqual(ids, ["netlify", "vercel", "deployment-status"]);
+    },
+  );
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -15,6 +15,11 @@
     { "path": "../integration-email" },
     { "path": "../integration-slack" },
     { "path": "../integration-telegram" },
+    { "path": "../platform-cloudflare" },
+    { "path": "../platform-deployment-status" },
+    { "path": "../platform-netlify" },
+    { "path": "../platform-vercel" },
+    { "path": "../visual-review" },
     { "path": "../observability-langfuse" },
     { "path": "../scm-github" }
   ]


### PR DESCRIPTION
## Summary

Completes the visual-diff story end-to-end from the CLI. `conclave review --pr 42 --visual` resolves both SHAs' preview URLs, captures via Playwright, runs pixel diff, writes 3 PNGs, prints severity.

## Flow

```
conclave review --pr 42 --visual
  ↓
Council deliberates (existing)
  ↓
buildPlatforms(config.visual.platforms)
  ↓
runVisualReview({ repo, beforeSha, afterSha, platforms, ... })
  ↓
Before/after/diff PNGs saved + severity printed to stdout
```

## Config

```json
{
  "visual": {
    "enabled": false,
    "platforms": ["vercel", "netlify", "cloudflare", "deployment-status"],
    "width": 1280,
    "height": 800,
    "fullPage": true,
    "waitSeconds": 60,
    "diffThreshold": 0.1
  }
}
```

Flags override config for the run:
- `--visual` force-enable
- `--no-visual` force-disable (overrides `enabled: true`)

## Platform factory

`buildPlatforms(ids)` lazy-imports each adapter, returns `{ platforms, skipped }`. Missing credentials → `skipped` with reason (stderr logged), never fatal. `deployment-status` always resolves since it only needs `gh auth`.

Order of input ids = order of output platforms → caller controls priority.

## Failure handling

Visual errors go to stderr. Verdict exit code is ALWAYS determined by the council — visual is purely informational.

Guard: if no prevSha (pullNumber=0 local review with no base), visual is skipped with a clear message.

## Tests — 6 cases

- No env → only `deployment-status` instantiated
- `VERCEL_TOKEN` alone → vercel works
- Netlify: token-only skipped / token+siteId succeeds
- Cloudflare: 2-of-3 env skipped / full set succeeds
- `deployment-status` always works
- Output order preserves input id order

🤖 Generated with [Claude Code](https://claude.com/claude-code)