### PR TITLE
feat(platform-railway): GraphQL adapter — completes decision #31 v2.0 platform set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,46 @@
 ## Unreleased
 
 ### Added
+- **`@ai-conclave/platform-railway`** — completes decision #31 v2.0
+  platform set (Vercel + Netlify + Railway + Cloudflare Pages +
+  `deployment-status`).
+  - Resolves preview URL for a commit SHA via Railway's GraphQL API
+    (`POST https://backboard.railway.com/graphql/v2`).
+  - Fetches the latest 20 deployments for a project (optionally
+    narrowed by `RAILWAY_ENVIRONMENT_ID`), filters client-side by
+    `meta.commitHash === sha` AND `status === "SUCCESS"`, picks newest
+    by `createdAt`.
+  - Prefers `staticUrl` (`*.up.railway.app`); falls back to `url` for
+    custom domains; returns null when neither is present.
+  - 404 → null, 401/403 → throws (auth), 5xx → throws, GraphQL
+    `errors[]` → throws with the message.
+  - Env: `RAILWAY_API_TOKEN` + `RAILWAY_PROJECT_ID` required;
+    `RAILWAY_ENVIRONMENT_ID` optional.
+  - Wired into `buildPlatforms` factory as `PlatformId = "railway"`
+    and into the CLI default visual platform list.
+  - 12 test cases mirror the Cloudflare adapter shape: missing envs,
+    newest-SUCCESS-wins, non-matching commit, non-SUCCESS status,
+    GraphQL errors, bearer auth + POST body shape, environmentId
+    forwarding, 401/404/500 handling, staticUrl fallback, no-URL
+    deployments → null.
+
+### Fixed
+- **Four test failures surfaced by fresh `pnpm build && pnpm test`
+  runs after PR #25 landed:**
+  - `core/memory/retrieval`: tag-only matches (text overlap = 0) now
+    contribute a base score so the tag boost can promote them past
+    `minScore`.
+  - `core/test/scoring`: tolerance compare for
+    `AGENT_SCORE_WEIGHTS` sum — IEEE 754 returns `0.9999999999999999`
+    for `0.4 + 0.3 + 0.2 + 0.1`, so strict equality was wrong.
+  - `visual-review/diff`: pad mismatched canvas with opaque magenta,
+    not transparent black — pixelmatch blends transparent pixels
+    against a white background and was reporting zero diff for any
+    size-mismatched pair.
+  - `visual-review/test orchestrator helper`: `fixedPlatform` stub now
+    filters by `input.sha`, matching the real `Platform` contract so
+    the preview-metadata test surfaces the correct before/after URLs.
+
 - **Agent scoring (decision #19)** — rolling weighted per-agent
   performance metrics from memory. Weights ported from solo-cto-agent
   where they were validated in production:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
     "@ai-conclave/platform-cloudflare": "workspace:*",
     "@ai-conclave/platform-deployment-status": "workspace:*",
     "@ai-conclave/platform-netlify": "workspace:*",
+    "@ai-conclave/platform-railway": "workspace:*",
     "@ai-conclave/platform-vercel": "workspace:*",
     "@ai-conclave/visual-review": "workspace:*",
     "@ai-conclave/observability-langfuse": "workspace:*",

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -319,7 +319,7 @@ export async function review(argv: string[]): Promise<void> {
     } else {
       try {
         const platformIds: PlatformId[] =
-          config.visual?.platforms ?? ["vercel", "netlify", "cloudflare", "deployment-status"];
+          config.visual?.platforms ?? ["vercel", "netlify", "cloudflare", "railway", "deployment-status"];
         const { platforms, skipped } = await buildPlatforms(platformIds);
         for (const sk of skipped) {
           process.stderr.write(`conclave review: visual platform "${sk.id}" skipped — ${sk.reason}\n`);

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -80,8 +80,8 @@ export const ConclaveConfigSchema = z.object({
     .object({
       enabled: z.boolean().default(false),
       platforms: z
-        .array(z.enum(["vercel", "netlify", "cloudflare", "deployment-status"]))
-        .default(["vercel", "netlify", "cloudflare", "deployment-status"]),
+        .array(z.enum(["vercel", "netlify", "cloudflare", "railway", "deployment-status"]))
+        .default(["vercel", "netlify", "cloudflare", "railway", "deployment-status"]),
       width: z.number().int().positive().default(1280),
       height: z.number().int().positive().default(800),
       fullPage: z.boolean().default(true),

--- a/packages/cli/src/lib/platform-factory.ts
+++ b/packages/cli/src/lib/platform-factory.ts
@@ -1,6 +1,6 @@
 import type { Platform } from "@ai-conclave/core";
 
-export type PlatformId = "vercel" | "netlify" | "cloudflare" | "deployment-status";
+export type PlatformId = "vercel" | "netlify" | "cloudflare" | "railway" | "deployment-status";
 
 export interface PlatformFactoryResult {
   platforms: Platform[];
@@ -61,6 +61,19 @@ export async function buildPlatforms(
         const mod = await import("@ai-conclave/platform-cloudflare");
         try {
           platforms.push(new mod.CloudflarePlatform());
+        } catch (err) {
+          skipped.push({ id, reason: (err as Error).message });
+        }
+        break;
+      }
+      case "railway": {
+        if (!process.env["RAILWAY_API_TOKEN"] || !process.env["RAILWAY_PROJECT_ID"]) {
+          skipped.push({ id, reason: "RAILWAY_API_TOKEN or RAILWAY_PROJECT_ID not set" });
+          continue;
+        }
+        const mod = await import("@ai-conclave/platform-railway");
+        try {
+          platforms.push(new mod.RailwayPlatform());
         } catch (err) {
           skipped.push({ id, reason: (err as Error).message });
         }

--- a/packages/cli/test/platform-factory.test.mjs
+++ b/packages/cli/test/platform-factory.test.mjs
@@ -26,15 +26,17 @@ test("buildPlatforms: no env → all platforms except deployment-status skipped"
       CLOUDFLARE_API_TOKEN: null,
       CLOUDFLARE_ACCOUNT_ID: null,
       CLOUDFLARE_PROJECT_NAME: null,
+      RAILWAY_API_TOKEN: null,
+      RAILWAY_PROJECT_ID: null,
     },
     async () => {
-      const out = await buildPlatforms(["vercel", "netlify", "cloudflare", "deployment-status"]);
+      const out = await buildPlatforms(["vercel", "netlify", "cloudflare", "railway", "deployment-status"]);
       // deployment-status has no env requirement — always resolves
       assert.equal(out.platforms.length, 1);
       assert.equal(out.platforms[0].id, "deployment-status");
-      assert.equal(out.skipped.length, 3);
+      assert.equal(out.skipped.length, 4);
       const skippedIds = out.skipped.map((s) => s.id);
-      assert.deepEqual(skippedIds.sort(), ["cloudflare", "netlify", "vercel"]);
+      assert.deepEqual(skippedIds.sort(), ["cloudflare", "netlify", "railway", "vercel"]);
     },
   );
 });
@@ -92,6 +94,20 @@ test("buildPlatforms: Cloudflare needs all three envs", async () => {
       assert.equal(out.platforms.length, 1);
     },
   );
+});
+
+test("buildPlatforms: Railway needs BOTH token + projectId", async () => {
+  await withEnv({ RAILWAY_API_TOKEN: "t", RAILWAY_PROJECT_ID: null }, async () => {
+    const out = await buildPlatforms(["railway"]);
+    assert.equal(out.platforms.length, 0);
+    assert.equal(out.skipped.length, 1);
+    assert.match(out.skipped[0].reason, /PROJECT_ID/);
+  });
+  await withEnv({ RAILWAY_API_TOKEN: "t", RAILWAY_PROJECT_ID: "proj" }, async () => {
+    const out = await buildPlatforms(["railway"]);
+    assert.equal(out.platforms.length, 1);
+    assert.equal(out.platforms[0].id, "railway");
+  });
 });
 
 test("buildPlatforms: deployment-status has no env requirement", async () => {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -18,6 +18,7 @@
     { "path": "../platform-cloudflare" },
     { "path": "../platform-deployment-status" },
     { "path": "../platform-netlify" },
+    { "path": "../platform-railway" },
     { "path": "../platform-vercel" },
     { "path": "../visual-review" },
     { "path": "../observability-langfuse" },

--- a/packages/platform-railway/README.md
+++ b/packages/platform-railway/README.md
@@ -1,0 +1,45 @@
+# @ai-conclave/platform-railway
+
+Ai-Conclave Railway adapter. Resolves a preview URL for a given commit SHA
+via Railway's GraphQL API
+(`POST https://backboard.railway.com/graphql/v2`).
+
+One of five v2.0 platform adapters per decision #31: Vercel + Netlify +
+Railway + Cloudflare Pages + `deployment-status`.
+
+## Install
+
+Bundled with the Ai-Conclave monorepo. Pulled in automatically when the
+CLI includes `railway` in `config.visual.platforms`.
+
+## Environment
+
+| Var | Required | Notes |
+|---|---|---|
+| `RAILWAY_API_TOKEN` | yes | Project or team token with read scope on deployments |
+| `RAILWAY_PROJECT_ID` | yes | Railway project UUID |
+| `RAILWAY_ENVIRONMENT_ID` | no | Narrows deployment results to one environment |
+
+If any required env var is missing the platform factory skips this adapter
+rather than throwing — see `packages/cli/src/lib/platform-factory.ts`.
+
+## Behavior
+
+- `resolve({ sha })` queries `deployments(first: 20, ...)` filtered by
+  project (+ optional environment).
+- Filters client-side by `meta.commitHash === sha` AND
+  `status === "SUCCESS"`.
+- Picks the newest by `createdAt`.
+- Prefers `staticUrl` (`*.up.railway.app`); falls back to `url` for
+  custom domains.
+- 404 → null. 401/403 → throws (auth failure). 5xx → throws.
+- GraphQL `errors[]` in the response body → throws.
+
+## Limits
+
+- Non-SUCCESS statuses (BUILDING, DEPLOYING, FAILED, etc.) are filtered.
+  For a staging preview that's still building, retry with
+  `waitSeconds > 0`.
+- Railway's GraphQL schema is not versioned. If this adapter breaks
+  after a Railway API change, the exact selection set in
+  `DEPLOYMENTS_QUERY` (src/index.ts) is the thing to update.

--- a/packages/platform-railway/package.json
+++ b/packages/platform-railway/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ai-conclave/platform-railway",
+  "version": "0.0.0",
+  "description": "Ai-Conclave Railway adapter — resolve preview URL for a commit SHA via Railway's GraphQL API.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@ai-conclave/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/platform-railway/src/index.ts
+++ b/packages/platform-railway/src/index.ts
@@ -1,0 +1,168 @@
+import type { Platform, PreviewResolution, ResolvePreviewInput } from "@ai-conclave/core";
+
+export interface HttpFetch {
+  (url: string, init: { method: string; headers: Record<string, string>; body?: string }): Promise<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+    text: () => Promise<string>;
+  }>;
+}
+
+export interface RailwayAdapterOptions {
+  apiToken?: string;
+  projectId?: string;
+  environmentId?: string;
+  baseUrl?: string;
+  waitSeconds?: number;
+  fetch?: HttpFetch;
+}
+
+interface RwDeploymentNode {
+  id?: string;
+  status?: string;
+  staticUrl?: string | null;
+  url?: string | null;
+  createdAt?: string;
+  meta?: { commitHash?: string } | null;
+}
+
+interface RwDeploymentsResponse {
+  data?: {
+    deployments?: {
+      edges?: Array<{ node?: RwDeploymentNode }>;
+    };
+  };
+  errors?: Array<{ message?: string }>;
+}
+
+const DEPLOYMENTS_QUERY = `
+query Deployments($projectId: String!, $environmentId: String) {
+  deployments(first: 20, input: { projectId: $projectId, environmentId: $environmentId }) {
+    edges {
+      node {
+        id
+        status
+        staticUrl
+        url
+        createdAt
+        meta { commitHash }
+      }
+    }
+  }
+}
+`.trim();
+
+/**
+ * RailwayPlatform — resolves preview URL for (repo, sha) via Railway's
+ * GraphQL API at `POST https://backboard.railway.com/graphql/v2`.
+ *
+ * Railway does not filter server-side by commit; we fetch the latest
+ * deployments for a project (optionally narrowed to an environment) and
+ * pick the newest one whose `meta.commitHash` matches `sha` AND whose
+ * `status` is SUCCESS.
+ *
+ * `staticUrl` (the `*.up.railway.app` hostname) is preferred when
+ * present; falls back to `url`.
+ *
+ * Env:
+ *   RAILWAY_API_TOKEN       — required (project or team token)
+ *   RAILWAY_PROJECT_ID      — required
+ *   RAILWAY_ENVIRONMENT_ID  — optional (narrow results to one env)
+ */
+export class RailwayPlatform implements Platform {
+  readonly id = "railway";
+  readonly displayName = "Railway";
+
+  private readonly apiToken: string;
+  private readonly projectId: string;
+  private readonly environmentId: string | undefined;
+  private readonly baseUrl: string;
+  private readonly waitSeconds: number;
+  private readonly fetchFn: HttpFetch;
+
+  constructor(opts: RailwayAdapterOptions = {}) {
+    const token = opts.apiToken ?? process.env["RAILWAY_API_TOKEN"] ?? "";
+    const project = opts.projectId ?? process.env["RAILWAY_PROJECT_ID"] ?? "";
+    const env = opts.environmentId ?? process.env["RAILWAY_ENVIRONMENT_ID"] ?? "";
+    if (!token) throw new Error("RailwayPlatform: RAILWAY_API_TOKEN not set");
+    if (!project) throw new Error("RailwayPlatform: RAILWAY_PROJECT_ID not set");
+    this.apiToken = token;
+    this.projectId = project;
+    this.environmentId = env || undefined;
+    this.baseUrl = opts.baseUrl ?? "https://backboard.railway.com/graphql/v2";
+    this.waitSeconds = opts.waitSeconds ?? 0;
+    this.fetchFn = opts.fetch ?? ((...args) => fetch(...(args as Parameters<typeof fetch>)) as ReturnType<HttpFetch>);
+  }
+
+  async resolve(input: ResolvePreviewInput): Promise<PreviewResolution | null> {
+    const wait = input.waitSeconds ?? this.waitSeconds;
+    const deadline = Date.now() + wait * 1_000;
+    while (true) {
+      const match = await this.pollOnce(input.sha);
+      if (match) return match;
+      if (Date.now() >= deadline) return null;
+      await sleep(Math.min(3_000, Math.max(500, deadline - Date.now())));
+    }
+  }
+
+  private async pollOnce(sha: string): Promise<PreviewResolution | null> {
+    const body = JSON.stringify({
+      query: DEPLOYMENTS_QUERY,
+      variables: {
+        projectId: this.projectId,
+        environmentId: this.environmentId ?? null,
+      },
+    });
+    const res = await this.fetchFn(this.baseUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${this.apiToken}`,
+        "content-type": "application/json",
+      },
+      body,
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status === 401 || res.status === 403) {
+        throw new Error(`RailwayPlatform: auth failed (status ${res.status})`);
+      }
+      if (res.status >= 500) {
+        const text = await res.text();
+        throw new Error(`RailwayPlatform: server error ${res.status}: ${text.slice(0, 200)}`);
+      }
+      return null;
+    }
+    const data = (await res.json()) as RwDeploymentsResponse;
+    if (data.errors && data.errors.length > 0) {
+      const msg = data.errors[0]?.message ?? "unknown";
+      throw new Error(`RailwayPlatform: GraphQL errors — ${msg}`);
+    }
+    const nodes = (data.data?.deployments?.edges ?? [])
+      .map((e) => e?.node)
+      .filter((n): n is RwDeploymentNode => !!n);
+    const matching = nodes
+      .filter(
+        (n) =>
+          n.meta?.commitHash === sha &&
+          (n.status ?? "").toUpperCase() === "SUCCESS",
+      )
+      .sort((a, b) => (b.createdAt ?? "").localeCompare(a.createdAt ?? ""));
+    const best = matching[0];
+    if (!best) return null;
+    const hostname = best.staticUrl ?? best.url ?? null;
+    if (!hostname) return null;
+    const out: PreviewResolution = {
+      url: hostname.startsWith("http") ? hostname : `https://${hostname}`,
+      provider: "railway",
+      sha,
+    };
+    if (best.id) out.deploymentId = best.id;
+    if (best.createdAt) out.createdAt = best.createdAt;
+    return out;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/packages/platform-railway/test/railway.test.mjs
+++ b/packages/platform-railway/test/railway.test.mjs
@@ -1,0 +1,236 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { RailwayPlatform } from "../dist/index.js";
+
+function mockFetch(responses) {
+  let i = 0;
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: async () => r.json,
+      text: async () => r.text ?? JSON.stringify(r.json),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const BASE_OPTS = {
+  apiToken: "tok",
+  projectId: "proj-123",
+};
+
+function deployment({ id, sha, status = "SUCCESS", staticUrl, url, createdAt }) {
+  return {
+    node: {
+      id,
+      status,
+      staticUrl: staticUrl ?? null,
+      url: url ?? null,
+      createdAt,
+      meta: { commitHash: sha },
+    },
+  };
+}
+
+test("RailwayPlatform: missing token / projectId throws", () => {
+  const origT = process.env.RAILWAY_API_TOKEN;
+  const origP = process.env.RAILWAY_PROJECT_ID;
+  delete process.env.RAILWAY_API_TOKEN;
+  delete process.env.RAILWAY_PROJECT_ID;
+  try {
+    assert.throws(() => new RailwayPlatform());
+    assert.throws(() => new RailwayPlatform({ apiToken: "t" }));
+  } finally {
+    if (origT !== undefined) process.env.RAILWAY_API_TOKEN = origT;
+    if (origP !== undefined) process.env.RAILWAY_PROJECT_ID = origP;
+  }
+});
+
+test("RailwayPlatform: newest success deployment matching commit wins", async () => {
+  const f = mockFetch([
+    {
+      json: {
+        data: {
+          deployments: {
+            edges: [
+              deployment({
+                id: "rw-older",
+                sha: "sha-head",
+                staticUrl: "older.up.railway.app",
+                createdAt: "2026-04-19T10:00:00Z",
+              }),
+              deployment({
+                id: "rw-newer",
+                sha: "sha-head",
+                staticUrl: "newer.up.railway.app",
+                createdAt: "2026-04-19T11:00:00Z",
+              }),
+            ],
+          },
+        },
+      },
+    },
+  ]);
+  const p = new RailwayPlatform({ ...BASE_OPTS, fetch: f });
+  const out = await p.resolve({ repo: "a/b", sha: "sha-head" });
+  assert.ok(out);
+  assert.equal(out.url, "https://newer.up.railway.app");
+  assert.equal(out.deploymentId, "rw-newer");
+  assert.equal(out.provider, "railway");
+});
+
+test("RailwayPlatform: non-matching commit filtered", async () => {
+  const f = mockFetch([
+    {
+      json: {
+        data: {
+          deployments: {
+            edges: [
+              deployment({
+                id: "d1",
+                sha: "other-sha",
+                staticUrl: "x.up.railway.app",
+                createdAt: "2026-04-19T10:00:00Z",
+              }),
+            ],
+          },
+        },
+      },
+    },
+  ]);
+  const p = new RailwayPlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "sha-head" }), null);
+});
+
+test("RailwayPlatform: non-SUCCESS status filtered", async () => {
+  const f = mockFetch([
+    {
+      json: {
+        data: {
+          deployments: {
+            edges: [
+              deployment({
+                id: "d1",
+                sha: "sha-head",
+                status: "BUILDING",
+                staticUrl: "x.up.railway.app",
+                createdAt: "2026-04-19T10:00:00Z",
+              }),
+            ],
+          },
+        },
+      },
+    },
+  ]);
+  const p = new RailwayPlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "sha-head" }), null);
+});
+
+test("RailwayPlatform: GraphQL errors throw with message", async () => {
+  const f = mockFetch([
+    {
+      json: {
+        errors: [{ message: "project not found" }],
+      },
+    },
+  ]);
+  const p = new RailwayPlatform({ ...BASE_OPTS, fetch: f });
+  await assert.rejects(
+    () => p.resolve({ repo: "a/b", sha: "sha-head" }),
+    /project not found/,
+  );
+});
+
+test("RailwayPlatform: bearer auth + POST + GraphQL body", async () => {
+  const f = mockFetch([{ json: { data: { deployments: { edges: [] } } } }]);
+  const p = new RailwayPlatform({ ...BASE_OPTS, fetch: f });
+  await p.resolve({ repo: "a/b", sha: "x" });
+  const call = f.calls[0];
+  assert.equal(call.init.method, "POST");
+  assert.equal(call.init.headers.authorization, "Bearer tok");
+  assert.equal(call.init.headers["content-type"], "application/json");
+  assert.equal(call.url, "https://backboard.railway.com/graphql/v2");
+  const body = JSON.parse(call.init.body);
+  assert.match(body.query, /deployments\(/);
+  assert.equal(body.variables.projectId, "proj-123");
+  assert.equal(body.variables.environmentId, null);
+});
+
+test("RailwayPlatform: environmentId forwarded when provided", async () => {
+  const f = mockFetch([{ json: { data: { deployments: { edges: [] } } } }]);
+  const p = new RailwayPlatform({ ...BASE_OPTS, environmentId: "env-prod", fetch: f });
+  await p.resolve({ repo: "a/b", sha: "x" });
+  const body = JSON.parse(f.calls[0].init.body);
+  assert.equal(body.variables.environmentId, "env-prod");
+});
+
+test("RailwayPlatform: 401 → auth error throw", async () => {
+  const f = mockFetch([{ ok: false, status: 401, json: {}, text: "unauthorized" }]);
+  const p = new RailwayPlatform({ ...BASE_OPTS, fetch: f });
+  await assert.rejects(() => p.resolve({ repo: "a/b", sha: "x" }), /auth failed/);
+});
+
+test("RailwayPlatform: 404 → null", async () => {
+  const f = mockFetch([{ ok: false, status: 404, json: {}, text: "not found" }]);
+  const p = new RailwayPlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "x" }), null);
+});
+
+test("RailwayPlatform: 500 → server error throw", async () => {
+  const f = mockFetch([{ ok: false, status: 500, json: {}, text: "oops internal" }]);
+  const p = new RailwayPlatform({ ...BASE_OPTS, fetch: f });
+  await assert.rejects(() => p.resolve({ repo: "a/b", sha: "x" }), /server error 500/);
+});
+
+test("RailwayPlatform: falls back to url when staticUrl missing", async () => {
+  const f = mockFetch([
+    {
+      json: {
+        data: {
+          deployments: {
+            edges: [
+              deployment({
+                id: "d1",
+                sha: "sha-head",
+                url: "custom.example.com",
+                createdAt: "2026-04-19T10:00:00Z",
+              }),
+            ],
+          },
+        },
+      },
+    },
+  ]);
+  const p = new RailwayPlatform({ ...BASE_OPTS, fetch: f });
+  const out = await p.resolve({ repo: "a/b", sha: "sha-head" });
+  assert.ok(out);
+  assert.equal(out.url, "https://custom.example.com");
+});
+
+test("RailwayPlatform: deployment without any URL → null", async () => {
+  const f = mockFetch([
+    {
+      json: {
+        data: {
+          deployments: {
+            edges: [
+              deployment({
+                id: "d1",
+                sha: "sha-head",
+                createdAt: "2026-04-19T10:00:00Z",
+              }),
+            ],
+          },
+        },
+      },
+    },
+  ]);
+  const p = new RailwayPlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "sha-head" }), null);
+});

