### PR TITLE
fix: pixelmatch types + Langfuse setTraceId race condition

### DIFF
--- a/packages/observability-langfuse/src/sink.ts
+++ b/packages/observability-langfuse/src/sink.ts
@@ -105,16 +105,21 @@ export class LangfuseMetricsSink implements MetricsSink {
    * MetricsSink.record is synchronous — we kick off the Langfuse call and
    * let the SDK queue handle delivery. Errors are swallowed to stderr so
    * observability failure never kills a running review.
+   *
+   * Captures `traceId` at call time (not inside the async `submit`) so a
+   * caller that flips `setTraceId` between records gets the correct id
+   * on each generation, not a race-y read-current value.
    */
   record(metric: CallMetric): void {
-    this.submit(metric).catch((err) => {
+    const traceIdSnapshot = this.traceId;
+    this.submit(metric, traceIdSnapshot).catch((err) => {
       process.stderr.write(
         `[langfuse] failed to record metric for ${metric.agent}/${metric.model}: ${(err as Error).message}\n`,
       );
     });
   }
 
-  private async submit(metric: CallMetric): Promise<void> {
+  private async submit(metric: CallMetric, traceId: string | undefined): Promise<void> {
     const client = await this.getClient();
     const startTime = new Date(metric.timestamp - metric.latencyMs);
     const endTime = new Date(metric.timestamp);
@@ -135,7 +140,7 @@ export class LangfuseMetricsSink implements MetricsSink {
         latencyMs: metric.latencyMs,
       },
     };
-    if (this.traceId) params.traceId = this.traceId;
+    if (traceId) params.traceId = traceId;
     const gen = client.generation(params);
     // Generations in the Langfuse SDK expect an `end()` call to finalize.
     gen.end();

--- a/packages/visual-review/src/pixelmatch.d.ts
+++ b/packages/visual-review/src/pixelmatch.d.ts
@@ -1,0 +1,26 @@
+/**
+ * Ambient module declaration for `pixelmatch` 6.x.
+ * The package ships without `.d.ts` files and there is no official
+ * `@types/pixelmatch` for v6. This declaration covers the call
+ * signature we actually use; keep it minimal.
+ */
+declare module "pixelmatch" {
+  interface PixelmatchOptions {
+    threshold?: number;
+    includeAA?: boolean;
+    alpha?: number;
+    aaColor?: [number, number, number];
+    diffColor?: [number, number, number];
+    diffColorAlt?: [number, number, number] | null;
+    diffMask?: boolean;
+  }
+  function pixelmatch(
+    img1: Uint8Array | Uint8ClampedArray,
+    img2: Uint8Array | Uint8ClampedArray,
+    output: Uint8Array | Uint8ClampedArray | null,
+    width: number,
+    height: number,
+    options?: PixelmatchOptions,
+  ): number;
+  export default pixelmatch;
+}


### PR DESCRIPTION
## Summary

Two issues surfaced when Bae ran the real toolchain locally.

### 1. `@ai-conclave/visual-review` build — TS7016 on pixelmatch

pixelmatch 6.x ships `index.js` only. No official `@types/pixelmatch` for v6.

**Fix**: local ambient declaration at `packages/visual-review/src/pixelmatch.d.ts`. Covers only the single call signature we use. Avoids an extra devDependency and doesn't require pnpm install re-run.

### 2. `LangfuseMetricsSink: setTraceId` race

Test expected consecutive records to capture each distinct traceId. Both were stamping the last value.

**Root cause**: `record()` fires `submit()` async. By the time `submit` reads `this.traceId`, the caller has already called `setTraceId("second")`.

**Fix**: snapshot `this.traceId` synchronously at `record()` time, pass to `submit(metric, traceId)` as argument. Race-free.

No test changes needed — existing assertions now reflect real behavior.

## Impact

```
pnpm build   # visual-review compiles clean
pnpm test    # langfuse setTraceId passes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)