### PR TITLE
feat(schema): 2-tier council prep — domain + tier fields + config

### DIFF
--- a/.conclaverc.json
+++ b/.conclaverc.json
@@ -3,8 +3,7 @@
   "agents": [
     "claude",
     "openai",
-    "gemini",
-    "deepseek"
+    "gemini"
   ],
   "budget": {
     "perPrUsd": 1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed (breaking prep — no runtime change yet)
+- **Schema prep for 2-tier council (reopens decisions #7 / #26 / #28).** This PR lays the foundation — next PRs bring the `TieredCouncil` class and CLI wiring.
+  - `ReviewContext` gains `domain: "code" | "design"` (optional; absent ≡ `"code"` for backward compat) and `tier: 1 | 2` (set by `TieredCouncil` at call time; legacy flat-Council callers leave it undefined).
+  - `ConclaveConfig.council.domains.{code,design}` — Zod schema with tier-1/tier-2 agent lists, per-tier maxRounds, `alwaysEscalate`, and optional per-tier model overrides. The legacy flat fields (`maxRounds`, `enableDebate`) stay in place as a fallback so existing `.conclaverc.json` files keep working.
+  - Dogfood `.conclaverc.json` drops `"deepseek"` from the agent list. The npm package `@conclave-ai/agent-deepseek@0.1.0` stays published (72-hour unpublish window passed, no need to burn it); users can opt it back in explicitly if they want.
+  - `docs/decision-status.md` records the reopen + the rationale + the explicit dropped items (idea domain, Deepseek default) + the trigger for a future revisit.
+
 ### Added
 - **`@conclave-ai/agent-grok` — xAI agent (decision #32).** Third v2.1 agent. OpenAI-wire-compatible; routes to `https://api.x.ai/v1` via the `openai` SDK. Default model `grok-code-fast-1` (code-tuned, cheapest at $0.20/M input, $1.50/M output); pricing table also covers `grok-3`, `grok-3-mini`, `grok-4`. `XAI_API_KEY` required. Missing key skips cleanly.
 

--- a/docs/decision-status.md
+++ b/docs/decision-status.md
@@ -23,7 +23,7 @@ Legend:
 | 4 | Target persona | 📄 | `ARCHITECTURE.md`, `README.md` |
 | 5 | Name registration plan | 📄 | `ARCHITECTURE.md` |
 | 6 | License + repo | 📄 | `package.json`, GitHub repo |
-| 7 | 3-round debate (Mastra label) | ✅ | `packages/core/src/council.ts` |
+| 7 | 3-round debate (Mastra label) | 🔄 | superseded by 2-tier council (reopened 2026-04-19 by Bae, see below) |
 | 8 | Claude agent loop → `@anthropic-ai/claude-agent-sdk` | 🔄 | see below |
 | 9 | OpenAI agent loop → `@openai/agents` | 🔄 | see below |
 | 10 | Gemini SDK → `@google/genai` | ✅ | `packages/agent-gemini` |
@@ -42,9 +42,9 @@ Legend:
 | 23 | Vision judge (semantic classification) | ✅ | `packages/visual-review/src/judge.ts` |
 | 24 | Equal-weight notifiers | ✅ | `integration-{telegram,discord,slack,email}` |
 | 25 | Cost per PR target | 📄 | `ARCHITECTURE.md`; `BudgetTracker` enforces |
-| 26 | Council verdicts (approve/rework/reject) | ✅ | `packages/core/src/agent.ts` |
+| 26 | Council verdicts (approve/rework/reject) | 🔄 | verdict enum unchanged, but tier-1 verdict is no longer binding — tier-2 (Opus 4.7 + GPT-5.4) produces the authoritative verdict after escalation |
 | 27 | v2.0 launch scope | 📄 | `ARCHITECTURE.md` |
-| 28 | v2.0 agent set (Claude + OpenAI + Gemini) | ✅ | 3 `agent-*` packages |
+| 28 | v2.0 agent set (Claude + OpenAI + Gemini) | 🔄 | retained at tier-1; tier-2 cross-review couple (Opus 4.7 + GPT-5.4) is the new authoritative layer. Grok / Ollama optional at tier-1 |
 | 29 | Architecture coherence > feature novelty | 📄 | `ARCHITECTURE.md` |
 | 30 | Migration path from solo-cto-agent | ✅ | `conclave migrate` |
 | 31 | v2.0 platform set (5/5) | ✅ | 5 `platform-*` packages |
@@ -99,6 +99,71 @@ The lock on #8/#9 is respected: we did not revisit the tradeoff
 casually. We implemented the use case they anticipated (one-shot
 structured review, with multi-round debate handled at the Council
 layer) and found the SDKs don't fit that shape.
+
+---
+
+## 🔄 #7 + #26 + #28 — 2-tier council (reopened 2026-04-19 by Bae)
+
+**Locked text (2026-04-19):**
+- #7: Council (Mastra graph, N pluggable agents) — 3-round debate
+- #26: Council verdicts `approve / rework / reject`
+- #28: v2.0 agent set = Claude + OpenAI + Gemini
+
+**Reopen rationale** (explicit, per Bae 2026-04-19):
+Flat 3-round debate made every review pay top-tier cost. Dogfood runs
+showed a typo-fix PR burning the same spend as a schema migration
+review. Moving to a tiered council keeps the cheap agents doing the
+bulk of the drafting and reserves the expensive cross-review (Opus
+4.7 ↔ GPT-5.4) for escalated cases.
+
+**New shape:**
+
+```
+Tier 1 (draft, 1-round, parallel):
+  Claude Sonnet 4.6  +  GPT-5 mini  +  Gemini 2.5 Pro
+  (+ Grok and/or Ollama opt-in when keys/daemon are available)
+                      │
+                      ▼
+Escalation rule:
+  - code:   blockers >= MAJOR present → escalate; else tier-1 verdict ships
+  - design: always escalate (mid-tier misses visual polish per research)
+                      │
+                      ▼
+Tier 2 (authoritative, up to 2-round cross-review):
+  Claude Opus 4.7  +  GPT-5.4
+  Final verdict is binding.
+```
+
+**What survives unchanged:**
+- The verdict enum (`approve / rework / reject`) — semantics preserved.
+- The memory substrate (answer-keys + failure-catalog) — tier-2's final
+  verdict is what gets written.
+- Agent scoring (#19) — weights unchanged; per-tier attribution via
+  `ReviewContext.tier` landing in PR 1.
+- Per-agent prompt caching and efficiency gate — every call still
+  routes through the gate.
+
+**What's new:**
+- `ReviewDomain = "code" | "design"` on `ReviewContext`
+- `config.council.domains.{code,design}` — per-domain tier-1 / tier-2
+  agent lists, maxRounds, always-escalate flag, optional model overrides
+- `TieredCouncil` class (PR 2, following this one)
+- CLI `--domain` flag (PR 3)
+
+**Explicitly dropped (also 2026-04-19, Bae):**
+- **Idea domain.** Not in scope for the review council. If idea/
+  brainstorm workflow lands it ships as a separate skill/package, not
+  part of `conclave review`.
+- **Deepseek from default agent list.** Still published at
+  `@conclave-ai/agent-deepseek@0.1.0` (npm 72-hour window passed,
+  can't unpublish and don't need to), but removed from the default
+  tier-1 config. User can opt back in via explicit `agents` entry.
+
+**Trigger for a future reopen:**
+If tier-2 gets called on >60% of reviews (meaning tier-1 isn't
+catching enough), rebalance — either stronger tier-1 models, or
+a third intermediate tier. If tier-2 gets called on <10% (tier-1 is
+too permissive), tighten the escalation rule.
 
 ---
 

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -79,8 +79,44 @@ export const ConclaveConfigSchema = z.object({
     .optional(),
   council: z
     .object({
+      // Legacy flat-Council knobs. Kept for backward compat — if
+      // `domains` is absent, the CLI falls back to the original
+      // 3-round flat Council with `maxRounds` + `enableDebate`.
       maxRounds: z.number().int().min(1).max(5).default(3),
       enableDebate: z.boolean().default(true),
+      /**
+       * 2-tier council config per domain (reopens decisions #7 / #26 /
+       * #28; see docs/decision-status.md). When present, overrides the
+       * flat fields above.
+       *
+       * Each domain picks its tier-1 (draft) + tier-2 (authoritative)
+       * agent lists. Design always escalates to tier-2; code escalates
+       * only when tier-1 can't reach a clean approve. `models` nests
+       * the per-agent model override per tier — defaults are sensible
+       * enough that most users leave it empty.
+       */
+      domains: z
+        .record(
+          z.enum(["code", "design"]),
+          z.object({
+            tier1: z
+              .array(z.enum(["claude", "openai", "gemini", "deepseek", "ollama", "grok"]))
+              .default([]),
+            tier2: z
+              .array(z.enum(["claude", "openai", "gemini", "deepseek", "ollama", "grok"]))
+              .default([]),
+            tier1MaxRounds: z.number().int().min(1).max(3).default(1),
+            tier2MaxRounds: z.number().int().min(1).max(3).default(2),
+            alwaysEscalate: z.boolean().default(false),
+            models: z
+              .object({
+                tier1: z.record(z.string(), z.string()).default({}),
+                tier2: z.record(z.string(), z.string()).default({}),
+              })
+              .default({ tier1: {}, tier2: {} }),
+          }),
+        )
+        .optional(),
     })
     .default({ maxRounds: 3, enableDebate: true }),
   federated: z

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -21,6 +21,13 @@ export interface PriorReview {
   summary?: string;
 }
 
+/**
+ * Domain of the review. Drives tier-aware routing in `TieredCouncil`
+ * (design always escalates to tier-2; code escalates conditionally).
+ * Absent ≡ "code" for backward compat with legacy `Council` callers.
+ */
+export type ReviewDomain = "code" | "design";
+
 export interface ReviewContext {
   diff: string;
   repo: string;
@@ -33,6 +40,14 @@ export interface ReviewContext {
   round?: number;
   /** Other agents' results from the previous round. Used only in Round 2+. */
   priors?: PriorReview[];
+  /** "code" (default) or "design" — see `ReviewDomain`. */
+  domain?: ReviewDomain;
+  /**
+   * Tier number, 1-indexed. Set by `TieredCouncil` when it calls agents
+   * so prompts + agent scoring can attribute results to the correct tier.
+   * Legacy flat-Council callers leave this undefined.
+   */
+  tier?: 1 | 2;
 }
 
 export interface ReviewResult {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export type { Agent, ReviewContext, ReviewResult, Blocker, Severity, PriorReview } from "./agent.js";
+export type { Agent, ReviewContext, ReviewResult, Blocker, Severity, PriorReview, ReviewDomain } from "./agent.js";
 export { Council } from "./council.js";
 export type { CouncilOutcome, CouncilOptions, RoundOutcome } from "./council.js";
 export { ReviewResultSchema, BlockerSchema } from "./schema.js";


### PR DESCRIPTION
## Summary
Foundation for the 2-tier council refactor. Pure schema + docs; no runtime behavior change. PR 2 drops \`TieredCouncil\` on top; PR 3 wires CLI.

**Reopens decisions #7 / #26 / #28** per Bae 2026-04-19. Rationale + drop list + revisit trigger all documented in \`docs/decision-status.md\`.

## What this PR does
- \`ReviewContext\` gains optional \`domain: \"code\" | \"design\"\` and \`tier: 1 | 2\` (both absent → legacy behavior)
- \`ConclaveConfig.council.domains.{code,design}\` — tier-1/tier-2 agent lists, per-tier maxRounds, \`alwaysEscalate\`, optional model overrides
- Legacy flat \`council.maxRounds\` / \`council.enableDebate\` remain as fallback — no existing config breaks
- Dogfood \`.conclaverc.json\` drops \`\"deepseek\"\` (package still published on npm, just not in the default list)
- \`docs/decision-status.md\` records the reopen with full rationale

## What it does NOT do yet
- No \`TieredCouncil\` class (PR 2)
- No CLI \`--domain\` flag (PR 3)
- No agent instantiation with tier-2 model overrides (PR 3)

## Test plan
- [x] \`pnpm build\` — 20/20
- [x] \`pnpm test\` — 39/39, 0 failures (existing flat Council tests still pass because behavior is unchanged)
- [ ] TieredCouncil tests come in PR 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)