### PR TITLE
feat(agent-ollama): local inference agent (decision #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 ### Added
+- **`@conclave-ai/agent-ollama` — local inference agent (decision #32).** Routes reviews to a local Ollama daemon via its OpenAI-compatible endpoint at `http://localhost:11434/v1`. Zero API key (placeholder "ollama" string satisfies the SDK), zero wire cost (`actualCost` returns 0). Default model `llama3.3`, override via constructor or pick any model `ollama list` shows. `OLLAMA_BASE_URL` env var supports self-hosted / remote Ollama instances. CLI factory adds `"ollama"` with no credential gating — user is responsible for the daemon being up. 11 unit tests use a stub client (no network).
+
 - **`@conclave-ai/agent-deepseek` — first v2.1 agent (decision #32).** OpenAI-wire-compatible; reuses the `openai` SDK pointed at `https://api.deepseek.com`. Supports `deepseek-chat` (V3, general) and `deepseek-reasoner` (R1, chain-of-thought). Pricing ~20× cheaper than GPT-5 input (0.27/M vs 5.0/M) with a deep cache discount (0.07/M — ~26% of standard). Wired into the CLI factory alongside `"claude" / "openai" / "gemini"`; missing `DEEPSEEK_API_KEY` skips cleanly like the others. `docs/configuration.md` + Zod config enum both updated. 18 tests mirror the agent-openai suite (16 agent + 8 pricing).
 
 ### Docs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ rejects unknown versions.
 
 ### `agents`
 
-Array of `"claude"`, `"openai"`, `"gemini"`, `"deepseek"`. An agent is only
+Array of `"claude"`, `"openai"`, `"gemini"`, `"deepseek"`, `"ollama"`. An agent is only
 instantiated if its env var is set — missing keys cleanly skip.
 
 | Agent | Env var |
@@ -60,6 +60,7 @@ instantiated if its env var is set — missing keys cleanly skip.
 | `openai` | `OPENAI_API_KEY` |
 | `gemini` | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) |
 | `deepseek` | `DEEPSEEK_API_KEY` |
+| `ollama` | none (local); optional `OLLAMA_BASE_URL`, default `http://localhost:11434/v1` |
 
 ### `budget.perPrUsd`
 

--- a/packages/agent-ollama/README.md
+++ b/packages/agent-ollama/README.md
@@ -1,0 +1,62 @@
+# @conclave-ai/agent-ollama
+
+Conclave AI Ollama agent. Routes reviews to a local or self-hosted
+Ollama instance via its OpenAI-compatible endpoint.
+
+## Install
+
+Pulled in automatically by `@conclave-ai/cli` when `"ollama"` is in
+`.conclaverc.json` → `agents`.
+
+Standalone:
+```bash
+pnpm add @conclave-ai/agent-ollama
+```
+
+## Why Ollama
+
+- **Zero API cost.** Compute is user-paid hardware; the wire is free.
+- **Zero API key.** Nothing leaves the machine if the Ollama instance
+  is local.
+- **Any model you've pulled.** `ollama pull llama3.3`, `qwen3`,
+  `deepseek-r1`, `gpt-oss`, etc. — whatever your hardware runs.
+
+## Prerequisites
+
+```bash
+# Install Ollama: https://ollama.com/download
+ollama serve                 # starts daemon on localhost:11434
+ollama pull llama3.3         # or whichever model the config names
+```
+
+## Env / options
+
+| Var / option | Default | Notes |
+|---|---|---|
+| `OLLAMA_BASE_URL` env / `baseURL` ctor opt | `http://localhost:11434/v1` | Override to point at a remote / container / non-default port |
+| `model` ctor opt | `llama3.3` | Any model `ollama list` shows |
+
+No API key required. The underlying `openai` SDK gets the literal
+string `"ollama"` as a placeholder so its constructor doesn't throw.
+
+## Usage
+
+```typescript
+import { OllamaAgent } from "@conclave-ai/agent-ollama";
+
+const agent = new OllamaAgent({ gate: efficiencyGate });
+const result = await agent.review(ctx);
+// result.costUsd === 0 always — local inference is not metered
+```
+
+## Caveats
+
+- `actualCost` always returns `0`. If you want wall-clock or kWh
+  accounting, layer it on top of `MetricsRecorder.latencyMs`; that
+  lives outside v0.1 scope.
+- `deepseek-r1` and other reasoning models emit far more output tokens
+  than the default `maxTokens: 8192` estimate. Bump `maxTokens` via
+  constructor if you route reasoning-heavy reviews through Ollama.
+- Structured JSON output depends on the model. Smaller models may
+  fail the strict schema; the CLI surfaces parse errors like any
+  other agent.

--- a/packages/agent-ollama/package.json
+++ b/packages/agent-ollama/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@conclave-ai/agent-ollama",
+  "version": "0.1.0",
+  "description": "Conclave AI Ollama agent — local inference via Ollama's OpenAI-compatible endpoint. Zero cost, zero API key.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@conclave-ai/core": "workspace:*",
+    "openai": "^4.76.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/agent-ollama/src/index.ts
+++ b/packages/agent-ollama/src/index.ts
@@ -1,0 +1,6 @@
+export { OllamaAgent, SYSTEM_PROMPT } from "./ollama-agent.js";
+export type { OllamaAgentOptions, OllamaLike, ChatCompletionParams, ChatCompletionResponse } from "./ollama-agent.js";
+export { buildReviewPrompt, buildCacheablePrefix } from "./prompts.js";
+export { REVIEW_SCHEMA_NAME, REVIEW_JSON_SCHEMA } from "./review-schema.js";
+export { actualCost, estimateCallCost, PRICING } from "./pricing.js";
+export type { OllamaModelPricing, UsageBreakdown } from "./pricing.js";

--- a/packages/agent-ollama/src/ollama-agent.ts
+++ b/packages/agent-ollama/src/ollama-agent.ts
@@ -1,0 +1,224 @@
+import type { Agent, ReviewContext, ReviewResult, Blocker } from "@conclave-ai/core";
+import { EfficiencyGate, estimateTokens } from "@conclave-ai/core";
+import { REVIEW_SCHEMA_NAME, REVIEW_JSON_SCHEMA } from "./review-schema.js";
+import { SYSTEM_PROMPT, buildReviewPrompt, buildCacheablePrefix } from "./prompts.js";
+import { actualCost, estimateCallCost } from "./pricing.js";
+
+/**
+ * Minimal shape of the Ollama SDK client that OllamaAgent needs.
+ * Typed against this subset to keep tests cheap to mock and tolerate SDK
+ * minor-version churn.
+ */
+export interface OllamaLike {
+  chat: {
+    completions: {
+      create(params: ChatCompletionParams): Promise<ChatCompletionResponse>;
+    };
+  };
+}
+
+export interface ChatCompletionParams {
+  model: string;
+  max_completion_tokens?: number;
+  max_tokens?: number;
+  messages: ReadonlyArray<{ role: "system" | "user" | "assistant"; content: string }>;
+  response_format?: {
+    type: "json_schema";
+    json_schema: { name: string; strict: true; schema: unknown };
+  };
+}
+
+export interface ChatCompletionResponse {
+  id: string;
+  model: string;
+  choices: ReadonlyArray<{
+    index: number;
+    finish_reason: string;
+    message: {
+      role: "assistant";
+      content: string | null;
+      refusal?: string | null;
+    };
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    prompt_tokens_details?: { cached_tokens?: number };
+  };
+}
+
+export interface OllamaAgentOptions {
+  /**
+   * Base URL for a local or remote Ollama instance.
+   * Defaults to `process.env["OLLAMA_BASE_URL"]`, then `http://localhost:11434/v1`.
+   */
+  baseURL?: string;
+  /** Defaults to `llama3.3`. Any model the local Ollama has pulled works. */
+  model?: string;
+  maxTokens?: number;
+  gate?: EfficiencyGate;
+  client?: OllamaLike;
+  clientFactory?: (baseURL: string) => Promise<OllamaLike>;
+}
+
+const DEFAULT_MODEL = "llama3.3";
+const DEFAULT_MAX_TOKENS = 8_192;
+const DEFAULT_BASE_URL = "http://localhost:11434/v1";
+const PLACEHOLDER_API_KEY = "ollama";
+
+/**
+ * Ollama's API is OpenAI-wire-compatible — we reuse the `openai` SDK
+ * with a custom baseURL. No real API key is needed (Ollama accepts any
+ * non-empty string); we pass the literal "ollama" as a placeholder so
+ * the SDK's client constructor doesn't throw.
+ */
+async function defaultClientFactory(baseURL: string): Promise<OllamaLike> {
+  const mod = (await import("openai")) as unknown as {
+    default: new (opts: { apiKey: string; baseURL?: string }) => OllamaLike;
+  };
+  const Ctor = mod.default;
+  return new Ctor({ apiKey: PLACEHOLDER_API_KEY, baseURL });
+}
+
+/**
+ * OllamaAgent — routes a real Ollama structured-output review call through
+ * the efficiency gate. Uses strict JSON Schema response format so the
+ * response is guaranteed to match `ReviewResult` shape (decision #12).
+ */
+export class OllamaAgent implements Agent {
+  readonly id = "ollama";
+  readonly displayName = "Ollama";
+
+  private readonly baseURL: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly gate: EfficiencyGate;
+  private readonly clientFactory: (baseURL: string) => Promise<OllamaLike>;
+  private clientPromise: Promise<OllamaLike> | null;
+
+  constructor(opts: OllamaAgentOptions = {}) {
+    this.baseURL = opts.baseURL ?? process.env["OLLAMA_BASE_URL"] ?? DEFAULT_BASE_URL;
+    this.model = opts.model ?? DEFAULT_MODEL;
+    this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.gate = opts.gate ?? new EfficiencyGate();
+    this.clientFactory = opts.clientFactory ?? defaultClientFactory;
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+  }
+
+  private async getClient(): Promise<OllamaLike> {
+    if (!this.clientPromise) this.clientPromise = this.clientFactory(this.baseURL);
+    return this.clientPromise;
+  }
+
+  async review(ctx: ReviewContext): Promise<ReviewResult> {
+    const cacheablePrefix = buildCacheablePrefix(ctx);
+    const userPrompt = buildReviewPrompt(ctx);
+    const inputTokenEstimate = estimateTokens(cacheablePrefix) + estimateTokens(userPrompt);
+    const estimatedCost = estimateCallCost(this.model, inputTokenEstimate, this.maxTokens);
+
+    const outcome = await this.gate.run<ReviewResult>(
+      {
+        agent: this.id,
+        cacheablePrefix,
+        prompt: cacheablePrefix + "\n" + userPrompt,
+        estimatedCostUsd: estimatedCost,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const response = await client.chat.completions.create({
+          model,
+          max_completion_tokens: this.maxTokens,
+          messages: [
+            { role: "system", content: cacheablePrefix },
+            { role: "user", content: userPrompt },
+          ],
+          response_format: {
+            type: "json_schema",
+            json_schema: { name: REVIEW_SCHEMA_NAME, strict: true, schema: REVIEW_JSON_SCHEMA },
+          },
+        });
+        const latencyMs = Date.now() - started;
+
+        const parsed = parseReviewResponse(response, this.id);
+        const usage = response.usage;
+        const inputTokens = usage?.prompt_tokens ?? inputTokenEstimate;
+        const outputTokens = usage?.completion_tokens ?? 0;
+        const cachedInput = usage?.prompt_tokens_details?.cached_tokens;
+        const costParts: { inputTokens: number; outputTokens: number; cachedInputTokens?: number } = {
+          inputTokens,
+          outputTokens,
+        };
+        if (cachedInput !== undefined) costParts.cachedInputTokens = cachedInput;
+        const cost = actualCost(model, costParts);
+
+        return {
+          result: {
+            ...parsed,
+            tokensUsed: inputTokens + outputTokens,
+            costUsd: cost,
+          },
+          inputTokens,
+          outputTokens,
+          costUsd: cost,
+          latencyMs,
+        };
+      },
+    );
+
+    return outcome.result;
+  }
+}
+
+function parseReviewResponse(response: ChatCompletionResponse, agentId: string): ReviewResult {
+  const choice = response.choices[0];
+  if (!choice) throw new Error("OllamaAgent: response had no choices");
+  if (choice.message.refusal) {
+    throw new Error(`OllamaAgent: model refused to respond — ${choice.message.refusal}`);
+  }
+  const text = choice.message.content;
+  if (!text) throw new Error(`OllamaAgent: response had no content (finish_reason=${choice.finish_reason})`);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new Error(`OllamaAgent: response content was not valid JSON: ${(err as Error).message}`);
+  }
+  return normalizeReview(parsed, agentId);
+}
+
+function normalizeReview(raw: unknown, agentId: string): ReviewResult {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("OllamaAgent: response is not an object");
+  }
+  const v = (raw as { verdict?: unknown }).verdict;
+  if (v !== "approve" && v !== "rework" && v !== "reject") {
+    throw new Error(`OllamaAgent: invalid verdict "${String(v)}"`);
+  }
+  const blockersRaw = (raw as { blockers?: unknown[] }).blockers;
+  const blockers: Blocker[] = [];
+  if (Array.isArray(blockersRaw)) {
+    for (const item of blockersRaw) {
+      if (!item || typeof item !== "object") continue;
+      const b = item as Record<string, unknown>;
+      const severity = b["severity"];
+      const category = b["category"];
+      const message = b["message"];
+      if (
+        (severity === "blocker" || severity === "major" || severity === "minor" || severity === "nit") &&
+        typeof category === "string" &&
+        typeof message === "string"
+      ) {
+        const blocker: Blocker = { severity, category, message };
+        if (typeof b["file"] === "string") blocker.file = b["file"] as string;
+        if (typeof b["line"] === "number") blocker.line = b["line"] as number;
+        blockers.push(blocker);
+      }
+    }
+  }
+  const summary = typeof (raw as { summary?: unknown }).summary === "string" ? (raw as { summary: string }).summary : "";
+  return { agent: agentId, verdict: v, blockers, summary };
+}
+
+export { SYSTEM_PROMPT };

