### PR TITLE
fix(ci): drop --experimental-test-coverage (flaky on Node 20)

### DIFF
--- a/packages/agent-claude/package.json
+++ b/packages/agent-claude/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/agent-deepseek/package.json
+++ b/packages/agent-deepseek/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/agent-gemini/package.json
+++ b/packages/agent-gemini/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/agent-grok/package.json
+++ b/packages/agent-grok/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/agent-ollama/package.json
+++ b/packages/agent-ollama/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/agent-openai/package.json
+++ b/packages/agent-openai/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "build": "tsc -p tsconfig.json && node scripts/copy-seeds.mjs",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/integration-discord/package.json
+++ b/packages/integration-discord/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/integration-email/package.json
+++ b/packages/integration-email/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/integration-slack/package.json
+++ b/packages/integration-slack/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/integration-telegram/package.json
+++ b/packages/integration-telegram/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/platform-deployment-status/package.json
+++ b/packages/platform-deployment-status/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/platform-netlify/package.json
+++ b/packages/platform-netlify/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/platform-railway/package.json
+++ b/packages/platform-railway/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/platform-vercel/package.json
+++ b/packages/platform-vercel/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/scm-github/package.json
+++ b/packages/scm-github/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {

--- a/packages/visual-review/package.json
+++ b/packages/visual-review/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-test-coverage test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {


### PR DESCRIPTION
v0.2.0 release workflow failed on Node 20 — experimental coverage reporter threw `Cannot read properties of undefined (reading 'line')` after all 12 platform-railway tests passed. Flag was never consumed. Drop everywhere. 39/39 tasks green locally. Will retry release after merge.