### PR TITLE
feat(agent-grok): xAI agent (decision #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 ### Added
+- **`@conclave-ai/agent-grok` — xAI agent (decision #32).** Third v2.1 agent. OpenAI-wire-compatible; routes to `https://api.x.ai/v1` via the `openai` SDK. Default model `grok-code-fast-1` (code-tuned, cheapest at $0.20/M input, $1.50/M output); pricing table also covers `grok-3`, `grok-3-mini`, `grok-4`. `XAI_API_KEY` required. Missing key skips cleanly.
+
 - **`@conclave-ai/agent-ollama` — local inference agent (decision #32).** Routes reviews to a local Ollama daemon via its OpenAI-compatible endpoint at `http://localhost:11434/v1`. Zero API key (placeholder "ollama" string satisfies the SDK), zero wire cost (`actualCost` returns 0). Default model `llama3.3`, override via constructor or pick any model `ollama list` shows. `OLLAMA_BASE_URL` env var supports self-hosted / remote Ollama instances. CLI factory adds `"ollama"` with no credential gating — user is responsible for the daemon being up. 11 unit tests use a stub client (no network).
 
 - **`@conclave-ai/agent-deepseek` — first v2.1 agent (decision #32).** OpenAI-wire-compatible; reuses the `openai` SDK pointed at `https://api.deepseek.com`. Supports `deepseek-chat` (V3, general) and `deepseek-reasoner` (R1, chain-of-thought). Pricing ~20× cheaper than GPT-5 input (0.27/M vs 5.0/M) with a deep cache discount (0.07/M — ~26% of standard). Wired into the CLI factory alongside `"claude" / "openai" / "gemini"`; missing `DEEPSEEK_API_KEY` skips cleanly like the others. `docs/configuration.md` + Zod config enum both updated. 18 tests mirror the agent-openai suite (16 agent + 8 pricing).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ rejects unknown versions.
 
 ### `agents`
 
-Array of `"claude"`, `"openai"`, `"gemini"`, `"deepseek"`, `"ollama"`. An agent is only
+Array of `"claude"`, `"openai"`, `"gemini"`, `"deepseek"`, `"ollama"`, `"grok"`. An agent is only
 instantiated if its env var is set — missing keys cleanly skip.
 
 | Agent | Env var |
@@ -61,6 +61,7 @@ instantiated if its env var is set — missing keys cleanly skip.
 | `gemini` | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) |
 | `deepseek` | `DEEPSEEK_API_KEY` |
 | `ollama` | none (local); optional `OLLAMA_BASE_URL`, default `http://localhost:11434/v1` |
+| `grok` | `XAI_API_KEY` |
 
 ### `budget.perPrUsd`
 

--- a/docs/decision-status.md
+++ b/docs/decision-status.md
@@ -48,7 +48,7 @@ Legend:
 | 29 | Architecture coherence > feature novelty | 📄 | `ARCHITECTURE.md` |
 | 30 | Migration path from solo-cto-agent | ✅ | `conclave migrate` |
 | 31 | v2.0 platform set (5/5) | ✅ | 5 `platform-*` packages |
-| 32 | v2.1 agents + platforms | 🟡 | in progress — Deepseek first (`agent-deepseek`); Ollama / Grok / Qwen / Bedrock / Vertex / Cheetah queued |
+| 32 | v2.1 agents + platforms | 🟡 | in progress — Deepseek + Ollama + Grok landed; Qwen / Bedrock / Vertex / Cheetah queued |
 | 33 | Tier model (Maker / Builder / CTO) | 📄 | `ARCHITECTURE.md`, README tier lines |
 | 34 | Self-evolve loop | ✅ | `outcome-writer.ts` + classifier + seeder |
 

--- a/packages/agent-grok/README.md
+++ b/packages/agent-grok/README.md
@@ -1,0 +1,41 @@
+# @conclave-ai/agent-grok
+
+Conclave AI Grok agent. Wraps xAI's OpenAI-wire-compatible API at
+`https://api.x.ai/v1` via the `openai` SDK.
+
+## Install
+
+Pulled in automatically by `@conclave-ai/cli` when `"grok"` is in
+`.conclaverc.json` → `agents`.
+
+Standalone:
+```bash
+pnpm add @conclave-ai/agent-grok
+```
+
+## Models
+
+| Model | Use |
+|---|---|
+| `grok-code-fast-1` | Default — code-tuned, cheapest per call (~$0.20/M input, $1.50/M output) |
+| `grok-3-mini` | General lightweight tier |
+| `grok-3` | Reasoning-capable general purpose |
+| `grok-4` | Flagship reasoning model |
+
+## Env
+
+| Var | Required | Notes |
+|---|---|---|
+| `XAI_API_KEY` | yes | Get one at https://console.x.ai |
+
+## Usage
+
+```typescript
+import { GrokAgent } from "@conclave-ai/agent-grok";
+
+const agent = new GrokAgent({ gate: efficiencyGate });
+const result = await agent.review(ctx);
+```
+
+Same `Agent` contract as the other council members. Prompt-cache
+discount applies on supported models (reflected in the pricing table).

--- a/packages/agent-grok/package.json
+++ b/packages/agent-grok/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@conclave-ai/agent-grok",
+  "version": "0.1.0",
+  "description": "Conclave AI Grok agent — OpenAI-wire-compatible, routes to xAI's api.x.ai/v1 with strict-JSON-schema structured output.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@conclave-ai/core": "workspace:*",
+    "openai": "^4.76.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/agent-grok/src/grok-agent.ts
+++ b/packages/agent-grok/src/grok-agent.ts
@@ -1,0 +1,223 @@
+import type { Agent, ReviewContext, ReviewResult, Blocker } from "@conclave-ai/core";
+import { EfficiencyGate, estimateTokens } from "@conclave-ai/core";
+import { REVIEW_SCHEMA_NAME, REVIEW_JSON_SCHEMA } from "./review-schema.js";
+import { SYSTEM_PROMPT, buildReviewPrompt, buildCacheablePrefix } from "./prompts.js";
+import { actualCost, estimateCallCost } from "./pricing.js";
+
+/**
+ * Minimal shape of the Grok SDK client that GrokAgent needs.
+ * Typed against this subset to keep tests cheap to mock and tolerate SDK
+ * minor-version churn.
+ */
+export interface GrokLike {
+  chat: {
+    completions: {
+      create(params: ChatCompletionParams): Promise<ChatCompletionResponse>;
+    };
+  };
+}
+
+export interface ChatCompletionParams {
+  model: string;
+  max_completion_tokens?: number;
+  max_tokens?: number;
+  messages: ReadonlyArray<{ role: "system" | "user" | "assistant"; content: string }>;
+  response_format?: {
+    type: "json_schema";
+    json_schema: { name: string; strict: true; schema: unknown };
+  };
+}
+
+export interface ChatCompletionResponse {
+  id: string;
+  model: string;
+  choices: ReadonlyArray<{
+    index: number;
+    finish_reason: string;
+    message: {
+      role: "assistant";
+      content: string | null;
+      refusal?: string | null;
+    };
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    prompt_tokens_details?: { cached_tokens?: number };
+  };
+}
+
+export interface GrokAgentOptions {
+  apiKey?: string;
+  /** Defaults to gpt-5-mini. Gate router may override per call. */
+  model?: string;
+  maxTokens?: number;
+  gate?: EfficiencyGate;
+  client?: GrokLike;
+  clientFactory?: (apiKey: string) => Promise<GrokLike>;
+}
+
+const DEFAULT_MODEL = "grok-code-fast-1";
+const DEFAULT_MAX_TOKENS = 8_192;
+
+const GROK_BASE_URL = "https://api.x.ai/v1";
+
+/**
+ * Grok's API is OpenAI-wire-compatible — we reuse the `openai` SDK
+ * with a custom baseURL. Keeps the structured-output schema + usage
+ * accounting identical to the OpenAI agent.
+ */
+async function defaultClientFactory(apiKey: string): Promise<GrokLike> {
+  const mod = (await import("openai")) as unknown as {
+    default: new (opts: { apiKey: string; baseURL?: string }) => GrokLike;
+  };
+  const Ctor = mod.default;
+  return new Ctor({ apiKey, baseURL: GROK_BASE_URL });
+}
+
+/**
+ * GrokAgent — routes a real Grok structured-output review call through
+ * the efficiency gate. Uses strict JSON Schema response format so the
+ * response is guaranteed to match `ReviewResult` shape (decision #12).
+ */
+export class GrokAgent implements Agent {
+  readonly id = "grok";
+  readonly displayName = "Grok";
+
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly gate: EfficiencyGate;
+  private readonly clientFactory: (apiKey: string) => Promise<GrokLike>;
+  private clientPromise: Promise<GrokLike> | null;
+
+  constructor(opts: GrokAgentOptions = {}) {
+    const key = opts.apiKey ?? process.env["OPENAI_API_KEY"] ?? "";
+    if (!key && !opts.client) {
+      throw new Error("GrokAgent: OPENAI_API_KEY not set (pass opts.apiKey, opts.client, or the env var)");
+    }
+    this.apiKey = key;
+    this.model = opts.model ?? DEFAULT_MODEL;
+    this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.gate = opts.gate ?? new EfficiencyGate();
+    this.clientFactory = opts.clientFactory ?? defaultClientFactory;
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+  }
+
+  private async getClient(): Promise<GrokLike> {
+    if (!this.clientPromise) this.clientPromise = this.clientFactory(this.apiKey);
+    return this.clientPromise;
+  }
+
+  async review(ctx: ReviewContext): Promise<ReviewResult> {
+    const cacheablePrefix = buildCacheablePrefix(ctx);
+    const userPrompt = buildReviewPrompt(ctx);
+    const inputTokenEstimate = estimateTokens(cacheablePrefix) + estimateTokens(userPrompt);
+    const estimatedCost = estimateCallCost(this.model, inputTokenEstimate, this.maxTokens);
+
+    const outcome = await this.gate.run<ReviewResult>(
+      {
+        agent: this.id,
+        cacheablePrefix,
+        prompt: cacheablePrefix + "\n" + userPrompt,
+        estimatedCostUsd: estimatedCost,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const response = await client.chat.completions.create({
+          model,
+          max_completion_tokens: this.maxTokens,
+          messages: [
+            { role: "system", content: cacheablePrefix },
+            { role: "user", content: userPrompt },
+          ],
+          response_format: {
+            type: "json_schema",
+            json_schema: { name: REVIEW_SCHEMA_NAME, strict: true, schema: REVIEW_JSON_SCHEMA },
+          },
+        });
+        const latencyMs = Date.now() - started;
+
+        const parsed = parseReviewResponse(response, this.id);
+        const usage = response.usage;
+        const inputTokens = usage?.prompt_tokens ?? inputTokenEstimate;
+        const outputTokens = usage?.completion_tokens ?? 0;
+        const cachedInput = usage?.prompt_tokens_details?.cached_tokens;
+        const costParts: { inputTokens: number; outputTokens: number; cachedInputTokens?: number } = {
+          inputTokens,
+          outputTokens,
+        };
+        if (cachedInput !== undefined) costParts.cachedInputTokens = cachedInput;
+        const cost = actualCost(model, costParts);
+
+        return {
+          result: {
+            ...parsed,
+            tokensUsed: inputTokens + outputTokens,
+            costUsd: cost,
+          },
+          inputTokens,
+          outputTokens,
+          costUsd: cost,
+          latencyMs,
+        };
+      },
+    );
+
+    return outcome.result;
+  }
+}
+
+function parseReviewResponse(response: ChatCompletionResponse, agentId: string): ReviewResult {
+  const choice = response.choices[0];
+  if (!choice) throw new Error("GrokAgent: response had no choices");
+  if (choice.message.refusal) {
+    throw new Error(`GrokAgent: model refused to respond — ${choice.message.refusal}`);
+  }
+  const text = choice.message.content;
+  if (!text) throw new Error(`GrokAgent: response had no content (finish_reason=${choice.finish_reason})`);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new Error(`GrokAgent: response content was not valid JSON: ${(err as Error).message}`);
+  }
+  return normalizeReview(parsed, agentId);
+}
+
+function normalizeReview(raw: unknown, agentId: string): ReviewResult {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("GrokAgent: response is not an object");
+  }
+  const v = (raw as { verdict?: unknown }).verdict;
+  if (v !== "approve" && v !== "rework" && v !== "reject") {
+    throw new Error(`GrokAgent: invalid verdict "${String(v)}"`);
+  }
+  const blockersRaw = (raw as { blockers?: unknown[] }).blockers;
+  const blockers: Blocker[] = [];
+  if (Array.isArray(blockersRaw)) {
+    for (const item of blockersRaw) {
+      if (!item || typeof item !== "object") continue;
+      const b = item as Record<string, unknown>;
+      const severity = b["severity"];
+      const category = b["category"];
+      const message = b["message"];
+      if (
+        (severity === "blocker" || severity === "major" || severity === "minor" || severity === "nit") &&
+        typeof category === "string" &&
+        typeof message === "string"
+      ) {
+        const blocker: Blocker = { severity, category, message };
+        if (typeof b["file"] === "string") blocker.file = b["file"] as string;
+        if (typeof b["line"] === "number") blocker.line = b["line"] as number;
+        blockers.push(blocker);
+      }
+    }
+  }
+  const summary = typeof (raw as { summary?: unknown }).summary === "string" ? (raw as { summary: string }).summary : "";
+  return { agent: agentId, verdict: v, blockers, summary };
+}
+
+export { SYSTEM_PROMPT };

--- a/packages/agent-grok/src/index.ts
+++ b/packages/agent-grok/src/index.ts
@@ -1,0 +1,6 @@
+export { GrokAgent, SYSTEM_PROMPT } from "./grok-agent.js";
+export type { GrokAgentOptions, GrokLike, ChatCompletionParams, ChatCompletionResponse } from "./grok-agent.js";
+export { buildReviewPrompt, buildCacheablePrefix } from "./prompts.js";
+export { REVIEW_SCHEMA_NAME, REVIEW_JSON_SCHEMA } from "./review-schema.js";
+export { actualCost, estimateCallCost, PRICING } from "./pricing.js";
+export type { GrokModelPricing, UsageBreakdown } from "./pricing.js";

--- a/packages/agent-grok/src/pricing.ts
+++ b/packages/agent-grok/src/pricing.ts
@@ -1,0 +1,51 @@
+export interface GrokModelPricing {
+  /** USD per 1M input tokens. */
+  inputPerMTok: number;
+  /** USD per 1M output tokens. */
+  outputPerMTok: number;
+  /** USD per 1M cached-input tokens. xAI supports prompt caching on newer models. */
+  cachedInputPerMTok?: number;
+}
+
+/**
+ * xAI (Grok) pricing as of 2026-04. Numbers sourced from
+ * https://docs.x.ai/docs/models — revisit each publish.
+ *
+ * `grok-code-fast-1` is the code-tuned, lower-cost tier (pairs well
+ * with review-style workloads). `grok-4` is the reasoning flagship.
+ * `grok-3-mini` is the cheapest option.
+ */
+export const PRICING: Record<string, GrokModelPricing> = {
+  "grok-4": { inputPerMTok: 3.0, outputPerMTok: 15.0, cachedInputPerMTok: 0.75 },
+  "grok-3": { inputPerMTok: 3.0, outputPerMTok: 15.0, cachedInputPerMTok: 0.75 },
+  "grok-3-mini": { inputPerMTok: 0.3, outputPerMTok: 0.5, cachedInputPerMTok: 0.075 },
+  "grok-code-fast-1": { inputPerMTok: 0.2, outputPerMTok: 1.5, cachedInputPerMTok: 0.02 },
+};
+
+export interface UsageBreakdown {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens?: number;
+}
+
+export function actualCost(model: string, usage: UsageBreakdown): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown Grok model "${model}"`);
+  const baseInput = usage.inputTokens - (usage.cachedInputTokens ?? 0);
+  return (
+    (Math.max(0, baseInput) * p.inputPerMTok +
+      (usage.cachedInputTokens ?? 0) * (p.cachedInputPerMTok ?? p.inputPerMTok) +
+      usage.outputTokens * p.outputPerMTok) /
+    1_000_000
+  );
+}
+
+export function estimateCallCost(
+  model: string,
+  estimatedInputTokens: number,
+  maxOutputTokens: number,
+): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown Grok model "${model}"`);
+  return (estimatedInputTokens * p.inputPerMTok + maxOutputTokens * p.outputPerMTok) / 1_000_000;
+}