--- a/packages/agent-ollama/src/pricing.ts
+++ b/packages/agent-ollama/src/pricing.ts
@@ -1,0 +1,43 @@
+/**
+ * Ollama runs locally — compute cost is user-paid hardware time, not
+ * metered tokens. From the efficiency gate's perspective, every call
+ * is free at the wire level. Any real resource-accounting for local
+ * inference is out of scope for v0.1; when we wire in wall-clock /
+ * kWh estimates, this file grows.
+ *
+ * The exported helpers mirror the shape of the other agent pricing
+ * modules so code that loops over pricing tables doesn't special-case
+ * Ollama.
+ */
+export interface OllamaModelPricing {
+  inputPerMTok: 0;
+  outputPerMTok: 0;
+  cachedInputPerMTok?: 0;
+}
+
+export const PRICING: Record<string, OllamaModelPricing> = {
+  /** Generic default — Ollama has an open model catalog, users pull their own. */
+  "llama3.3": { inputPerMTok: 0, outputPerMTok: 0 },
+};
+
+export interface UsageBreakdown {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens?: number;
+}
+
+/**
+ * Always 0 for Ollama. Callers that want wall-clock billing should
+ * layer it on top of the `MetricsRecorder.latency` field instead.
+ */
+export function actualCost(_model: string, _usage: UsageBreakdown): number {
+  return 0;
+}
+
+export function estimateCallCost(
+  _model: string,
+  _estimatedInputTokens: number,
+  _maxOutputTokens: number,
+): number {
+  return 0;
+}

