### PR TITLE
feat(core,cli): federated sync skeleton (decision #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## Unreleased
 
 ### Added
+- **Federated sync skeleton (decision #21)** — `@ai-conclave/core/federated` subpath + `conclave sync` CLI command. Opt-in cross-user baseline exchange that carries ONLY category + severity + normalized tag vector + day bucket + a deterministic sha256 hash. The `lesson` text, `title`, `body`, `snippet`, `seedBlocker`, `repo`, `user`, `pattern`, and `episodicId` are stripped before anything touches the wire.
+  - `redactAnswerKey` / `redactFailure` — pure, synchronous, deterministic. Same (domain, tags) across users produce the same `contentHash`, which is the aggregation key a federation server uses for counts.
+  - `HttpFederatedSyncTransport` — thin JSON contract (`POST /baselines`, `GET /baselines?since=…`) so community aggregators can implement the endpoint without a vendor SDK. `NoopFederatedSyncTransport` for disabled/test paths.
+  - `runFederatedSync({ transport, answerKeys, failures, dryRun, since, pushDisabled, pullDisabled })` — the orchestrator. All redaction happens here; the transport never sees raw memory entries.
+  - **Default OFF.** Must set `federated.enabled = true` + `federated.endpoint = "https://…"` in `.conclaverc.json` to opt in. Optional `AI_CONCLAVE_FEDERATION_TOKEN` env var for bearer auth.
+  - `conclave sync --dry-run` prints the exact payload that would be uploaded so you can audit before opting in.
+  - Schema is v1; servers MUST reject unknown versions. Bumping the version is the breaking-change lever.
+  - 29 core tests (11 redact + 11 transport + 7 sync). Retrieval-side merge of pulled baselines is DEFERRED — no live endpoint exists yet and the read path stays local-only until one does. CLI command is wired but not test-covered yet; it's thin enough that the underlying core tests carry the guarantees.
+
 - **`@ai-conclave/platform-railway`** — completes decision #31 v2.0
   platform set (Vercel + Netlify + Railway + Cloudflare Pages +
   `deployment-status`).

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,0 +1,130 @@
+import {
+  FileSystemMemoryStore,
+  HttpFederatedSyncTransport,
+  NoopFederatedSyncTransport,
+  runFederatedSync,
+} from "@ai-conclave/core";
+import type { FederatedSyncTransport } from "@ai-conclave/core";
+import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
+
+const HELP = `conclave sync — exchange k-anonymous baseline signal (decision #21)
+
+Usage:
+  conclave sync [--dry-run] [--push-only] [--pull-only] [--since <ISO>]
+
+Federation is OPT-IN. Nothing leaves your machine unless
+\`federated.enabled = true\` AND \`federated.endpoint\` are set in
+.conclaverc.json.
+
+What leaves: category + severity + normalized tag vector + day-bucket +
+a sha256 hash derived from those fields. Nothing else — not the lesson
+text, not the failure body, not the diff, not the repo name, not your
+username.
+
+Flags:
+  --dry-run      Redact locally but DO NOT hit the network. Prints what
+                 would be sent so you can audit the payload first.
+  --push-only    Only upload — don't pull baselines from the server.
+  --pull-only    Only download — don't upload local redacted entries.
+  --since <ISO>  Pull baselines newer than the timestamp (default: all).
+  --json         Emit a machine-readable summary on stdout.
+
+Env:
+  AI_CONCLAVE_FEDERATION_TOKEN  Optional bearer token for the endpoint.
+`;
+
+interface ParsedArgs {
+  help: boolean;
+  dryRun: boolean;
+  pushOnly: boolean;
+  pullOnly: boolean;
+  since: string | undefined;
+  json: boolean;
+}
+
+function parseArgv(argv: string[]): ParsedArgs {
+  const args: ParsedArgs = {
+    help: argv.includes("--help") || argv.includes("-h"),
+    dryRun: argv.includes("--dry-run"),
+    pushOnly: argv.includes("--push-only"),
+    pullOnly: argv.includes("--pull-only"),
+    since: undefined,
+    json: argv.includes("--json"),
+  };
+  const i = argv.indexOf("--since");
+  if (i >= 0 && argv[i + 1]) args.since = argv[i + 1];
+  return args;
+}
+
+export async function sync(argv: string[]): Promise<void> {
+  const args = parseArgv(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  if (args.pushOnly && args.pullOnly) {
+    process.stderr.write("conclave sync: --push-only and --pull-only are mutually exclusive\n");
+    process.exit(2);
+  }
+
+  const { config, configDir } = await loadConfig();
+  const fed = config.federated;
+
+  let transport: FederatedSyncTransport;
+  let reason: string | null = null;
+  if (!fed || !fed.enabled) {
+    reason = "federation disabled in config (set federated.enabled = true to opt in)";
+    transport = new NoopFederatedSyncTransport();
+  } else if (!fed.endpoint) {
+    reason = "federated.endpoint not configured";
+    transport = new NoopFederatedSyncTransport();
+  } else {
+    transport = new HttpFederatedSyncTransport({
+      endpoint: fed.endpoint,
+      apiToken: process.env["AI_CONCLAVE_FEDERATION_TOKEN"],
+    });
+  }
+
+  const memoryRoot = resolveMemoryRoot(config, configDir);
+  const store = new FileSystemMemoryStore({ root: memoryRoot });
+  const answerKeys = await store.listAnswerKeys();
+  const failures = await store.listFailures();
+
+  const result = await runFederatedSync({
+    transport,
+    answerKeys,
+    failures,
+    dryRun: args.dryRun,
+    ...(args.pushOnly ? { pullDisabled: true } : {}),
+    ...(args.pullOnly ? { pushDisabled: true } : {}),
+    ...(args.since ? { since: args.since } : {}),
+  });
+
+  const summary = {
+    transport: result.transportId,
+    dryRun: result.dryRun,
+    pushed: result.pushed.length,
+    accepted: result.accepted,
+    pulled: result.pulled.length,
+    reason,
+  };
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
+    return;
+  }
+
+  if (reason) process.stderr.write(`conclave sync: ${reason}\n`);
+  process.stdout.write(
+    `conclave sync: transport=${summary.transport} dryRun=${summary.dryRun} pushed=${summary.pushed} accepted=${summary.accepted} pulled=${summary.pulled}\n`,
+  );
+  if (args.dryRun && result.pushed.length > 0) {
+    process.stdout.write("\nBaselines that would be uploaded:\n");
+    for (const b of result.pushed) {
+      const extra = b.kind === "failure" ? ` ${b.category}/${b.severity}` : "";
+      process.stdout.write(
+        `  ${b.kind}/${b.domain}${extra} tags=[${b.tags.join(",")}] hash=${b.contentHash.slice(0, 12)}…\n`,
+      );
+    }
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { pollOutcomesCommand } from "./commands/poll-outcomes.js";
 import { seed } from "./commands/seed.js";
 import { migrate } from "./commands/migrate.js";
 import { scores } from "./commands/scores.js";
+import { sync } from "./commands/sync.js";
 
 const HELP = `conclave — Ai-Conclave CLI
 
@@ -19,6 +20,7 @@ Commands:
   seed                  Bootstrap failure-catalog from a legacy source (default: bundled solo-cto-agent)
   migrate               Port a solo-cto-agent install over to ai-conclave (config + failure-catalog + checklist)
   scores                Show per-agent performance scores from memory (decision #19)
+  sync                  Exchange k-anonymous baseline signal with a federation endpoint (decision #21, opt-in)
   --help, -h            Show this
   --version, -v         Show version
 
@@ -66,6 +68,9 @@ export async function run(argv: string[]): Promise<void> {
       return;
     case "scores":
       await scores(rest);
+      return;
+    case "sync":
+      await sync(rest);
       return;
     default:
       process.stderr.write(`Unknown command: ${cmd}\n\n${HELP}`);

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -76,6 +76,12 @@ export const ConclaveConfigSchema = z.object({
         .optional(),
     })
     .optional(),
+  federated: z
+    .object({
+      enabled: z.boolean().default(false),
+      endpoint: z.string().url().optional(),
+    })
+    .optional(),
   visual: z
     .object({
       enabled: z.boolean().default(false),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,10 @@
     "./memory": {
       "types": "./dist/memory/index.d.ts",
       "import": "./dist/memory/index.js"
+    },
+    "./federated": {
+      "types": "./dist/federated/index.d.ts",
+      "import": "./dist/federated/index.js"
     }
   },
   "files": [

--- a/packages/core/src/federated/index.ts
+++ b/packages/core/src/federated/index.ts
@@ -1,0 +1,14 @@
+export { FederatedBaselineSchema, FederatedBaselineKindSchema } from "./schema.js";
+export type { FederatedBaseline, FederatedBaselineKind } from "./schema.js";
+export { redactAnswerKey, redactFailure, redactAll, normalizeTags } from "./redact.js";
+export {
+  HttpFederatedSyncTransport,
+  NoopFederatedSyncTransport,
+} from "./transport.js";
+export type {
+  FederatedSyncTransport,
+  HttpFetch,
+  HttpTransportOptions,
+} from "./transport.js";
+export { runFederatedSync } from "./sync.js";
+export type { RunSyncInput, RunSyncResult } from "./sync.js";

--- a/packages/core/src/federated/redact.ts
+++ b/packages/core/src/federated/redact.ts
@@ -1,0 +1,76 @@
+import { createHash } from "node:crypto";
+import type { AnswerKey, FailureEntry } from "../memory/schema.js";
+import type { FederatedBaseline, FederatedBaselineKind } from "./schema.js";
+
+/**
+ * normalizeTags — deterministic tag vocabulary.
+ * Same tag set across users must produce the same output so downstream
+ * `contentHash` is stable.
+ */
+export function normalizeTags(tags: readonly string[]): string[] {
+  const seen = new Set<string>();
+  for (const raw of tags) {
+    const t = raw.trim().toLowerCase();
+    if (t.length > 0) seen.add(t);
+  }
+  return Array.from(seen).sort();
+}
+
+function dayBucket(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function baselineHash(
+  kind: FederatedBaselineKind,
+  domain: string,
+  category: string | undefined,
+  severity: string | undefined,
+  normalizedTags: readonly string[],
+): string {
+  const tuple = JSON.stringify([kind, domain, category ?? "", severity ?? "", normalizedTags]);
+  return createHash("sha256").update(tuple).digest("hex");
+}
+
+/**
+ * Redact an AnswerKey into the minimal shape that may leave the
+ * machine. `lesson`, `repo`, `user`, `pattern`, and `episodicId` are
+ * dropped entirely.
+ */
+export function redactAnswerKey(key: AnswerKey): FederatedBaseline {
+  const tags = normalizeTags(key.tags);
+  return {
+    version: 1,
+    kind: "answer-key",
+    contentHash: baselineHash("answer-key", key.domain, undefined, undefined, tags),
+    domain: key.domain,
+    tags,
+    dayBucket: dayBucket(key.createdAt),
+  };
+}
+
+/**
+ * Redact a FailureEntry. `title`, `body`, `snippet`, `seedBlocker`, and
+ * `episodicId` are dropped entirely — only category/severity/tags/hash
+ * leave.
+ */
+export function redactFailure(entry: FailureEntry): FederatedBaseline {
+  const tags = normalizeTags(entry.tags);
+  return {
+    version: 1,
+    kind: "failure",
+    contentHash: baselineHash("failure", entry.domain, entry.category, entry.severity, tags),
+    domain: entry.domain,
+    category: entry.category,
+    severity: entry.severity,
+    tags,
+    dayBucket: dayBucket(entry.createdAt),
+  };
+}
+
+/** Tiny batch helper — redacts a mixed list. */
+export function redactAll(
+  answerKeys: readonly AnswerKey[],
+  failures: readonly FailureEntry[],
+): FederatedBaseline[] {
+  return [...answerKeys.map(redactAnswerKey), ...failures.map(redactFailure)];
+}

--- a/packages/core/src/federated/schema.ts
+++ b/packages/core/src/federated/schema.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import {
+  AnswerKeyDomainSchema,
+  FailureCategorySchema,
+  FailureSeveritySchema,
+} from "../memory/schema.js";
+
+/**
+ * FederatedBaseline — the ONLY shape that leaves the user's machine per
+ * decision #21. Carries category + severity + normalized tag vector +
+ * a deterministic hash. NO code, diffs, lesson text, titles, bodies,
+ * snippets, repos, or user identifiers.
+ *
+ * Same pattern across users produces the same `contentHash` — servers
+ * aggregate by hash to build a cross-user frequency signal without
+ * being able to reconstruct any individual's review history.
+ */
+export const FederatedBaselineKindSchema = z.enum(["answer-key", "failure"]);
+export type FederatedBaselineKind = z.infer<typeof FederatedBaselineKindSchema>;
+
+export const FederatedBaselineSchema = z.object({
+  /** Bump on any breaking wire-format change. Servers MUST reject unknown versions. */
+  version: z.literal(1),
+  kind: FederatedBaselineKindSchema,
+  /**
+   * Deterministic sha256 of `(kind, domain, category, severity, sorted-tags)`.
+   * Same five-tuple across users → same hash → server-side aggregation.
+   */
+  contentHash: z.string().length(64),
+  domain: AnswerKeyDomainSchema,
+  /** Present only for `kind = "failure"`. */
+  category: FailureCategorySchema.optional(),
+  severity: FailureSeveritySchema.optional(),
+  /** Normalized vocabulary — trimmed, lowercased, deduped, sorted. */
+  tags: z.array(z.string()).default([]),
+  /** `YYYY-MM-DD` day bucket. Raw timestamp deliberately discarded — enough granularity for trends, not enough to fingerprint. */
+  dayBucket: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+export type FederatedBaseline = z.infer<typeof FederatedBaselineSchema>;

--- a/packages/core/src/federated/sync.ts
+++ b/packages/core/src/federated/sync.ts
@@ -1,0 +1,59 @@
+import type { AnswerKey, FailureEntry } from "../memory/schema.js";
+import { redactAll } from "./redact.js";
+import type { FederatedBaseline } from "./schema.js";
+import type { FederatedSyncTransport } from "./transport.js";
+
+export interface RunSyncInput {
+  transport: FederatedSyncTransport;
+  answerKeys: readonly AnswerKey[];
+  failures: readonly FailureEntry[];
+  /** Collect + redact but don't push or pull. Useful for inspection. */
+  dryRun?: boolean;
+  /** ISO timestamp — pull baselines newer than this. */
+  since?: string;
+  /** Skip the push half of the round-trip. */
+  pushDisabled?: boolean;
+  /** Skip the pull half of the round-trip. */
+  pullDisabled?: boolean;
+}
+
+export interface RunSyncResult {
+  /** Redacted payload that was (or would have been) pushed. */
+  pushed: FederatedBaseline[];
+  /** Baselines received from the server. `[]` on dryRun. */
+  pulled: FederatedBaseline[];
+  /** Server-acknowledged count from push. 0 on dryRun. */
+  accepted: number;
+  dryRun: boolean;
+  transportId: string;
+}
+
+/**
+ * runFederatedSync — orchestrates the round-trip. All privacy-sensitive
+ * transformation happens here (via `redactAll`); the transport only
+ * ever sees the already-redacted `FederatedBaseline[]`.
+ *
+ * `dryRun: true` makes this function pure — no network I/O — so it's
+ * safe to expose via `conclave sync --dry-run` for users who want to
+ * audit exactly what leaves their machine before opting in.
+ */
+export async function runFederatedSync(input: RunSyncInput): Promise<RunSyncResult> {
+  const toSend = redactAll(input.answerKeys, input.failures);
+  const dryRun = input.dryRun ?? false;
+
+  let accepted = 0;
+  if (!dryRun && !input.pushDisabled && toSend.length > 0) {
+    const res = await input.transport.push(toSend);
+    accepted = res.accepted;
+  }
+
+  const pulled = dryRun || input.pullDisabled ? [] : await input.transport.pull(input.since);
+
+  return {
+    pushed: toSend,
+    pulled,
+    accepted,
+    dryRun,
+    transportId: input.transport.id,
+  };
+}

--- a/packages/core/src/federated/transport.ts
+++ b/packages/core/src/federated/transport.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+import { FederatedBaselineSchema, type FederatedBaseline } from "./schema.js";
+
+export interface HttpFetch {
+  (url: string, init: { method: string; headers: Record<string, string>; body?: string }): Promise<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+    text: () => Promise<string>;
+  }>;
+}
+
+/**
+ * FederatedSyncTransport — pluggable wire for decision #21.
+ *
+ * Contract:
+ *   - `push(baselines)` — uploads redacted entries; server returns an
+ *     `accepted` count (may be < input.length if server dedupes).
+ *   - `pull(since?)` — returns baselines newer than the ISO timestamp,
+ *     or all available if omitted.
+ *   - Implementations MUST NOT mutate the input.
+ *   - Hard errors (auth failure, 5xx) throw. Empty results (no
+ *     baselines yet on server) return `[]`, not throw.
+ */
+export interface FederatedSyncTransport {
+  readonly id: string;
+  push(baselines: readonly FederatedBaseline[]): Promise<{ accepted: number }>;
+  pull(since?: string): Promise<FederatedBaseline[]>;
+}
+
+export interface HttpTransportOptions {
+  endpoint: string;
+  apiToken?: string;
+  fetch?: HttpFetch;
+}
+
+const PushResponseSchema = z.object({ accepted: z.number().int().nonnegative() });
+const PullResponseSchema = z.object({ baselines: z.array(FederatedBaselineSchema) });
+
+/**
+ * HttpFederatedSyncTransport — v2.0 default. Expects a JSON API at:
+ *   POST   {endpoint}/baselines        body: { baselines: [...] }    → { accepted: N }
+ *   GET    {endpoint}/baselines?since  body: none                     → { baselines: [...] }
+ *
+ * The endpoint contract is deliberately thin so community-hosted
+ * aggregators can implement it without adopting a vendor SDK.
+ */
+export class HttpFederatedSyncTransport implements FederatedSyncTransport {
+  readonly id = "http";
+  private readonly endpoint: string;
+  private readonly apiToken: string | undefined;
+  private readonly fetchFn: HttpFetch;
+
+  constructor(opts: HttpTransportOptions) {
+    if (!opts.endpoint) {
+      throw new Error("HttpFederatedSyncTransport: endpoint required");
+    }
+    this.endpoint = opts.endpoint.replace(/\/$/, "");
+    this.apiToken = opts.apiToken;
+    this.fetchFn = opts.fetch ?? ((...args) => fetch(...(args as Parameters<typeof fetch>)) as ReturnType<HttpFetch>);
+  }
+
+  async push(baselines: readonly FederatedBaseline[]): Promise<{ accepted: number }> {
+    if (baselines.length === 0) return { accepted: 0 };
+    const res = await this.fetchFn(`${this.endpoint}/baselines`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ baselines }),
+    });
+    if (!res.ok) await this.throwHttp(res, "push");
+    const data = PushResponseSchema.parse(await res.json());
+    return { accepted: data.accepted };
+  }
+
+  async pull(since?: string): Promise<FederatedBaseline[]> {
+    const url = since
+      ? `${this.endpoint}/baselines?since=${encodeURIComponent(since)}`
+      : `${this.endpoint}/baselines`;
+    const res = await this.fetchFn(url, { method: "GET", headers: this.headers() });
+    if (!res.ok) await this.throwHttp(res, "pull");
+    const data = PullResponseSchema.parse(await res.json());
+    return data.baselines;
+  }
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { "content-type": "application/json" };
+    if (this.apiToken) h.authorization = `Bearer ${this.apiToken}`;
+    return h;
+  }
+
+  private async throwHttp(
+    res: { status: number; text: () => Promise<string> },
+    op: string,
+  ): Promise<never> {
+    if (res.status === 401 || res.status === 403) {
+      throw new Error(`HttpFederatedSyncTransport: auth failed during ${op} (status ${res.status})`);
+    }
+    const body = await res.text();
+    throw new Error(
+      `HttpFederatedSyncTransport: ${op} failed (status ${res.status}): ${body.slice(0, 200)}`,
+    );
+  }
+}
+
+/**
+ * NoopFederatedSyncTransport — used when federation is disabled in
+ * config. Reports `accepted` equal to input length so upstream metrics
+ * stay consistent but performs zero network I/O.
+ */
+export class NoopFederatedSyncTransport implements FederatedSyncTransport {
+  readonly id = "noop";
+  async push(baselines: readonly FederatedBaseline[]): Promise<{ accepted: number }> {
+    return { accepted: baselines.length };
+  }
+  async pull(): Promise<FederatedBaseline[]> {
+    return [];
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,29 @@ export type {
   NewFailureCategory,
 } from "./memory/index.js";
 
+// Federated sync (decision #21) — redact answer-keys + failures to the
+// k-anonymous baseline shape and ship them across a pluggable transport.
+// Re-exported here for convenience; dedicated subpath at @ai-conclave/core/federated.
+export {
+  FederatedBaselineSchema,
+  FederatedBaselineKindSchema,
+  redactAnswerKey,
+  redactFailure,
+  redactAll,
+  normalizeTags,
+  HttpFederatedSyncTransport,
+  NoopFederatedSyncTransport,
+  runFederatedSync,
+} from "./federated/index.js";
+export type {
+  FederatedBaseline,
+  FederatedBaselineKind,
+  FederatedSyncTransport,
+  HttpTransportOptions,
+  RunSyncInput,
+  RunSyncResult,
+} from "./federated/index.js";
+
 // Efficiency Gate (decision #22: first-class from day 1) — every LLM call
 // routes through `EfficiencyGate.run(...)`. Re-exported here for convenience;
 // the dedicated subpath export lives at @ai-conclave/core/efficiency.

--- a/packages/core/test/federated-redact.test.mjs
+++ b/packages/core/test/federated-redact.test.mjs
@@ -1,0 +1,137 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  redactAnswerKey,
+  redactFailure,
+  redactAll,
+  normalizeTags,
+  FederatedBaselineSchema,
+} from "../dist/index.js";
+
+const SAMPLE_KEY = {
+  id: "ak-abc123",
+  createdAt: "2026-04-19T10:34:56.000Z",
+  domain: "code",
+  pattern: "by-pattern/auth-middleware",
+  repo: "secretorg/private-app",
+  user: "seunghunbae-3svs",
+  lesson: "Always validate JWT signatures BEFORE unpacking claims.",
+  tags: ["Auth", "security", "auth", "  JWT "],
+  episodicId: "ep-xyz",
+};
+
+const SAMPLE_FAILURE = {
+  id: "fc-def456",
+  createdAt: "2026-04-19T10:34:56.000Z",
+  domain: "code",
+  category: "security",
+  severity: "blocker",
+  title: "JWT signature check missing on /admin routes",
+  body: "We accept unsigned tokens — replace with server-side verification.",
+  snippet: "const payload = jwt.decode(token); // BUG",
+  tags: ["auth", "security"],
+  seedBlocker: {
+    agent: "claude",
+    severity: "blocker",
+    message: "unsigned JWT accepted",
+    file: "src/server/routes/admin.ts",
+    line: 42,
+  },
+  episodicId: "ep-xyz",
+};
+
+test("normalizeTags: trims, lowercases, dedupes, sorts", () => {
+  const out = normalizeTags(["Security", "  auth ", "AUTH", "a11y", ""]);
+  assert.deepEqual(out, ["a11y", "auth", "security"]);
+});
+
+test("normalizeTags: empty input → empty output", () => {
+  assert.deepEqual(normalizeTags([]), []);
+});
+
+test("redactAnswerKey: strips lesson/pattern/repo/user/id/episodicId", () => {
+  const out = redactAnswerKey(SAMPLE_KEY);
+  // Parse against the schema so any leaked field would fail validation
+  const parsed = FederatedBaselineSchema.parse(out);
+  assert.equal(parsed.version, 1);
+  assert.equal(parsed.kind, "answer-key");
+  assert.equal(parsed.domain, "code");
+  assert.deepEqual(parsed.tags, ["auth", "jwt", "security"]);
+  assert.equal(parsed.dayBucket, "2026-04-19");
+  // No category/severity on answer-keys
+  assert.equal(parsed.category, undefined);
+  assert.equal(parsed.severity, undefined);
+  // Hash is sha256 (64 hex chars)
+  assert.match(parsed.contentHash, /^[0-9a-f]{64}$/);
+  // Sanity: the baseline object should NOT carry any of the private fields
+  assert.equal("lesson" in out, false);
+  assert.equal("pattern" in out, false);
+  assert.equal("repo" in out, false);
+  assert.equal("user" in out, false);
+  assert.equal("id" in out, false);
+  assert.equal("episodicId" in out, false);
+});
+
+test("redactFailure: strips title/body/snippet/seedBlocker/id/episodicId", () => {
+  const out = redactFailure(SAMPLE_FAILURE);
+  const parsed = FederatedBaselineSchema.parse(out);
+  assert.equal(parsed.kind, "failure");
+  assert.equal(parsed.category, "security");
+  assert.equal(parsed.severity, "blocker");
+  assert.deepEqual(parsed.tags, ["auth", "security"]);
+  assert.equal("title" in out, false);
+  assert.equal("body" in out, false);
+  assert.equal("snippet" in out, false);
+  assert.equal("seedBlocker" in out, false);
+});
+
+test("redactAnswerKey: deterministic hash — same (domain, tags) across users produces same hash", () => {
+  const a = redactAnswerKey(SAMPLE_KEY);
+  const b = redactAnswerKey({
+    ...SAMPLE_KEY,
+    id: "ak-different",
+    repo: "otheruser/other-repo",
+    user: "someone-else",
+    lesson: "different wording, same pattern",
+    pattern: "by-pattern/something-else", // pattern does NOT participate in the hash
+  });
+  assert.equal(a.contentHash, b.contentHash);
+});
+
+test("redactFailure: hash changes when category/severity changes", () => {
+  const base = redactFailure(SAMPLE_FAILURE);
+  const major = redactFailure({ ...SAMPLE_FAILURE, severity: "major" });
+  const perf = redactFailure({ ...SAMPLE_FAILURE, category: "performance" });
+  assert.notEqual(base.contentHash, major.contentHash);
+  assert.notEqual(base.contentHash, perf.contentHash);
+});
+
+test("redactFailure: hash stable despite differing tag order + casing", () => {
+  const a = redactFailure(SAMPLE_FAILURE);
+  const b = redactFailure({ ...SAMPLE_FAILURE, tags: ["SECURITY", "Auth"] });
+  assert.equal(a.contentHash, b.contentHash);
+});
+
+test("redactFailure vs redactAnswerKey: different kinds → different hashes even with same (domain, tags)", () => {
+  const tags = ["x"];
+  const ak = redactAnswerKey({ ...SAMPLE_KEY, tags });
+  const fl = redactFailure({ ...SAMPLE_FAILURE, tags });
+  assert.notEqual(ak.contentHash, fl.contentHash);
+});
+
+test("redactAll: concatenates answer-keys + failures, preserving order", () => {
+  const out = redactAll([SAMPLE_KEY, SAMPLE_KEY], [SAMPLE_FAILURE]);
+  assert.equal(out.length, 3);
+  assert.equal(out[0].kind, "answer-key");
+  assert.equal(out[1].kind, "answer-key");
+  assert.equal(out[2].kind, "failure");
+});
+
+test("redactAnswerKey: dayBucket is YYYY-MM-DD even for end-of-day timestamps", () => {
+  const key = { ...SAMPLE_KEY, createdAt: "2026-04-19T23:59:59.999Z" };
+  assert.equal(redactAnswerKey(key).dayBucket, "2026-04-19");
+});
+
+test("redactAll: empty inputs → empty array", () => {
+  assert.deepEqual(redactAll([], []), []);
+});

--- a/packages/core/test/federated-sync.test.mjs
+++ b/packages/core/test/federated-sync.test.mjs
@@ -1,0 +1,138 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runFederatedSync } from "../dist/index.js";
+
+const KEY = {
+  id: "ak-1",
+  createdAt: "2026-04-19T10:00:00.000Z",
+  domain: "code",
+  pattern: "by-pattern/auth",
+  lesson: "check JWT",
+  tags: ["auth"],
+};
+
+const FAILURE = {
+  id: "fc-1",
+  createdAt: "2026-04-19T11:00:00.000Z",
+  domain: "code",
+  category: "type-error",
+  severity: "major",
+  title: "bad cast",
+  body: "type assertion without runtime validation",
+  tags: ["types"],
+};
+
+class RecordingTransport {
+  id = "record";
+  pushCalls = [];
+  pullCalls = [];
+  pulled = [];
+  acceptedOverride = null;
+  async push(baselines) {
+    this.pushCalls.push([...baselines]);
+    return { accepted: this.acceptedOverride ?? baselines.length };
+  }
+  async pull(since) {
+    this.pullCalls.push(since);
+    return this.pulled;
+  }
+}
+
+test("runFederatedSync: happy path pushes redacted + returns pulled", async () => {
+  const t = new RecordingTransport();
+  t.pulled = [
+    {
+      version: 1,
+      kind: "failure",
+      contentHash: "b".repeat(64),
+      domain: "code",
+      category: "security",
+      severity: "blocker",
+      tags: ["remote-pulled"],
+      dayBucket: "2026-04-18",
+    },
+  ];
+  const result = await runFederatedSync({ transport: t, answerKeys: [KEY], failures: [FAILURE] });
+  assert.equal(result.pushed.length, 2);
+  assert.equal(result.accepted, 2);
+  assert.equal(result.pulled.length, 1);
+  assert.equal(result.dryRun, false);
+  assert.equal(result.transportId, "record");
+  // The transport should see only redacted baselines, never raw AnswerKey/FailureEntry
+  const sent = t.pushCalls[0];
+  assert.ok(sent.every((b) => "contentHash" in b && !("lesson" in b) && !("title" in b)));
+});
+
+test("runFederatedSync: dryRun = true performs zero network I/O", async () => {
+  const t = new RecordingTransport();
+  t.pulled = [{ version: 1, kind: "failure", contentHash: "c".repeat(64), domain: "code", category: "type-error", severity: "minor", tags: [], dayBucket: "2026-04-18" }];
+  const result = await runFederatedSync({
+    transport: t,
+    answerKeys: [KEY],
+    failures: [FAILURE],
+    dryRun: true,
+  });
+  assert.equal(t.pushCalls.length, 0);
+  assert.equal(t.pullCalls.length, 0);
+  assert.equal(result.pushed.length, 2);
+  assert.equal(result.accepted, 0);
+  assert.deepEqual(result.pulled, []);
+  assert.equal(result.dryRun, true);
+});
+
+test("runFederatedSync: pushDisabled skips push but still pulls", async () => {
+  const t = new RecordingTransport();
+  await runFederatedSync({
+    transport: t,
+    answerKeys: [KEY],
+    failures: [],
+    pushDisabled: true,
+  });
+  assert.equal(t.pushCalls.length, 0);
+  assert.equal(t.pullCalls.length, 1);
+});
+
+test("runFederatedSync: pullDisabled skips pull but still pushes", async () => {
+  const t = new RecordingTransport();
+  const result = await runFederatedSync({
+    transport: t,
+    answerKeys: [KEY],
+    failures: [],
+    pullDisabled: true,
+  });
+  assert.equal(t.pushCalls.length, 1);
+  assert.equal(t.pullCalls.length, 0);
+  assert.deepEqual(result.pulled, []);
+});
+
+test("runFederatedSync: empty inputs skip push network call, still pulls", async () => {
+  const t = new RecordingTransport();
+  const result = await runFederatedSync({ transport: t, answerKeys: [], failures: [] });
+  assert.equal(t.pushCalls.length, 0); // we skip push when there's nothing to send
+  assert.equal(t.pullCalls.length, 1);
+  assert.equal(result.pushed.length, 0);
+  assert.equal(result.accepted, 0);
+});
+
+test("runFederatedSync: since timestamp forwarded to transport.pull", async () => {
+  const t = new RecordingTransport();
+  await runFederatedSync({
+    transport: t,
+    answerKeys: [],
+    failures: [],
+    since: "2026-04-18T00:00:00Z",
+  });
+  assert.equal(t.pullCalls[0], "2026-04-18T00:00:00Z");
+});
+
+test("runFederatedSync: server accepted count (may be < sent) surfaced as-is", async () => {
+  const t = new RecordingTransport();
+  t.acceptedOverride = 1; // server dedupes: we sent 2, it accepted 1
+  const result = await runFederatedSync({
+    transport: t,
+    answerKeys: [KEY],
+    failures: [FAILURE],
+  });
+  assert.equal(result.pushed.length, 2);
+  assert.equal(result.accepted, 1);
+});

--- a/packages/core/test/federated-transport.test.mjs
+++ b/packages/core/test/federated-transport.test.mjs
@@ -1,0 +1,116 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  HttpFederatedSyncTransport,
+  NoopFederatedSyncTransport,
+} from "../dist/index.js";
+
+function mockFetch(responses) {
+  let i = 0;
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: async () => r.json,
+      text: async () => r.text ?? JSON.stringify(r.json),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const BASELINE = {
+  version: 1,
+  kind: "failure",
+  contentHash: "a".repeat(64),
+  domain: "code",
+  category: "security",
+  severity: "blocker",
+  tags: ["auth"],
+  dayBucket: "2026-04-19",
+};
+
+test("HttpFederatedSyncTransport: constructor throws on empty endpoint", () => {
+  assert.throws(() => new HttpFederatedSyncTransport({ endpoint: "" }));
+});
+
+test("HttpFederatedSyncTransport: trailing slash in endpoint is stripped", async () => {
+  const f = mockFetch([{ json: { accepted: 1 } }]);
+  const t = new HttpFederatedSyncTransport({ endpoint: "https://api.example.com/", fetch: f });
+  await t.push([BASELINE]);
+  assert.equal(f.calls[0].url, "https://api.example.com/baselines");
+});
+
+test("HttpFederatedSyncTransport: push POSTs JSON body with baselines array", async () => {
+  const f = mockFetch([{ json: { accepted: 1 } }]);
+  const t = new HttpFederatedSyncTransport({ endpoint: "https://api.example.com", apiToken: "tok", fetch: f });
+  const out = await t.push([BASELINE]);
+  assert.equal(out.accepted, 1);
+  assert.equal(f.calls[0].init.method, "POST");
+  assert.equal(f.calls[0].init.headers.authorization, "Bearer tok");
+  assert.equal(f.calls[0].init.headers["content-type"], "application/json");
+  const body = JSON.parse(f.calls[0].init.body);
+  assert.equal(body.baselines.length, 1);
+  assert.equal(body.baselines[0].contentHash, BASELINE.contentHash);
+});
+
+test("HttpFederatedSyncTransport: empty push skips network call", async () => {
+  const f = mockFetch([{ json: { accepted: 999 } }]);
+  const t = new HttpFederatedSyncTransport({ endpoint: "https://api.example.com", fetch: f });
+  const out = await t.push([]);
+  assert.equal(out.accepted, 0);
+  assert.equal(f.calls.length, 0);
+});
+
+test("HttpFederatedSyncTransport: push response validated by Zod — bad shape throws", async () => {
+  const f = mockFetch([{ json: { wrong: "shape" } }]);
+  const t = new HttpFederatedSyncTransport({ endpoint: "https://api.example.com", fetch: f });
+  await assert.rejects(() => t.push([BASELINE]));
+});
+
+test("HttpFederatedSyncTransport: pull returns baselines from response", async () => {
+  const f = mockFetch([{ json: { baselines: [BASELINE] } }]);
+  const t = new HttpFederatedSyncTransport({ endpoint: "https://api.example.com", fetch: f });
+  const out = await t.pull();
+  assert.equal(out.length, 1);
+  assert.equal(out[0].contentHash, BASELINE.contentHash);
+  assert.equal(f.calls[0].init.method, "GET");
+});
+
+test("HttpFederatedSyncTransport: pull with since URL-encodes the timestamp", async () => {
+  const f = mockFetch([{ json: { baselines: [] } }]);
+  const t = new HttpFederatedSyncTransport({ endpoint: "https://api.example.com", fetch: f });
+  await t.pull("2026-04-19T00:00:00Z");
+  assert.match(f.calls[0].url, /\/baselines\?since=2026-04-19T00%3A00%3A00Z$/);
+});
+
+test("HttpFederatedSyncTransport: 401 on push throws auth error", async () => {
+  const f = mockFetch([{ ok: false, status: 401, json: {}, text: "no" }]);
+  const t = new HttpFederatedSyncTransport({ endpoint: "https://api.example.com", fetch: f });
+  await assert.rejects(() => t.push([BASELINE]), /auth failed during push/);
+});
+
+test("HttpFederatedSyncTransport: 500 on pull throws server error with snippet", async () => {
+  const f = mockFetch([{ ok: false, status: 500, json: {}, text: "internal explode" }]);
+  const t = new HttpFederatedSyncTransport({ endpoint: "https://api.example.com", fetch: f });
+  await assert.rejects(() => t.pull(), /pull failed \(status 500\): internal explode/);
+});
+
+test("HttpFederatedSyncTransport: no apiToken → no authorization header", async () => {
+  const f = mockFetch([{ json: { baselines: [] } }]);
+  const t = new HttpFederatedSyncTransport({ endpoint: "https://api.example.com", fetch: f });
+  await t.pull();
+  assert.equal(f.calls[0].init.headers.authorization, undefined);
+});
+
+test("NoopFederatedSyncTransport: push reports full acceptance, pull is empty", async () => {
+  const t = new NoopFederatedSyncTransport();
+  assert.equal(t.id, "noop");
+  const push = await t.push([BASELINE, BASELINE]);
+  assert.equal(push.accepted, 2);
+  assert.deepEqual(await t.pull(), []);
+});


### PR DESCRIPTION
## Summary
- Opt-in cross-user baseline exchange per decision #21. Ships ONLY `{ kind, domain, category, severity, normalized tags, day bucket, contentHash }` — never the lesson, title, body, snippet, repo, user, or pattern.
- New subpath: `@ai-conclave/core/federated`. New CLI: `conclave sync [--dry-run] [--push-only] [--pull-only] [--since ISO] [--json]`.
- Default OFF. Requires `federated.enabled = true` + `federated.endpoint` in `.conclaverc.json`. Optional `AI_CONCLAVE_FEDERATION_TOKEN` for bearer auth.

## What's in / What's out
| | In this PR | Deferred |
|---|---|---|
| Schema | ✅ `FederatedBaselineSchema` v1 | — |
| Redaction | ✅ pure `redactAnswerKey` / `redactFailure` / `redactAll` | — |
| Transport | ✅ `HttpFederatedSyncTransport` + `NoopFederatedSyncTransport` | Gossip / S3 adapters |
| Orchestrator | ✅ `runFederatedSync` — dryRun, since, push/pull disable | Scheduled/cron runs |
| CLI | ✅ `conclave sync` | CLI-level tests (core tests cover the behavior) |
| Read path | 🚧 Retrieval merge of pulled baselines — **deferred until a live endpoint exists** |

## Privacy boundary (locked)
- `contentHash = sha256([kind, domain, category, severity, sorted-tags])` — same pattern across users produces the same hash so servers aggregate by frequency without seeing any individual's content.
- Tags are normalized (trim + lowercase + dedupe + sort) before hashing so reorder/casing drift doesn't fork the signal.
- `--dry-run` prints the full payload that would be uploaded. Users can audit before opting in.
- `version: 1` is literal; servers MUST reject unknown versions — this is the breaking-change lever.

## Test plan
- [x] `pnpm build` — 17/17 packages successful
- [x] `pnpm test` — 33/33 tasks, 0 failures. `@ai-conclave/core`: 123 → 152 tests (+29 federated).
- [ ] E2E — deferred until an actual federation endpoint is stood up; `NoopFederatedSyncTransport` is the tested stand-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)