### PR TITLE
chore: dogfood setup — .conclaverc.json + .conclave/ gitignore

### DIFF
--- a/.conclaverc.json
+++ b/.conclaverc.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "agents": [
+    "claude",
+    "openai",
+    "gemini"
+  ],
+  "budget": {
+    "perPrUsd": 1.0
+  },
+  "efficiency": {
+    "cacheEnabled": true,
+    "compactEnabled": true
+  },
+  "memory": {
+    "answerKeysDir": ".conclave/answer-keys",
+    "failureCatalogDir": ".conclave/failure-catalog"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ coverage/
 # Temp
 *.tmp
 tmp/
+
+# Conclave — dogfood the memory substrate but keep the noisy parts out
+# of git. Learned patterns (answer-keys + failure-catalog) ARE tracked
+# so clones inherit them; raw events + federated cache aren't.
+.conclave/episodic/
+.conclave/federated/
+.conclave/visual/


### PR DESCRIPTION
## Summary
Conclave AI reviews its own PRs from now on.

- \`.conclaverc.json\` at repo root — all three agents enabled, \$1.00 per-PR budget (headroom for 3 agents × 3 debate rounds). Missing keys are skipped silently.
- \`.gitignore\` split keeps noise out of git while letting learned patterns travel with clones:
  - committed: \`.conclave/answer-keys/**\` (정답지), \`.conclave/failure-catalog/**\` (오답지)
  - ignored: \`.conclave/episodic/**\` (raw events), \`.conclave/federated/**\` (cache), \`.conclave/visual/**\` (screenshots)

## Test plan
- [x] Works with \`conclave init\` output as the baseline
- [ ] First real review run — pending Bae wiring \`ANTHROPIC_API_KEY\` into a shell-readable location

🤖 Generated with [Claude Code](https://claude.com/claude-code)