--- a/packages/agent-grok/src/prompts.ts
+++ b/packages/agent-grok/src/prompts.ts
@@ -1,0 +1,82 @@
+import type { ReviewContext } from "@conclave-ai/core";
+
+export const SYSTEM_PROMPT = `You are a senior code reviewer on a multi-agent council for Conclave AI. The council reviews AI-generated code and design changes before merge.
+
+Your goal: catch real blockers, not style nits. You work alongside other agents (Claude, Gemini, possibly domain-specific specialists). Your reviews are weighed against theirs; spurious blockers hurt your agent score and waste the rework budget.
+
+Rules:
+- Focus on: correctness, security, regression risk, missing tests for non-trivial changes, accessibility + contrast on UI, obvious performance cliffs.
+- Do NOT comment on: style bikeshedding, import order, variable renames that are already consistent, personal formatting preferences.
+- When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
+- Never pad with encouragement ("great work but...") — go straight to the concerns.
+- When the diff is small, low-risk, and has test coverage, approve cleanly. Over-flagging is a bigger sin than missing a nit.
+- You MUST respond in the provided JSON schema. Any field marked nullable uses null when not applicable (do not omit it).`;
+
+export function buildReviewPrompt(ctx: ReviewContext): string {
+  const sections: string[] = [];
+  sections.push(`# Review target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`pull: #${ctx.pullNumber}`);
+  sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
+  sections.push("");
+
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(
+      `These are reviews that led to merged changes on similar code in this repo. Lean on them as a style + quality bar — match their tolerance for what counts as a blocker.`,
+    );
+    sections.push("");
+    for (const entry of ctx.answerKeys.slice(0, 8)) sections.push(`- ${entry}`);
+    sections.push("");
+  }
+
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(
+      `These are patterns that caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
+    );
+    sections.push("");
+    for (const entry of ctx.failureCatalog.slice(0, 8)) sections.push(`- ${entry}`);
+    sections.push("");
+  }
+
+  sections.push(`# Diff`);
+  sections.push("```diff");
+  sections.push(ctx.diff || "(empty diff — respond with verdict=approve, summary noting nothing to review, blockers=[])");
+  sections.push("```");
+  sections.push("");
+
+  if (ctx.priors && ctx.priors.length > 0) {
+    sections.push(`# Round ${ctx.round ?? 2} — other agents' verdicts from the previous round`);
+    sections.push(
+      `The council is in a multi-round debate. Read each agent's verdict + blockers. Update your verdict ONLY if you see a real issue you missed, or a false-positive you can now retract. Do not mirror the majority — the dissenting voice is often the correct one.`,
+    );
+    sections.push("");
+    for (const p of ctx.priors) {
+      sections.push(`## ${p.agent}: ${p.verdict}`);
+      if (p.blockers.length > 0) {
+        for (const b of p.blockers.slice(0, 5)) {
+          const loc = b.file ? ` (${b.file}${b.line ? ":" + b.line : ""})` : "";
+          sections.push(`- [${b.severity}/${b.category}] ${b.message}${loc}`);
+        }
+      } else {
+        sections.push(`- (no blockers)`);
+      }
+      sections.push("");
+    }
+  }
+
+  sections.push(`Respond using the conclave_review JSON schema.`);
+  return sections.join("\n");
+}
+
+export function buildCacheablePrefix(ctx: ReviewContext): string {
+  const parts: string[] = [SYSTEM_PROMPT];
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
+  }
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    parts.push("failure-catalog:\n" + ctx.failureCatalog.slice(0, 8).join("\n"));
+  }
+  return parts.join("\n---\n");
+}

