### PR TITLE
feat(cli): cosmiconfig loader (decision #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- **Cosmiconfig loader (decision #16)** — `.conclaverc.json` still works; now accepts any of `.conclaverc[.json|.yaml|.yml|.js|.cjs|.mjs]`, `conclave.config.{js,cjs,mjs}`, and a top-level `conclave` field in `package.json`. Search strategy "global" walks from cwd to filesystem root (matches the original manual walker). searchPlaces reorders cosmiconfig's defaults so an explicit rc file wins over an incidental `conclave` field in package.json. Four new loader tests (YAML, package.json field, cjs, rc-vs-package.json precedence); `docs/configuration.md` gets a Config Discovery section with YAML / JS / package.json examples.
+
 ### Docs
 - **README rewrite + `docs/` directory** for public-launch readiness.
   README now reflects actual state (18 packages, 9 CLI commands, 29/34

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,7 +131,59 @@ Optional `AI_CONCLAVE_FEDERATION_TOKEN` env for bearer auth.
 
 ## Config discovery
 
-`loadConfig(cwd)` walks up from `cwd` looking for `.conclaverc.json`.
-When found, the file is Zod-validated against the schema above — any
-unknown field is rejected. When not found, `DEFAULT_CONFIG` is used
-silently.
+`loadConfig(cwd)` uses [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig)
+to walk up from `cwd` looking for (in order; first hit wins):
+
+1. `.conclaverc` (auto-detected JSON or YAML)
+2. `.conclaverc.json`
+3. `.conclaverc.yaml` / `.conclaverc.yml`
+4. `.conclaverc.js` / `.cjs` / `.mjs`
+5. `conclave.config.js` / `.cjs` / `.mjs`
+6. `package.json` with a top-level `"conclave"` field
+
+The ordering is deliberate: an explicit `.conclaverc.*` file wins over
+an incidental `conclave` field in `package.json`. Cosmiconfig's default
+puts `package.json` first; we override that so users can keep the rc
+file authoritative.
+
+The resolved config is Zod-validated against the schema above — any
+unknown field is rejected. When nothing is found, `DEFAULT_CONFIG` is
+used silently.
+
+### YAML example
+
+```yaml
+# .conclaverc.yaml
+version: 1
+agents:
+  - claude
+  - openai
+budget:
+  perPrUsd: 0.5
+council:
+  maxRounds: 3
+```
+
+### JS example (dynamic config)
+
+```js
+// conclave.config.js
+module.exports = {
+  version: 1,
+  agents: process.env.CI ? ["claude"] : ["claude", "openai", "gemini"],
+  budget: { perPrUsd: process.env.CI ? 0.2 : 1.0 },
+};
+```
+
+### package.json example
+
+```json
+{
+  "name": "my-app",
+  "version": "1.0.0",
+  "conclave": {
+    "version": 1,
+    "agents": ["claude"]
+  }
+}
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,14 +30,15 @@
     "@ai-conclave/integration-email": "workspace:*",
     "@ai-conclave/integration-slack": "workspace:*",
     "@ai-conclave/integration-telegram": "workspace:*",
+    "@ai-conclave/observability-langfuse": "workspace:*",
     "@ai-conclave/platform-cloudflare": "workspace:*",
     "@ai-conclave/platform-deployment-status": "workspace:*",
     "@ai-conclave/platform-netlify": "workspace:*",
     "@ai-conclave/platform-railway": "workspace:*",
     "@ai-conclave/platform-vercel": "workspace:*",
-    "@ai-conclave/visual-review": "workspace:*",
-    "@ai-conclave/observability-langfuse": "workspace:*",
     "@ai-conclave/scm-github": "workspace:*",
+    "@ai-conclave/visual-review": "workspace:*",
+    "cosmiconfig": "^9.0.1",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,7 +1,8 @@
-import { promises as fs } from "node:fs";
 import path from "node:path";
+import { cosmiconfig } from "cosmiconfig";
 import { z } from "zod";
 
+/** Canonical config file that `conclave init` writes. cosmiconfig also accepts .json / .yaml / .yml / .js / .cjs / .mjs and `conclave` fields in package.json. */
 export const CONFIG_FILENAME = ".conclaverc.json";
 
 export const ConclaveConfigSchema = z.object({
@@ -119,31 +120,63 @@ export const DEFAULT_CONFIG: ConclaveConfig = {
 };
 
 /**
- * Loads .conclaverc.json from `cwd` or any ancestor directory. Returns the
- * merged+validated config + the directory the config was found in (or
- * `cwd` if none found). Missing config → DEFAULT_CONFIG with cwd root.
+ * Cosmiconfig-powered config loader. Searches from `cwd` up to the
+ * filesystem root for any of (first hit wins):
+ *
+ *   - `package.json` with a top-level `conclave` field
+ *   - `.conclaverc` (no extension; auto-detected as JSON or YAML)
+ *   - `.conclaverc.json`
+ *   - `.conclaverc.yaml` / `.conclaverc.yml`
+ *   - `.conclaverc.js` / `.cjs` / `.mjs`
+ *   - `conclave.config.js` / `.cjs` / `.mjs`
+ *
+ * The raw config is validated against `ConclaveConfigSchema`; unknown
+ * fields raise a Zod error. Missing config returns `DEFAULT_CONFIG`
+ * with `configDir = cwd`.
  */
 export async function loadConfig(cwd: string = process.cwd()): Promise<{
   config: ConclaveConfig;
   configDir: string;
   found: boolean;
+  configPath?: string;
 }> {
-  let dir = path.resolve(cwd);
-  while (true) {
-    const candidate = path.join(dir, CONFIG_FILENAME);
-    try {
-      const raw = await fs.readFile(candidate, "utf8");
-      const parsed = ConclaveConfigSchema.parse(JSON.parse(raw));
-      return { config: parsed, configDir: dir, found: true };
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== "ENOENT") throw err;
-    }
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
+  // searchStrategy "global" walks up to the filesystem root (matches the
+  // original manual walker). "project" would stop at the nearest
+  // package.json, which would miss configs placed at the workspace root
+  // above a package's own package.json.
+  //
+  // searchPlaces reorders cosmiconfig's defaults so an explicit
+  // `.conclaverc.*` wins over an incidental `conclave` field in
+  // package.json. Cosmiconfig's default puts package.json first; our
+  // users expect "if I wrote a config file, it's authoritative."
+  const explorer = cosmiconfig("conclave", {
+    searchStrategy: "global",
+    stopDir: path.parse(path.resolve(cwd)).root,
+    searchPlaces: [
+      ".conclaverc",
+      ".conclaverc.json",
+      ".conclaverc.yaml",
+      ".conclaverc.yml",
+      ".conclaverc.js",
+      ".conclaverc.cjs",
+      ".conclaverc.mjs",
+      "conclave.config.js",
+      "conclave.config.cjs",
+      "conclave.config.mjs",
+      "package.json",
+    ],
+  });
+  const result = await explorer.search(path.resolve(cwd));
+  if (!result || result.isEmpty) {
+    return { config: DEFAULT_CONFIG, configDir: cwd, found: false };
   }
-  return { config: DEFAULT_CONFIG, configDir: cwd, found: false };
+  const parsed = ConclaveConfigSchema.parse(result.config);
+  return {
+    config: parsed,
+    configDir: path.dirname(result.filepath),
+    found: true,
+    configPath: result.filepath,
+  };
 }
 
 export function resolveMemoryRoot(config: ConclaveConfig, configDir: string): string {

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -98,3 +98,77 @@ test("resolveMemoryRoot: absolute path passes through", () => {
   const root = resolveMemoryRoot({ ...DEFAULT_CONFIG, memory: { ...DEFAULT_CONFIG.memory, root: abs } }, "/other/dir");
   assert.equal(root, abs);
 });
+
+test("loadConfig: reads .conclaverc.yaml (cosmiconfig YAML support)", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aic-cli-cfg-"));
+  try {
+    fs.writeFileSync(
+      path.join(dir, ".conclaverc.yaml"),
+      "version: 1\nagents:\n  - claude\nbudget:\n  perPrUsd: 0.75\n",
+    );
+    const { config, found, configPath } = await loadConfig(dir);
+    assert.equal(found, true);
+    assert.equal(config.budget.perPrUsd, 0.75);
+    assert.ok(configPath.endsWith(".conclaverc.yaml"));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig: reads `conclave` field in package.json", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aic-cli-cfg-"));
+  try {
+    fs.writeFileSync(
+      path.join(dir, "package.json"),
+      JSON.stringify({
+        name: "some-project",
+        version: "1.0.0",
+        conclave: { version: 1, agents: ["openai"], budget: { perPrUsd: 1.5 } },
+      }),
+    );
+    const { config, found } = await loadConfig(dir);
+    assert.equal(found, true);
+    assert.deepEqual(config.agents, ["openai"]);
+    assert.equal(config.budget.perPrUsd, 1.5);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig: reads .conclaverc.cjs module", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aic-cli-cfg-"));
+  try {
+    fs.writeFileSync(
+      path.join(dir, ".conclaverc.cjs"),
+      "module.exports = { version: 1, agents: ['gemini'] };\n",
+    );
+    const { config, found } = await loadConfig(dir);
+    assert.equal(found, true);
+    assert.deepEqual(config.agents, ["gemini"]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig: .conclaverc.json wins over package.json when both present (cosmiconfig default order)", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aic-cli-cfg-"));
+  try {
+    fs.writeFileSync(
+      path.join(dir, "package.json"),
+      JSON.stringify({
+        name: "x",
+        version: "1.0.0",
+        conclave: { version: 1, budget: { perPrUsd: 99 } },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(dir, CONFIG_FILENAME),
+      JSON.stringify({ version: 1, budget: { perPrUsd: 0.1 } }),
+    );
+    const { config, configPath } = await loadConfig(dir);
+    assert.equal(config.budget.perPrUsd, 0.1);
+    assert.ok(configPath.endsWith(CONFIG_FILENAME));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@ai-conclave/visual-review':
         specifier: workspace:*
         version: link:../visual-review
+      cosmiconfig:
+        specifier: ^9.0.1
+        version: 9.0.1(typescript@5.9.3)
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -274,6 +277,14 @@ packages:
       zod:
         optional: true
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
@@ -336,6 +347,9 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -352,9 +366,22 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -375,6 +402,13 @@ packages:
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -469,12 +503,29 @@ packages:
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
@@ -493,6 +544,9 @@ packages:
   langfuse@3.38.20:
     resolution: {integrity: sha512-MAmBAASSzJtmK1O9HQegA1mFsQhT8Yf+OJRGvE7FXkyv3g/eiBE0glLD0Ohg3pkxhoPdggM5SejK7ue9ctlaMA==}
     engines: {node: '>=18'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -539,6 +593,17 @@ packages:
       zod:
         optional: true
 
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   pixelmatch@6.0.0:
     resolution: {integrity: sha512-FYpL4XiIWakTnIqLqvt3uN4L9B3TsuHIvhLILzTiJZMJUsGvmKNeL4H3b6I99LRyerK9W4IuOXw+N28AtRgK2g==}
     hasBin: true
@@ -556,6 +621,10 @@ packages:
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -623,6 +692,14 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
   '@babel/runtime@7.29.2': {}
 
   '@google/genai@0.10.0':
@@ -682,6 +759,8 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
+  argparse@2.0.1: {}
+
   asynckit@0.4.0: {}
 
   base64-js@1.5.1: {}
@@ -695,9 +774,20 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  callsites@3.1.0: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   debug@4.4.3:
     dependencies:
@@ -714,6 +804,12 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-define-property@1.0.1: {}
 
@@ -837,11 +933,26 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  is-arrayish@0.2.1: {}
+
   is-stream@2.0.1: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
+
+  json-parse-even-better-errors@2.3.1: {}
 
   json-schema-to-ts@3.1.1:
     dependencies:
@@ -866,6 +977,8 @@ snapshots:
   langfuse@3.38.20:
     dependencies:
       langfuse-core: 3.38.20
+
+  lines-and-columns@1.2.4: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -900,6 +1013,19 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  picocolors@1.1.1: {}
+
   pixelmatch@6.0.0:
     dependencies:
       pngjs: 7.0.0
@@ -913,6 +1039,8 @@ snapshots:
       fsevents: 2.3.2
 
   pngjs@7.0.0: {}
+
+  resolve-from@4.0.0: {}
 
   safe-buffer@5.2.1: {}
 


### PR DESCRIPTION
## Summary
- Replace the manual config walker in `loadConfig()` with [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig). `.conclaverc.json` still works; users can now also use `.yaml`, `.yml`, `.js`, `.cjs`, `.mjs`, `conclave.config.{js,cjs,mjs}`, or a top-level `conclave` field in `package.json`.
- Two intentional deviations from cosmiconfig defaults:
  - `searchStrategy: "global"` — walk to the filesystem root like the original loader (default "project" would stop at the nearest `package.json`, missing workspace-root configs).
  - `searchPlaces` reordered so explicit rc files win over an incidental `conclave` field in `package.json`. Cosmiconfig default is reversed; users expect their written file to be authoritative.

## Test plan
- [x] `pnpm build` — 17/17 packages
- [x] `pnpm test` — 33/33 tasks, 0 failures
  - CLI: 42 → 46 tests (+4: YAML, package.json field, .cjs, rc-vs-package.json precedence)
- [x] Existing behavior preserved — all legacy tests (.conclaverc.json read, walk-up, malformed JSON throws, schema-invalid throws) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)