--- a/packages/agent-ollama/src/prompts.ts
+++ b/packages/agent-ollama/src/prompts.ts
@@ -1,0 +1,82 @@
+import type { ReviewContext } from "@conclave-ai/core";
+
+export const SYSTEM_PROMPT = `You are a senior code reviewer on a multi-agent council for Conclave AI. The council reviews AI-generated code and design changes before merge.
+
+Your goal: catch real blockers, not style nits. You work alongside other agents (Claude, Gemini, possibly domain-specific specialists). Your reviews are weighed against theirs; spurious blockers hurt your agent score and waste the rework budget.
+
+Rules:
+- Focus on: correctness, security, regression risk, missing tests for non-trivial changes, accessibility + contrast on UI, obvious performance cliffs.
+- Do NOT comment on: style bikeshedding, import order, variable renames that are already consistent, personal formatting preferences.
+- When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
+- Never pad with encouragement ("great work but...") — go straight to the concerns.
+- When the diff is small, low-risk, and has test coverage, approve cleanly. Over-flagging is a bigger sin than missing a nit.
+- You MUST respond in the provided JSON schema. Any field marked nullable uses null when not applicable (do not omit it).`;
+
+export function buildReviewPrompt(ctx: ReviewContext): string {
+  const sections: string[] = [];
+  sections.push(`# Review target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`pull: #${ctx.pullNumber}`);
+  sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
+  sections.push("");
+
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(
+      `These are reviews that led to merged changes on similar code in this repo. Lean on them as a style + quality bar — match their tolerance for what counts as a blocker.`,
+    );
+    sections.push("");
+    for (const entry of ctx.answerKeys.slice(0, 8)) sections.push(`- ${entry}`);
+    sections.push("");
+  }
+
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(
+      `These are patterns that caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
+    );
+    sections.push("");
+    for (const entry of ctx.failureCatalog.slice(0, 8)) sections.push(`- ${entry}`);
+    sections.push("");
+  }
+
+  sections.push(`# Diff`);
+  sections.push("```diff");
+  sections.push(ctx.diff || "(empty diff — respond with verdict=approve, summary noting nothing to review, blockers=[])");
+  sections.push("```");
+  sections.push("");
+
+  if (ctx.priors && ctx.priors.length > 0) {
+    sections.push(`# Round ${ctx.round ?? 2} — other agents' verdicts from the previous round`);
+    sections.push(
+      `The council is in a multi-round debate. Read each agent's verdict + blockers. Update your verdict ONLY if you see a real issue you missed, or a false-positive you can now retract. Do not mirror the majority — the dissenting voice is often the correct one.`,
+    );
+    sections.push("");
+    for (const p of ctx.priors) {
+      sections.push(`## ${p.agent}: ${p.verdict}`);
+      if (p.blockers.length > 0) {
+        for (const b of p.blockers.slice(0, 5)) {
+          const loc = b.file ? ` (${b.file}${b.line ? ":" + b.line : ""})` : "";
+          sections.push(`- [${b.severity}/${b.category}] ${b.message}${loc}`);
+        }
+      } else {
+        sections.push(`- (no blockers)`);
+      }
+      sections.push("");
+    }
+  }
+
+  sections.push(`Respond using the conclave_review JSON schema.`);
+  return sections.join("\n");
+}
+
+export function buildCacheablePrefix(ctx: ReviewContext): string {
+  const parts: string[] = [SYSTEM_PROMPT];
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
+  }
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    parts.push("failure-catalog:\n" + ctx.failureCatalog.slice(0, 8).join("\n"));
+  }
+  return parts.join("\n---\n");
+}