--- a/packages/agent-grok/src/review-schema.ts
+++ b/packages/agent-grok/src/review-schema.ts
@@ -1,0 +1,40 @@
+/**
+ * OpenAI strict JSON Schema for the review response.
+ * Per decision #12: "OpenAI strict json_schema via openai-zod-to-json-schema".
+ *
+ * Strict mode requires:
+ *   - `additionalProperties: false` at every level
+ *   - every field in `properties` must be listed in `required`
+ *
+ * The schema mirrors agent-claude's tool_use schema so both agents emit
+ * compatible `ReviewResult` shapes.
+ */
+export const REVIEW_SCHEMA_NAME = "conclave_review";
+
+export const REVIEW_JSON_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    verdict: {
+      type: "string",
+      enum: ["approve", "rework", "reject"],
+    },
+    blockers: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          severity: { type: "string", enum: ["blocker", "major", "minor", "nit"] },
+          category: { type: "string" },
+          message: { type: "string" },
+          file: { type: ["string", "null"] },
+          line: { type: ["number", "null"] },
+        },
+        required: ["severity", "category", "message", "file", "line"],
+      },
+    },
+    summary: { type: "string" },
+  },
+  required: ["verdict", "blockers", "summary"],
+} as const;

--- a/packages/agent-grok/test/grok-agent.test.mjs
+++ b/packages/agent-grok/test/grok-agent.test.mjs
@@ -1,0 +1,120 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { GrokAgent } from "../dist/index.js";
+import { EfficiencyGate } from "../../core/dist/index.js";
+
+function stubClient(responses) {
+  let i = 0;
+  const calls = [];
+  const client = {
+    chat: {
+      completions: {
+        create: async (params) => {
+          calls.push(params);
+          const r = responses[Math.min(i, responses.length - 1)];
+          i += 1;
+          if (r.throws) throw r.throws;
+          return r;
+        },
+      },
+    },
+  };
+  return { client, calls };
+}
+
+function approveResponse() {
+  return {
+    id: "resp-1",
+    model: "grok-code-fast-1",
+    choices: [
+      {
+        index: 0,
+        finish_reason: "stop",
+        message: {
+          role: "assistant",
+          content: JSON.stringify({
+            agent: "grok",
+            verdict: "approve",
+            blockers: [],
+            summary: "ok",
+          }),
+        },
+      },
+    ],
+    usage: { prompt_tokens: 200, completion_tokens: 50 },
+  };
+}
+
+const ctx = { diff: "small diff", repo: "acme/x", pullNumber: 1, newSha: "abc" };
+
+test("GrokAgent: missing XAI_API_KEY throws", () => {
+  const orig = process.env["XAI_API_KEY"];
+  delete process.env["XAI_API_KEY"];
+  try {
+    assert.throws(() => new GrokAgent());
+  } finally {
+    if (orig !== undefined) process.env["XAI_API_KEY"] = orig;
+  }
+});
+
+test("GrokAgent: constructs cleanly with injected client", () => {
+  const { client } = stubClient([approveResponse()]);
+  const agent = new GrokAgent({ client, gate: new EfficiencyGate() });
+  assert.equal(agent.id, "grok");
+  assert.equal(agent.displayName, "Grok");
+});
+
+test("GrokAgent: parses approve through the gate", async () => {
+  const { client } = stubClient([approveResponse()]);
+  const agent = new GrokAgent({ client, gate: new EfficiencyGate() });
+  const res = await agent.review(ctx);
+  assert.equal(res.verdict, "approve");
+  assert.equal(res.agent, "grok");
+});
+
+test("GrokAgent: parses rework with blockers", async () => {
+  const { client } = stubClient([
+    {
+      ...approveResponse(),
+      choices: [
+        {
+          index: 0,
+          finish_reason: "stop",
+          message: {
+            role: "assistant",
+            content: JSON.stringify({
+              agent: "grok",
+              verdict: "rework",
+              blockers: [{ severity: "major", category: "correctness", message: "bug" }],
+              summary: "fix",
+            }),
+          },
+        },
+      ],
+    },
+  ]);
+  const agent = new GrokAgent({ client, gate: new EfficiencyGate() });
+  const res = await agent.review(ctx);
+  assert.equal(res.verdict, "rework");
+  assert.equal(res.blockers.length, 1);
+});
+
+test("GrokAgent: cost uses Grok pricing table, not OpenAI's", async () => {
+  const { client } = stubClient([
+    {
+      ...approveResponse(),
+      model: "grok-code-fast-1",
+      usage: { prompt_tokens: 1_000, completion_tokens: 500 },
+    },
+  ]);
+  const agent = new GrokAgent({
+    client,
+    gate: new EfficiencyGate(),
+    model: "grok-code-fast-1",
+    apiKey: "xai-test",
+  });
+  const res = await agent.review(ctx);
+  // 1000 * 0.20 + 500 * 1.50 = 950 per 1M = 0.00095
+  assert.ok(res.costUsd < 0.001);
+  assert.ok(res.costUsd > 0.0009);
+});

