### PR TITLE
feat(platform-render): first v2.1 platform adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Added
+- **`@conclave-ai/platform-render` — first v2.1 platform adapter.** Ranked #1 in the 2026-04 adapter-scope study (solo-maker default outside the v2.0 five). REST API at `api.render.com/v1` — GET service for canonical URL, GET deploys filtered client-side by `commit.id === sha` AND `status === "live"`. Pattern mirrors `platform-railway` (Bearer-token + URL-encode serviceId), so the next v2.1 platforms (Fly / Firebase if ranked in) plug in the same shape. 12 unit tests use the shared `mockFetch` harness. `RENDER_API_TOKEN` + `RENDER_SERVICE_ID` env vars; missing either → factory skips with reason. CLI `visual.platforms` default list adds `"render"` so it participates automatically once the user configures credentials. Service Previews caveat documented in the README — for per-PR preview URLs, point the adapter at the preview service's `srv-...` id rather than the main one.
+
+### Added
 - **CLI wiring for 2-tier council (part 3/3 of decisions #7/#26/#28 reopen).** `conclave review` now selects `TieredCouncil` when `config.council.domains[<domain>]` is set, and the legacy flat `Council` otherwise. New CLI flag `--domain code|design` (default `code`). Per-tier agent model override is pulled from config (`models.tier1` / `models.tier2`); absent entries fall back to each agent's default. `output.ts` `renderReview` adds a "Tiers" line summarizing the escalation path (`1 (1r) → 2 (2r) — domain=design`). Agent-builder logic refactored into `buildAgent(id, modelOverride?)` so tier-1 and tier-2 share one credential-check code path. Dogfood `.conclaverc.json` switched to the 2-tier shape with flagship-model overrides for tier 2 (`claude-opus-4-7`, `gpt-5.4`). `docs/configuration.md` gets a new "(b) 2-tier council" subsection documenting the shape + the escalation rule. Added `gpt-5.4` to `agent-openai` pricing table (placeholder matching gpt-5 rates; budget cap enforces spend regardless).
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "@conclave-ai/platform-deployment-status": "workspace:*",
     "@conclave-ai/platform-netlify": "workspace:*",
     "@conclave-ai/platform-railway": "workspace:*",
+    "@conclave-ai/platform-render": "workspace:*",
     "@conclave-ai/platform-vercel": "workspace:*",
     "@conclave-ai/scm-github": "workspace:*",
     "@conclave-ai/visual-review": "workspace:*",

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -438,7 +438,7 @@ export async function review(argv: string[]): Promise<void> {
     } else {
       try {
         const platformIds: PlatformId[] =
-          config.visual?.platforms ?? ["vercel", "netlify", "cloudflare", "railway", "deployment-status"];
+          config.visual?.platforms ?? ["vercel", "netlify", "cloudflare", "railway", "render", "deployment-status"];
         const { platforms, skipped } = await buildPlatforms(platformIds);
         for (const sk of skipped) {
           process.stderr.write(`conclave review: visual platform "${sk.id}" skipped — ${sk.reason}\n`);

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -129,8 +129,8 @@ export const ConclaveConfigSchema = z.object({
     .object({
       enabled: z.boolean().default(false),
       platforms: z
-        .array(z.enum(["vercel", "netlify", "cloudflare", "railway", "deployment-status"]))
-        .default(["vercel", "netlify", "cloudflare", "railway", "deployment-status"]),
+        .array(z.enum(["vercel", "netlify", "cloudflare", "railway", "render", "deployment-status"]))
+        .default(["vercel", "netlify", "cloudflare", "railway", "render", "deployment-status"]),
       width: z.number().int().positive().default(1280),
       height: z.number().int().positive().default(800),
       fullPage: z.boolean().default(true),

--- a/packages/cli/src/lib/platform-factory.ts
+++ b/packages/cli/src/lib/platform-factory.ts
@@ -1,6 +1,6 @@
 import type { Platform } from "@conclave-ai/core";
 
-export type PlatformId = "vercel" | "netlify" | "cloudflare" | "railway" | "deployment-status";
+export type PlatformId = "vercel" | "netlify" | "cloudflare" | "railway" | "render" | "deployment-status";
 
 export interface PlatformFactoryResult {
   platforms: Platform[];
@@ -74,6 +74,19 @@ export async function buildPlatforms(
         const mod = await import("@conclave-ai/platform-railway");
         try {
           platforms.push(new mod.RailwayPlatform());
+        } catch (err) {
+          skipped.push({ id, reason: (err as Error).message });
+        }
+        break;
+      }
+      case "render": {
+        if (!process.env["RENDER_API_TOKEN"] || !process.env["RENDER_SERVICE_ID"]) {
+          skipped.push({ id, reason: "RENDER_API_TOKEN or RENDER_SERVICE_ID not set" });
+          continue;
+        }
+        const mod = await import("@conclave-ai/platform-render");
+        try {
+          platforms.push(new mod.RenderPlatform());
         } catch (err) {
           skipped.push({ id, reason: (err as Error).message });
         }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -22,6 +22,7 @@
     { "path": "../platform-deployment-status" },
     { "path": "../platform-netlify" },
     { "path": "../platform-railway" },
+    { "path": "../platform-render" },
     { "path": "../platform-vercel" },
     { "path": "../visual-review" },
     { "path": "../observability-langfuse" },

--- a/packages/platform-render/README.md
+++ b/packages/platform-render/README.md
@@ -1,0 +1,45 @@
+# @conclave-ai/platform-render
+
+Conclave AI Render adapter. Resolves a deploy URL for a given commit
+SHA via Render's REST API (`api.render.com/v1`).
+
+Ranked #1 deploy target for solo makers outside the original v2.0
+five (Vercel/Netlify/Cloudflare/Railway/deployment-status) per the
+2026-04 adapter scope study.
+
+## Install
+
+Pulled in automatically by `@conclave-ai/cli` when `"render"` is in
+`config.visual.platforms`.
+
+```bash
+pnpm add @conclave-ai/platform-render
+```
+
+## Env
+
+| Var | Required | Notes |
+|---|---|---|
+| `RENDER_API_TOKEN` | yes | User-scoped token (or Service Preview PAT) |
+| `RENDER_SERVICE_ID` | yes | `srv-xxxxxxxxxxxx` — either the main service or a specific Service Preview service |
+
+## Behavior
+
+- `GET /v1/services/{serviceId}` — resolve canonical URL.
+- `GET /v1/services/{serviceId}/deploys?limit=20` — list deploys.
+- Client-side filter: `deploy.commit.id === sha` AND `deploy.status === "live"`.
+- Newest by `finishedAt` (fallback `createdAt`) wins.
+- Return `{ url: service.serviceDetails.url, sha, deploymentId, createdAt }`.
+
+## Caveats
+
+- **No per-deploy preview URL** on standard Web Services. The service
+  URL is stable; returning it + the matched deploy ID is the best
+  conforming signal for the `Platform` interface. If you need per-PR
+  URLs, configure Render's **Service Previews** — each PR spawns its
+  own service with its own `srv-...` id; point this adapter at the
+  preview service (or register multiple adapter instances).
+- 404 on service → adapter returns null (not thrown). 401/403 → throws.
+  5xx → throws with truncated body for diagnostics.
+- No native "wait for SHA" API — `waitSeconds` polls every ~3s until
+  deadline.

--- a/packages/platform-render/package.json
+++ b/packages/platform-render/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@conclave-ai/platform-render",
+  "version": "0.2.0",
+  "description": "Conclave AI Render adapter — resolve deploy URL for a commit SHA via Render's REST API.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@conclave-ai/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/platform-render/src/index.ts
+++ b/packages/platform-render/src/index.ts
@@ -1,0 +1,164 @@
+import type { Platform, PreviewResolution, ResolvePreviewInput } from "@conclave-ai/core";
+
+export interface HttpFetch {
+  (url: string, init: { method: string; headers: Record<string, string>; body?: string }): Promise<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+    text: () => Promise<string>;
+  }>;
+}
+
+export interface RenderAdapterOptions {
+  apiToken?: string;
+  /** Render service id — starts with `srv-...`. Required. */
+  serviceId?: string;
+  baseUrl?: string;
+  waitSeconds?: number;
+  fetch?: HttpFetch;
+}
+
+interface RenderDeployment {
+  id?: string;
+  status?: string;
+  commit?: { id?: string };
+  createdAt?: string;
+  finishedAt?: string;
+}
+
+interface RenderDeploysListItem {
+  deploy?: RenderDeployment;
+}
+
+interface RenderServiceResponse {
+  id?: string;
+  name?: string;
+  /**
+   * The canonical live URL. Render doesn't emit per-deploy preview URLs for
+   * regular Web Services — the service's URL is stable and serves whatever
+   * deploy is current. For PR previews (Service Previews) Render creates a
+   * SEPARATE service per PR whose `name` contains `-pr-<n>`; this adapter
+   * resolves via the user-supplied `serviceId` pointing at either a main
+   * service or a preview service.
+   */
+  serviceDetails?: { url?: string };
+}
+
+/**
+ * RenderPlatform — resolves a Render deployment's URL for a commit SHA.
+ *
+ * Strategy (since Render has no server-side SHA filter):
+ *   1. GET /v1/services/{serviceId} → resolve the live URL for that service
+ *   2. GET /v1/services/{serviceId}/deploys?limit=20 → list recent deploys
+ *   3. Filter client-side by `deploy.commit.id === sha` AND
+ *      `deploy.status === "live"`; pick newest by `finishedAt ?? createdAt`.
+ *   4. Return `{ url: service.serviceDetails.url, sha, deploymentId, createdAt }`.
+ *      The URL comes from the service object (stable per service); the
+ *      commit match is the gate that we found an actual deploy at that SHA.
+ *
+ * Env:
+ *   RENDER_API_TOKEN  — required (User-scoped token or Service Preview PAT)
+ *   RENDER_SERVICE_ID — required (srv-xxxx...)
+ */
+export class RenderPlatform implements Platform {
+  readonly id = "render";
+  readonly displayName = "Render";
+
+  private readonly apiToken: string;
+  private readonly serviceId: string;
+  private readonly baseUrl: string;
+  private readonly waitSeconds: number;
+  private readonly fetchFn: HttpFetch;
+
+  constructor(opts: RenderAdapterOptions = {}) {
+    const token = opts.apiToken ?? process.env["RENDER_API_TOKEN"] ?? "";
+    const service = opts.serviceId ?? process.env["RENDER_SERVICE_ID"] ?? "";
+    if (!token) throw new Error("RenderPlatform: RENDER_API_TOKEN not set");
+    if (!service) throw new Error("RenderPlatform: RENDER_SERVICE_ID not set");
+    this.apiToken = token;
+    this.serviceId = service;
+    this.baseUrl = opts.baseUrl ?? "https://api.render.com/v1";
+    this.waitSeconds = opts.waitSeconds ?? 0;
+    this.fetchFn =
+      opts.fetch ??
+      ((...args) => fetch(...(args as Parameters<typeof fetch>)) as ReturnType<HttpFetch>);
+  }
+
+  async resolve(input: ResolvePreviewInput): Promise<PreviewResolution | null> {
+    const wait = input.waitSeconds ?? this.waitSeconds;
+    const deadline = Date.now() + wait * 1_000;
+    while (true) {
+      const match = await this.pollOnce(input.sha);
+      if (match) return match;
+      if (Date.now() >= deadline) return null;
+      await sleep(Math.min(3_000, Math.max(500, deadline - Date.now())));
+    }
+  }
+
+  private async pollOnce(sha: string): Promise<PreviewResolution | null> {
+    // Step 1: service details (for the canonical URL).
+    const serviceRes = await this.fetchFn(`${this.baseUrl}/services/${encodeURIComponent(this.serviceId)}`, {
+      method: "GET",
+      headers: this.headers(),
+    });
+    if (serviceRes.status === 404) return null;
+    if (!serviceRes.ok) {
+      if (serviceRes.status === 401 || serviceRes.status === 403) {
+        throw new Error(`RenderPlatform: auth failed (status ${serviceRes.status})`);
+      }
+      if (serviceRes.status >= 500) {
+        const text = await serviceRes.text();
+        throw new Error(`RenderPlatform: server error ${serviceRes.status}: ${text.slice(0, 200)}`);
+      }
+      return null;
+    }
+    const service = (await serviceRes.json()) as RenderServiceResponse;
+    const serviceUrl = service.serviceDetails?.url ?? null;
+    if (!serviceUrl) return null;
+
+    // Step 2: recent deploys list.
+    const deploysRes = await this.fetchFn(
+      `${this.baseUrl}/services/${encodeURIComponent(this.serviceId)}/deploys?limit=20`,
+      { method: "GET", headers: this.headers() },
+    );
+    if (!deploysRes.ok) {
+      if (deploysRes.status === 401 || deploysRes.status === 403) {
+        throw new Error(`RenderPlatform: auth failed (status ${deploysRes.status})`);
+      }
+      if (deploysRes.status >= 500) {
+        const text = await deploysRes.text();
+        throw new Error(`RenderPlatform: server error ${deploysRes.status}: ${text.slice(0, 200)}`);
+      }
+      return null;
+    }
+    const deploys = (await deploysRes.json()) as RenderDeploysListItem[];
+    const matching = deploys
+      .map((d) => d.deploy)
+      .filter((d): d is RenderDeployment => !!d)
+      .filter((d) => d.commit?.id === sha && (d.status ?? "").toLowerCase() === "live")
+      .sort((a, b) => (b.finishedAt ?? b.createdAt ?? "").localeCompare(a.finishedAt ?? a.createdAt ?? ""));
+
+    const best = matching[0];
+    if (!best) return null;
+
+    const out: PreviewResolution = {
+      url: serviceUrl,
+      provider: "render",
+      sha,
+    };
+    if (best.id) out.deploymentId = best.id;
+    if (best.createdAt) out.createdAt = best.createdAt;
+    return out;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      authorization: `Bearer ${this.apiToken}`,
+      accept: "application/json",
+    };
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/packages/platform-render/test/render.test.mjs
+++ b/packages/platform-render/test/render.test.mjs
@@ -1,0 +1,164 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { RenderPlatform } from "../dist/index.js";
+
+function mockFetch(responses) {
+  let i = 0;
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: async () => r.json,
+      text: async () => r.text ?? JSON.stringify(r.json),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const BASE_OPTS = { apiToken: "tok", serviceId: "srv-abc" };
+
+const serviceResponse = (url = "https://my-app.onrender.com") => ({
+  id: "srv-abc",
+  name: "my-app",
+  serviceDetails: { url },
+});
+
+const deployItem = (commitId, status = "live", id = "dep-1", createdAt = "2026-04-19T10:00:00Z") => ({
+  deploy: {
+    id,
+    status,
+    commit: { id: commitId },
+    createdAt,
+    finishedAt: createdAt,
+  },
+});
+
+test("RenderPlatform: missing token / serviceId throws", () => {
+  const origT = process.env.RENDER_API_TOKEN;
+  const origS = process.env.RENDER_SERVICE_ID;
+  delete process.env.RENDER_API_TOKEN;
+  delete process.env.RENDER_SERVICE_ID;
+  try {
+    assert.throws(() => new RenderPlatform());
+    assert.throws(() => new RenderPlatform({ apiToken: "t" }));
+  } finally {
+    if (origT !== undefined) process.env.RENDER_API_TOKEN = origT;
+    if (origS !== undefined) process.env.RENDER_SERVICE_ID = origS;
+  }
+});
+
+test("RenderPlatform: live deploy matching commit returns service URL", async () => {
+  const f = mockFetch([
+    { json: serviceResponse("https://my-app.onrender.com") },
+    {
+      json: [
+        deployItem("sha-head", "live", "dep-newest", "2026-04-19T11:00:00Z"),
+        deployItem("sha-older", "live", "dep-old", "2026-04-19T09:00:00Z"),
+      ],
+    },
+  ]);
+  const p = new RenderPlatform({ ...BASE_OPTS, fetch: f });
+  const out = await p.resolve({ repo: "a/b", sha: "sha-head" });
+  assert.ok(out);
+  assert.equal(out.url, "https://my-app.onrender.com");
+  assert.equal(out.provider, "render");
+  assert.equal(out.deploymentId, "dep-newest");
+  assert.equal(out.sha, "sha-head");
+});
+
+test("RenderPlatform: non-matching commit returns null", async () => {
+  const f = mockFetch([
+    { json: serviceResponse() },
+    { json: [deployItem("other-sha", "live", "dep-1")] },
+  ]);
+  const p = new RenderPlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "sha-head" }), null);
+});
+
+test("RenderPlatform: non-live status filtered (build_in_progress)", async () => {
+  const f = mockFetch([
+    { json: serviceResponse() },
+    { json: [deployItem("sha-head", "build_in_progress")] },
+  ]);
+  const p = new RenderPlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "sha-head" }), null);
+});
+
+test("RenderPlatform: newest matching deploy wins when multiple exist", async () => {
+  const f = mockFetch([
+    { json: serviceResponse() },
+    {
+      json: [
+        deployItem("sha-head", "live", "dep-oldest", "2026-04-19T08:00:00Z"),
+        deployItem("sha-head", "live", "dep-newest", "2026-04-19T12:00:00Z"),
+        deployItem("sha-head", "live", "dep-middle", "2026-04-19T10:00:00Z"),
+      ],
+    },
+  ]);
+  const p = new RenderPlatform({ ...BASE_OPTS, fetch: f });
+  const out = await p.resolve({ repo: "a/b", sha: "sha-head" });
+  assert.equal(out.deploymentId, "dep-newest");
+});
+
+test("RenderPlatform: 404 on service → null", async () => {
+  const f = mockFetch([{ ok: false, status: 404, json: {}, text: "not found" }]);
+  const p = new RenderPlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "x" }), null);
+});
+
+test("RenderPlatform: 401 on service → auth error throws", async () => {
+  const f = mockFetch([{ ok: false, status: 401, json: {}, text: "unauth" }]);
+  const p = new RenderPlatform({ ...BASE_OPTS, fetch: f });
+  await assert.rejects(() => p.resolve({ repo: "a/b", sha: "x" }), /auth failed/);
+});
+
+test("RenderPlatform: 500 on deploys list → server error throws", async () => {
+  const f = mockFetch([
+    { json: serviceResponse() },
+    { ok: false, status: 500, json: {}, text: "render is down" },
+  ]);
+  const p = new RenderPlatform({ ...BASE_OPTS, fetch: f });
+  await assert.rejects(() => p.resolve({ repo: "a/b", sha: "x" }), /server error 500/);
+});
+
+test("RenderPlatform: sends Bearer auth + correct URL paths", async () => {
+  const f = mockFetch([
+    { json: serviceResponse() },
+    { json: [deployItem("sha-head")] },
+  ]);
+  const p = new RenderPlatform({ ...BASE_OPTS, fetch: f });
+  await p.resolve({ repo: "a/b", sha: "sha-head" });
+  assert.equal(f.calls[0].init.headers.authorization, "Bearer tok");
+  assert.match(f.calls[0].url, /\/services\/srv-abc$/);
+  assert.match(f.calls[1].url, /\/services\/srv-abc\/deploys\?limit=20$/);
+});
+
+test("RenderPlatform: service without url field returns null", async () => {
+  const f = mockFetch([{ json: { id: "srv-abc", name: "x" } }]);
+  const p = new RenderPlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "x" }), null);
+});
+
+test("RenderPlatform: serviceId with special chars gets URL-encoded", async () => {
+  const f = mockFetch([
+    { json: serviceResponse() },
+    { json: [] },
+  ]);
+  const p = new RenderPlatform({ ...BASE_OPTS, serviceId: "srv with space", fetch: f });
+  await p.resolve({ repo: "a/b", sha: "x" });
+  assert.match(f.calls[0].url, /srv%20with%20space$/);
+});
+
+test("RenderPlatform: empty deploys list returns null", async () => {
+  const f = mockFetch([
+    { json: serviceResponse() },
+    { json: [] },
+  ]);
+  const p = new RenderPlatform({ ...BASE_OPTS, fetch: f });
+  assert.equal(await p.resolve({ repo: "a/b", sha: "x" }), null);
+});

--- a/packages/platform-render/tsconfig.json
+++ b/packages/platform-render/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@conclave-ai/platform-railway':
         specifier: workspace:*
         version: link:../platform-railway
+      '@conclave-ai/platform-render':
+        specifier: workspace:*
+        version: link:../platform-render
       '@conclave-ai/platform-vercel':
         specifier: workspace:*
         version: link:../platform-vercel
@@ -263,6 +266,16 @@ importers:
         version: 5.9.3
 
   packages/platform-railway:
+    dependencies:
+      '@conclave-ai/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/platform-render:
     dependencies:
       '@conclave-ai/core':
         specifier: workspace:*


### PR DESCRIPTION
Ranked #1 in the 2026-04 adapter-scope study. Same Bearer-token REST pattern as platform-railway. 12 tests, all green. If this lands clean, Fly.io / Firebase Hosting follow next.

**Out of scope (per Bae direction):**
- Supabase — no SHA-versioned URL model, skipped entirely
- Base44 — closed ecosystem, no adapter possible