--- a/packages/agent-ollama/src/review-schema.ts
+++ b/packages/agent-ollama/src/review-schema.ts
@@ -1,0 +1,40 @@
+/**
+ * OpenAI strict JSON Schema for the review response.
+ * Per decision #12: "OpenAI strict json_schema via openai-zod-to-json-schema".
+ *
+ * Strict mode requires:
+ *   - `additionalProperties: false` at every level
+ *   - every field in `properties` must be listed in `required`
+ *
+ * The schema mirrors agent-claude's tool_use schema so both agents emit
+ * compatible `ReviewResult` shapes.
+ */
+export const REVIEW_SCHEMA_NAME = "conclave_review";
+
+export const REVIEW_JSON_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    verdict: {
+      type: "string",
+      enum: ["approve", "rework", "reject"],
+    },
+    blockers: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          severity: { type: "string", enum: ["blocker", "major", "minor", "nit"] },
+          category: { type: "string" },
+          message: { type: "string" },
+          file: { type: ["string", "null"] },
+          line: { type: ["number", "null"] },
+        },
+        required: ["severity", "category", "message", "file", "line"],
+      },
+    },
+    summary: { type: "string" },
+  },
+  required: ["verdict", "blockers", "summary"],
+} as const;

--- a/packages/agent-ollama/test/ollama-agent.test.mjs
+++ b/packages/agent-ollama/test/ollama-agent.test.mjs
@@ -1,0 +1,166 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { OllamaAgent } from "../dist/index.js";
+import { EfficiencyGate } from "../../core/dist/index.js";
+
+/**
+ * Minimal OpenAI-like client stub.
+ */
+function stubClient(responses) {
+  let i = 0;
+  const calls = [];
+  const client = {
+    chat: {
+      completions: {
+        create: async (params) => {
+          calls.push(params);
+          const r = responses[Math.min(i, responses.length - 1)];
+          i += 1;
+          if (r.throws) throw r.throws;
+          return r;
+        },
+      },
+    },
+  };
+  return { client, calls };
+}
+
+function approveResponse(extra = {}) {
+  return {
+    id: "resp-1",
+    model: "llama3.3",
+    choices: [
+      {
+        index: 0,
+        finish_reason: "stop",
+        message: {
+          role: "assistant",
+          content: JSON.stringify({
+            agent: "ollama",
+            verdict: "approve",
+            blockers: [],
+            summary: "ok",
+          }),
+        },
+      },
+    ],
+    usage: { prompt_tokens: 200, completion_tokens: 50 },
+    ...extra,
+  };
+}
+
+const ctx = {
+  diff: "small diff",
+  repo: "acme/x",
+  pullNumber: 1,
+  newSha: "abc",
+};
+
+test("OllamaAgent: default baseURL is localhost:11434/v1", async () => {
+  const { client, calls } = stubClient([approveResponse()]);
+  const agent = new OllamaAgent({ client, gate: new EfficiencyGate() });
+  await agent.review(ctx);
+  assert.equal(calls.length, 1);
+  // The client stub doesn't expose baseURL, but `new OllamaAgent({})` must
+  // not throw (no API key required) — that's the load-bearing contract.
+  assert.equal(agent.id, "ollama");
+});
+
+test("OllamaAgent: parses approve through the gate", async () => {
+  const { client } = stubClient([approveResponse()]);
+  const agent = new OllamaAgent({ client, gate: new EfficiencyGate() });
+  const res = await agent.review(ctx);
+  assert.equal(res.verdict, "approve");
+  assert.equal(res.agent, "ollama");
+  assert.equal(res.costUsd, 0, "Ollama calls are free");
+});
+
+test("OllamaAgent: parses rework with blockers", async () => {
+  const { client } = stubClient([
+    {
+      ...approveResponse(),
+      choices: [
+        {
+          index: 0,
+          finish_reason: "stop",
+          message: {
+            role: "assistant",
+            content: JSON.stringify({
+              agent: "ollama",
+              verdict: "rework",
+              blockers: [{ severity: "major", category: "correctness", message: "bug" }],
+              summary: "fix bug",
+            }),
+          },
+        },
+      ],
+    },
+  ]);
+  const agent = new OllamaAgent({ client, gate: new EfficiencyGate() });
+  const res = await agent.review(ctx);
+  assert.equal(res.verdict, "rework");
+  assert.equal(res.blockers.length, 1);
+  assert.equal(res.blockers[0].message, "bug");
+});
+
+test("OllamaAgent: zero cost regardless of token volume", async () => {
+  const { client } = stubClient([
+    {
+      ...approveResponse(),
+      usage: { prompt_tokens: 100_000, completion_tokens: 50_000 },
+    },
+  ]);
+  const agent = new OllamaAgent({ client, gate: new EfficiencyGate() });
+  const res = await agent.review(ctx);
+  assert.equal(res.costUsd, 0);
+});
+
+test("OllamaAgent: custom baseURL flows through to clientFactory", async () => {
+  let capturedBaseURL;
+  const customFactory = async (baseURL) => {
+    capturedBaseURL = baseURL;
+    const { client } = stubClient([approveResponse()]);
+    return client;
+  };
+  const agent = new OllamaAgent({
+    baseURL: "http://remote.ollama:11434/v1",
+    clientFactory: customFactory,
+    gate: new EfficiencyGate(),
+  });
+  await agent.review(ctx);
+  assert.equal(capturedBaseURL, "http://remote.ollama:11434/v1");
+});
+
+test("OllamaAgent: OLLAMA_BASE_URL env overrides default", async () => {
+  const orig = process.env["OLLAMA_BASE_URL"];
+  process.env["OLLAMA_BASE_URL"] = "http://env.ollama:11434/v1";
+  try {
+    let captured;
+    const agent = new OllamaAgent({
+      clientFactory: async (baseURL) => {
+        captured = baseURL;
+        const { client } = stubClient([approveResponse()]);
+        return client;
+      },
+      gate: new EfficiencyGate(),
+    });
+    await agent.review(ctx);
+    assert.equal(captured, "http://env.ollama:11434/v1");
+  } finally {
+    if (orig === undefined) delete process.env["OLLAMA_BASE_URL"];
+    else process.env["OLLAMA_BASE_URL"] = orig;
+  }
+});
+
+test("OllamaAgent: no API key required — constructs with empty env", () => {
+  const origOpenAI = process.env["OPENAI_API_KEY"];
+  delete process.env["OPENAI_API_KEY"];
+  try {
+    const { client } = stubClient([approveResponse()]);
+    // Must not throw — this is the big differentiator vs other agents.
+    const agent = new OllamaAgent({ client, gate: new EfficiencyGate() });
+    assert.equal(agent.id, "ollama");
+  } finally {
+    if (origOpenAI !== undefined) process.env["OPENAI_API_KEY"] = origOpenAI;
+  }
+});

