### PR TITLE
feat(core,agents,cli): 3-round council debate (decision #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## Unreleased
 
 ### Added
+- **Council 3-round debate (decision #7)** — Council now runs up to 3 rounds of review before verdict. Round 1 is independent; rounds 2+ pass each agent the other agents' results (`ctx.priors`) so they can update their verdict on arguments they missed, or hold firm. Consensus (all approve OR any reject) triggers early exit at any point.
+  - `ReviewContext` gets two optional additive fields: `round?: number` + `priors?: PriorReview[]`. Backward compat: agents that ignore them stay valid; the three in-repo agents (claude, openai, gemini) all render priors into their prompts so they actually use the debate signal.
+  - `CouncilOutcome` gains two optional fields: `roundHistory?: RoundOutcome[]` + `earlyExit?: boolean`. The legacy-shape fields (`verdict`, `rounds`, `results`, `consensusReached`) are unchanged, so existing consumers (notifiers, memory writer, CLI renderer) keep working without knowing debate happened.
+  - New `Council` options: `maxRounds` (default 3, cap 5) + `enableDebate` (default true; set false to preserve legacy 1-round behavior).
+  - New config block: `council.maxRounds` + `council.enableDebate` in `.conclaverc.json`, defaults match.
+  - CLI `conclave review` renders `Rounds: N (early exit on consensus)` in the output when debate ran.
+  - 13 Council tests (up from 6) cover: early exit on round 1, full 3-round fallthrough, scripted verdict changes reaching consensus mid-debate, priors + round wiring, `enableDebate=false` preserves legacy, `maxRounds` cap, consensus-in-final-round, roundHistory shape, blockers-in-priors end-to-end.
+
 - **Federated sync skeleton (decision #21)** — `@ai-conclave/core/federated` subpath + `conclave sync` CLI command. Opt-in cross-user baseline exchange that carries ONLY category + severity + normalized tag vector + day bucket + a deterministic sha256 hash. The `lesson` text, `title`, `body`, `snippet`, `seedBlocker`, `repo`, `user`, `pattern`, and `episodicId` are stripped before anything touches the wire.
   - `redactAnswerKey` / `redactFailure` — pure, synchronous, deterministic. Same (domain, tags) across users produce the same `contentHash`, which is the aggregation key a federation server uses for counts.
   - `HttpFederatedSyncTransport` — thin JSON contract (`POST /baselines`, `GET /baselines?since=…`) so community aggregators can implement the endpoint without a vendor SDK. `NoopFederatedSyncTransport` for disabled/test paths.

--- a/packages/agent-claude/src/prompts.ts
+++ b/packages/agent-claude/src/prompts.ts
@@ -49,6 +49,27 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push(ctx.diff || "(empty diff — respond with verdict=approve, summary noting nothing to review)");
   sections.push("```");
   sections.push("");
+
+  if (ctx.priors && ctx.priors.length > 0) {
+    sections.push(`# Round ${ctx.round ?? 2} — other agents' verdicts from the previous round`);
+    sections.push(
+      `The council is in a multi-round debate. Read each agent's verdict + blockers. Update your verdict ONLY if you see a real issue you missed, or a false-positive you can now retract. Do not mirror the majority — the dissenting voice is often the correct one.`,
+    );
+    sections.push("");
+    for (const p of ctx.priors) {
+      sections.push(`## ${p.agent}: ${p.verdict}`);
+      if (p.blockers.length > 0) {
+        for (const b of p.blockers.slice(0, 5)) {
+          const loc = b.file ? ` (${b.file}${b.line ? ":" + b.line : ""})` : "";
+          sections.push(`- [${b.severity}/${b.category}] ${b.message}${loc}`);
+        }
+      } else {
+        sections.push(`- (no blockers)`);
+      }
+      sections.push("");
+    }
+  }
+
   sections.push(`Call submit_review exactly once with your verdict, blockers (if any), and a one-paragraph summary.`);
   return sections.join("\n");
 }

--- a/packages/agent-gemini/src/prompts.ts
+++ b/packages/agent-gemini/src/prompts.ts
@@ -47,6 +47,27 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push(ctx.diff || "(empty diff — respond with verdict=approve, summary noting nothing to review, blockers=[])");
   sections.push("```");
   sections.push("");
+
+  if (ctx.priors && ctx.priors.length > 0) {
+    sections.push(`# Round ${ctx.round ?? 2} — other agents' verdicts from the previous round`);
+    sections.push(
+      `The council is in a multi-round debate. Read each agent's verdict + blockers. Update your verdict ONLY if you see a real issue you missed, or a false-positive you can now retract. Do not mirror the majority — the dissenting voice is often the correct one.`,
+    );
+    sections.push("");
+    for (const p of ctx.priors) {
+      sections.push(`## ${p.agent}: ${p.verdict}`);
+      if (p.blockers.length > 0) {
+        for (const b of p.blockers.slice(0, 5)) {
+          const loc = b.file ? ` (${b.file}${b.line ? ":" + b.line : ""})` : "";
+          sections.push(`- [${b.severity}/${b.category}] ${b.message}${loc}`);
+        }
+      } else {
+        sections.push(`- (no blockers)`);
+      }
+      sections.push("");
+    }
+  }
+
   sections.push(`Respond as JSON matching the response schema (verdict, blockers, summary).`);
   return sections.join("\n");
 }

--- a/packages/agent-openai/src/prompts.ts
+++ b/packages/agent-openai/src/prompts.ts
@@ -45,6 +45,27 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push(ctx.diff || "(empty diff — respond with verdict=approve, summary noting nothing to review, blockers=[])");
   sections.push("```");
   sections.push("");
+
+  if (ctx.priors && ctx.priors.length > 0) {
+    sections.push(`# Round ${ctx.round ?? 2} — other agents' verdicts from the previous round`);
+    sections.push(
+      `The council is in a multi-round debate. Read each agent's verdict + blockers. Update your verdict ONLY if you see a real issue you missed, or a false-positive you can now retract. Do not mirror the majority — the dissenting voice is often the correct one.`,
+    );
+    sections.push("");
+    for (const p of ctx.priors) {
+      sections.push(`## ${p.agent}: ${p.verdict}`);
+      if (p.blockers.length > 0) {
+        for (const b of p.blockers.slice(0, 5)) {
+          const loc = b.file ? ` (${b.file}${b.line ? ":" + b.line : ""})` : "";
+          sections.push(`- [${b.severity}/${b.category}] ${b.message}${loc}`);
+        }
+      } else {
+        sections.push(`- (no blockers)`);
+      }
+      sections.push("");
+    }
+  }
+
   sections.push(`Respond using the conclave_review JSON schema.`);
   return sections.join("\n");
 }

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -162,7 +162,11 @@ export async function review(argv: string[]): Promise<void> {
     process.exit(1);
     return;
   }
