### PR TITLE
feat(cli): conclave migrate — solo-cto-agent bridge (decision #27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 ## Unreleased
 
 ### Added
+- **CLI `conclave migrate`** (decision #27) — brings an existing
+  solo-cto-agent install over to ai-conclave without deleting the
+  legacy install:
+  - Auto-detects the legacy root by walking up from cwd or checking
+    sibling `solo-cto-agent/` folder. `--from <path>` override.
+  - Ports `failure-catalog.json` into ai-conclave's memory store (same
+    heuristic mapper as `conclave seed`); tags entries with
+    `["legacy", "solo-cto-agent", "migrated"]`.
+  - Reads `.solo-cto/tracked.json` if present and prints tracked repo
+    names for manual migration (tokens are NOT copied — audit required).
+  - Writes `.conclaverc.json` with defaults if none exists.
+  - Prints an env checklist (ANTHROPIC_API_KEY / OPENAI_API_KEY /
+    GOOGLE_API_KEY / Telegram / Discord / Slack / Email / platform
+    tokens / Langfuse) so users know what to carry over.
+  - `--dry-run` flag to preview without writing.
+  - 11 test cases: arg parsing (3), detectLegacy (3: happy / empty dir
+    / tracked.json surfacing), findLegacyUpwards (2: sibling folder
+    detection, null on isolated tree), buildPlan (3: willWriteConfig
+    true on fresh cwd, false when config exists, trackedRepoNames
+    surfaced), applyPlan (3: writes config + seeds 2 failures, skips
+    config write when present, seeded=0 when no legacy catalog).
 - **CLI `--visual` / `--no-visual` on `conclave review`** — completes the
   visual-diff story end-to-end from the CLI.
   - Config block `visual.{enabled, platforms[], width, height, fullPage,

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,0 +1,235 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { FileSystemMemoryStore, seedFromLegacyCatalogPath } from "@ai-conclave/core";
+import { loadConfig, resolveMemoryRoot, CONFIG_FILENAME, DEFAULT_CONFIG } from "../lib/config.js";
+
+const HELP = `conclave migrate — bring a solo-cto-agent install over to ai-conclave
+
+Usage:
+  conclave migrate [--from <solo-cto-agent-root>] [--dry-run]
+
+--from <path>   Path to the solo-cto-agent install root (contains
+                tiers.json + failure-catalog.json + optional .solo-cto/).
+                Defaults to detect from CWD upwards.
+--dry-run       Print the migration plan without writing anything.
+
+What it does:
+  1. Detect solo-cto-agent's failure-catalog.json and port every entry
+     to ai-conclave's memory store as a FailureEntry (same mapping as
+     \`conclave seed --from <path>\`).
+  2. Read any TRACKED_REPOS config in solo-cto-agent/.solo-cto/tracked.json
+     (if present) and surface them for the user to configure under
+     ai-conclave manually.
+  3. Emit a .conclaverc.json with sensible defaults if none exists in the
+     current directory.
+  4. Print a checklist of env vars the user should migrate
+     (ANTHROPIC_API_KEY is shared; solo-cto-agent-specific secrets are
+     listed but NOT copied — user must audit).
+
+solo-cto-agent 1.4.x stays installable via npm (decision #27); this
+command only creates the v2 configuration — it does NOT delete or
+modify the legacy install.
+`;
+
+export interface MigrateArgs {
+  from?: string;
+  dryRun: boolean;
+  help: boolean;
+}
+
+export function parseMigrateArgs(argv: readonly string[]): MigrateArgs {
+  const out: MigrateArgs = { dryRun: false, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--from" && argv[i + 1]) {
+      out.from = argv[i + 1];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+export interface LegacyDetection {
+  root: string;
+  failureCatalogPath: string | null;
+  trackedReposPath: string | null;
+  tiersPath: string | null;
+}
+
+/**
+ * Probe for solo-cto-agent markers at the given root. Returns paths of
+ * every legacy artefact we know how to port; null means "did not find
+ * that one; skip it silently".
+ */
+export async function detectLegacy(root: string): Promise<LegacyDetection | null> {
+  const abs = path.resolve(root);
+  const stat = await safeStat(abs);
+  if (!stat?.isDirectory()) return null;
+  const catalog = path.join(abs, "failure-catalog.json");
+  const tiers = path.join(abs, "tiers.json");
+  const tracked = path.join(abs, ".solo-cto", "tracked.json");
+  const [hasCatalog, hasTiers, hasTracked] = await Promise.all([exists(catalog), exists(tiers), exists(tracked)]);
+  if (!hasCatalog && !hasTiers) return null;
+  return {
+    root: abs,
+    failureCatalogPath: hasCatalog ? catalog : null,
+    trackedReposPath: hasTracked ? tracked : null,
+    tiersPath: hasTiers ? tiers : null,
+  };
+}
+
+/** Walk CWD up to filesystem root looking for a solo-cto-agent install. */
+export async function findLegacyUpwards(startDir: string): Promise<LegacyDetection | null> {
+  let dir = path.resolve(startDir);
+  while (true) {
+    const hit = await detectLegacy(dir);
+    if (hit) return hit;
+    // Also try a sibling "solo-cto-agent" folder (common layout:
+    // parent/solo-cto-agent + parent/ai-conclave).
+    const sibling = path.join(dir, "solo-cto-agent");
+    const sibHit = await detectLegacy(sibling);
+    if (sibHit) return sibHit;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+export interface MigratePlan {
+  legacy: LegacyDetection;
+  willWriteConfig: boolean;
+  configTargetPath: string;
+  willSeedFailures: boolean;
+  trackedRepoNames: readonly string[];
+  envChecklist: readonly string[];
+}
+
+const ENV_CHECKLIST = [
+  "ANTHROPIC_API_KEY (required — same as solo-cto-agent)",
+  "OPENAI_API_KEY (optional — enables second council agent)",
+  "GOOGLE_API_KEY or GEMINI_API_KEY (optional — third council agent, long-context)",
+  "TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID (optional — notifications)",
+  "DISCORD_WEBHOOK_URL (optional)",
+  "SLACK_WEBHOOK_URL (optional)",
+  "RESEND_API_KEY + CONCLAVE_EMAIL_FROM + CONCLAVE_EMAIL_TO (optional email)",
+  "VERCEL_TOKEN / NETLIFY_TOKEN + NETLIFY_SITE_ID / CLOUDFLARE_API_TOKEN+ACCOUNT_ID+PROJECT_NAME (optional — visual review)",
+  "LANGFUSE_PUBLIC_KEY + LANGFUSE_SECRET_KEY (optional — observability)",
+];
+
+export async function buildPlan(legacy: LegacyDetection, cwd: string): Promise<MigratePlan> {
+  const configTarget = path.join(cwd, CONFIG_FILENAME);
+  const configExists = await exists(configTarget);
+  const trackedRepoNames = await readTrackedRepos(legacy.trackedReposPath);
+  return {
+    legacy,
+    willWriteConfig: !configExists,
+    configTargetPath: configTarget,
+    willSeedFailures: !!legacy.failureCatalogPath,
+    trackedRepoNames,
+    envChecklist: ENV_CHECKLIST,
+  };
+}
+
+export async function applyPlan(plan: MigratePlan, cwd: string): Promise<{ wroteConfig: boolean; seeded: number }> {
+  let wroteConfig = false;
+  if (plan.willWriteConfig) {
+    await fs.writeFile(plan.configTargetPath, JSON.stringify(DEFAULT_CONFIG, null, 2) + "\n", "utf8");
+    wroteConfig = true;
+  }
+  let seeded = 0;
+  if (plan.willSeedFailures && plan.legacy.failureCatalogPath) {
+    const { config } = await loadConfig(cwd);
+    const memoryRoot = resolveMemoryRoot(config, cwd);
+    const store = new FileSystemMemoryStore({ root: memoryRoot });
+    const res = await seedFromLegacyCatalogPath(plan.legacy.failureCatalogPath, store, {
+      extraTags: ["legacy", "solo-cto-agent", "migrated"],
+    });
+    seeded = res.entries.length;
+  }
+  return { wroteConfig, seeded };
+}
+
+export async function migrate(argv: string[]): Promise<void> {
+  const args = parseMigrateArgs(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  const cwd = process.cwd();
+  const legacy = args.from ? await detectLegacy(args.from) : await findLegacyUpwards(cwd);
+  if (!legacy) {
+    process.stderr.write(
+      "conclave migrate: no solo-cto-agent install found. Pass --from <path> or run from near the legacy root.\n",
+    );
+    process.exit(1);
+    return;
+  }
+
+  const plan = await buildPlan(legacy, cwd);
+
+  process.stdout.write(
+    `conclave migrate:\n` +
+      `  legacy root:         ${plan.legacy.root}\n` +
+      `  failure-catalog:     ${plan.legacy.failureCatalogPath ?? "(not found)"}\n` +
+      `  tiers.json:          ${plan.legacy.tiersPath ?? "(not found)"}\n` +
+      `  tracked repos:       ${plan.trackedRepoNames.length} found\n` +
+      `  config to write:     ${plan.willWriteConfig ? plan.configTargetPath : "(already exists — skipping)"}\n` +
+      `  seed failures:       ${plan.willSeedFailures ? "yes" : "no"}\n` +
+      `  mode:                ${args.dryRun ? "DRY RUN — no changes will be written" : "APPLY"}\n`,
+  );
+
+  if (plan.trackedRepoNames.length > 0) {
+    process.stdout.write(`\n  tracked-repo names (migrate manually to scm-github config):\n`);
+    for (const n of plan.trackedRepoNames) process.stdout.write(`    - ${n}\n`);
+  }
+
+  process.stdout.write(`\n  env checklist (audit each; don't copy tokens blindly):\n`);
+  for (const e of plan.envChecklist) process.stdout.write(`    • ${e}\n`);
+
+  if (!args.dryRun) {
+    const applied = await applyPlan(plan, cwd);
+    process.stdout.write(
+      `\n  applied:\n` +
+        `    config written:    ${applied.wroteConfig ? "yes → " + plan.configTargetPath : "skipped"}\n` +
+        `    failures seeded:   ${applied.seeded}\n`,
+    );
+  } else {
+    process.stdout.write(`\n  (dry run — re-run without --dry-run to apply)\n`);
+  }
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function safeStat(p: string): Promise<import("node:fs").Stats | null> {
+  try {
+    return await fs.stat(p);
+  } catch {
+    return null;
+  }
+}
+
+async function readTrackedRepos(trackedPath: string | null): Promise<readonly string[]> {
+  if (!trackedPath) return [];
+  try {
+    const raw = await fs.readFile(trackedPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) return parsed.filter((x): x is string => typeof x === "string");
+    if (parsed && typeof parsed === "object") {
+      const maybe = (parsed as { selected?: unknown }).selected;
+      if (Array.isArray(maybe)) return maybe.filter((x): x is string => typeof x === "string");
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { review } from "./commands/review.js";
 import { recordOutcome } from "./commands/record-outcome.js";
 import { pollOutcomesCommand } from "./commands/poll-outcomes.js";
 import { seed } from "./commands/seed.js";
+import { migrate } from "./commands/migrate.js";
 
 const HELP = `conclave — Ai-Conclave CLI
 
@@ -15,15 +16,18 @@ Commands:
   record-outcome        Record a PR's merge/reject/rework outcome manually
   poll-outcomes         Auto-classify pending reviews against live GitHub PR state
   seed                  Bootstrap failure-catalog from a legacy source (default: bundled solo-cto-agent)
+  migrate               Port a solo-cto-agent install over to ai-conclave (config + failure-catalog + checklist)
   --help, -h            Show this
   --version, -v         Show version
 
 Examples:
   conclave init
-  conclave review --pr 42
+  conclave review --pr 42 --visual
   conclave record-outcome --id ep-... --result merged
   conclave poll-outcomes                 # cron-friendly automatic outcome capture
   conclave seed                           # one-time bootstrap from the bundled solo-cto-agent catalog
+  conclave migrate --dry-run              # preview migration from solo-cto-agent
+  conclave migrate --from ../solo-cto-agent
 `;
 
 export async function run(argv: string[]): Promise<void> {
@@ -54,6 +58,9 @@ export async function run(argv: string[]): Promise<void> {
       return;
     case "seed":
       await seed(rest);
+      return;
+    case "migrate":
+      await migrate(rest);
       return;
     default:
       process.stderr.write(`Unknown command: ${cmd}\n\n${HELP}`);

--- a/packages/cli/test/migrate.test.mjs
+++ b/packages/cli/test/migrate.test.mjs
@@ -1,0 +1,213 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  parseMigrateArgs,
+  detectLegacy,
+  findLegacyUpwards,
+  buildPlan,
+  applyPlan,
+} from "../dist/commands/migrate.js";
+
+function mkLegacyRoot({ withCatalog = true, withTiers = true, withTracked = false } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aic-legacy-"));
+  if (withCatalog) {
+    fs.writeFileSync(
+      path.join(dir, "failure-catalog.json"),
+      JSON.stringify({
+        version: 1,
+        updated_at: "2026-04-13",
+        items: [
+          { id: "ERR-001", category: "build", pattern: "Module not found", description: "desc", fix: "fix" },
+          { id: "ERR-002", category: "runtime", pattern: "PrismaClientInitializationError", description: "db", fix: "check" },
+        ],
+      }),
+    );
+  }
+  if (withTiers) {
+    fs.writeFileSync(path.join(dir, "tiers.json"), JSON.stringify({ tiers: { base: {}, pro: {} } }));
+  }
+  if (withTracked) {
+    fs.mkdirSync(path.join(dir, ".solo-cto"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, ".solo-cto", "tracked.json"),
+      JSON.stringify({ selected: ["acme/my-app", "acme/other"] }),
+    );
+  }
+  return dir;
+}
+
+function mkCwd() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "aic-cwd-"));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+test("parseMigrateArgs: flags + --from value", () => {
+  assert.deepEqual(parseMigrateArgs(["--help"]), { dryRun: false, help: true });
+  assert.deepEqual(parseMigrateArgs(["--dry-run"]), { dryRun: true, help: false });
+  assert.deepEqual(parseMigrateArgs(["--from", "/x/y"]), { dryRun: false, help: false, from: "/x/y" });
+  assert.deepEqual(parseMigrateArgs(["--from", "/a", "--dry-run"]), { dryRun: true, help: false, from: "/a" });
+});
+
+test("detectLegacy: returns paths when catalog + tiers present", async () => {
+  const root = mkLegacyRoot();
+  try {
+    const out = await detectLegacy(root);
+    assert.ok(out);
+    assert.equal(out.root, path.resolve(root));
+    assert.ok(out.failureCatalogPath?.endsWith("failure-catalog.json"));
+    assert.ok(out.tiersPath?.endsWith("tiers.json"));
+    assert.equal(out.trackedReposPath, null);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("detectLegacy: returns null when neither catalog nor tiers present", async () => {
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), "aic-empty-"));
+  try {
+    const out = await detectLegacy(empty);
+    assert.equal(out, null);
+  } finally {
+    cleanup(empty);
+  }
+});
+
+test("detectLegacy: surfaces tracked.json when present", async () => {
+  const root = mkLegacyRoot({ withTracked: true });
+  try {
+    const out = await detectLegacy(root);
+    assert.ok(out.trackedReposPath);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("findLegacyUpwards: finds sibling solo-cto-agent folder", async () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), "aic-parent-"));
+  const sibling = path.join(parent, "solo-cto-agent");
+  fs.mkdirSync(sibling);
+  fs.writeFileSync(
+    path.join(sibling, "failure-catalog.json"),
+    JSON.stringify({ version: 1, updated_at: "2026-04-13", items: [] }),
+  );
+  try {
+    const out = await findLegacyUpwards(parent);
+    assert.ok(out);
+    assert.equal(path.basename(out.root), "solo-cto-agent");
+  } finally {
+    cleanup(parent);
+  }
+});
+
+test("findLegacyUpwards: returns null when nothing in the tree", async () => {
+  const iso = fs.mkdtempSync(path.join(os.tmpdir(), "aic-iso-"));
+  try {
+    const out = await findLegacyUpwards(iso);
+    assert.equal(out, null);
+  } finally {
+    cleanup(iso);
+  }
+});
+
+test("buildPlan: willWriteConfig true when .conclaverc.json absent", async () => {
+  const legacyDir = mkLegacyRoot();
+  const cwd = mkCwd();
+  try {
+    const legacy = await detectLegacy(legacyDir);
+    const plan = await buildPlan(legacy, cwd);
+    assert.equal(plan.willWriteConfig, true);
+    assert.equal(plan.willSeedFailures, true);
+    assert.ok(plan.configTargetPath.endsWith(".conclaverc.json"));
+  } finally {
+    cleanup(legacyDir);
+    cleanup(cwd);
+  }
+});
+
+test("buildPlan: willWriteConfig false when .conclaverc.json already exists", async () => {
+  const legacyDir = mkLegacyRoot();
+  const cwd = mkCwd();
+  fs.writeFileSync(path.join(cwd, ".conclaverc.json"), JSON.stringify({ version: 1 }));
+  try {
+    const legacy = await detectLegacy(legacyDir);
+    const plan = await buildPlan(legacy, cwd);
+    assert.equal(plan.willWriteConfig, false);
+  } finally {
+    cleanup(legacyDir);
+    cleanup(cwd);
+  }
+});
+
+test("buildPlan: surfaces trackedRepoNames from .solo-cto/tracked.json", async () => {
+  const legacyDir = mkLegacyRoot({ withTracked: true });
+  const cwd = mkCwd();
+  try {
+    const legacy = await detectLegacy(legacyDir);
+    const plan = await buildPlan(legacy, cwd);
+    assert.deepEqual(plan.trackedRepoNames, ["acme/my-app", "acme/other"]);
+  } finally {
+    cleanup(legacyDir);
+    cleanup(cwd);
+  }
+});
+
+test("applyPlan: writes .conclaverc.json + seeds failures + returns counts", async () => {
+  const legacyDir = mkLegacyRoot();
+  const cwd = mkCwd();
+  try {
+    const legacy = await detectLegacy(legacyDir);
+    const plan = await buildPlan(legacy, cwd);
+    const result = await applyPlan(plan, cwd);
+    assert.equal(result.wroteConfig, true);
+    assert.equal(result.seeded, 2); // two items in fixture catalog
+    assert.ok(fs.existsSync(path.join(cwd, ".conclaverc.json")));
+    // failures landed under the memory root
+    const codeDir = path.join(cwd, ".conclave", "failure-catalog", "code");
+    assert.ok(fs.existsSync(codeDir));
+    const files = fs.readdirSync(codeDir).filter((f) => f.endsWith(".json"));
+    assert.equal(files.length, 2);
+  } finally {
+    cleanup(legacyDir);
+    cleanup(cwd);
+  }
+});
+
+test("applyPlan: skips config write when one already exists", async () => {
+  const legacyDir = mkLegacyRoot();
+  const cwd = mkCwd();
+  const existing = JSON.stringify({ version: 1, agents: ["claude"], budget: { perPrUsd: 0.25 } });
+  fs.writeFileSync(path.join(cwd, ".conclaverc.json"), existing);
+  try {
+    const legacy = await detectLegacy(legacyDir);
+    const plan = await buildPlan(legacy, cwd);
+    const result = await applyPlan(plan, cwd);
+    assert.equal(result.wroteConfig, false);
+    // Original content should not have been overwritten
+    const after = fs.readFileSync(path.join(cwd, ".conclaverc.json"), "utf8");
+    assert.equal(after, existing);
+  } finally {
+    cleanup(legacyDir);
+    cleanup(cwd);
+  }
+});
+
+test("applyPlan: no failure catalog in legacy → seeded count is 0", async () => {
+  const legacyDir = mkLegacyRoot({ withCatalog: false, withTiers: true });
+  const cwd = mkCwd();
+  try {
+    const legacy = await detectLegacy(legacyDir);
+    const plan = await buildPlan(legacy, cwd);
+    const result = await applyPlan(plan, cwd);
+    assert.equal(result.seeded, 0);
+    assert.equal(plan.willSeedFailures, false);
+  } finally {
+    cleanup(legacyDir);
+    cleanup(cwd);
+  }
+});


### PR DESCRIPTION
## Summary

Decision #27 locks: solo-cto-agent 1.4.x stays on npm in maintenance mode; `conclave migrate` provides a soft transition path. This PR lands that command.

## What it does

1. **Detect legacy root** — walks up from cwd looking for `failure-catalog.json` / `tiers.json`; also checks sibling `solo-cto-agent/` folder (common layout). `--from <path>` override.
2. **Port failure-catalog** — every ERR-XXX entry lands in `.conclave/failure-catalog/` via the existing seeder (PR #12). Tagged `["legacy", "solo-cto-agent", "migrated"]`.
3. **Surface tracked repos** — reads `.solo-cto/tracked.json`, prints names for manual migration. Tokens never copied.
4. **Write `.conclaverc.json`** with defaults if none exists. Never overwrites.
5. **Print env checklist** — all v2.0 surfaces (Anthropic / OpenAI / Google / 4 notifiers / 4 platforms / Langfuse) so users know what to carry over.

## Safe-by-default

- `--dry-run` prints the plan without touching disk.
- Apply mode only writes files that DON'T already exist.
- Legacy install never modified — solo-cto-agent + ai-conclave can coexist during transition.

## Usage

```bash
# Preview from a sibling solo-cto-agent folder
conclave migrate --dry-run

# Explicit path + apply
conclave migrate --from ../solo-cto-agent

# Example output:
#   legacy root:         /path/to/solo-cto-agent
#   failure-catalog:     /path/to/solo-cto-agent/failure-catalog.json
#   tiers.json:          /path/to/solo-cto-agent/tiers.json
#   tracked repos:       2 found
#   config to write:     /path/to/cwd/.conclaverc.json
#   seed failures:       yes
#   mode:                APPLY
#
#   tracked-repo names (migrate manually to scm-github config):
#     - acme/my-app
#     - acme/other
#
#   env checklist (audit each; don't copy tokens blindly):
#     • ANTHROPIC_API_KEY (required — same as solo-cto-agent)
#     • OPENAI_API_KEY (optional — enables second council agent)
#     ...
#
#   applied:
#     config written:    yes → /path/to/cwd/.conclaverc.json
#     failures seeded:   15
```

## Tests — 11 cases

- **parseMigrateArgs** (3): `--help`, `--dry-run`, `--from`.
- **detectLegacy** (3): happy (catalog + tiers), empty dir → null, tracked.json surfaced.
- **findLegacyUpwards** (2): sibling folder, isolated tree → null.
- **buildPlan** (3): willWriteConfig on fresh cwd, false when config exists, trackedRepoNames surfaced.
- **applyPlan** (3): writes config + seeds 2 failures round-trip, skips config write when exists (original preserved), seeded=0 when legacy catalog absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)