--- a/packages/agent-ollama/test/pricing.test.mjs
+++ b/packages/agent-ollama/test/pricing.test.mjs
@@ -1,0 +1,27 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { actualCost, estimateCallCost, PRICING } from "../dist/index.js";
+
+test("PRICING: default llama3.3 entry has zero rates", () => {
+  const p = PRICING["llama3.3"];
+  assert.ok(p);
+  assert.equal(p.inputPerMTok, 0);
+  assert.equal(p.outputPerMTok, 0);
+});
+
+test("actualCost: always 0 regardless of usage", () => {
+  assert.equal(actualCost("llama3.3", { inputTokens: 1_000_000, outputTokens: 500_000 }), 0);
+  assert.equal(actualCost("anything", { inputTokens: 0, outputTokens: 0 }), 0);
+});
+
+test("actualCost: zero even with cached tokens (free is free)", () => {
+  assert.equal(
+    actualCost("llama3.3", { inputTokens: 1_000_000, outputTokens: 0, cachedInputTokens: 500_000 }),
+    0,
+  );
+});
+
+test("estimateCallCost: always 0", () => {
+  assert.equal(estimateCallCost("llama3.3", 100_000, 50_000), 0);
+  assert.equal(estimateCallCost("anything", 0, 0), 0);
+});