-  const council = new Council({ agents });
+  const council = new Council({
+    agents,
+    maxRounds: config.council.maxRounds,
+    enableDebate: config.council.enableDebate,
+  });
 
   // 5. Deliberate
   const reviewCtx: ReviewContext = {
@@ -198,6 +202,8 @@ export async function review(argv: string[]): Promise<void> {
       consensus: outcome.consensusReached,
       results: outcome.results,
       metrics: gate.metrics.summary(),
+      rounds: outcome.rounds,
+      ...(outcome.earlyExit !== undefined ? { earlyExit: outcome.earlyExit } : {}),
     }),
   );
   process.stdout.write(

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -76,6 +76,12 @@ export const ConclaveConfigSchema = z.object({
         .optional(),
     })
     .optional(),
+  council: z
+    .object({
+      maxRounds: z.number().int().min(1).max(5).default(3),
+      enableDebate: z.boolean().default(true),
+    })
+    .default({ maxRounds: 3, enableDebate: true }),
   federated: z
     .object({
       enabled: z.boolean().default(false),
@@ -104,6 +110,7 @@ export const DEFAULT_CONFIG: ConclaveConfig = {
   agents: ["claude"],
   budget: { perPrUsd: 0.5 },
   efficiency: { cacheEnabled: true, compactEnabled: true },
+  council: { maxRounds: 3, enableDebate: true },
   memory: {
     answerKeysDir: ".conclave/answer-keys",
     failureCatalogDir: ".conclave/failure-catalog",

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -9,6 +9,10 @@ export interface PrintReviewInput {
   consensus: boolean;
   results: readonly ReviewResult[];
   metrics: MetricsSummary;
+  /** Number of debate rounds executed (≥ 1). Omit for legacy 1-round flows. */
+  rounds?: number;
+  /** `true` when debate halted on consensus before reaching maxRounds. */
+  earlyExit?: boolean;
 }
 
 const SEVERITY_ORDER: Record<Blocker["severity"], number> = {
@@ -49,6 +53,10 @@ export function renderReview(input: PrintReviewInput): string {
   lines.push(`  source: ${input.source}`);
   lines.push("");
   lines.push(`Verdict: ${verdictTag(input.councilVerdict)}${input.consensus ? "" : "  (no consensus)"}`);
+  if (input.rounds && input.rounds > 1) {
+    const tail = input.earlyExit ? " (early exit on consensus)" : "";
+    lines.push(`Rounds:  ${input.rounds}${tail}`);
+  }
   lines.push("");
 
   for (const r of input.results) {

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -8,6 +8,19 @@ export interface Blocker {
   line?: number;
 }
 
+/**
+ * PriorReview — a compact view of another agent's result, passed back as
+ * context in Round 2+ of a multi-round debate (decision #7).
+ * Intentionally a subset of ReviewResult: token / cost fields drop so
+ * the wire stays small and agents focus on blockers + reasoning.
+ */
+export interface PriorReview {
+  agent: string;
+  verdict: "approve" | "rework" | "reject";
+  blockers: Blocker[];
+  summary?: string;
+}
+
 export interface ReviewContext {
   diff: string;
   repo: string;
@@ -16,6 +29,10 @@ export interface ReviewContext {
   newSha: string;
   answerKeys?: string[];
   failureCatalog?: string[];
+  /** 1-indexed round number. Absent ≡ first (or only) round. */
+  round?: number;
+  /** Other agents' results from the previous round. Used only in Round 2+. */
+  priors?: PriorReview[];
 }
 
 export interface ReviewResult {

--- a/packages/core/src/council.ts
+++ b/packages/core/src/council.ts
@@ -1,28 +1,63 @@
-import type { Agent, ReviewContext, ReviewResult } from "./agent.js";
+import type { Agent, PriorReview, ReviewContext, ReviewResult } from "./agent.js";
 
 export interface CouncilOptions {
   agents: Agent[];
+  /** Cap on rounds. Default 3 (per decision #7). */
   maxRounds?: number;
+  /** Set `false` to preserve legacy single-round behavior. Default `true`. */
+  enableDebate?: boolean;
+}
+
+/**
+ * Per-round snapshot — kept in `CouncilOutcome.roundHistory` for
+ * observability. Notifiers + UI can render "Round 1 was reject, Round 2
+ * flipped to rework after Claude withdrew blocker X" without Council
+ * having to expose round-level behavior as a first-class contract.
+ */
+export interface RoundOutcome {
+  round: number;
+  results: ReviewResult[];
+  verdict: "approve" | "rework" | "reject";
+  consensusReached: boolean;
 }
 
 export interface CouncilOutcome {
   verdict: "approve" | "rework" | "reject";
+  /** 1-indexed count of rounds actually executed (≤ maxRounds). */
   rounds: number;
+  /**
+   * FINAL-round results. Matches legacy shape so existing consumers
+   * (notifiers, memory writer, CLI renderer) keep working without
+   * knowing a debate happened.
+   */
   results: ReviewResult[];
   consensusReached: boolean;
+  /** Per-round detail, newest last. Omitted for legacy 1-round flows. */
+  roundHistory?: RoundOutcome[];
+  /** `true` if the loop halted on consensus before `maxRounds`. */
+  earlyExit?: boolean;
 }
 
 /**
  * Council — orchestrates N agents across up to `maxRounds` of review.
  *
- * This is a skeleton. The real Mastra-graph implementation (3-round A/B/C
- * debate with early-exit on agreement, rework dispatch, efficiency-gate
- * routing) lands in a subsequent PR. For now, Council runs a single round
- * and returns each agent's individual verdict.
+ * Round 1: each agent reviews independently. If consensus (all approve
+ * OR any reject) → early-exit, return round-1 result.
+ *
+ * Round 2+: each agent re-reviews with `ctx.priors` populated from the
+ * previous round's results. Agents MAY update their verdict based on
+ * arguments they missed, or hold firm. Early-exit on consensus still
+ * applies. After `maxRounds`, return whatever the last round produced.
+ *
+ * Agents that ignore `ctx.priors` simply restate their original verdict
+ * — harmless; the debate just doesn't move them. Agents that use the
+ * field (claude/openai/gemini all render `priors` into their prompts)
+ * can actually change their mind on new arguments.
  */
 export class Council {
   private readonly agents: Agent[];
   private readonly maxRounds: number;
+  private readonly enableDebate: boolean;
 
   constructor(opts: CouncilOptions) {
     if (opts.agents.length === 0) {
@@ -30,24 +65,79 @@ export class Council {
     }
     this.agents = opts.agents;
     this.maxRounds = opts.maxRounds ?? 3;
+    this.enableDebate = opts.enableDebate ?? true;
   }
 
   async deliberate(ctx: ReviewContext): Promise<CouncilOutcome> {
-    const results = await Promise.all(this.agents.map((a) => a.review(ctx)));
+    const roundCap = this.enableDebate ? this.maxRounds : 1;
+    const roundHistory: RoundOutcome[] = [];
+    let priors: PriorReview[] = [];
+    let lastResults: ReviewResult[] = [];
+    let lastVerdict: CouncilOutcome["verdict"] = "rework";
+    let lastConsensus = false;
+
+    for (let round = 1; round <= roundCap; round++) {
+      const roundCtx: ReviewContext = { ...ctx, round };
+      if (priors.length > 0) roundCtx.priors = priors;
+      const results = await Promise.all(this.agents.map((a) => a.review(roundCtx)));
+      const tally = this.tally(results);
+      roundHistory.push({
+        round,
+        results,
+        verdict: tally.verdict,
+        consensusReached: tally.consensusReached,
+      });
+      lastResults = results;
+      lastVerdict = tally.verdict;
+      lastConsensus = tally.consensusReached;
+
+      if (tally.consensusReached) {
+        return {
+          verdict: tally.verdict,
+          rounds: round,
+          results,
+          consensusReached: true,
+          roundHistory,
+          earlyExit: round < roundCap,
+        };
+      }
+
+      priors = results.map((r) => {
+        const p: PriorReview = { agent: r.agent, verdict: r.verdict, blockers: r.blockers };
+        if (r.summary) p.summary = r.summary;
+        return p;
+      });
+    }
+
+    return {
+      verdict: lastVerdict,
+      rounds: roundCap,
+      results: lastResults,
+      consensusReached: lastConsensus,
+      roundHistory,
+      earlyExit: false,
+    };
+  }
+
+  /**
+   * Consensus rule (stable across v2.0 per decision #7):
+   *   - All approve → approve, consensus.
+   *   - Any reject → reject, consensus. One agent flagging a hard block
+   *     is load-bearing; we don't outvote it.
+   *   - Otherwise → rework, no consensus.
+   */
+  private tally(
+    results: readonly ReviewResult[],
+  ): { verdict: CouncilOutcome["verdict"]; consensusReached: boolean } {
     const verdicts = results.map((r) => r.verdict);
     const allApprove = verdicts.every((v) => v === "approve");
     const anyReject = verdicts.some((v) => v === "reject");
     const verdict: CouncilOutcome["verdict"] = anyReject
       ? "reject"
       : allApprove
-      ? "approve"
-      : "rework";
-    return {
-      verdict,
-      rounds: 1,
-      results,
-      consensusReached: allApprove || anyReject,
-    };
+        ? "approve"
+        : "rework";
+    return { verdict, consensusReached: allApprove || anyReject };
   }
 
   get agentCount(): number {
@@ -56,5 +146,9 @@ export class Council {
 
   get roundLimit(): number {
     return this.maxRounds;
+  }
+
+  get debateEnabled(): boolean {
+    return this.enableDebate;
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
-export type { Agent, ReviewContext, ReviewResult, Blocker, Severity } from "./agent.js";
+export type { Agent, ReviewContext, ReviewResult, Blocker, Severity, PriorReview } from "./agent.js";
 export { Council } from "./council.js";
-export type { CouncilOutcome } from "./council.js";
+export type { CouncilOutcome, CouncilOptions, RoundOutcome } from "./council.js";
 export { ReviewResultSchema, BlockerSchema } from "./schema.js";
 export type { Notifier, NotifyReviewInput } from "./notifier.js";
 export { resolveFirstPreview } from "./platform.js";

--- a/packages/core/test/council.test.mjs
+++ b/packages/core/test/council.test.mjs
@@ -2,17 +2,54 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { Council } from "../dist/index.js";
 
-function fakeAgent(id, verdict) {
+function fakeAgent(id, verdict, blockers = []) {
   return {
     id,
     displayName: id,
     review: async () => ({
       agent: id,
       verdict,
-      blockers: [],
+      blockers,
       summary: `${id} says ${verdict}`,
     }),
   };
+}
+
+/** Agent whose verdict evolves per round, driven by a list. */
+function scriptedAgent(id, script) {
+  let i = 0;
+  return {
+    id,
+    displayName: id,
+    review: async () => {
+      const verdict = script[Math.min(i, script.length - 1)];
+      i += 1;
+      return {
+        agent: id,
+        verdict,
+        blockers: [],
+        summary: `${id} round ${i} says ${verdict}`,
+      };
+    },
+  };
+}
+
+/** Agent that records every ReviewContext it sees — used to assert that priors + round are wired. */
+function recordingAgent(id, script) {
+  const seen = [];
+  let i = 0;
+  const agent = {
+    id,
+    displayName: id,
+    review: async (ctx) => {
+      seen.push(ctx);
+      const verdict = script[Math.min(i, script.length - 1)];
+      i += 1;
+      return { agent: id, verdict, blockers: [], summary: `${id} r${i}` };
+    },
+  };
+  agent.seen = seen;
+  return agent;
 }
 
 const ctx = { diff: "", repo: "acme/x", pullNumber: 1, newSha: "HEAD" };
@@ -21,46 +58,180 @@ test("Council: empty agents throws", () => {
   assert.throws(() => new Council({ agents: [] }));
 });
 
-test("Council: single approve → approve + consensus", async () => {
+test("Council: single approve → approve + consensus, 1 round", async () => {
   const council = new Council({ agents: [fakeAgent("claude", "approve")] });
   const outcome = await council.deliberate(ctx);
   assert.equal(outcome.verdict, "approve");
   assert.equal(outcome.consensusReached, true);
+  assert.equal(outcome.rounds, 1);
   assert.equal(outcome.results.length, 1);
 });
 
-test("Council: all approve → approve", async () => {
+test("Council: all approve → approve, early exit round 1", async () => {
   const council = new Council({
     agents: [fakeAgent("claude", "approve"), fakeAgent("openai", "approve")],
   });
   const outcome = await council.deliberate(ctx);
   assert.equal(outcome.verdict, "approve");
   assert.equal(outcome.consensusReached, true);
+  assert.equal(outcome.rounds, 1);
+  assert.equal(outcome.earlyExit, true);
 });
 
-test("Council: any reject → reject (consensus)", async () => {
+test("Council: any reject → reject + consensus, early exit round 1", async () => {
   const council = new Council({
     agents: [fakeAgent("claude", "approve"), fakeAgent("openai", "reject")],
   });
   const outcome = await council.deliberate(ctx);
   assert.equal(outcome.verdict, "reject");
   assert.equal(outcome.consensusReached, true);
+  assert.equal(outcome.rounds, 1);
 });
 
-test("Council: mixed approve + rework → rework (no consensus)", async () => {
+test("Council: mixed approve + rework with no movement → rework, runs full 3 rounds", async () => {
   const council = new Council({
     agents: [fakeAgent("claude", "approve"), fakeAgent("openai", "rework")],
   });
   const outcome = await council.deliberate(ctx);
   assert.equal(outcome.verdict, "rework");
   assert.equal(outcome.consensusReached, false);
+  assert.equal(outcome.rounds, 3);
+  assert.equal(outcome.earlyExit, false);
+  assert.ok(Array.isArray(outcome.roundHistory));
+  assert.equal(outcome.roundHistory.length, 3);
 });
 
-test("Council: exposes config", async () => {
+test("Council: debate reaches consensus in round 2 (agent changes mind)", async () => {
+  const council = new Council({
+    agents: [
+      // stays approve every round
+      scriptedAgent("claude", ["approve", "approve", "approve"]),
+      // rework in round 1, flips to approve in round 2 after seeing priors
+      scriptedAgent("openai", ["rework", "approve", "approve"]),
+    ],
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.verdict, "approve");
+  assert.equal(outcome.consensusReached, true);
+  assert.equal(outcome.rounds, 2);
+  assert.equal(outcome.earlyExit, true);
+  assert.equal(outcome.roundHistory.length, 2);
+});
+
+test("Council: round 2+ passes priors + round number to agents", async () => {
+  const a = recordingAgent("a", ["rework", "rework", "rework"]);
+  const b = recordingAgent("b", ["approve", "approve", "approve"]);
+  const council = new Council({ agents: [a, b] });
+  await council.deliberate(ctx);
+
+  // Round 1 contexts should have no priors
+  assert.equal(a.seen[0].round, 1);
+  assert.equal(a.seen[0].priors, undefined);
+  assert.equal(b.seen[0].priors, undefined);
+
+  // Round 2 contexts should have priors from round 1
+  assert.equal(a.seen[1].round, 2);
+  assert.equal(a.seen[1].priors.length, 2);
+  const priorAgents = a.seen[1].priors.map((p) => p.agent).sort();
+  assert.deepEqual(priorAgents, ["a", "b"]);
+  const aPrior = a.seen[1].priors.find((p) => p.agent === "a");
+  assert.equal(aPrior.verdict, "rework");
+  const bPrior = a.seen[1].priors.find((p) => p.agent === "b");
+  assert.equal(bPrior.verdict, "approve");
+
+  // Round 3 should see priors from round 2
+  assert.equal(a.seen[2].round, 3);
+  assert.equal(a.seen[2].priors.length, 2);
+});
+
+test("Council: enableDebate=false preserves 1-round behavior", async () => {
+  const council = new Council({
+    agents: [
+      scriptedAgent("claude", ["rework", "approve"]),
+      scriptedAgent("openai", ["approve", "approve"]),
+    ],
+    enableDebate: false,
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.rounds, 1);
+  assert.equal(outcome.verdict, "rework"); // mixed verdicts in round 1, no debate allowed to resolve
+  assert.equal(outcome.consensusReached, false);
+});
+
+test("Council: maxRounds caps the loop even when no consensus reached", async () => {
+  const council = new Council({
+    agents: [fakeAgent("a", "approve"), fakeAgent("b", "rework")],
+    maxRounds: 5,
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.rounds, 5);
+  assert.equal(outcome.consensusReached, false);
+  assert.equal(outcome.roundHistory.length, 5);
+});
+
+test("Council: consensus in the final round still sets earlyExit=false", async () => {
+  // Round 1 + 2 = rework; Round 3 = approve. consensus in the LAST permitted round.
+  const council = new Council({
+    agents: [
+      scriptedAgent("a", ["approve", "approve", "approve"]),
+      scriptedAgent("b", ["rework", "rework", "approve"]),
+    ],
+    maxRounds: 3,
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.verdict, "approve");
+  assert.equal(outcome.consensusReached, true);
+  assert.equal(outcome.rounds, 3);
+  assert.equal(outcome.earlyExit, false);
+});
+
+test("Council: roundHistory preserves each round's verdict + results", async () => {
+  const council = new Council({
+    agents: [
+      scriptedAgent("a", ["rework", "approve", "approve"]),
+      scriptedAgent("b", ["approve", "approve", "approve"]),
+    ],
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.roundHistory[0].verdict, "rework");
+  assert.equal(outcome.roundHistory[0].consensusReached, false);
+  assert.equal(outcome.roundHistory[1].verdict, "approve");
+  assert.equal(outcome.roundHistory[1].consensusReached, true);
+  assert.equal(outcome.roundHistory[0].results.length, 2);
+});
+
+test("Council: priors carry blockers so agents can respond to specific issues", async () => {
+  const agentWithBlockers = {
+    id: "a",
+    displayName: "a",
+    review: async () => ({
+      agent: "a",
+      verdict: "rework",
+      blockers: [
+        { severity: "major", category: "security", message: "missing auth check", file: "x.ts", line: 42 },
+      ],
+      summary: "a says rework",
+    }),
+  };
+  const recorder = recordingAgent("b", ["approve", "approve", "approve"]);
+  const council = new Council({ agents: [agentWithBlockers, recorder] });
+  await council.deliberate(ctx);
+  const r2Priors = recorder.seen[1].priors;
+  const aBlocker = r2Priors.find((p) => p.agent === "a").blockers[0];
+  assert.equal(aBlocker.message, "missing auth check");
+  assert.equal(aBlocker.file, "x.ts");
+  assert.equal(aBlocker.line, 42);
+});
+
+test("Council: exposes config (agentCount, roundLimit, debateEnabled)", async () => {
   const council = new Council({
     agents: [fakeAgent("a", "approve"), fakeAgent("b", "approve")],
     maxRounds: 5,
   });
   assert.equal(council.agentCount, 2);
   assert.equal(council.roundLimit, 5);
+  assert.equal(council.debateEnabled, true);
+
+  const legacy = new Council({ agents: [fakeAgent("a", "approve")], enableDebate: false });
+  assert.equal(legacy.debateEnabled, false);
 });


### PR DESCRIPTION
## Summary
- Council upgrades from single-round to up to 3 rounds of review per decision #7. Round 1 is independent; rounds 2+ pass each agent the other agents' priors (`{verdict, blockers, summary}`) via `ctx.priors` so agents can revise on arguments they missed — or hold firm.
- Early-exit on consensus (all approve OR any reject) short-circuits the loop at any round.
- All three in-repo agents (Claude, OpenAI, Gemini) render the `priors` block into their review prompts, so the debate signal actually reaches the model.
- Legacy behavior preserved at the `CouncilOutcome` surface; notifiers, memory writer, and CLI renderer keep working without knowing debate happened.

## Design
| Area | Before | After |
|---|---|---|
| Rounds | always 1 | 1-`maxRounds` (default 3, cap 5), early-exit on consensus |
| `ReviewContext` | `{ diff, repo, pullNumber, prevSha?, newSha, answerKeys?, failureCatalog? }` | + optional `round?: number`, `priors?: PriorReview[]` |
| `CouncilOutcome` | `{ verdict, rounds, results, consensusReached }` | + optional `roundHistory?: RoundOutcome[]`, `earlyExit?: boolean` |
| Agent prompt | diff + RAG context | +"Round N: other agents said X" block when priors present |
| Config | — | `council.maxRounds` (1-5, default 3) + `council.enableDebate` (default true) |

## Backward compat
- `new Council({ agents })` still works — 3-round default.
- For all-approve / any-reject cases → early-exit at round 1, indistinguishable from old behavior.
- For mixed-verdict cases, the debate now has room to move. Consumers reading `outcome.results` get the FINAL-round results. `outcome.consensusReached` semantics unchanged (all approve OR any reject).
- `enableDebate: false` forces legacy 1-round behavior verbatim.

## Test plan
- [x] `pnpm build` — 17/17 packages
- [x] `pnpm test` — 33/33 tasks, 0 failures. Core tests: 152 → 159 (+7 new council tests; +6 rewritten to cover new shape).
- [ ] Live smoke — deferred until next `conclave review` with all three agent API keys set; mock scripted-verdict tests cover the plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)