### PR TITLE
docs: README rewrite + docs/ directory for launch readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Docs
+- **README rewrite + `docs/` directory** for public-launch readiness.
+  README now reflects actual state (18 packages, 9 CLI commands, 29/34
+  decisions implemented, 28 PRs merged) instead of the pre-alpha
+  scaffolding text it opened with.
+- `docs/getting-started.md` — zero-to-review walkthrough with env
+  vars, init, review, outcome recording, optional visual + federated
+  paths, troubleshooting.
+- `docs/configuration.md` — full `.conclaverc.json` schema reference
+  with every env var mapped to the feature it enables.
+- `docs/federated-sync.md` — the privacy model, exact wire format,
+  three independent off-switches, and an audit pointer into the four
+  files that define the entire redaction + transport flow.
+
 ### Added
 - **Council 3-round debate (decision #7)** — Council now runs up to 3 rounds of review before verdict. Round 1 is independent; rounds 2+ pass each agent the other agents' results (`ctx.priors`) so they can update their verdict on arguments they missed, or hold firm. Consensus (all approve OR any reject) triggers early exit at any point.
   - `ReviewContext` gets two optional additive fields: `round?: number` + `priors?: PriorReview[]`. Backward compat: agents that ignore them stay valid; the three in-repo agents (claude, openai, gemini) all render priors into their prompts so they actually use the debate signal.

--- a/README.md
+++ b/README.md
@@ -2,67 +2,139 @@
 
 **AI drafted. Council refined.**
 
-A multi-agent council reviews your AI-generated code and design, debates
-issues across rounds until it reaches consensus, auto-fixes blockers, and
-learns your preferences over time. Built for solo makers who ship with AI.
+A multi-agent council reviews your AI-generated code, debates blockers
+across up to 3 rounds until it reaches consensus, and learns from every
+merge + rejection so future reviews match your repo's real tolerance for
+"blocker" vs "nit". Built for solo makers who ship with AI.
 
-> **Status**: pre-alpha scaffolding. The architecture is locked; the
-> monorepo skeleton is landing in stages. See `ARCHITECTURE.md` for the
-> full 7-layer design.
+> **Status**: v2.0 development. Architecture locked; 29/34 decisions
+> implemented across 28 PRs. Not yet published to npm — see `ARCHITECTURE.md`
+> for the full 7-layer design.
 
 ## Who this is for
 
-Anyone who ships AI-generated code or AI-built apps but doesn't want
-to hire a reviewer. Concretely:
+Anyone shipping AI-generated code or AI-built apps but not hiring a
+reviewer. Concretely:
 
 - **AI coding assistants** — Cursor, Claude Code, Windsurf, Copilot
 - **App-from-prompt builders** — v0, Lovable, Bolt, Base44
 - **Autonomous agents** — Manus AI, Devin, Cognition-style task runners
 
-If the output is often mediocre, off-style, or needs human polish — and
-the reviewer's job is "catch the blockers, ignore the nits" — the
-council sits in that seat.
-
 This is **not** a tool for seasoned engineers polishing code they wrote
 themselves. It is a council for code that came out of an AI.
 
-## The core idea
+## How it works
 
 ```
-You ship AI-generated code
+You push AI-generated code
   ↓
-Council (N pluggable agents) debates it (up to 3 rounds, early-exit on agreement)
+Efficiency gate (cache / triage / budget / compact / route)
   ↓
-Blockers → auto-rework commits back to your PR
+Council — up to 3 rounds of debate across N agents
+  Round 1: independent review
+  Round 2: each agent sees the others' blockers, can revise
+  Round 3: final vote; early-exit the moment all approve OR any reject
   ↓
-Merge → success pattern → answer-keys (정답지)
-Reject → failure pattern → failure-catalog (오답지)
+Merged  → success pattern → answer-keys  (정답지)
+Rejected → failure pattern → failure-catalog (오답지)
   ↓
-Next review reads both catalogs as RAG context → gets smarter over time
+Next review reads BOTH catalogs as RAG context → the council gets smarter
 ```
 
-Two substrates (정답지 + 오답지) seed the self-evolve loop. Most systems
-use one signal (positive OR negative). Here both are first-class.
+Both signals are first-class. Most ML systems use one (positive OR
+negative); here `정답지 ∥ 오답지` is the primitive — decision #17.
+
+## The numbers
+
+- **18 workspace packages** — core + 3 agents (Claude/OpenAI/Gemini) +
+  4 notifiers (Telegram/Discord/Slack/Email) + 5 platform adapters
+  (Vercel/Netlify/Cloudflare Pages/Railway/GitHub deployment_status) +
+  SCM + observability + visual review + CLI.
+- **9 CLI commands** covering init → review → outcome capture →
+  seeding → migration → scoring → federated sync.
+- **Cost per PR**: ~$0.05-$0.20 at current pricing with caching + triage,
+  capped by a per-PR budget that the efficiency gate enforces before any
+  LLM call fires.
+- **Privacy-first federation**: `conclave sync` exchanges k-anonymous
+  baseline signal (category + severity + tag vector + hash) with other
+  users — no code, diffs, titles, or repo names ever leave your machine.
+  OFF by default.
 
 ## Packages
 
 | Package | Purpose |
 |---|---|
-| `@ai-conclave/core` | Agent interface, council orchestration, self-evolve substrate, efficiency gate |
-| `@ai-conclave/agent-claude` | Claude agent wrapper (built on `@anthropic-ai/claude-agent-sdk`) |
-| `@ai-conclave/cli` | `conclave` binary — `init` / `review` / `migrate` |
+| `@ai-conclave/core` | Agent interface, Council (3-round debate), efficiency gate, memory substrate (정답지 + 오답지), scoring (decision #19), federated sync (decision #21) |
+| `@ai-conclave/agent-claude` | Claude reviewer — tool-use with `submit_review` + prompt caching |
+| `@ai-conclave/agent-openai` | OpenAI reviewer — strict JSON schema + cached-token discount |
+| `@ai-conclave/agent-gemini` | Gemini reviewer — long-context routing tier |
+| `@ai-conclave/cli` | `conclave` binary — 9 commands |
+| `@ai-conclave/scm-github` | `gh`-CLI wrapper + `conclave poll-outcomes` |
+| `@ai-conclave/platform-vercel` · `-netlify` · `-cloudflare` · `-railway` · `-deployment-status` | Preview URL resolution for visual review (decision #31) |
+| `@ai-conclave/integration-telegram` · `-discord` · `-slack` · `-email` | Equal-weight notifiers (decision #24) |
+| `@ai-conclave/observability-langfuse` | `LangfuseMetricsSink` for the efficiency gate |
+| `@ai-conclave/visual-review` | Playwright capture + pixelmatch diff + `ClaudeVisionJudge` |
 
-More agents (`agent-openai`, `agent-gemini`, …) and infrastructure packages
-(`scm-github`, `platform-vercel`, `integration-telegram`, …) land in
-subsequent PRs per `ARCHITECTURE.md`.
+## CLI commands
 
-## Quickstart (once published)
+```
+conclave init                              # scaffold config + .conclave/ in repo
+conclave review [--pr N] [--visual]        # run the 3-round council review
+conclave record-outcome --id <ep-id> --result merged|rejected|reworked
+conclave poll-outcomes [--quiet]           # auto outcome capture via gh
+conclave seed [--from <path>]              # bootstrap failure-catalog
+conclave migrate [--from <solo-cto-agent>] # port a v1 install
+conclave scores [--json]                   # per-agent weighted performance
+conclave sync [--dry-run|--push-only|--pull-only]  # federated baseline (opt-in)
+```
+
+## Quickstart (from source, pre-publish)
 
 ```bash
-pnpm add -g @ai-conclave/cli
-conclave init            # wire up your repo
-conclave review          # run a council review on the current branch
+git clone https://github.com/seunghunbae-3svs/ai-conclave
+cd ai-conclave
+pnpm install
+pnpm build
+
+# Set at least one agent key:
+export ANTHROPIC_API_KEY=sk-ant-...
+# Optional additional agents:
+export OPENAI_API_KEY=...
+export GOOGLE_API_KEY=...
+
+# Drop into a repo you want to review:
+cd /path/to/your-repo
+node /path/to/ai-conclave/packages/cli/dist/bin/conclave.js init
+node /path/to/ai-conclave/packages/cli/dist/bin/conclave.js review --pr 42
 ```
+
+Once published: `pnpm add -g @ai-conclave/cli`.
+
+Full walkthrough: [docs/getting-started.md](docs/getting-started.md).
+
+## Configuration
+
+`.conclaverc.json` at your repo root. Minimal:
+
+```json
+{
+  "version": 1,
+  "agents": ["claude", "openai", "gemini"],
+  "budget": { "perPrUsd": 0.5 },
+  "council": { "maxRounds": 3, "enableDebate": true }
+}
+```
+
+Full reference: [docs/configuration.md](docs/configuration.md).
+
+## Privacy & federated sync
+
+`conclave sync` is **opt-in**. Full privacy model + the exact wire format:
+[docs/federated-sync.md](docs/federated-sync.md).
+
+TL;DR: only `{kind, domain, category, severity, normalized tags, day
+bucket, sha256(those fields)}` leaves — never the lesson text, title,
+body, snippet, repo name, user name, diff, or commit message.
 
 ## Development
 
@@ -70,18 +142,29 @@ conclave review          # run a council review on the current branch
 pnpm install
 pnpm build               # compile all packages
 pnpm dev                 # watch-mode
-pnpm test
+pnpm test                # node --test across every package
 ```
 
-Requires Node >= 20 and pnpm >= 9.
+Requires Node ≥ 20 and pnpm ≥ 9. Monorepo is [Turbo](https://turbo.build/repo).
+
+## Roadmap
+
+See [CHANGELOG.md](CHANGELOG.md) for what's shipped. Remaining v2.0+
+work: Agent SDK migrations (cosmetic), MCP tool protocol, odiff native
+adapter, cosmiconfig, live federation endpoint + retrieval-side merge,
+v2.1 agent set (Grok/Deepseek/Qwen/Bedrock/Vertex/Cheetah/Ollama).
+
+Locked design decisions (do not reopen without explicit reason) live in
+`ARCHITECTURE.md`.
 
 ## Relation to solo-cto-agent
 
-`solo-cto-agent` is the v1 predecessor. It stays at
+`solo-cto-agent` is the v1 predecessor, still on
 [npm](https://www.npmjs.com/package/solo-cto-agent) in maintenance mode
 (security fixes only). Ai-Conclave is a clean-slate rewrite under a new
-npm scope (`@ai-conclave`) with a multi-agent architecture. A
-`conclave migrate` CLI command will be provided at v2.0 RC.
+`@ai-conclave` scope with a multi-agent architecture. `conclave migrate`
+ports an existing solo-cto-agent install — config + failure-catalog +
+per-step checklist.
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,137 @@
+# Configuration reference
+
+`.conclaverc.json` lives at the repo root. All fields are optional
+except `version`.
+
+## Full shape
+
+```json
+{
+  "version": 1,
+  "agents": ["claude", "openai", "gemini"],
+  "budget": { "perPrUsd": 0.5 },
+  "efficiency": { "cacheEnabled": true, "compactEnabled": true },
+  "council": { "maxRounds": 3, "enableDebate": true },
+  "memory": {
+    "answerKeysDir": ".conclave/answer-keys",
+    "failureCatalogDir": ".conclave/failure-catalog",
+    "root": ".conclave"
+  },
+  "observability": {
+    "langfuse": { "enabled": true, "baseUrl": "https://cloud.langfuse.com" }
+  },
+  "integrations": {
+    "telegram": { "enabled": true, "chatId": -1001234567890, "includeActionButtons": true },
+    "discord":  { "enabled": true, "webhookUrl": "https://discord.com/api/webhooks/..." },
+    "slack":    { "enabled": true, "webhookUrl": "https://hooks.slack.com/..." },
+    "email":    { "enabled": true, "from": "bot@example.com", "to": "you@example.com" }
+  },
+  "visual": {
+    "enabled": true,
+    "platforms": ["vercel", "netlify", "cloudflare", "railway", "deployment-status"],
+    "width": 1280,
+    "height": 800,
+    "fullPage": true,
+    "waitSeconds": 60,
+    "diffThreshold": 0.1
+  },
+  "federated": {
+    "enabled": false,
+    "endpoint": "https://baseline.example.com"
+  }
+}
+```
+
+## Fields
+
+### `version` (required)
+
+Always `1`. Bump the schema when making a breaking change; the CLI
+rejects unknown versions.
+
+### `agents`
+
+Array of `"claude"`, `"openai"`, `"gemini"`. An agent is only
+instantiated if its env var is set — missing keys cleanly skip.
+
+| Agent | Env var |
+|---|---|
+| `claude` | `ANTHROPIC_API_KEY` |
+| `openai` | `OPENAI_API_KEY` |
+| `gemini` | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) |
+
+### `budget.perPrUsd`
+
+Hard cap on total LLM spend per `conclave review`. The efficiency
+gate reserves cost before each call and throws `BudgetExceededError`
+if a call would breach the cap. Default `0.5`.
+
+### `efficiency`
+
+- `cacheEnabled` — Anthropic prompt-cache for Claude agent (5-min TTL,
+  model-scoped). Default `true`.
+- `compactEnabled` — message-list compaction for long review chains.
+  Default `true`.
+
+### `council`
+
+- `maxRounds` — cap on debate rounds. `1` = legacy single-round. Cap
+  of `5`. Default `3` per decision #7.
+- `enableDebate` — set `false` to force single-round regardless of
+  `maxRounds`. Default `true`.
+
+### `memory`
+
+Filesystem paths, relative to repo root unless `root` is absolute.
+
+### `observability.langfuse`
+
+- `enabled` — when `true`, every LLM call records a metric to Langfuse.
+  Set `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY` env vars.
+- `baseUrl` — Langfuse Cloud (default) or self-hosted URL.
+
+### `integrations.*`
+
+Equal-weight notifiers per decision #24. Each one runs independently;
+failures in one do not block the others. Set the matching env vars:
+
+| Integration | Required env |
+|---|---|
+| telegram | `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` (or `chatId` in config) |
+| discord  | `DISCORD_WEBHOOK_URL` (or `webhookUrl` in config) |
+| slack    | `SLACK_WEBHOOK_URL` (or `webhookUrl` in config) |
+| email    | SMTP envs: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` |
+
+### `visual`
+
+Playwright-driven visual regression per decision #23. Requires at
+least one `platforms` entry to successfully resolve a preview URL.
+
+| Platform ID | Required env |
+|---|---|
+| `vercel` | `VERCEL_TOKEN` |
+| `netlify` | `NETLIFY_TOKEN` + `NETLIFY_SITE_ID` |
+| `cloudflare` | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_PROJECT_NAME` |
+| `railway` | `RAILWAY_API_TOKEN` + `RAILWAY_PROJECT_ID` (optional `RAILWAY_ENVIRONMENT_ID`) |
+| `deployment-status` | none (uses `gh` CLI auth) |
+
+Platforms are tried in order; first non-null preview wins. Missing-creds
+platforms are skipped with a stderr notice, not thrown.
+
+### `federated`
+
+Off by default. See [federated-sync.md](federated-sync.md) for the
+privacy model before enabling.
+
+- `enabled` — must be `true` to opt in.
+- `endpoint` — HTTPS URL of the federation server. Must implement
+  `POST /baselines` + `GET /baselines?since=<ISO>`.
+
+Optional `AI_CONCLAVE_FEDERATION_TOKEN` env for bearer auth.
+
+## Config discovery
+
+`loadConfig(cwd)` walks up from `cwd` looking for `.conclaverc.json`.
+When found, the file is Zod-validated against the schema above — any
+unknown field is rejected. When not found, `DEFAULT_CONFIG` is used
+silently.

--- a/docs/federated-sync.md
+++ b/docs/federated-sync.md
@@ -1,0 +1,189 @@
+# Federated sync — privacy model + protocol
+
+Decision #21. **Opt-in.** Off by default.
+
+## What leaves your machine
+
+Exactly this shape (Zod-enforced at the source):
+
+```jsonc
+{
+  "version": 1,
+  "kind": "failure",              // or "answer-key"
+  "contentHash": "sha256 hex, 64 chars",
+  "domain": "code",               // or "design"
+  "category": "security",         // failure-only
+  "severity": "blocker",          // failure-only: blocker | major | minor
+  "tags": ["auth", "jwt"],        // normalized: trim + lowercase + dedupe + sort
+  "dayBucket": "2026-04-19"       // raw timestamp discarded
+}
+```
+
+## What does NOT leave
+
+Nothing else. Specifically:
+
+- ❌ `lesson` (answer-key natural-language distillation)
+- ❌ `title` / `body` / `snippet` (failure-entry details)
+- ❌ `seedBlocker` (original blocker object with file + line)
+- ❌ `pattern` (e.g. `by-pattern/auth-middleware`)
+- ❌ `repo` / `user` — user-identifying strings
+- ❌ `episodicId` — links back to your local episodic log
+- ❌ `id` — your local sha-prefix identifiers
+- ❌ Any diff content, commit message, or code snippet
+
+The redactor (`packages/core/src/federated/redact.ts`) is a pure
+function. You can run `conclave sync --dry-run --json` at any time to
+see the exact payload that would be uploaded, offline, without touching
+the network.
+
+## The hash
+
+```
+contentHash = sha256(JSON.stringify([
+  kind,                    // "answer-key" | "failure"
+  domain,                  // "code" | "design"
+  category ?? "",          // failure-only; empty string for answer-keys
+  severity ?? "",          // failure-only
+  sortedNormalizedTags     // e.g. ["auth", "jwt", "security"]
+]))
+```
+
+Properties:
+- **Deterministic.** Same 5-tuple across users → same hash. A
+  federation server aggregates by hash to count frequency without
+  seeing any individual contribution's content.
+- **K-anonymous.** Many users reviewing auth-related security blockers
+  produce the same hash. The server sees "this hash was seen 487
+  times" — not "user X reviewed this PR".
+- **Unreversible in practice.** SHA-256 over a 5-tuple of enumerated
+  values. A motivated attacker could brute-force the tag vocabulary
+  space, but there's nothing useful at the end of that attack — the
+  input is itself public vocabulary.
+
+## The wire
+
+Thin JSON contract — no vendor SDK. Community-hosted aggregators can
+implement it in any language.
+
+### Push
+
+```
+POST {endpoint}/baselines
+Content-Type: application/json
+Authorization: Bearer <AI_CONCLAVE_FEDERATION_TOKEN>   // optional
+
+{
+  "baselines": [
+    { "version": 1, "kind": "failure", "contentHash": "...", ... },
+    ...
+  ]
+}
+
+→ 200 { "accepted": 12 }
+```
+
+Servers MAY dedupe (return `accepted` < input length).
+
+### Pull
+
+```
+GET {endpoint}/baselines?since=<ISO-8601>
+Authorization: Bearer <...>     // optional
+
+→ 200 { "baselines": [...] }
+```
+
+`since` is optional; omit to get all available.
+
+### Errors
+
+- `401` / `403` → auth failure; the HTTP transport throws.
+- `5xx` → server error; throws with a truncated body for diagnostics.
+- `404` → server has nothing for your query; throws (not null —
+  treated as a hard error distinct from "empty but valid" response).
+
+## Schema version
+
+`version: 1` is literal. Servers MUST reject unknown versions to
+prevent silent data shape drift. Bumping the version is the single
+breaking-change lever for the federation protocol.
+
+## Enabling
+
+In `.conclaverc.json`:
+
+```json
+{
+  "federated": {
+    "enabled": true,
+    "endpoint": "https://baseline.your-org.example"
+  }
+}
+```
+
+Optional auth:
+
+```bash
+export AI_CONCLAVE_FEDERATION_TOKEN=...
+```
+
+Then run:
+
+```bash
+# See the payload first (zero network I/O):
+conclave sync --dry-run --json
+
+# Actual round-trip:
+conclave sync
+
+# Upload only, don't pull:
+conclave sync --push-only
+
+# Download only, don't upload:
+conclave sync --pull-only
+
+# Delta pull:
+conclave sync --since 2026-04-19T00:00:00Z
+```
+
+## What the pulled baselines are FOR
+
+Today: diagnostic — `conclave sync` returns them in the CLI output but
+the review path does not merge them yet. This is deliberate; retrieval
+merge lands after a live federation endpoint exists and the tag
+vocabulary is validated in practice.
+
+Future (retrieval merge): pulled baselines will boost local retrieval
+of answer-keys / failures that share tag-vector fingerprints with the
+federated frequency signal, so a pattern that's "seen 487 times across
+the fleet" outranks a pattern that's "seen 2 times in your local
+history" — weighted by how well the tag match holds up.
+
+## Opting out
+
+Three independent off-switches:
+
+1. **Don't configure it.** If `federated.enabled` is absent or `false`,
+   the CLI uses `NoopFederatedSyncTransport` — zero network I/O, zero
+   redaction, zero payload.
+2. **Don't run `conclave sync`.** Nothing in the normal `review` path
+   touches federation. Opt-in is a separate command.
+3. **Disable the CLI command.** Remove it from your shell history /
+   CI / cron. There is no background thread or scheduled worker; sync
+   runs only when invoked.
+
+## If you audit the code
+
+Start here:
+
+- `packages/core/src/federated/schema.ts` — the only shape that leaves.
+- `packages/core/src/federated/redact.ts` — `redactAnswerKey` /
+  `redactFailure` / `redactAll`. Pure, synchronous, no I/O.
+- `packages/core/src/federated/transport.ts` — the HTTP wire. No state
+  beyond endpoint + token.
+- `packages/core/src/federated/sync.ts` — orchestrator.
+  `runFederatedSync` ONLY hands `FederatedBaseline[]` (the redacted
+  shape) to the transport. The transport never sees raw memory.
+
+Any deviation from this flow is a bug.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,173 @@
+# Getting started with Ai-Conclave
+
+Step-by-step from zero to a real council review. Pre-publish, so the
+path is "clone + link" rather than "npm install".
+
+## Prerequisites
+
+- Node ≥ 20 (24.x tested)
+- pnpm ≥ 9 (10.x tested; install via `corepack prepare pnpm@10 --activate`)
+- At least ONE LLM API key. The council needs a minimum of one agent
+  available to run; more agents = more useful debate.
+
+## 1. Clone and build
+
+```bash
+git clone https://github.com/seunghunbae-3svs/ai-conclave
+cd ai-conclave
+pnpm install
+pnpm build
+pnpm test   # optional, confirms everything works on your machine
+```
+
+## 2. Set agent API keys
+
+Every agent is skipped cleanly if its key is missing — the council runs
+on whatever subset you have keys for.
+
+| Agent | Env var |
+|---|---|
+| Claude | `ANTHROPIC_API_KEY` |
+| OpenAI | `OPENAI_API_KEY` |
+| Gemini | `GOOGLE_API_KEY` (or `GEMINI_API_KEY` as fallback) |
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+# Optional:
+export OPENAI_API_KEY=sk-...
+export GOOGLE_API_KEY=...
+```
+
+## 3. Initialize the target repo
+
+The target is whatever repo you want to review. In a new shell:
+
+```bash
+cd /path/to/your-repo
+node /path/to/ai-conclave/packages/cli/dist/bin/conclave.js init
+```
+
+This writes `.conclaverc.json` at the repo root and creates
+`.conclave/` for the memory substrate. Edit `.conclaverc.json` to enable
+only the agents you set keys for:
+
+```json
+{
+  "version": 1,
+  "agents": ["claude"],
+  "budget": { "perPrUsd": 0.5 },
+  "council": { "maxRounds": 3, "enableDebate": true }
+}
+```
+
+## 4. First review
+
+For a PR:
+
+```bash
+node /path/to/ai-conclave/packages/cli/dist/bin/conclave.js review --pr 42
+```
+
+For the current branch against its base:
+
+```bash
+node /path/to/ai-conclave/packages/cli/dist/bin/conclave.js review --base main
+```
+
+From a diff file:
+
+```bash
+git diff main... > /tmp/change.diff
+node /path/to/ai-conclave/packages/cli/dist/bin/conclave.js review --diff /tmp/change.diff
+```
+
+Exit codes:
+- `0` — approve
+- `1` — rework
+- `2` — reject
+
+## 5. Record the outcome when the PR lands
+
+Either automatic (recommended — cron the `poll-outcomes` command):
+
+```bash
+node /path/to/conclave.js poll-outcomes --quiet
+```
+
+This checks every pending episodic entry against live GitHub state
+(`gh pr view`) and classifies into answer-keys / failures.
+
+Or manual:
+
+```bash
+node /path/to/conclave.js record-outcome --id ep-... --result merged
+```
+
+Both paths write the distilled pattern into the memory substrate, where
+the next review picks it up as RAG context.
+
+## 6. (Optional) Bootstrap from failure-catalog
+
+If you want the council to inherit lessons from an existing
+solo-cto-agent installation:
+
+```bash
+node /path/to/conclave.js migrate --from ../path/to/solo-cto-agent --dry-run
+node /path/to/conclave.js migrate --from ../path/to/solo-cto-agent
+```
+
+Or seed from the bundled default catalog (~15 failure patterns
+harvested from v1's incident log):
+
+```bash
+node /path/to/conclave.js seed
+```
+
+## 7. (Optional) Visual review for UI work
+
+Enable in `.conclaverc.json`:
+
+```json
+{
+  "visual": {
+    "enabled": true,
+    "platforms": ["vercel", "netlify", "cloudflare", "railway", "deployment-status"]
+  }
+}
+```
+
+Set whichever platform env vars apply to your deploy target (see
+[configuration.md](configuration.md) for the full matrix). Then:
+
+```bash
+node /path/to/conclave.js review --pr 42 --visual
+```
+
+## 8. (Optional) Agent performance tracking
+
+```bash
+node /path/to/conclave.js scores
+node /path/to/conclave.js scores --json | jq .
+```
+
+After a few merges, each agent's rolling score shows who's carrying
+the council. Weights per decision #19: build-pass 40%, review-approval
+30%, time 20% (not yet tracked), rework 10%.
+
+## 9. (Optional) Federated baseline signal
+
+OFF by default. See [federated-sync.md](federated-sync.md) before
+enabling. Privacy model is strict: only hash + category + severity +
+normalized tag vector leaves.
+
+## Troubleshooting
+
+- **"no agents available"** — no agent API key is set. Export at least
+  `ANTHROPIC_API_KEY` or update `agents` in `.conclaverc.json`.
+- **"conclave review: visual platform X skipped — TOKEN not set"** —
+  expected; the platform factory skips adapters with missing creds. If
+  no platforms resolve, visual review silently disables.
+- **Build fails with "module does not provide export"** — a downstream
+  package lost its `dist/`. Run `pnpm build` from the monorepo root.
+- **`gh` CLI prompts for auth** — `gh auth login` once. `poll-outcomes`
+  and `deployment-status` platform both require it.


### PR DESCRIPTION
## Summary
- README was still describing the repo as \"pre-alpha scaffolding\" with 3 packages and 3 CLI commands. Current reality: 18 packages, 9 CLI commands, 29/34 decisions implemented, 28 PRs merged.
- Three new long-form docs under \`docs/\` so the README stays scannable:

| File | What |
|---|---|
| \`docs/getting-started.md\` | zero-to-review walkthrough — prerequisites, agent API keys, \`init\`, \`review\`, outcome capture, optional visual + federated, troubleshooting |
| \`docs/configuration.md\` | full \`.conclaverc.json\` schema reference + env var matrix for every agent / integration / visual platform / federated option |
| \`docs/federated-sync.md\` | privacy model, exact wire format, three off-switches, audit pointer into the four files that own the redaction + transport flow |

## Out of scope
- \`ARCHITECTURE.md\` left untouched — locked design doc, separate concern.
- No repo-visibility flip. That's a Level-3 decision for Bae.
- No code changes — pure docs; build + test state unaffected.

## Test plan
- [x] No code touched → build / test not re-run for this PR.
- [ ] Manual read-through to catch typos / broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)