--- a/packages/agent-ollama/tsconfig.json
+++ b/packages/agent-ollama/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
     "@conclave-ai/agent-claude": "workspace:*",
     "@conclave-ai/agent-deepseek": "workspace:*",
     "@conclave-ai/agent-gemini": "workspace:*",
+    "@conclave-ai/agent-ollama": "workspace:*",
     "@conclave-ai/agent-openai": "workspace:*",
     "@conclave-ai/core": "workspace:*",
     "@conclave-ai/integration-discord": "workspace:*",

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -17,6 +17,7 @@ import { ClaudeAgent } from "@conclave-ai/agent-claude";
 import { OpenAIAgent } from "@conclave-ai/agent-openai";
 import { GeminiAgent } from "@conclave-ai/agent-gemini";
 import { DeepseekAgent } from "@conclave-ai/agent-deepseek";
+import { OllamaAgent } from "@conclave-ai/agent-ollama";
 import { LangfuseMetricsSink } from "@conclave-ai/observability-langfuse";
 import { TelegramNotifier } from "@conclave-ai/integration-telegram";
 import { DiscordNotifier } from "@conclave-ai/integration-discord";
@@ -178,6 +179,11 @@ export async function review(argv: string[]): Promise<void> {
         continue;
       }
       agents.push(new DeepseekAgent({ gate }));
