### PR TITLE
fix(agents): raise default maxTokens 2,048 → 8,192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- **Agents' default `maxTokens` 2,048 → 8,192** across Claude, OpenAI, and Gemini. Surfaced during the first real `conclave review` run against PR #37 — OpenAI returned `finish_reason=length` because a medium-sized review prompt + structured JSON output + reasoning tokens exceeded the old cap. 2k was a fixture-friendly default that never tripped in unit tests (mocks don't emit real tokens). Budget reservation math still fits comfortably under the default `$1.00/PR` cap even at 8k × 3 agents × 3 rounds.
+
 ### Ops
 - **`.github/workflows/release.yml` — automated release pipeline.** Two triggers: (1) `workflow_dispatch` with a `patch | minor | major` bump input, runs build + test, bumps every `packages/*` version in lockstep, commits + tags + pushes, then publishes via `pnpm publish -r --access public` with npm provenance. (2) `push: tags: ["v*"]` — skips the bump step (tag is truth) and goes straight to publish. `docs/release-process.md` covers both paths, the one-time secrets setup (`NPM_TOKEN`), and the lockstep-versioning pre-1.0 policy.
 

--- a/packages/agent-claude/src/claude-agent.ts
+++ b/packages/agent-claude/src/claude-agent.ts
@@ -58,7 +58,7 @@ export interface ClaudeAgentOptions {
 }
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
-const DEFAULT_MAX_TOKENS = 2_048;
+const DEFAULT_MAX_TOKENS = 8_192;
 
 async function defaultClientFactory(apiKey: string): Promise<AnthropicLike> {
   // Dynamic import so tests that inject a client never pay the SDK load cost.

--- a/packages/agent-gemini/src/gemini-agent.ts
+++ b/packages/agent-gemini/src/gemini-agent.ts
@@ -54,7 +54,7 @@ export interface GeminiAgentOptions {
 }
 
 const DEFAULT_MODEL = "gemini-2.5-pro";
-const DEFAULT_MAX_TOKENS = 2_048;
+const DEFAULT_MAX_TOKENS = 8_192;
 
 async function defaultClientFactory(apiKey: string): Promise<GenAILike> {
   const mod = (await import("@google/genai")) as unknown as {

--- a/packages/agent-openai/src/openai-agent.ts
+++ b/packages/agent-openai/src/openai-agent.ts
@@ -58,7 +58,7 @@ export interface OpenAIAgentOptions {
 }
 
 const DEFAULT_MODEL = "gpt-5-mini";
-const DEFAULT_MAX_TOKENS = 2_048;
+const DEFAULT_MAX_TOKENS = 8_192;
 
 async function defaultClientFactory(apiKey: string): Promise<OpenAILike> {
   const mod = (await import("openai")) as unknown as {


### PR DESCRIPTION
First dogfood finding. `conclave review --pr 37` hit `finish_reason=length` on OpenAI. 2k was a fixture-friendly default that never tripped in unit tests. Real reviews need more headroom for reasoning + structured JSON.

Bumped uniformly across all three agents. Budget reservation math fits under the default $1.00/PR cap at 8k × 3 agents × 3 rounds.