### PR TITLE
feat(core,cli): retrieval-side merge of federated baselines (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## Unreleased
 
 ### Added
+- **Retrieval-side merge of federated baselines (decision #21)** — closes the gap the sync skeleton left. `conclave sync` now persists pulled baselines to `.conclave/federated/baselines.jsonl` (JSONL, deduped by `contentHash`); `conclave review` reads that cache when `federated.enabled = true` and boosts retrieval proportionally.
+  - `computeBaselineHash` / `hashAnswerKey` / `hashFailure` exported from `core/federated` so retrieval-time code can recompute the hash a local doc would produce.
+  - `buildFrequencyMap(baselines)` aggregates by `contentHash`; `rerankByFrequency(scored, map, hashDoc, { boost, saturationAt })` applies a logarithmic boost — `factor = 1 + min(1, log2(1+freq) / log2(1+saturationAt)) * (boost - 1)`. Default `boost = 2.0`, `saturationAt = 256`. Docs with zero matches keep their score.
+  - `FileSystemFederatedBaselineStore` — JSONL on disk, `read` / `write` / `append` (dedupe by hash) / `clear`. Malformed lines are skipped silently to survive partial writes.
+  - `MemoryReadQuery` gains optional `federatedFrequency?: ReadonlyMap<string, number>`; `FileSystemMemoryStore.retrieve` reranks answer-keys + failures when it's set. No-op when absent — legacy callers unaffected.
+  - `conclave sync` output adds a `cached: N` field (baselines written to local cache).
+  - 21 new core tests (9 frequency + 8 baseline-store + 4 fs-store rerank). Full suite: 33/33 tasks, core 159 → 180.
+
 - **Cosmiconfig loader (decision #16)** — `.conclaverc.json` still works; now accepts any of `.conclaverc[.json|.yaml|.yml|.js|.cjs|.mjs]`, `conclave.config.{js,cjs,mjs}`, and a top-level `conclave` field in `package.json`. Search strategy "global" walks from cwd to filesystem root (matches the original manual walker). searchPlaces reorders cosmiconfig's defaults so an explicit rc file wins over an incidental `conclave` field in package.json. Four new loader tests (YAML, package.json field, cjs, rc-vs-package.json precedence); `docs/configuration.md` gets a Config Discovery section with YAML / JS / package.json examples.
 
 ### Docs

--- a/docs/federated-sync.md
+++ b/docs/federated-sync.md
@@ -149,16 +149,27 @@ conclave sync --since 2026-04-19T00:00:00Z
 
 ## What the pulled baselines are FOR
 
-Today: diagnostic — `conclave sync` returns them in the CLI output but
-the review path does not merge them yet. This is deliberate; retrieval
-merge lands after a live federation endpoint exists and the tag
-vocabulary is validated in practice.
+`conclave sync` persists pulled baselines to
+`.conclave/federated/baselines.jsonl` (JSONL, deduped by `contentHash`).
+`conclave review` reads that cache when `federated.enabled = true` and
+boosts local retrieval by federated frequency.
 
-Future (retrieval merge): pulled baselines will boost local retrieval
-of answer-keys / failures that share tag-vector fingerprints with the
-federated frequency signal, so a pattern that's "seen 487 times across
-the fleet" outranks a pattern that's "seen 2 times in your local
-history" — weighted by how well the tag match holds up.
+Boost mechanics (`packages/core/src/federated/frequency.ts`):
+
+```
+factor = 1 + min(1, log2(1 + freq) / log2(1 + saturationAt)) * (boost - 1)
+```
+
+- Default `boost = 2.0`, `saturationAt = 256`.
+- Docs with zero federated matches keep their original score (factor = 1).
+- Logarithmic so "seen 10,000×" doesn't drown out "seen 100×" — it just
+  moves ahead.
+
+A local answer-key or failure that shares `(kind, domain, category,
+severity, normalized-tags)` with a federated baseline gets this boost.
+Hash parity is computed with `hashAnswerKey` / `hashFailure`, which
+use the same `computeBaselineHash` that redaction uses — guarantees
+the match semantics stay identical across the pipeline.
 
 ## Opting out
 

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -1,10 +1,13 @@
+import path from "node:path";
 import {
   BudgetTracker,
   Council,
   EfficiencyGate,
+  FileSystemFederatedBaselineStore,
   FileSystemMemoryStore,
   MetricsRecorder,
   OutcomeWriter,
+  buildFrequencyMap,
   formatAnswerKeyForPrompt,
   formatFailureForPrompt,
   type MetricsSink,
@@ -105,10 +108,23 @@ export async function review(argv: string[]): Promise<void> {
     return;
   }
 
-  // 2. Retrieve RAG context from memory
+  // 2. Retrieve RAG context from memory (+ federated frequency rerank if available)
   const store = new FileSystemMemoryStore({ root: memoryRoot });
   const queryText = `${loaded.repo} ${loaded.diff.slice(0, 4_000)}`;
-  const retrieval = await store.retrieve({ query: queryText, repo: loaded.repo, k: 8 });
+  let federatedFrequency: ReadonlyMap<string, number> | undefined;
+  if (config.federated?.enabled) {
+    const baselineStore = new FileSystemFederatedBaselineStore({
+      root: path.join(memoryRoot, "federated"),
+    });
+    const cached = await baselineStore.read();
+    if (cached.length > 0) federatedFrequency = buildFrequencyMap(cached);
+  }
+  const retrieval = await store.retrieve({
+    query: queryText,
+    repo: loaded.repo,
+    k: 8,
+    ...(federatedFrequency ? { federatedFrequency } : {}),
+  });
 
   // 3. Build the efficiency gate with config-driven budget + optional Langfuse sink
   const budget = new BudgetTracker({ perPrUsd: config.budget.perPrUsd });

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import {
+  FileSystemFederatedBaselineStore,
   FileSystemMemoryStore,
   HttpFederatedSyncTransport,
   NoopFederatedSyncTransport,
@@ -100,12 +102,24 @@ export async function sync(argv: string[]): Promise<void> {
     ...(args.since ? { since: args.since } : {}),
   });
 
+  // Persist pulled baselines so `conclave review` can boost retrieval
+  // by federated frequency (decision #21 — retrieval merge).
+  let cachedCount = 0;
+  if (!result.dryRun && result.pulled.length > 0) {
+    const baselineStore = new FileSystemFederatedBaselineStore({
+      root: path.join(memoryRoot, "federated"),
+    });
+    await baselineStore.append(result.pulled);
+    cachedCount = result.pulled.length;
+  }
+
   const summary = {
     transport: result.transportId,
     dryRun: result.dryRun,
     pushed: result.pushed.length,
     accepted: result.accepted,
     pulled: result.pulled.length,
+    cached: cachedCount,
     reason,
   };
 
@@ -116,7 +130,7 @@ export async function sync(argv: string[]): Promise<void> {
 
   if (reason) process.stderr.write(`conclave sync: ${reason}\n`);
   process.stdout.write(
-    `conclave sync: transport=${summary.transport} dryRun=${summary.dryRun} pushed=${summary.pushed} accepted=${summary.accepted} pulled=${summary.pulled}\n`,
+    `conclave sync: transport=${summary.transport} dryRun=${summary.dryRun} pushed=${summary.pushed} accepted=${summary.accepted} pulled=${summary.pulled} cached=${summary.cached}\n`,
   );
   if (args.dryRun && result.pushed.length > 0) {
     process.stdout.write("\nBaselines that would be uploaded:\n");

--- a/packages/core/src/federated/baseline-store.ts
+++ b/packages/core/src/federated/baseline-store.ts
@@ -1,0 +1,81 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { FederatedBaselineSchema, type FederatedBaseline } from "./schema.js";
+
+/**
+ * Cache for pulled federated baselines. The review path reads from this
+ * between sync runs; `conclave sync` writes fresh baselines here.
+ *
+ * JSONL format on disk — one FederatedBaseline per line — so append + read
+ * are O(1) / O(n) without needing a DB. Lines that fail schema validation
+ * are skipped (not thrown) to survive partial writes.
+ */
+export interface FederatedBaselineStore {
+  read(): Promise<FederatedBaseline[]>;
+  /** Replace the entire store contents atomically. */
+  write(baselines: readonly FederatedBaseline[]): Promise<void>;
+  /** Append new baselines (dedupes by contentHash — last write wins). */
+  append(baselines: readonly FederatedBaseline[]): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export interface FileSystemBaselineStoreOptions {
+  /** Repo-relative directory that owns the cache file. Default `.conclave/federated`. */
+  root: string;
+  /** File name inside `root`. Default `baselines.jsonl`. */
+  filename?: string;
+}
+
+export class FileSystemFederatedBaselineStore implements FederatedBaselineStore {
+  private readonly filePath: string;
+
+  constructor(opts: FileSystemBaselineStoreOptions) {
+    this.filePath = path.join(opts.root, opts.filename ?? "baselines.jsonl");
+  }
+
+  async read(): Promise<FederatedBaseline[]> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.filePath, "utf8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") return [];
+      throw err;
+    }
+    const out: FederatedBaseline[] = [];
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        out.push(FederatedBaselineSchema.parse(JSON.parse(trimmed)));
+      } catch {
+        // Partial writes or old-schema rows — skip silently.
+      }
+    }
+    return out;
+  }
+
+  async write(baselines: readonly FederatedBaseline[]): Promise<void> {
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+    const body = baselines.map((b) => JSON.stringify(b)).join("\n") + (baselines.length > 0 ? "\n" : "");
+    await fs.writeFile(this.filePath, body, "utf8");
+  }
+
+  async append(baselines: readonly FederatedBaseline[]): Promise<void> {
+    if (baselines.length === 0) return;
+    const existing = await this.read();
+    const merged = new Map<string, FederatedBaseline>();
+    for (const b of existing) merged.set(b.contentHash, b);
+    for (const b of baselines) merged.set(b.contentHash, b);
+    await this.write(Array.from(merged.values()));
+  }
+
+  async clear(): Promise<void> {
+    try {
+      await fs.unlink(this.filePath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") throw err;
+    }
+  }
+}

--- a/packages/core/src/federated/frequency.ts
+++ b/packages/core/src/federated/frequency.ts
@@ -1,0 +1,55 @@
+import type { FederatedBaseline } from "./schema.js";
+
+/**
+ * Aggregate a list of federated baselines by `contentHash` to a frequency map.
+ *
+ * The map is what retrieval-time rerank consumes: "this hash was seen N
+ * times across the fleet" becomes a boost signal for local docs whose
+ * (kind, domain, category, severity, normalized-tags) hash matches.
+ *
+ * Pure; safe to call inside the review path without I/O side effects.
+ */
+export function buildFrequencyMap(
+  baselines: readonly FederatedBaseline[],
+): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const b of baselines) {
+    m.set(b.contentHash, (m.get(b.contentHash) ?? 0) + 1);
+  }
+  return m;
+}
+
+export interface RerankedDoc<T> {
+  doc: T;
+  score: number;
+  federatedFrequency: number;
+}
+
+/**
+ * Post-hoc rerank — multiply each scored doc's score by
+ * `1 + log2(1 + freq) / log2(1 + saturationAt) * (boost - 1)`, clamped so
+ * the multiplicative factor is bounded in `[1, boost]`. Logarithmic so a
+ * pattern seen 10,000 times doesn't drown out everything else — just
+ * moves ahead of patterns seen 100 times.
+ *
+ * Docs with zero federated matches keep their original score (factor = 1).
+ */
+export function rerankByFrequency<T>(
+  scored: ReadonlyArray<{ doc: T; score: number }>,
+  frequencyMap: ReadonlyMap<string, number>,
+  hashDoc: (doc: T) => string,
+  opts: { boost?: number; saturationAt?: number } = {},
+): RerankedDoc<T>[] {
+  const boost = opts.boost ?? 2.0;
+  const saturationAt = opts.saturationAt ?? 256;
+  const denom = Math.log2(1 + saturationAt);
+  const out: RerankedDoc<T>[] = scored.map((s) => {
+    const hash = hashDoc(s.doc);
+    const freq = frequencyMap.get(hash) ?? 0;
+    const norm = Math.min(1, Math.log2(1 + freq) / denom);
+    const factor = 1 + norm * (boost - 1);
+    return { doc: s.doc, score: s.score * factor, federatedFrequency: freq };
+  });
+  out.sort((a, b) => b.score - a.score);
+  return out;
+}

--- a/packages/core/src/federated/index.ts
+++ b/packages/core/src/federated/index.ts
@@ -1,6 +1,23 @@
 export { FederatedBaselineSchema, FederatedBaselineKindSchema } from "./schema.js";
 export type { FederatedBaseline, FederatedBaselineKind } from "./schema.js";
-export { redactAnswerKey, redactFailure, redactAll, normalizeTags } from "./redact.js";
+export {
+  redactAnswerKey,
+  redactFailure,
+  redactAll,
+  normalizeTags,
+  computeBaselineHash,
+  hashAnswerKey,
+  hashFailure,
+} from "./redact.js";
+export { buildFrequencyMap, rerankByFrequency } from "./frequency.js";
+export type { RerankedDoc } from "./frequency.js";
+export {
+  FileSystemFederatedBaselineStore,
+} from "./baseline-store.js";
+export type {
+  FederatedBaselineStore,
+  FileSystemBaselineStoreOptions,
+} from "./baseline-store.js";
 export {
   HttpFederatedSyncTransport,
   NoopFederatedSyncTransport,

--- a/packages/core/src/federated/redact.ts
+++ b/packages/core/src/federated/redact.ts
@@ -2,6 +2,30 @@ import { createHash } from "node:crypto";
 import type { AnswerKey, FailureEntry } from "../memory/schema.js";
 import type { FederatedBaseline, FederatedBaselineKind } from "./schema.js";
 
+/** Exported so retrieval-time code can re-compute the hash for a local doc
+ *  and look it up in a federated frequency map. Private `baselineHash`
+ *  below is the real implementation; this is the stable public wrapper. */
+export function computeBaselineHash(
+  kind: FederatedBaselineKind,
+  domain: string,
+  category: string | undefined,
+  severity: string | undefined,
+  tags: readonly string[],
+): string {
+  return baselineHash(kind, domain, category, severity, normalizeTags(tags));
+}
+
+/** Compute the same hash we'd ship for an AnswerKey — used when reranking
+ *  local retrieval results by federated frequency. */
+export function hashAnswerKey(key: AnswerKey): string {
+  return computeBaselineHash("answer-key", key.domain, undefined, undefined, key.tags);
+}
+
+/** Compute the same hash we'd ship for a FailureEntry. */
+export function hashFailure(entry: FailureEntry): string {
+  return computeBaselineHash("failure", entry.domain, entry.category, entry.severity, entry.tags);
+}
+
 /**
  * normalizeTags — deterministic tag vocabulary.
  * Same tag set across users must produce the same output so downstream

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,17 +60,26 @@ export {
   redactFailure,
   redactAll,
   normalizeTags,
+  computeBaselineHash,
+  hashAnswerKey,
+  hashFailure,
+  buildFrequencyMap,
+  rerankByFrequency,
   HttpFederatedSyncTransport,
   NoopFederatedSyncTransport,
   runFederatedSync,
+  FileSystemFederatedBaselineStore,
 } from "./federated/index.js";
 export type {
   FederatedBaseline,
   FederatedBaselineKind,
   FederatedSyncTransport,
   HttpTransportOptions,
+  RerankedDoc,
   RunSyncInput,
   RunSyncResult,
+  FederatedBaselineStore,
+  FileSystemBaselineStoreOptions,
 } from "./federated/index.js";
 
 // Efficiency Gate (decision #22: first-class from day 1) — every LLM call

--- a/packages/core/src/memory/fs-store.ts
+++ b/packages/core/src/memory/fs-store.ts
@@ -12,6 +12,8 @@ import {
 } from "./schema.js";
 import type { MemoryReadQuery, MemoryRetrieval, MemoryStore } from "./store.js";
 import { retrieve } from "./retrieval.js";
+import { hashAnswerKey, hashFailure } from "../federated/redact.js";
+import { rerankByFrequency } from "../federated/frequency.js";
 
 export interface FsStoreOptions {
   root: string;
@@ -42,7 +44,7 @@ export class FileSystemMemoryStore implements MemoryStore {
     const failureCorpus = await this.listFailures(q.domain);
     const ruleCorpus = await this.listRules();
 
-    const answerKeys = retrieve(
+    const answerKeyScored = retrieve(
       answerKeyCorpus,
       q.query,
       {
@@ -52,9 +54,9 @@ export class FileSystemMemoryStore implements MemoryStore {
       },
       k,
       { queryRepo: q.repo },
-    ).map((s) => s.doc);
+    );
 
-    const failures = retrieve(
+    const failureScored = retrieve(
       failureCorpus,
       q.query,
       {
@@ -62,7 +64,15 @@ export class FileSystemMemoryStore implements MemoryStore {
         tags: (d) => [d.category, ...d.tags],
       },
       k,
-    ).map((s) => s.doc);
+    );
+
+    const answerKeys = q.federatedFrequency
+      ? rerankByFrequency(answerKeyScored, q.federatedFrequency, hashAnswerKey).map((s) => s.doc)
+      : answerKeyScored.map((s) => s.doc);
+
+    const failures = q.federatedFrequency
+      ? rerankByFrequency(failureScored, q.federatedFrequency, hashFailure).map((s) => s.doc)
+      : failureScored.map((s) => s.doc);
 
     const rules = retrieve(
       ruleCorpus,

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -9,6 +9,13 @@ export interface MemoryReadQuery {
   k?: number;
   /** Repo scope — prefer entries tagged for this repo; falls back to global. */
   repo?: string;
+  /**
+   * Optional federated-frequency map (`contentHash → count`). When set,
+   * retrieval output is re-ranked so local docs whose (kind, domain,
+   * category, severity, normalized-tags) hash matches a federated
+   * baseline get a logarithmic frequency boost. Decision #21.
+   */
+  federatedFrequency?: ReadonlyMap<string, number>;
 }
 
 export interface MemoryRetrieval {

--- a/packages/core/test/federated-baseline-store.test.mjs
+++ b/packages/core/test/federated-baseline-store.test.mjs
@@ -1,0 +1,146 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FileSystemFederatedBaselineStore } from "../dist/index.js";
+
+function fresh() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "aic-fbs-"));
+}
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function baseline(hash, kind = "failure") {
+  return {
+    version: 1,
+    kind,
+    contentHash: hash,
+    domain: "code",
+    ...(kind === "failure" ? { category: "security", severity: "blocker" } : {}),
+    tags: ["auth"],
+    dayBucket: "2026-04-19",
+  };
+}
+
+test("FSBaselineStore: read() on missing file returns []", async () => {
+  const dir = fresh();
+  try {
+    const store = new FileSystemFederatedBaselineStore({ root: dir });
+    const out = await store.read();
+    assert.deepEqual(out, []);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("FSBaselineStore: write + read round-trip", async () => {
+  const dir = fresh();
+  try {
+    const store = new FileSystemFederatedBaselineStore({ root: dir });
+    const a = baseline("a".repeat(64));
+    const b = baseline("b".repeat(64), "answer-key");
+    await store.write([a, b]);
+    const out = await store.read();
+    assert.equal(out.length, 2);
+    assert.equal(out[0].contentHash, a.contentHash);
+    assert.equal(out[1].contentHash, b.contentHash);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("FSBaselineStore: append dedupes by contentHash (last write wins)", async () => {
+  const dir = fresh();
+  try {
+    const store = new FileSystemFederatedBaselineStore({ root: dir });
+    await store.write([baseline("a".repeat(64))]);
+    await store.append([baseline("a".repeat(64)), baseline("b".repeat(64))]);
+    const out = await store.read();
+    assert.equal(out.length, 2);
+    const hashes = out.map((b) => b.contentHash).sort();
+    assert.deepEqual(hashes, ["a".repeat(64), "b".repeat(64)]);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("FSBaselineStore: append with no existing file creates it", async () => {
+  const dir = fresh();
+  try {
+    const nested = path.join(dir, "deep", "nested");
+    const store = new FileSystemFederatedBaselineStore({ root: nested });
+    await store.append([baseline("a".repeat(64))]);
+    const out = await store.read();
+    assert.equal(out.length, 1);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("FSBaselineStore: malformed lines are skipped silently", async () => {
+  const dir = fresh();
+  try {
+    const filePath = path.join(dir, "baselines.jsonl");
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify(baseline("a".repeat(64))) +
+        "\n" +
+        "not json\n" +
+        JSON.stringify({ version: 999, contentHash: "x" }) +
+        "\n" +
+        JSON.stringify(baseline("c".repeat(64))) +
+        "\n",
+    );
+    const store = new FileSystemFederatedBaselineStore({ root: dir });
+    const out = await store.read();
+    assert.equal(out.length, 2);
+    assert.equal(out[0].contentHash, "a".repeat(64));
+    assert.equal(out[1].contentHash, "c".repeat(64));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("FSBaselineStore: clear() removes the file; subsequent read returns []", async () => {
+  const dir = fresh();
+  try {
+    const store = new FileSystemFederatedBaselineStore({ root: dir });
+    await store.write([baseline("a".repeat(64))]);
+    await store.clear();
+    assert.deepEqual(await store.read(), []);
+    // Idempotent clear
+    await store.clear();
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("FSBaselineStore: respects custom filename", async () => {
+  const dir = fresh();
+  try {
+    const store = new FileSystemFederatedBaselineStore({
+      root: dir,
+      filename: "custom.jsonl",
+    });
+    await store.write([baseline("a".repeat(64))]);
+    assert.ok(fs.existsSync(path.join(dir, "custom.jsonl")));
+    assert.ok(!fs.existsSync(path.join(dir, "baselines.jsonl")));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("FSBaselineStore: empty write clears file contents", async () => {
+  const dir = fresh();
+  try {
+    const store = new FileSystemFederatedBaselineStore({ root: dir });
+    await store.write([baseline("a".repeat(64))]);
+    await store.write([]);
+    const out = await store.read();
+    assert.deepEqual(out, []);
+  } finally {
+    cleanup(dir);
+  }
+});

--- a/packages/core/test/federated-frequency.test.mjs
+++ b/packages/core/test/federated-frequency.test.mjs
@@ -1,0 +1,134 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildFrequencyMap,
+  rerankByFrequency,
+  hashAnswerKey,
+  hashFailure,
+  computeBaselineHash,
+} from "../dist/index.js";
+
+function baseline(kind, domain, category, severity, tags) {
+  return {
+    version: 1,
+    kind,
+    contentHash: computeBaselineHash(kind, domain, category, severity, tags),
+    domain,
+    ...(category ? { category } : {}),
+    ...(severity ? { severity } : {}),
+    tags: [...tags].map((t) => t.toLowerCase()).sort(),
+    dayBucket: "2026-04-19",
+  };
+}
+
+test("buildFrequencyMap: empty list → empty map", () => {
+  assert.equal(buildFrequencyMap([]).size, 0);
+});
+
+test("buildFrequencyMap: counts repeats of the same contentHash", () => {
+  const b1 = baseline("failure", "code", "security", "blocker", ["auth"]);
+  const b2 = baseline("failure", "code", "security", "blocker", ["auth"]);
+  const b3 = baseline("failure", "code", "type-error", "major", ["types"]);
+  const m = buildFrequencyMap([b1, b2, b3]);
+  assert.equal(m.get(b1.contentHash), 2);
+  assert.equal(m.get(b3.contentHash), 1);
+});
+
+test("rerankByFrequency: zero-match docs keep their original order + score", () => {
+  const docs = [
+    { doc: { id: "x", tags: [], domain: "code" }, score: 1.0 },
+    { doc: { id: "y", tags: [], domain: "code" }, score: 0.5 },
+  ];
+  const out = rerankByFrequency(docs, new Map(), () => "no-match");
+  assert.equal(out[0].doc.id, "x");
+  assert.equal(out[0].score, 1.0);
+  assert.equal(out[0].federatedFrequency, 0);
+});
+
+test("rerankByFrequency: matched docs get a frequency-proportional boost", () => {
+  const docs = [
+    { doc: { id: "hit", bucket: "a" }, score: 1.0 },
+    { doc: { id: "miss", bucket: "b" }, score: 1.0 },
+  ];
+  const freqMap = new Map([
+    ["hash-a", 100],
+    ["hash-b", 0],
+  ]);
+  const hashDoc = (d) => `hash-${d.bucket}`;
+  const out = rerankByFrequency(docs, freqMap, hashDoc);
+  assert.equal(out[0].doc.id, "hit");
+  assert.ok(out[0].score > 1.0); // boosted
+  assert.equal(out[0].federatedFrequency, 100);
+  assert.equal(out[1].federatedFrequency, 0);
+});
+
+test("rerankByFrequency: boost factor is clamped between 1 and opts.boost", () => {
+  const docs = [{ doc: { id: "x", bucket: "a" }, score: 1.0 }];
+  const freqMap = new Map([["hash-a", 1_000_000]]);
+  const hashDoc = (d) => `hash-${d.bucket}`;
+  const out = rerankByFrequency(docs, freqMap, hashDoc, { boost: 2.0, saturationAt: 256 });
+  // Even at absurdly high frequency, factor saturates at boost
+  assert.ok(out[0].score <= 2.0 + 1e-9);
+});
+
+test("rerankByFrequency: logarithmic — 10× frequency does NOT mean 10× boost", () => {
+  const docs = [
+    { doc: { id: "low", bucket: "a" }, score: 1.0 },
+    { doc: { id: "high", bucket: "b" }, score: 1.0 },
+  ];
+  const freqMap = new Map([
+    ["hash-a", 10],
+    ["hash-b", 100],
+  ]);
+  const hashDoc = (d) => `hash-${d.bucket}`;
+  const out = rerankByFrequency(docs, freqMap, hashDoc);
+  const highScore = out.find((r) => r.doc.id === "high").score;
+  const lowScore = out.find((r) => r.doc.id === "low").score;
+  const ratio = highScore / lowScore;
+  // If it were linear, ratio would be ~10. Log scale means it's much less.
+  assert.ok(ratio < 3, `expected log-scaled ratio << 10, got ${ratio}`);
+});
+
+test("hashAnswerKey: stable across tag order + case", () => {
+  const a = {
+    id: "ak-1",
+    createdAt: "2026-04-19T00:00:00Z",
+    domain: "code",
+    pattern: "anything",
+    lesson: "x",
+    tags: ["Security", "auth"],
+  };
+  const b = { ...a, tags: ["AUTH", "security"] };
+  assert.equal(hashAnswerKey(a), hashAnswerKey(b));
+});
+
+test("hashFailure: different severity → different hash", () => {
+  const base = {
+    id: "fc-1",
+    createdAt: "2026-04-19T00:00:00Z",
+    domain: "code",
+    category: "security",
+    severity: "blocker",
+    title: "t",
+    body: "b",
+    tags: ["auth"],
+  };
+  const minor = { ...base, severity: "minor" };
+  assert.notEqual(hashFailure(base), hashFailure(minor));
+});
+
+test("computeBaselineHash: matches hashAnswerKey for equivalent inputs", () => {
+  const tags = ["auth", "jwt"];
+  const key = {
+    id: "ak-x",
+    createdAt: "2026-04-19T00:00:00Z",
+    domain: "code",
+    pattern: "p",
+    lesson: "l",
+    tags,
+  };
+  assert.equal(
+    hashAnswerKey(key),
+    computeBaselineHash("answer-key", "code", undefined, undefined, tags),
+  );
+});

--- a/packages/core/test/fs-store-federated-rerank.test.mjs
+++ b/packages/core/test/fs-store-federated-rerank.test.mjs
@@ -1,0 +1,133 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  FileSystemMemoryStore,
+  buildFrequencyMap,
+  hashAnswerKey,
+  hashFailure,
+} from "../dist/index.js";
+
+function fresh() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "aic-fs-rerank-"));
+}
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeJson(dir, subdir, id, payload) {
+  const target = path.join(dir, subdir);
+  fs.mkdirSync(target, { recursive: true });
+  fs.writeFileSync(path.join(target, `${id}.json`), JSON.stringify(payload));
+}
+
+function ak(id, tags, pattern = "by-pattern/x") {
+  return {
+    id,
+    createdAt: "2026-04-19T00:00:00.000Z",
+    domain: "code",
+    pattern,
+    lesson: `lesson for ${id} — matches query`,
+    tags,
+  };
+}
+
+function fc(id, tags, category = "security", severity = "blocker") {
+  return {
+    id,
+    createdAt: "2026-04-19T00:00:00.000Z",
+    domain: "code",
+    category,
+    severity,
+    title: `title ${id} — matches query`,
+    body: `body ${id}`,
+    tags,
+  };
+}
+
+test("retrieve: no federatedFrequency → legacy ordering preserved", async () => {
+  const dir = fresh();
+  try {
+    writeJson(dir, "answer-keys/code", "a1", ak("ak-1", ["auth"]));
+    writeJson(dir, "answer-keys/code", "a2", ak("ak-2", ["react"]));
+    writeJson(dir, "failure-catalog/code", "f1", fc("fc-1", ["auth"]));
+    const store = new FileSystemMemoryStore({ root: dir });
+    const out = await store.retrieve({ query: "matches query", k: 8 });
+    assert.equal(out.answerKeys.length, 2);
+    assert.equal(out.failures.length, 1);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("retrieve: federatedFrequency promotes matching-hash answer-key to the top", async () => {
+  const dir = fresh();
+  try {
+    // Both docs match the query text equally (same lesson phrasing)
+    const popular = ak("ak-popular", ["auth", "security"]);
+    const rare = ak("ak-rare", ["react"]);
+    writeJson(dir, "answer-keys/code", "ak-popular", popular);
+    writeJson(dir, "answer-keys/code", "ak-rare", rare);
+
+    const store = new FileSystemMemoryStore({ root: dir });
+
+    // Baseline that hashes the "auth + security" combination, seen 100 times
+    const popularHash = hashAnswerKey(popular);
+    const freqMap = new Map([[popularHash, 100]]);
+
+    const out = await store.retrieve({
+      query: "matches query lesson",
+      k: 8,
+      federatedFrequency: freqMap,
+    });
+    assert.equal(out.answerKeys[0].id, "ak-popular");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("retrieve: federatedFrequency boosts failure entries by hash match", async () => {
+  const dir = fresh();
+  try {
+    const popular = fc("fc-popular", ["auth"], "security", "blocker");
+    const rare = fc("fc-rare", ["react"], "accessibility", "minor");
+    writeJson(dir, "failure-catalog/code", "fc-popular", popular);
+    writeJson(dir, "failure-catalog/code", "fc-rare", rare);
+    const store = new FileSystemMemoryStore({ root: dir });
+    const popularHash = hashFailure(popular);
+    const freqMap = new Map([[popularHash, 250]]);
+    const out = await store.retrieve({
+      query: "title matches query body",
+      k: 8,
+      federatedFrequency: freqMap,
+    });
+    assert.equal(out.failures[0].id, "fc-popular");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("retrieve: buildFrequencyMap from baselines → plugs into retrieve directly", async () => {
+  const dir = fresh();
+  try {
+    const popular = ak("ak-pop", ["auth"]);
+    writeJson(dir, "answer-keys/code", "ak-pop", popular);
+    const store = new FileSystemMemoryStore({ root: dir });
+    const popularHash = hashAnswerKey(popular);
+    const baselines = [
+      { version: 1, kind: "answer-key", contentHash: popularHash, domain: "code", tags: ["auth"], dayBucket: "2026-04-19" },
+      { version: 1, kind: "answer-key", contentHash: popularHash, domain: "code", tags: ["auth"], dayBucket: "2026-04-19" },
+    ];
+    const freqMap = buildFrequencyMap(baselines);
+    const out = await store.retrieve({
+      query: "matches query",
+      k: 8,
+      federatedFrequency: freqMap,
+    });
+    assert.equal(out.answerKeys[0].id, "ak-pop");
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
## Summary
Closes the gap the sync skeleton left. Pulled baselines now persist to
`.conclave/federated/baselines.jsonl`; `conclave review` reads that cache
and boosts retrieval of local answer-keys / failures whose hash matches
a federated baseline, weighted by frequency.

## Boost mechanics
```
factor = 1 + min(1, log2(1+freq) / log2(1+saturationAt)) * (boost - 1)
```
- Default `boost = 2.0`, `saturationAt = 256`
- Docs with zero matches keep their original score (factor = 1)
- Log-scaled so "seen 10,000×" doesn't drown out "seen 100×" — just moves ahead

## Privacy
No change to what leaves the wire. This PR only changes what the client
does with what it already pulls. The redaction pipeline (`redactAnswerKey`
/ `redactFailure` / `FederatedBaselineSchema`) is untouched.

## Test plan
- [x] `pnpm build` — 17/17
- [x] `pnpm test` — 33/33 tasks, 0 failures. Core: 159 → 180 (+21).
  - 9 frequency (hash stability, log scaling, boost saturation)
  - 8 baseline-store (write/read/append/dedupe/clear/malformed-tolerance)
  - 4 fs-store rerank (no-op without freq, promotion with freq, both answer-key + failure paths, buildFrequencyMap integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)