### PR TITLE
fix(ci): release.yml safety hardening — dogfood feedback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ on:
     tags: ["v*"]
 
 concurrency:
+  # `cancel-in-progress: false` is deliberate. A running release has
+  # already started publishing npm tarballs; killing it mid-flight
+  # leaves the registry in a split state (some packages on the new
+  # version, some on the old). With `false`, the second trigger queues
+  # until the first finishes — the GitHub Actions concurrency group
+  # only keeps at most one pending run, so there is no race.
   group: release
   cancel-in-progress: false
 
@@ -52,21 +58,42 @@ jobs:
       - run: pnpm build
       - run: pnpm test
 
+      # workflow_dispatch must run on main — protects against accidentally
+      # pushing a feature branch into main via the release pipeline.
+      - name: Require main branch for manual runs
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' }}
+        run: |
+          echo "::error::release workflow_dispatch must run on 'main', got ${{ github.ref }}"
+          exit 1
+
       # Bump + commit + tag (workflow_dispatch path). No-op on tag-push path.
       - name: Bump versions + commit + tag
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           BUMP: ${{ inputs.bump }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           pnpm -r --filter "./packages/*" exec npm version "$BUMP" --no-git-tag-version
           ROOT_VERSION=$(node -p "require('./packages/core/package.json').version")
-          git add -A
-          git commit -m "chore(release): v$ROOT_VERSION"
-          git tag "v$ROOT_VERSION"
-          git push origin HEAD:main
-          git push origin "v$ROOT_VERSION"
+          # Idempotent: only commit when there are actual changes (covers
+          # pnpm no-op re-runs and manual-bump recoveries).
+          if git diff --cached --quiet && git diff --quiet; then
+            echo "No version changes staged. Nothing to commit."
+          else
+            git add -A
+            git commit -m "chore(release): v$ROOT_VERSION"
+            git push origin HEAD:main
+          fi
+          # Idempotent tag — don't fail if the tag already exists on a
+          # re-run of the same version.
+          if git rev-parse -q --verify "refs/tags/v$ROOT_VERSION" >/dev/null; then
+            echo "Tag v$ROOT_VERSION already exists; skipping create + push."
+          else
+            git tag "v$ROOT_VERSION"
+            git push origin "v$ROOT_VERSION"
+          fi
 
       - name: Publish to npm
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 
 ### Fixed
+- **`release.yml` safety hardening (dogfood feedback)** — OpenAI's review of PR #37 flagged five workflow correctness issues during the first real E2E run. Three land as real fixes, two are intentional and now documented:
+  - **Fixed:** bump+commit step now idempotent (skips when there are no staged changes, covers no-op re-runs).
+  - **Fixed:** tag creation idempotent (checks for existing `vX.Y.Z` ref before creating + pushing).
+  - **Fixed:** manual (`workflow_dispatch`) runs gated to `main` — fast-fail with actionable error when dispatched from a feature branch, prevents accidentally pushing a non-main branch into `main` via the release pipeline.
+  - **Kept as-is with rationale in code:** `cancel-in-progress: false` is deliberate. A running release is already publishing tarballs; cancelling mid-flight leaves the registry split. Concurrency group keeps at most one pending run, so there is no race.
+  - **Deferred:** workspace-level atomic versioning (vs per-package `npm version -r`) — `pnpm -r --filter` runs sequentially from a common starting version, so drift only occurs on mid-loop failure. Revisit when/if Changesets lands.
+
 - **Agents' default `maxTokens` 2,048 → 8,192** across Claude, OpenAI, and Gemini. Surfaced during the first real `conclave review` run against PR #37 — OpenAI returned `finish_reason=length` because a medium-sized review prompt + structured JSON output + reasoning tokens exceeded the old cap. 2k was a fixture-friendly default that never tripped in unit tests (mocks don't emit real tokens). Budget reservation math still fits comfortably under the default `$1.00/PR` cap even at 8k × 3 agents × 3 rounds.
 
 ### Ops

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -11,6 +11,10 @@ work — you almost never run `npm publish` locally.
 - Workflow permissions: `Settings → Actions → General → Workflow
   permissions` set to **Read and write** (needed for the commit + tag
   the workflow pushes back to `main`).
+- Manual (`workflow_dispatch`) runs are **gated to `main`**. The
+  workflow fails fast with an actionable error if dispatched from a
+  feature branch — guards against accidentally pushing that branch
+  into `main` via the release pipeline.
 
 ## Option A — Ship from the GitHub UI (recommended)
 


### PR DESCRIPTION
## Summary
First real dogfood-fed fix. \`conclave review --pr 37\` (OpenAI, 3 rounds) flagged five workflow correctness issues. Three land as real fixes, two intentional + now documented.

## Fixed
- **Idempotent commit** — skip when nothing staged (no-op re-runs)
- **Idempotent tag** — check existing \`vX.Y.Z\` before create + push
- **Main-branch gate** — \`workflow_dispatch\` from a feature branch fast-fails before any git push, preventing accidental branch-into-main pushes

## Kept as-is (rationale in code)
- \`cancel-in-progress: false\` — intentional. Killing a publish mid-flight splits the npm registry. Concurrency group already serializes, so no race.

## Deferred
- Workspace-level atomic version bump — \`pnpm -r --filter\` runs sequentially from a common start; drift only on mid-loop failure. Revisit with Changesets if/when.

## Meta: why this PR exists
This finding would never have surfaced from unit tests — it took a real council review of a real PR diff to catch. This is the use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)