+    } else if (id === "ollama") {
+      // Ollama has no API key; we assume a local daemon is running at
+      // OLLAMA_BASE_URL (default http://localhost:11434/v1). The user
+      // is responsible for pulling the configured model.
+      agents.push(new OllamaAgent({ gate }));
     }
   }
   if (agents.length === 0) {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -7,7 +7,7 @@ export const CONFIG_FILENAME = ".conclaverc.json";
 
 export const ConclaveConfigSchema = z.object({
   version: z.literal(1),
-  agents: z.array(z.enum(["claude", "openai", "gemini", "deepseek"])).default(["claude"]),
+  agents: z.array(z.enum(["claude", "openai", "gemini", "deepseek", "ollama"])).default(["claude"]),
   budget: z
     .object({
       perPrUsd: z.number().positive(),

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../agent-claude" },
     { "path": "../agent-deepseek" },
     { "path": "../agent-gemini" },
+    { "path": "../agent-ollama" },
     { "path": "../agent-openai" },
     { "path": "../integration-discord" },
     { "path": "../integration-email" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,19 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/agent-ollama:
+    dependencies:
+      '@conclave-ai/core':
+        specifier: workspace:*
+        version: link:../core
+      openai:
+        specifier: ^4.76.0
+        version: 4.104.0(ws@8.20.0)(zod@3.25.76)
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/agent-openai:
     dependencies:
       '@conclave-ai/core':
@@ -81,6 +94,9 @@ importers:
       '@conclave-ai/agent-gemini':
         specifier: workspace:*
         version: link:../agent-gemini
+      '@conclave-ai/agent-ollama':
+        specifier: workspace:*
+        version: link:../agent-ollama
       '@conclave-ai/agent-openai':
         specifier: workspace:*
         version: link:../agent-openai


### PR DESCRIPTION
## Summary
Second v2.1 agent. Routes reviews to a local Ollama daemon via its OpenAI-compatible endpoint. Reuses the \`openai\` SDK with a placeholder API key.

## Differentiators
- **Zero API cost.** \`actualCost\` returns 0 unconditionally.
- **Zero API key.** CLI factory doesn't gate on an env var — user ensures \`ollama serve\` is running.
- **Any model Ollama has pulled works** — \`llama3.3\`, \`qwen3\`, \`deepseek-r1\`, \`gpt-oss\`, etc.

## Env / options
| Var / option | Default |
|---|---|
| \`OLLAMA_BASE_URL\` env or \`baseURL\` ctor opt | \`http://localhost:11434/v1\` |
| \`model\` ctor opt | \`llama3.3\` |

## Caveats (documented in README)
- Reasoning-heavy models need \`maxTokens\` bump
- Smaller models may fail the strict JSON schema
- Wall-clock / kWh accounting is out of v0.1 scope

## Test plan
- [x] \`pnpm build\` — 19/19 (was 18)
- [x] \`pnpm test\` — 37/37 tasks. New package: 7 agent + 4 pricing tests, all stubbed.
- [ ] Live smoke — pending local ollama daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)