--- a/packages/agent-grok/test/pricing.test.mjs
+++ b/packages/agent-grok/test/pricing.test.mjs
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { actualCost, estimateCallCost, PRICING } from "../dist/index.js";
+
+test("PRICING: table covers the four supported Grok tiers", () => {
+  assert.ok(PRICING["grok-4"]);
+  assert.ok(PRICING["grok-3"]);
+  assert.ok(PRICING["grok-3-mini"]);
+  assert.ok(PRICING["grok-code-fast-1"]);
+});
+
+test("actualCost: grok-code-fast-1 baseline", () => {
+  // 1000 * 0.20 + 500 * 1.50 = 200 + 750 = 950 / 1M = 0.00095
+  const cost = actualCost("grok-code-fast-1", { inputTokens: 1_000, outputTokens: 500 });
+  assert.equal(cost.toFixed(5), "0.00095");
+});
+
+test("actualCost: grok-4 flagship 5× more expensive than grok-3-mini", () => {
+  const grok4 = actualCost("grok-4", { inputTokens: 10_000, outputTokens: 1_000 });
+  const grokMini = actualCost("grok-3-mini", { inputTokens: 10_000, outputTokens: 1_000 });
+  assert.ok(grok4 > grokMini * 5);
+});
+
+test("actualCost: cached input applies 75% discount on grok-4", () => {
+  const noCache = actualCost("grok-4", { inputTokens: 10_000, outputTokens: 0 });
+  const cached = actualCost("grok-4", {
+    inputTokens: 10_000,
+    outputTokens: 0,
+    cachedInputTokens: 10_000,
+  });
+  assert.ok(cached < noCache);
+  const ratio = cached / noCache;
+  assert.ok(ratio > 0.24 && ratio < 0.26, `expected cache ratio ~0.25, got ${ratio.toFixed(3)}`);
+});
+
+test("actualCost: throws on unknown model", () => {
+  assert.throws(() => actualCost("grok-99", { inputTokens: 1, outputTokens: 1 }));
+});
+
+test("estimateCallCost: grok-code-fast-1 deterministic", () => {
+  // 5_000 * 0.20/M + 1_000 * 1.50/M = 0.001 + 0.0015 = 0.0025
+  const est = estimateCallCost("grok-code-fast-1", 5_000, 1_000);
+  assert.equal(est.toFixed(4), "0.0025");
+});
+
+test("estimateCallCost: throws on unknown model", () => {
+  assert.throws(() => estimateCallCost("grok-99", 1, 1));
+});

