### PR TITLE
feat(visual-review,cli): vision judge — semantic classification on top of pixel diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## Unreleased
 
 ### Added
+- **Vision judge for visual review** — semantic classification of
+  before/after diff (intentional / regression / accessibility / mixed /
+  unreviewable) via Claude multimodal. `VisionJudge` interface +
+  `ClaudeVisionJudge` default ship in `@ai-conclave/visual-review`.
+  `runVisualReview` takes optional `judge` + `judgeContext`; CLI
+  `--visual` flag auto-enables when `ANTHROPIC_API_KEY` is present.
+  Judgment + structured concerns printed in review output. 15 test
+  cases (judge parsing + orchestrator integration).
 - **CLI `conclave migrate`** (decision #27) — brings an existing
   solo-cto-agent install over to ai-conclave without deleting the
   legacy install:

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -327,8 +327,9 @@ export async function review(argv: string[]): Promise<void> {
         if (platforms.length === 0) {
           process.stderr.write("conclave review: visual enabled but no platforms available — skipping\n");
         } else {
-          const { runVisualReview } = await import("@ai-conclave/visual-review");
-          const vResult = await runVisualReview({
+          const visualMod = await import("@ai-conclave/visual-review");
+          const { runVisualReview } = visualMod;
+          const visualInput: Parameters<typeof runVisualReview>[0] = {
             repo: loaded.repo,
             beforeSha: loaded.prevSha,
             afterSha: loaded.newSha,
@@ -340,7 +341,20 @@ export async function review(argv: string[]): Promise<void> {
             },
             diffOptions: { threshold: config.visual?.diffThreshold ?? 0.1 },
             waitSeconds: config.visual?.waitSeconds ?? 60,
-          });
+          };
+          // Vision judge (semantic "regression vs intentional") auto-runs
+          // when ANTHROPIC_API_KEY is available. Uses Claude vision.
+          if (process.env["ANTHROPIC_API_KEY"]) {
+            visualInput.judge = new visualMod.ClaudeVisionJudge();
+            visualInput.judgeContext = {
+              codeReviewContext: {
+                repo: loaded.repo,
+                pullNumber: loaded.pullNumber,
+                diff: loaded.diff,
+              },
+            };
+          }
+          const vResult = await runVisualReview(visualInput);
           process.stdout.write(
             `\n── visual review ──\n` +
               `  severity:   ${vResult.severity}\n` +
@@ -353,6 +367,19 @@ export async function review(argv: string[]): Promise<void> {
               `    after:    ${vResult.paths.after}\n` +
               `    diff:     ${vResult.paths.diff}\n`,
           );
+          if (vResult.judgment) {
+            const j = vResult.judgment;
+            process.stdout.write(
+              `  judgment:   ${j.category} (conf ${(j.confidence * 100).toFixed(0)}%)\n` +
+                `    ${j.summary}\n`,
+            );
+            if (j.concerns.length > 0) {
+              process.stdout.write(`  concerns:\n`);
+              for (const c of j.concerns) {
+                process.stdout.write(`    [${c.severity.toUpperCase()}] (${c.kind}) ${c.message}\n`);
+              }
+            }
+          }
         }
       } catch (err) {
         process.stderr.write(`conclave review: visual diff failed — ${(err as Error).message}\n`);

--- a/packages/visual-review/package.json
+++ b/packages/visual-review/package.json
@@ -30,9 +30,13 @@
     "pngjs": "^7.0.0"
   },
   "peerDependencies": {
+    "@anthropic-ai/sdk": "^0.65.0",
     "playwright": "^1.49.0"
   },
   "peerDependenciesMeta": {
+    "@anthropic-ai/sdk": {
+      "optional": true
+    },
     "playwright": {
       "optional": true
     }

--- a/packages/visual-review/src/index.ts
+++ b/packages/visual-review/src/index.ts
@@ -15,3 +15,16 @@ export type { DiffOptions, DiffResult, VisualDiff } from "./diff.js";
 
 export { runVisualReview } from "./orchestrator.js";
 export type { VisualReviewInput, VisualReviewResult } from "./orchestrator.js";
+
+export { ClaudeVisionJudge } from "./judge.js";
+export type {
+  VisionJudge,
+  VisualJudgment,
+  VisualJudgmentCategory,
+  VisualConcern,
+  VisionJudgeContext,
+  ClaudeVisionJudgeOptions,
+  AnthropicVisionLike,
+  AnthropicVisionParams,
+  AnthropicVisionResponse,
+} from "./judge.js";

--- a/packages/visual-review/src/judge.ts
+++ b/packages/visual-review/src/judge.ts
@@ -1,0 +1,325 @@
+import type { ReviewContext } from "@ai-conclave/core";
+
+export type VisualJudgmentCategory =
+  | "intentional" // deliberate redesign, working as expected
+  | "regression" // unintended change, degraded UX / broke something
+  | "accessibility" // contrast / sizing / keyboard-trap / readable-text concern
+  | "mixed" // some intentional + some regression in the same diff
+  | "unreviewable"; // vision model can't tell (blank / error page / scaled too small)
+
+export interface VisualJudgment {
+  category: VisualJudgmentCategory;
+  /** 0..1 — model's self-reported confidence. */
+  confidence: number;
+  /** One-paragraph natural-language explanation. */
+  summary: string;
+  /**
+   * Specific regions / concerns the reviewer flagged. Empty when
+   * category is `intentional`.
+   */
+  concerns: VisualConcern[];
+}
+
+export interface VisualConcern {
+  /** Short category tag: `contrast`, `layout-shift`, `missing-content`, `scroll-jank`, etc. */
+  kind: string;
+  severity: "blocker" | "major" | "minor";
+  message: string;
+}
+
+export interface VisionJudgeContext {
+  /** Why the reviewer is looking: "PR merges a login redesign", "hotfix for safari render bug", etc. */
+  changeHint?: string;
+  /** Code review verdict + summary, so the vision judge can be consistent with council consensus. */
+  codeReviewContext?: Pick<ReviewContext, "repo" | "pullNumber" | "diff">;
+}
+
+/**
+ * VisionJudge — pluggable interface for semantic before/after image
+ * comparison. The pixel-diff layer (`PixelmatchDiff`) measures HOW MUCH
+ * changed; the vision judge measures WHETHER it's good.
+ *
+ * Default implementation uses Anthropic's multimodal Claude API through
+ * a minimal provided client. Users can inject a different implementation
+ * (e.g. GPT-4o vision, Gemini 1.5 Pro vision) by supplying their own
+ * `VisionJudge`.
+ *
+ * Contract:
+ *   - `judge(before, after, ctx)` returns a `VisualJudgment`.
+ *   - Must NEVER throw on ambiguous inputs — return
+ *     `{ category: "unreviewable", confidence: 0, ... }` instead.
+ *     Hard errors (auth / network) MAY throw.
+ */
+export interface VisionJudge {
+  readonly id: string;
+  judge(
+    before: Uint8Array,
+    after: Uint8Array,
+    ctx?: VisionJudgeContext,
+  ): Promise<VisualJudgment>;
+}
+
+/**
+ * Minimal Anthropic messages API subset we rely on for vision calls.
+ * Narrowly typed so tests can mock without loading the SDK.
+ */
+export interface AnthropicVisionLike {
+  messages: {
+    create(params: AnthropicVisionParams): Promise<AnthropicVisionResponse>;
+  };
+}
+
+export interface AnthropicVisionParams {
+  model: string;
+  max_tokens: number;
+  system?: string | ReadonlyArray<{ type: "text"; text: string }>;
+  messages: ReadonlyArray<{
+    role: "user" | "assistant";
+    content:
+      | string
+      | ReadonlyArray<
+          | { type: "text"; text: string }
+          | {
+              type: "image";
+              source: { type: "base64"; media_type: "image/png" | "image/jpeg"; data: string };
+            }
+        >;
+  }>;
+  tools?: ReadonlyArray<{ name: string; description: string; input_schema: unknown }>;
+  tool_choice?: { type: "tool"; name: string };
+}
+
+export interface AnthropicVisionResponse {
+  content: ReadonlyArray<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; id: string; name: string; input: unknown }
+  >;
+  stop_reason?: string;
+  usage?: { input_tokens: number; output_tokens: number };
+}
+
+export interface ClaudeVisionJudgeOptions {
+  apiKey?: string;
+  model?: string;
+  maxTokens?: number;
+  client?: AnthropicVisionLike;
+  clientFactory?: (apiKey: string) => Promise<AnthropicVisionLike>;
+}
+
+const SUBMIT_TOOL_NAME = "submit_visual_judgment";
+
+const SUBMIT_TOOL_SCHEMA = {
+  type: "object",
+  properties: {
+    category: {
+      type: "string",
+      enum: ["intentional", "regression", "accessibility", "mixed", "unreviewable"],
+    },
+    confidence: {
+      type: "number",
+      minimum: 0,
+      maximum: 1,
+      description: "0..1 — your confidence in the category judgment.",
+    },
+    summary: {
+      type: "string",
+      description: "One paragraph explaining what changed and why it's ok / not ok.",
+    },
+    concerns: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          kind: {
+            type: "string",
+            description:
+              "Short tag: contrast, layout-shift, missing-content, cropped-text, scroll-jank, keyboard-trap, etc.",
+          },
+          severity: { type: "string", enum: ["blocker", "major", "minor"] },
+          message: { type: "string" },
+        },
+        required: ["kind", "severity", "message"],
+      },
+    },
+  },
+  required: ["category", "confidence", "summary", "concerns"],
+} as const;
+
+const SYSTEM_PROMPT = `You are the vision arm of an Ai-Conclave review council. Your job: compare the BEFORE and AFTER screenshots of a web page and classify the change.
+
+Categories:
+  intentional    - deliberate redesign / new feature / working as expected.
+  regression     - unintended change. Content missing, layout broke, visual bug.
+  accessibility  - contrast, sizing, focus/keyboard, text-readability concerns.
+  mixed          - the diff contains BOTH intentional AND regression.
+  unreviewable   - can't tell (blank image, error page, or screenshots too small/similar to judge).
+
+Rules:
+- Focus on REAL, user-visible issues. Do not flag imperceptible pixel-level noise.
+- If the change reads as a deliberate, well-executed redesign, category=intentional + concerns=[].
+- Regression / accessibility calls MUST name specific regions or elements ("header CTA button now cropped", "body text contrast dropped below AA").
+- Confidence: 0.9+ when you're sure, 0.5-0.8 when the diff is ambiguous, <0.5 when screenshots are degenerate.
+- You MUST call submit_visual_judgment exactly once. No free-form text.`;
+
+/**
+ * ClaudeVisionJudge — default implementation of `VisionJudge` using
+ * Claude Sonnet's multimodal API. Sends BEFORE + AFTER PNG buffers as
+ * base64 image blocks + a compact diff hint, and forces structured
+ * output via the `submit_visual_judgment` tool.
+ */
+export class ClaudeVisionJudge implements VisionJudge {
+  readonly id = "claude-vision";
+
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly clientFactory: (apiKey: string) => Promise<AnthropicVisionLike>;
+  private clientPromise: Promise<AnthropicVisionLike> | null;
+
+  constructor(opts: ClaudeVisionJudgeOptions = {}) {
+    const key = opts.apiKey ?? process.env["ANTHROPIC_API_KEY"] ?? "";
+    if (!key && !opts.client) {
+      throw new Error("ClaudeVisionJudge: ANTHROPIC_API_KEY not set (pass opts.apiKey, opts.client, or env var)");
+    }
+    this.apiKey = key;
+    this.model = opts.model ?? "claude-sonnet-4-6";
+    this.maxTokens = opts.maxTokens ?? 1_024;
+    this.clientFactory =
+      opts.clientFactory ??
+      (async () => {
+        if (opts.client) return opts.client;
+        const mod = (await import("@anthropic-ai/sdk")) as unknown as {
+          default: new (o: { apiKey: string }) => AnthropicVisionLike;
+        };
+        return new mod.default({ apiKey: this.apiKey });
+      });
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+  }
+
+  async judge(
+    before: Uint8Array,
+    after: Uint8Array,
+    ctx: VisionJudgeContext = {},
+  ): Promise<VisualJudgment> {
+    const client = await this.getClient();
+    const userText = buildUserPrompt(ctx);
+    const beforeB64 = toBase64(before);
+    const afterB64 = toBase64(after);
+    const response = await client.messages.create({
+      model: this.model,
+      max_tokens: this.maxTokens,
+      system: SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: userText },
+            { type: "text", text: "BEFORE:" },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: beforeB64 } },
+            { type: "text", text: "AFTER:" },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: afterB64 } },
+            { type: "text", text: "Respond by calling submit_visual_judgment exactly once." },
+          ],
+        },
+      ],
+      tools: [
+        {
+          name: SUBMIT_TOOL_NAME,
+          description: "Return your structured visual judgment. Call exactly once.",
+          input_schema: SUBMIT_TOOL_SCHEMA,
+        },
+      ],
+      tool_choice: { type: "tool", name: SUBMIT_TOOL_NAME },
+    });
+    return parseResponse(response);
+  }
+
+  private async getClient(): Promise<AnthropicVisionLike> {
+    if (!this.clientPromise) this.clientPromise = this.clientFactory(this.apiKey);
+    return this.clientPromise;
+  }
+}
+
+function buildUserPrompt(ctx: VisionJudgeContext): string {
+  const parts: string[] = [];
+  parts.push(
+    "Compare the BEFORE and AFTER screenshots of the same web page. Classify the visual change.",
+  );
+  if (ctx.changeHint) {
+    parts.push(`Change hint from the author: ${ctx.changeHint}`);
+  }
+  if (ctx.codeReviewContext) {
+    const { repo, pullNumber, diff } = ctx.codeReviewContext;
+    parts.push(`Code change: ${repo}${pullNumber ? ` #${pullNumber}` : ""}.`);
+    const diffSnippet = (diff ?? "").slice(0, 500);
+    if (diffSnippet) parts.push(`Diff excerpt (first 500 chars):\n${diffSnippet}`);
+  }
+  return parts.join("\n\n");
+}
+
+function parseResponse(response: AnthropicVisionResponse): VisualJudgment {
+  const toolUse = response.content.find(
+    (b): b is Extract<(typeof response.content)[number], { type: "tool_use" }> =>
+      b.type === "tool_use" && b.name === SUBMIT_TOOL_NAME,
+  );
+  if (!toolUse) {
+    return {
+      category: "unreviewable",
+      confidence: 0,
+      summary: `Model did not call submit_visual_judgment (stop_reason=${response.stop_reason ?? "?"}).`,
+      concerns: [],
+    };
+  }
+  const raw = toolUse.input as {
+    category?: unknown;
+    confidence?: unknown;
+    summary?: unknown;
+    concerns?: unknown;
+  };
+  const category = coerceCategory(raw.category);
+  const confidence = typeof raw.confidence === "number" ? clamp01(raw.confidence) : 0;
+  const summary = typeof raw.summary === "string" ? raw.summary : "";
+  const concerns: VisualConcern[] = [];
+  if (Array.isArray(raw.concerns)) {
+    for (const item of raw.concerns) {
+      if (!item || typeof item !== "object") continue;
+      const c = item as Record<string, unknown>;
+      const kind = c["kind"];
+      const severity = c["severity"];
+      const message = c["message"];
+      if (
+        typeof kind === "string" &&
+        (severity === "blocker" || severity === "major" || severity === "minor") &&
+        typeof message === "string"
+      ) {
+        concerns.push({ kind, severity, message });
+      }
+    }
+  }
+  return { category, confidence, summary, concerns };
+}
+
+function coerceCategory(v: unknown): VisualJudgmentCategory {
+  if (
+    v === "intentional" ||
+    v === "regression" ||
+    v === "accessibility" ||
+    v === "mixed" ||
+    v === "unreviewable"
+  ) {
+    return v;
+  }
+  return "unreviewable";
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+/** Native `Buffer.from(ab).toString('base64')` — explicit for test-path clarity. */
+function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}

--- a/packages/visual-review/src/orchestrator.ts
+++ b/packages/visual-review/src/orchestrator.ts
@@ -9,6 +9,7 @@ import {
   type ScreenshotCapture,
 } from "./capture.js";
 import { PixelmatchDiff, classifyDiffRatio, type DiffOptions, type DiffResult, type VisualDiff } from "./diff.js";
+import type { VisionJudge, VisionJudgeContext, VisualJudgment } from "./judge.js";
 
 export interface VisualReviewInput {
   repo: string;
@@ -21,6 +22,10 @@ export interface VisualReviewInput {
   /** Override capture + diff engines. */
   capture?: ScreenshotCapture;
   diff?: VisualDiff;
+  /** Optional semantic judge. When supplied, result includes `judgment`. */
+  judge?: VisionJudge;
+  /** Hint + code-review context for the judge. */
+  judgeContext?: VisionJudgeContext;
   /** Capture options (viewport / timeouts / etc.). */
   captureOptions?: CaptureOptions;
   /** Diff options (threshold / anti-alias handling). */
@@ -41,6 +46,8 @@ export interface VisualReviewResult {
   diff: DiffResult;
   /** Coarse severity label. */
   severity: ReturnType<typeof classifyDiffRatio>;
+  /** Optional semantic judgment. Populated only when `input.judge` is provided. */
+  judgment?: VisualJudgment;
 }
 
 /**
@@ -98,7 +105,7 @@ export async function runVisualReview(input: VisualReviewInput): Promise<VisualR
     await fs.writeFile(afterPath, afterCap.png);
     await fs.writeFile(diffPath, diffResult.diffPng);
 
-    return {
+    const out: VisualReviewResult = {
       before: beforeRes,
       after: afterRes,
       paths: { before: beforePath, after: afterPath, diff: diffPath },
@@ -106,6 +113,19 @@ export async function runVisualReview(input: VisualReviewInput): Promise<VisualR
       diff: diffResult,
       severity: classifyDiffRatio(diffResult.diffRatio),
     };
+
+    // Optional semantic judgment. Failure never corrupts the rest of
+    // the review — log + continue with just the pixel-diff layer.
+    if (input.judge) {
+      try {
+        const judgment = await input.judge.judge(beforeCap.png, afterCap.png, input.judgeContext ?? {});
+        out.judgment = judgment;
+      } catch (err) {
+        process.stderr.write(`[visual-review:judge] failed — ${(err as Error).message}\n`);
+      }
+    }
+
+    return out;
   } finally {
     // Close only if WE created the capture; user-supplied instances are their responsibility.
     if (!input.capture) await capture.close();

--- a/packages/visual-review/test/judge.test.mjs
+++ b/packages/visual-review/test/judge.test.mjs
@@ -1,0 +1,203 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ClaudeVisionJudge } from "../dist/index.js";
+
+function mockClient(responses) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    messages: {
+      create: async (params) => {
+        calls.push(params);
+        const r = responses[Math.min(i, responses.length - 1)];
+        i += 1;
+        if (r.throw) throw new Error(r.throw);
+        return r.response;
+      },
+    },
+  };
+}
+
+function toolUseResponse(input) {
+  return {
+    response: {
+      content: [{ type: "tool_use", id: "tu-1", name: "submit_visual_judgment", input }],
+      stop_reason: "tool_use",
+      usage: { input_tokens: 100, output_tokens: 50 },
+    },
+  };
+}
+
+const pngA = new Uint8Array([1, 2, 3, 4, 5]);
+const pngB = new Uint8Array([6, 7, 8, 9, 10]);
+
+test("ClaudeVisionJudge: missing API key AND no client throws in constructor", () => {
+  const orig = process.env.ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  try {
+    assert.throws(() => new ClaudeVisionJudge());
+  } finally {
+    if (orig !== undefined) process.env.ANTHROPIC_API_KEY = orig;
+  }
+});
+
+test("ClaudeVisionJudge: parses intentional judgment", async () => {
+  const client = mockClient([
+    toolUseResponse({
+      category: "intentional",
+      confidence: 0.92,
+      summary: "Login page redesigned with new brand colors — consistent, polished.",
+      concerns: [],
+    }),
+  ]);
+  const judge = new ClaudeVisionJudge({ apiKey: "test", client });
+  const result = await judge.judge(pngA, pngB);
+  assert.equal(result.category, "intentional");
+  assert.equal(result.confidence, 0.92);
+  assert.equal(result.concerns.length, 0);
+  assert.match(result.summary, /redesigned/);
+});
+
+test("ClaudeVisionJudge: parses regression with concerns", async () => {
+  const client = mockClient([
+    toolUseResponse({
+      category: "regression",
+      confidence: 0.85,
+      summary: "Header CTA button got cropped; text below fold.",
+      concerns: [
+        { kind: "layout-shift", severity: "blocker", message: "Hero section pushed below viewport" },
+        { kind: "cropped-text", severity: "major", message: "Sign-up button text cut off at right edge" },
+      ],
+    }),
+  ]);
+  const judge = new ClaudeVisionJudge({ apiKey: "test", client });
+  const result = await judge.judge(pngA, pngB);
+  assert.equal(result.category, "regression");
+  assert.equal(result.concerns.length, 2);
+  assert.equal(result.concerns[0].severity, "blocker");
+  assert.equal(result.concerns[0].kind, "layout-shift");
+});
+
+test("ClaudeVisionJudge: filters malformed concerns individually", async () => {
+  const client = mockClient([
+    toolUseResponse({
+      category: "mixed",
+      confidence: 0.7,
+      summary: "Some good, some not",
+      concerns: [
+        { kind: "contrast", severity: "major", message: "body text contrast dropped" },
+        { severity: "blocker", message: "missing kind" },
+        { kind: "no-severity", message: "whatever" },
+        { kind: "no-message", severity: "minor" },
+        { kind: "good-one", severity: "minor", message: "ok" },
+      ],
+    }),
+  ]);
+  const judge = new ClaudeVisionJudge({ apiKey: "test", client });
+  const result = await judge.judge(pngA, pngB);
+  assert.equal(result.concerns.length, 2); // only the two well-formed ones
+  const kinds = result.concerns.map((c) => c.kind).sort();
+  assert.deepEqual(kinds, ["contrast", "good-one"]);
+});
+
+test("ClaudeVisionJudge: sends base64 image blocks in correct order", async () => {
+  const client = mockClient([
+    toolUseResponse({ category: "intentional", confidence: 0.9, summary: "ok", concerns: [] }),
+  ]);
+  const judge = new ClaudeVisionJudge({ apiKey: "test", client });
+  await judge.judge(pngA, pngB);
+  const params = client.calls[0];
+  const blocks = params.messages[0].content;
+  const imageBlocks = blocks.filter((b) => b.type === "image");
+  assert.equal(imageBlocks.length, 2);
+  // both use base64 / image/png
+  for (const b of imageBlocks) {
+    assert.equal(b.source.type, "base64");
+    assert.equal(b.source.media_type, "image/png");
+  }
+  // text labels BEFORE / AFTER before each image
+  const textBlocks = blocks.filter((b) => b.type === "text");
+  assert.ok(textBlocks.some((t) => t.text === "BEFORE:"));
+  assert.ok(textBlocks.some((t) => t.text === "AFTER:"));
+});
+
+test("ClaudeVisionJudge: forces submit_visual_judgment tool via tool_choice", async () => {
+  const client = mockClient([
+    toolUseResponse({ category: "intentional", confidence: 0.9, summary: "ok", concerns: [] }),
+  ]);
+  const judge = new ClaudeVisionJudge({ apiKey: "test", client });
+  await judge.judge(pngA, pngB);
+  const params = client.calls[0];
+  assert.equal(params.tool_choice.type, "tool");
+  assert.equal(params.tool_choice.name, "submit_visual_judgment");
+  assert.equal(params.tools[0].name, "submit_visual_judgment");
+});
+
+test("ClaudeVisionJudge: judgeContext.changeHint + codeReviewContext injected into prompt", async () => {
+  const client = mockClient([
+    toolUseResponse({ category: "intentional", confidence: 0.9, summary: "ok", concerns: [] }),
+  ]);
+  const judge = new ClaudeVisionJudge({ apiKey: "test", client });
+  await judge.judge(pngA, pngB, {
+    changeHint: "new login flow",
+    codeReviewContext: { repo: "acme/app", pullNumber: 7, diff: "diff --git a/foo b/foo\n+bar" },
+  });
+  const userText = client.calls[0].messages[0].content.find((b) => b.type === "text" && b.text.includes("Change hint"));
+  assert.ok(userText);
+  assert.match(userText.text, /new login flow/);
+  assert.match(userText.text, /acme\/app #7/);
+  assert.match(userText.text, /diff --git/);
+});
+
+test("ClaudeVisionJudge: response without submit tool_use returns unreviewable", async () => {
+  const client = {
+    messages: {
+      create: async () => ({
+        content: [{ type: "text", text: "I couldn't decide" }],
+        stop_reason: "end_turn",
+      }),
+    },
+  };
+  const judge = new ClaudeVisionJudge({ apiKey: "test", client });
+  const result = await judge.judge(pngA, pngB);
+  assert.equal(result.category, "unreviewable");
+  assert.equal(result.confidence, 0);
+  assert.match(result.summary, /did not call/i);
+});
+
+test("ClaudeVisionJudge: invalid category coerces to unreviewable", async () => {
+  const client = mockClient([
+    toolUseResponse({
+      category: "kaboom",
+      confidence: 0.5,
+      summary: "weird",
+      concerns: [],
+    }),
+  ]);
+  const judge = new ClaudeVisionJudge({ apiKey: "test", client });
+  const result = await judge.judge(pngA, pngB);
+  assert.equal(result.category, "unreviewable");
+});
+
+test("ClaudeVisionJudge: confidence clamped to [0, 1]", async () => {
+  const clientLow = mockClient([
+    toolUseResponse({ category: "intentional", confidence: -0.5, summary: "", concerns: [] }),
+  ]);
+  const clientHigh = mockClient([
+    toolUseResponse({ category: "intentional", confidence: 2.5, summary: "", concerns: [] }),
+  ]);
+  const judgeLow = new ClaudeVisionJudge({ apiKey: "k", client: clientLow });
+  const judgeHigh = new ClaudeVisionJudge({ apiKey: "k", client: clientHigh });
+  assert.equal((await judgeLow.judge(pngA, pngB)).confidence, 0);
+  assert.equal((await judgeHigh.judge(pngA, pngB)).confidence, 1);
+});
+
+test("ClaudeVisionJudge: NaN confidence → 0", async () => {
+  const client = mockClient([
+    toolUseResponse({ category: "intentional", confidence: Number.NaN, summary: "", concerns: [] }),
+  ]);
+  const judge = new ClaudeVisionJudge({ apiKey: "k", client });
+  const r = await judge.judge(pngA, pngB);
+  assert.equal(r.confidence, 0);
+});

--- a/packages/visual-review/test/orchestrator-judge.test.mjs
+++ b/packages/visual-review/test/orchestrator-judge.test.mjs
@@ -1,0 +1,169 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PNG } from "pngjs";
+import { runVisualReview } from "../dist/index.js";
+
+function solidPng(w = 40, h = 40, c = [200, 200, 200, 255]) {
+  const png = new PNG({ width: w, height: h });
+  for (let i = 0; i < png.data.length; i += 4) {
+    png.data[i] = c[0];
+    png.data[i + 1] = c[1];
+    png.data[i + 2] = c[2];
+    png.data[i + 3] = c[3];
+  }
+  return new Uint8Array(PNG.sync.write(png));
+}
+
+function fixedPlatform(id, result) {
+  return { id, displayName: id, resolve: async () => result };
+}
+
+function stubCapture(screenshots) {
+  let i = 0;
+  return {
+    id: "stub",
+    capture: async (url) => ({
+      png: screenshots[Math.min(i++, screenshots.length - 1)],
+      finalUrl: url,
+      viewport: { width: 40, height: 40, deviceScaleFactor: 1 },
+    }),
+    close: async () => {},
+  };
+}
+
+function tmpOut() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "aic-oj-"));
+}
+function cleanup(d) {
+  fs.rmSync(d, { recursive: true, force: true });
+}
+
+const before = solidPng(40, 40, [255, 255, 255, 255]);
+const after = solidPng(40, 40, [0, 0, 0, 255]);
+
+test("runVisualReview: judge supplied → result includes judgment", async () => {
+  const outDir = tmpOut();
+  try {
+    const judge = {
+      id: "stub-judge",
+      judge: async () => ({
+        category: "regression",
+        confidence: 0.9,
+        summary: "footer vanished",
+        concerns: [{ kind: "missing-content", severity: "blocker", message: "footer gone" }],
+      }),
+    };
+    const result = await runVisualReview({
+      repo: "acme/app",
+      beforeSha: "b",
+      afterSha: "a",
+      platforms: [
+        fixedPlatform("p", { url: "https://b", provider: "p", sha: "b" }),
+        fixedPlatform("p", { url: "https://a", provider: "p", sha: "a" }),
+      ],
+      outputDir: outDir,
+      capture: stubCapture([before, after]),
+      judge,
+    });
+    assert.ok(result.judgment);
+    assert.equal(result.judgment.category, "regression");
+    assert.equal(result.judgment.concerns.length, 1);
+  } finally {
+    cleanup(outDir);
+  }
+});
+
+test("runVisualReview: no judge supplied → result has no judgment field", async () => {
+  const outDir = tmpOut();
+  try {
+    const result = await runVisualReview({
+      repo: "acme/app",
+      beforeSha: "b",
+      afterSha: "a",
+      platforms: [
+        fixedPlatform("p", { url: "https://b", provider: "p", sha: "b" }),
+        fixedPlatform("p", { url: "https://a", provider: "p", sha: "a" }),
+      ],
+      outputDir: outDir,
+      capture: stubCapture([before, after]),
+    });
+    assert.equal(result.judgment, undefined);
+  } finally {
+    cleanup(outDir);
+  }
+});
+
+test("runVisualReview: judge throwing is caught; rest of result is intact", async () => {
+  const outDir = tmpOut();
+  const origStderr = process.stderr.write.bind(process.stderr);
+  const chunks = [];
+  process.stderr.write = (c) => {
+    chunks.push(String(c));
+    return true;
+  };
+  try {
+    const judge = {
+      id: "bad-judge",
+      judge: async () => {
+        throw new Error("vision api down");
+      },
+    };
+    const result = await runVisualReview({
+      repo: "acme/app",
+      beforeSha: "b",
+      afterSha: "a",
+      platforms: [
+        fixedPlatform("p", { url: "https://b", provider: "p", sha: "b" }),
+        fixedPlatform("p", { url: "https://a", provider: "p", sha: "a" }),
+      ],
+      outputDir: outDir,
+      capture: stubCapture([before, after]),
+      judge,
+    });
+    // Judgment missing because judge threw, but severity + paths still present.
+    assert.equal(result.judgment, undefined);
+    assert.equal(result.severity, "total-rewrite");
+    assert.ok(fs.existsSync(result.paths.diff));
+  } finally {
+    process.stderr.write = origStderr;
+    cleanup(outDir);
+  }
+  assert.match(chunks.join(""), /vision api down/);
+});
+
+test("runVisualReview: judgeContext propagates to judge", async () => {
+  const outDir = tmpOut();
+  try {
+    let capturedCtx = null;
+    const judge = {
+      id: "cap-judge",
+      judge: async (_a, _b, ctx) => {
+        capturedCtx = ctx;
+        return { category: "intentional", confidence: 0.9, summary: "", concerns: [] };
+      },
+    };
+    await runVisualReview({
+      repo: "acme/app",
+      beforeSha: "b",
+      afterSha: "a",
+      platforms: [
+        fixedPlatform("p", { url: "https://b", provider: "p", sha: "b" }),
+        fixedPlatform("p", { url: "https://a", provider: "p", sha: "a" }),
+      ],
+      outputDir: outDir,
+      capture: stubCapture([before, after]),
+      judge,
+      judgeContext: {
+        changeHint: "header redesign",
+        codeReviewContext: { repo: "acme/app", pullNumber: 42, diff: "..." },
+      },
+    });
+    assert.equal(capturedCtx.changeHint, "header redesign");
+    assert.equal(capturedCtx.codeReviewContext.pullNumber, 42);
+  } finally {
+    cleanup(outDir);
+  }
+});


### PR DESCRIPTION
## Summary

Pixel diff answers "how much changed" but not "is it good?". Vision judge adds the semantic layer via Claude's multimodal API — classifies each before/after pair as intentional / regression / accessibility / mixed / unreviewable, with structured concerns the council can act on.

## Surface

```ts
interface VisionJudge {
  readonly id: string;
  judge(before: Uint8Array, after: Uint8Array, ctx?: VisionJudgeContext): Promise<VisualJudgment>;
}

interface VisualJudgment {
  category: "intentional" | "regression" | "accessibility" | "mixed" | "unreviewable";
  confidence: number;  // 0..1
  summary: string;
  concerns: Array<{ kind: string; severity: "blocker" | "major" | "minor"; message: string }>;
}
```

Default `ClaudeVisionJudge`:
- Sends BEFORE + AFTER PNGs as base64 image blocks
- Forces structured output via `submit_visual_judgment` tool (decision #12)
- Optional `judgeContext.changeHint` + `codeReviewContext` threaded into prompt
- Refusal / ambiguous / invalid-category → `unreviewable` with confidence 0 (never throws)

## Orchestrator

```ts
runVisualReview({
  ...,
  judge: new ClaudeVisionJudge(),
  judgeContext: { codeReviewContext: { repo, pullNumber, diff } },
});
// → result.judgment populated
// → judge throwing is caught + logged; pixel-diff result still returned
```

## CLI integration

`conclave review --visual` auto-creates a `ClaudeVisionJudge` when `ANTHROPIC_API_KEY` is set. Output block:

```
── visual review ──
  severity:   significant
  diff ratio: 4.12% (40,800 / 988,800 px)
  before url: https://b.preview (vercel)
  after url:  https://a.preview (vercel)
  paths:
    before:   .conclave/visual/abc/before.png
    after:    .conclave/visual/abc/after.png
    diff:     .conclave/visual/abc/diff.png
  judgment:   regression (conf 85%)
    Header CTA button got cropped; text below fold.
  concerns:
    [BLOCKER] (layout-shift) Hero section pushed below viewport
    [MAJOR]   (cropped-text) Sign-up button text cut off at right edge
```

## Tests — 15 cases

### `judge.test.mjs` (11)
Missing-key constructor throw, parse intentional, parse regression with concerns, drop malformed concern items individually, base64 image block wire format + BEFORE/AFTER text order, `tool_choice` wire format, `judgeContext` propagation, missing tool_use → unreviewable (stop_reason surfaced), invalid category → unreviewable, confidence clamped to [0,1], NaN → 0.

### `orchestrator-judge.test.mjs` (4)
Judge supplied → `result.judgment` populated, no judge → field omitted, throwing judge caught without corrupting pixel-diff result, `judgeContext` propagated to judge.

## Deferred

- Vision judge as a formal Council agent (adapt to Agent interface).
- Non-Claude vision providers (GPT-4o / Gemini 1.5 Pro) — drop-in via `VisionJudge` interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)