### PR TITLE
feat: public-launch prep — install path + CONTRIBUTING + CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,24 @@ concurrency:
 
 jobs:
   typecheck-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
+
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-      # No `cache: pnpm` yet — lockfile lands after first successful install.
-      # Swap to `pnpm install --frozen-lockfile` + cache once pnpm-lock.yaml is committed.
-      - run: pnpm install
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
       - run: pnpm build
       - run: pnpm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Docs
+- **Public-launch prep.** README install path switched from "clone + build" to `pnpm add -g @conclave-ai/cli` now that packages are live on npm. Added npm version / scope / license / node badges. `docs/getting-started.md` updated the same way — every `node /path/to/conclave-ai/packages/cli/dist/bin/conclave.js ...` collapsed to plain `conclave ...`. New `CONTRIBUTING.md` at the repo root — setup, ground rules (architecture lock, one package per responsibility, Zod at boundaries, tests alongside code, lockstep versioning), PR flow, and release flow pointer.
+
+### Ops
+- **`ci.yml` hardening.** Switched to `pnpm install --frozen-lockfile` now that `pnpm-lock.yaml` is committed; added `cache: pnpm` to the Node setup action for faster installs; added Node 20 + 22 matrix so we catch breaks on newer runtimes before users do. No test or behavior change, just faster and stricter.
+
 ### Fixed
 - **`release.yml` safety hardening (dogfood feedback)** — OpenAI's review of PR #37 flagged five workflow correctness issues during the first real E2E run. Three land as real fixes, two are intentional and now documented:
   - **Fixed:** bump+commit step now idempotent (skips when there are no staged changes, covers no-op re-runs).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to Conclave AI
+
+Thanks for taking an interest. The repo is small and opinionated — a
+PR is easiest to accept when it matches the conventions here.
+
+## Local setup
+
+```bash
+git clone https://github.com/seunghunbae-3svs/conclave-ai
+cd conclave-ai
+pnpm install
+pnpm build
+pnpm test
+```
+
+Requires Node ≥ 20 and pnpm ≥ 9 (via `corepack prepare pnpm@10 --activate`).
+
+## Ground rules
+
+1. **`ARCHITECTURE.md` is locked.** The 34 decisions frozen on
+   2026-04-19 shouldn't be re-litigated casually. If a PR needs to
+   diverge from a decision, the PR description must name the decision
+   number and make the case. Current divergences + "what would trigger
+   revisit" live in [docs/decision-status.md](docs/decision-status.md).
+
+2. **One package, one responsibility.** New behavior goes in an
+   existing package when it extends that package's responsibility; in
+   a new package otherwise. No "utility" or "common" packages — those
+   become dumping grounds.
+
+3. **Zod schemas at external boundaries.** Anything that crosses a
+   wire (HTTP body, file format, CLI input) validates via Zod. Don't
+   trust `as` casts at the edge.
+
+4. **Tests alongside the code.** Every `packages/X/src/*` change
+   lands with a corresponding `packages/X/test/*.test.mjs` update.
+   Use `node --test` (no Jest / Vitest). Mock at the seam (e.g.,
+   inject `fetch`, `spawn`, LLM clients) so tests don't hit the
+   network.
+
+5. **Don't touch published package semantics without a version bump.**
+   Breaking changes wait for a `major` bump; additive changes get a
+   `minor`; bug fixes get a `patch`. Version bumps are lockstep
+   across all packages via the release workflow.
+
+## PR flow
+
+1. Branch from `main`. No direct pushes.
+2. Make the change + tests + changelog entry under `## Unreleased`.
+3. `pnpm build && pnpm test` locally.
+4. Open PR, wait for CI to go green.
+5. The council reviews its own PRs — `conclave review --pr <N>`
+   blockers are considered alongside human feedback.
+
+## Release flow
+
+See [docs/release-process.md](docs/release-process.md). Shipping from
+this repo goes through the `release.yml` GitHub Action — never run
+`npm publish` from a laptop.
+
+## Scope of this repo
+
+**In scope:** the 18 workspace packages, the docs under `docs/`, the
+CI workflows, the architecture + decisions files.
+
+**Out of scope:** a hosted service around Conclave AI (that would be
+a separate repo). A web dashboard for reviews (also separate). Plugins
+for IDEs other than via MCP (MCP is the integration story).
+
+## When in doubt
+
+Look at how similar packages are shaped (e.g., if you're adding a
+platform adapter, mirror `packages/platform-railway`). Consistency
+across the monorepo is the point of the monorepo.
+
+## License
+
+MIT — same as the project.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Conclave AI
 