--- a/packages/agent-grok/tsconfig.json
+++ b/packages/agent-grok/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
     "@conclave-ai/agent-claude": "workspace:*",
     "@conclave-ai/agent-deepseek": "workspace:*",
     "@conclave-ai/agent-gemini": "workspace:*",
+    "@conclave-ai/agent-grok": "workspace:*",
     "@conclave-ai/agent-ollama": "workspace:*",
     "@conclave-ai/agent-openai": "workspace:*",
     "@conclave-ai/core": "workspace:*",

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -18,6 +18,7 @@ import { OpenAIAgent } from "@conclave-ai/agent-openai";
 import { GeminiAgent } from "@conclave-ai/agent-gemini";
 import { DeepseekAgent } from "@conclave-ai/agent-deepseek";
 import { OllamaAgent } from "@conclave-ai/agent-ollama";
+import { GrokAgent } from "@conclave-ai/agent-grok";
 import { LangfuseMetricsSink } from "@conclave-ai/observability-langfuse";
 import { TelegramNotifier } from "@conclave-ai/integration-telegram";
 import { DiscordNotifier } from "@conclave-ai/integration-discord";
@@ -184,6 +185,12 @@ export async function review(argv: string[]): Promise<void> {
       // OLLAMA_BASE_URL (default http://localhost:11434/v1). The user
       // is responsible for pulling the configured model.
       agents.push(new OllamaAgent({ gate }));
+    } else if (id === "grok") {
+      if (!process.env["XAI_API_KEY"]) {
+        process.stderr.write("conclave review: XAI_API_KEY not set — skipping Grok agent\n");
+        continue;
+      }
+      agents.push(new GrokAgent({ gate }));
     }
   }
   if (agents.length === 0) {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -7,7 +7,7 @@ export const CONFIG_FILENAME = ".conclaverc.json";
 
 export const ConclaveConfigSchema = z.object({
   version: z.literal(1),
-  agents: z.array(z.enum(["claude", "openai", "gemini", "deepseek", "ollama"])).default(["claude"]),
+  agents: z.array(z.enum(["claude", "openai", "gemini", "deepseek", "ollama", "grok"])).default(["claude"]),
   budget: z
     .object({
       perPrUsd: z.number().positive(),

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../agent-claude" },
     { "path": "../agent-deepseek" },
     { "path": "../agent-gemini" },
+    { "path": "../agent-grok" },
     { "path": "../agent-ollama" },
     { "path": "../agent-openai" },
     { "path": "../integration-discord" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,19 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/agent-grok:
+    dependencies:
+      '@conclave-ai/core':
+        specifier: workspace:*
+        version: link:../core
+      openai:
+        specifier: ^4.76.0
+        version: 4.104.0(ws@8.20.0)(zod@3.25.76)
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/agent-ollama:
     dependencies:
       '@conclave-ai/core':
@@ -94,6 +107,9 @@ importers:
       '@conclave-ai/agent-gemini':
         specifier: workspace:*
         version: link:../agent-gemini
+      '@conclave-ai/agent-grok':
+        specifier: workspace:*
+        version: link:../agent-grok
       '@conclave-ai/agent-ollama':
         specifier: workspace:*
         version: link:../agent-ollama


### PR DESCRIPTION
Third v2.1 agent. OpenAI-wire-compatible, routes to `api.x.ai/v1`. Default model `grok-code-fast-1` (code-tuned, cheapest). Pricing table covers grok-4 / grok-3 / grok-3-mini / grok-code-fast-1.

Test plan: 39/39 tasks (+2 new), all stubbed — no xAI credentials needed in CI.