--- a/packages/platform-railway/tsconfig.json
+++ b/packages/platform-railway/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@ai-conclave/platform-netlify':
         specifier: workspace:*
         version: link:../platform-netlify
+      '@ai-conclave/platform-railway':
+        specifier: workspace:*
+        version: link:../platform-railway
       '@ai-conclave/platform-vercel':
         specifier: workspace:*
         version: link:../platform-vercel
@@ -196,6 +199,16 @@ importers:
         version: 5.9.3
 
   packages/platform-netlify:
+    dependencies:
+      '@ai-conclave/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/platform-railway:
     dependencies:
       '@ai-conclave/core':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- New `@ai-conclave/platform-railway` adapter — 5th and final v2.0 deploy platform (decision #31). Queries Railway's GraphQL API for deployments, filters by commit SHA + `SUCCESS` status, returns newest preview URL.
- Wired into `buildPlatforms` factory (`PlatformId = "railway"`) + default visual platform list in `conclave review` + Zod config schema enum.
- 12 adapter tests + 1 factory test mirror the Cloudflare pattern.

## Details
- Env: `RAILWAY_API_TOKEN` + `RAILWAY_PROJECT_ID` required; `RAILWAY_ENVIRONMENT_ID` optional (narrows results to one environment).
- `staticUrl` (`*.up.railway.app`) preferred; falls back to `url` for custom domains.
- 404 → null, 401/403 → throws (auth), 5xx → throws, GraphQL `errors[]` → throws with message.
- No server-side SHA filter in Railway's API — fetches latest 20 deployments and filters client-side.

## Test plan
- [x] `pnpm build` — 17/17 packages successful
- [x] `pnpm test` — 33/33 tasks successful, 0 failures
  - `@ai-conclave/platform-railway`: 12/12 tests pass
  - `@ai-conclave/cli`: 42/42 tests pass (added Railway env-gating test)
- [ ] E2E smoke — deferred until a real Railway token is available in the user's env; factory correctly skips the adapter when envs are unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)