+[![npm version](https://img.shields.io/npm/v/@conclave-ai/cli?label=%40conclave-ai%2Fcli&color=brightgreen)](https://www.npmjs.com/package/@conclave-ai/cli)
+[![npm scope](https://img.shields.io/badge/npm%20scope-%40conclave--ai-blue)](https://www.npmjs.com/org/conclave-ai)
+[![license](https://img.shields.io/github/license/seunghunbae-3svs/conclave-ai)](LICENSE)
+[![node](https://img.shields.io/node/v/@conclave-ai/cli)](https://nodejs.org)
+
 **AI drafted. Council refined.**
 
 A multi-agent council reviews your AI-generated code, debates blockers
@@ -7,9 +12,8 @@ across up to 3 rounds until it reaches consensus, and learns from every
 merge + rejection so future reviews match your repo's real tolerance for
 "blocker" vs "nit". Built for solo makers who ship with AI.
 
-> **Status**: v2.0 development. Architecture locked; 29/34 decisions
-> implemented across 28 PRs. Not yet published to npm — see `ARCHITECTURE.md`
-> for the full 7-layer design.
+> **Status**: v0.1 on npm. Architecture locked (see `ARCHITECTURE.md`);
+> dogfood-tested on this repo's own PRs.
 
 ## Who this is for
 
@@ -50,8 +54,8 @@ negative); here `정답지 ∥ 오답지` is the primitive — decision #17.
   4 notifiers (Telegram/Discord/Slack/Email) + 5 platform adapters
   (Vercel/Netlify/Cloudflare Pages/Railway/GitHub deployment_status) +
   SCM + observability + visual review + CLI.
-- **9 CLI commands** covering init → review → outcome capture →
-  seeding → migration → scoring → federated sync.
+- **10 CLI commands** covering init → review → outcome capture →
+  seeding → migration → scoring → federated sync → MCP server.
 - **Cost per PR**: ~$0.05-$0.20 at current pricing with caching + triage,
   capped by a per-PR budget that the efficiency gate enforces before any
   LLM call fires.
@@ -86,29 +90,23 @@ conclave seed [--from <path>]              # bootstrap failure-catalog
 conclave migrate [--from <solo-cto-agent>] # port a v1 install
 conclave scores [--json]                   # per-agent weighted performance
 conclave sync [--dry-run|--push-only|--pull-only]  # federated baseline (opt-in)
+conclave mcp-server                        # MCP stdio — Claude Desktop / Cursor / Windsurf
 ```
 
-## Quickstart (from source, pre-publish)
+## Quickstart
 
 ```bash
-git clone https://github.com/seunghunbae-3svs/conclave-ai
-cd conclave-ai
-pnpm install
-pnpm build
+pnpm add -g @conclave-ai/cli
 
-# Set at least one agent key:
+# At least one agent key (any combination works; missing ones skip cleanly):
 export ANTHROPIC_API_KEY=sk-ant-...
-# Optional additional agents:
-export OPENAI_API_KEY=...
+export OPENAI_API_KEY=sk-proj-...
 export GOOGLE_API_KEY=...
 
-# Drop into a repo you want to review:
 cd /path/to/your-repo
-node /path/to/conclave-ai/packages/cli/dist/bin/conclave.js init
-node /path/to/conclave-ai/packages/cli/dist/bin/conclave.js review --pr 42
+conclave init
+conclave review --pr 42
 ```
-
-Once published: `pnpm add -g @conclave-ai/cli`.
 
 Full walkthrough: [docs/getting-started.md](docs/getting-started.md).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,29 +1,30 @@
 # Getting started with Conclave AI
 
-Step-by-step from zero to a real council review. Pre-publish, so the
-path is "clone + link" rather than "npm install".
+Step-by-step from zero to a real council review.
 
 ## Prerequisites
 
 - Node ≥ 20 (24.x tested)
 - pnpm ≥ 9 (10.x tested; install via `corepack prepare pnpm@10 --activate`)
-- At least ONE LLM API key. The council needs a minimum of one agent
-  available to run; more agents = more useful debate.
+- At least ONE LLM API key. The council runs on whatever subset of
+  agents you have keys for; missing agents skip cleanly.
 
-## 1. Clone and build
+## 1. Install the CLI
 
 ```bash
-git clone https://github.com/seunghunbae-3svs/conclave-ai
-cd conclave-ai
-pnpm install
-pnpm build
-pnpm test   # optional, confirms everything works on your machine
+pnpm add -g @conclave-ai/cli
+# or: npm install -g @conclave-ai/cli
 ```
 
-## 2. Set agent API keys
+This installs the `conclave` binary. Verify:
 
-Every agent is skipped cleanly if its key is missing — the council runs
-on whatever subset you have keys for.
+```bash
+conclave --version
+```
+
+(Prefer building from source? See the [Contributing guide](../CONTRIBUTING.md).)
+
+## 2. Set agent API keys
 
 | Agent | Env var |
 |---|---|
@@ -34,17 +35,15 @@ on whatever subset you have keys for.
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
 # Optional:
-export OPENAI_API_KEY=sk-...
+export OPENAI_API_KEY=sk-proj-...
 export GOOGLE_API_KEY=...
 ```
 
 ## 3. Initialize the target repo
 
-The target is whatever repo you want to review. In a new shell:
-
 ```bash
 cd /path/to/your-repo
-node /path/to/conclave-ai/packages/cli/dist/bin/conclave.js init
+conclave init
 ```
 
 This writes `.conclaverc.json` at the repo root and creates
@@ -65,20 +64,20 @@ only the agents you set keys for:
 For a PR:
 
 ```bash
-node /path/to/conclave-ai/packages/cli/dist/bin/conclave.js review --pr 42
+conclave review --pr 42
 ```
 
 For the current branch against its base:
 
 ```bash
-node /path/to/conclave-ai/packages/cli/dist/bin/conclave.js review --base main
+conclave review --base main
 ```
 
 From a diff file:
 
 ```bash
 git diff main... > /tmp/change.diff
-node /path/to/conclave-ai/packages/cli/dist/bin/conclave.js review --diff /tmp/change.diff
+conclave review --diff /tmp/change.diff
 ```
 
 Exit codes:
@@ -91,7 +90,7 @@ Exit codes:
 Either automatic (recommended — cron the `poll-outcomes` command):
 
 ```bash
-node /path/to/conclave.js poll-outcomes --quiet
+conclave poll-outcomes --quiet
 ```
 
 This checks every pending episodic entry against live GitHub state
@@ -100,7 +99,7 @@ This checks every pending episodic entry against live GitHub state
 Or manual:
 
 ```bash
-node /path/to/conclave.js record-outcome --id ep-... --result merged
+conclave record-outcome --id ep-... --result merged
 ```
 
 Both paths write the distilled pattern into the memory substrate, where
@@ -112,15 +111,15 @@ If you want the council to inherit lessons from an existing
 solo-cto-agent installation:
 
 ```bash
-node /path/to/conclave.js migrate --from ../path/to/solo-cto-agent --dry-run
-node /path/to/conclave.js migrate --from ../path/to/solo-cto-agent
+conclave migrate --from ../path/to/solo-cto-agent --dry-run
+conclave migrate --from ../path/to/solo-cto-agent
 ```
 
 Or seed from the bundled default catalog (~15 failure patterns
 harvested from v1's incident log):
 
 ```bash
-node /path/to/conclave.js seed
+conclave seed
 ```
 
 ## 7. (Optional) Visual review for UI work
@@ -140,14 +139,14 @@ Set whichever platform env vars apply to your deploy target (see
 [configuration.md](configuration.md) for the full matrix). Then:
 
 ```bash
-node /path/to/conclave.js review --pr 42 --visual
+conclave review --pr 42 --visual
 ```
 
 ## 8. (Optional) Agent performance tracking
 
 ```bash
-node /path/to/conclave.js scores
-node /path/to/conclave.js scores --json | jq .
+conclave scores
+conclave scores --json | jq .
 ```
 
 After a few merges, each agent's rolling score shows who's carrying


### PR DESCRIPTION
## Summary
- README + getting-started switch to npm install path (\`pnpm add -g @conclave-ai/cli\`) + add npm / license / node badges
- New \`CONTRIBUTING.md\` — setup, architecture lock rules, Zod-at-boundaries rule, test/versioning conventions, PR + release flow pointers
- \`ci.yml\` hardened: \`--frozen-lockfile\`, pnpm cache, Node 20/22 matrix
- No package behavior change

## Out of scope
- Repo private → public flip (Level 3 — Bae action)
- Test coverage reporting (can add later via codecov)

## Test plan
- [x] \`pnpm test\` — 33/33 tasks
- [ ] First CI run with new matrix — verifies on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)