### PR TITLE
chore: bump all packages to 0.1.0 and publish

### DIFF
--- a/packages/agent-claude/package.json
+++ b/packages/agent-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-claude",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI Claude agent — wraps @anthropic-ai/claude-agent-sdk.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-gemini/package.json
+++ b/packages/agent-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-gemini",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI Gemini agent — wraps @google/genai with responseSchema structured output. Long-context slot per decision #10.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-openai/package.json
+++ b/packages/agent-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-openai",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI OpenAI agent — wraps the OpenAI SDK with strict-JSON-schema structured output.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-discord/package.json
+++ b/packages/integration-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-discord",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI Discord notifier — posts review outcomes to a Discord channel via incoming webhook.",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-email/package.json
+++ b/packages/integration-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-email",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI email notifier — pluggable transport (Resend default; SMTP/SES/nodemailer drop-ins).",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-slack/package.json
+++ b/packages/integration-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-slack",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI Slack notifier — posts review outcomes to a Slack channel via incoming webhook.",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-telegram/package.json
+++ b/packages/integration-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-telegram",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI Telegram notifier — posts review outcomes to a Telegram chat via Bot API.",
   "license": "MIT",
   "type": "module",

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/observability-langfuse",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI observability sink — forwards efficiency-gate metrics to Langfuse (self-hosted per decision #13).",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-cloudflare",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI Cloudflare Pages adapter — resolve preview URL for a commit SHA via Cloudflare API.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-deployment-status/package.json
+++ b/packages/platform-deployment-status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-deployment-status",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI generic platform adapter — resolves preview URL via GitHub Deployments API, works with any host that reports back.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-netlify/package.json
+++ b/packages/platform-netlify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-netlify",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI Netlify adapter — resolve preview URL for a commit SHA via Netlify API.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-railway/package.json
+++ b/packages/platform-railway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-railway",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI Railway adapter — resolve preview URL for a commit SHA via Railway's GraphQL API.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-vercel/package.json
+++ b/packages/platform-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-vercel",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI Vercel adapter — resolve preview URL for a commit SHA via Vercel REST API.",
   "license": "MIT",
   "type": "module",

--- a/packages/scm-github/package.json
+++ b/packages/scm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/scm-github",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI SCM adapter for GitHub — resolve PR state for automatic outcome capture.",
   "license": "MIT",
   "type": "module",

--- a/packages/visual-review/package.json
+++ b/packages/visual-review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/visual-review",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Conclave AI visual review — Playwright screenshots + pixel diff for before/after design review.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
First public release. 18 packages @ \`0.1.0\` on npm under \`@conclave-ai\`:

- \`@conclave-ai/core\` (published separately earlier in the session)
- \`@conclave-ai/cli\` + 16 sibling packages (published via this branch)

## Install paths
\`\`\`bash
pnpm add -g @conclave-ai/cli              # global CLI (installs 'conclave' binary)
pnpm add @conclave-ai/core                # library consumers
\`\`\`

## Workspace resolution
pnpm's \`workspace:\` protocol resolver replaced all \`workspace:*\` refs with \`^0.1.0\` in the published tarballs. The monorepo workspace files still use \`workspace:*\` for local dev.

## Test plan
- [x] \`pnpm build\` — 17/17
- [x] \`pnpm test\` — 33/33 tasks
- [x] \`pnpm publish -r --access public --no-git-checks\` — 17 successful (core skipped as already-published)
- [x] Verified all 18 names resolve on \`https://registry.npmjs.org/@conclave-ai/*/latest\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)