### PR TITLE
fix(core): Council resilience (P0 — Promise.allSettled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- **P0: `Council.deliberate()` no longer dies when one agent throws.** `Promise.all` → `Promise.allSettled`. Previously, any single agent 4xx/5xx/network error (e.g. Gemini free-tier 429, provider timeout, invalid key) killed the entire round and surfaced as a top-level CLI crash. Now failed agents drop out of the tally with a synthesized `rework` result carrying a `category: "agent-failure"` blocker explaining the cause. Only throws when ALL agents fail (aggregated reasons in the message). Dogfood on eventbadge PR surfaced this: Gemini 429 crashed Claude + OpenAI's otherwise-successful tier-1 pass. 3 new regression tests.
+
 ### Added
 - **`@conclave-ai/platform-render` — first v2.1 platform adapter.** Ranked #1 in the 2026-04 adapter-scope study (solo-maker default outside the v2.0 five). REST API at `api.render.com/v1` — GET service for canonical URL, GET deploys filtered client-side by `commit.id === sha` AND `status === "live"`. Pattern mirrors `platform-railway` (Bearer-token + URL-encode serviceId), so the next v2.1 platforms (Fly / Firebase if ranked in) plug in the same shape. 12 unit tests use the shared `mockFetch` harness. `RENDER_API_TOKEN` + `RENDER_SERVICE_ID` env vars; missing either → factory skips with reason. CLI `visual.platforms` default list adds `"render"` so it participates automatically once the user configures credentials. Service Previews caveat documented in the README — for per-PR preview URLs, point the adapter at the preview service's `srv-...` id rather than the main one.
 

--- a/packages/core/src/council.ts
+++ b/packages/core/src/council.ts
@@ -79,7 +79,50 @@ export class Council {
     for (let round = 1; round <= roundCap; round++) {
       const roundCtx: ReviewContext = { ...ctx, round };
       if (priors.length > 0) roundCtx.priors = priors;
-      const results = await Promise.all(this.agents.map((a) => a.review(roundCtx)));
+      // Promise.allSettled — one agent failing (rate-limit, network blip,
+      // provider 5xx) must NOT kill the rest of the council. Failed
+      // agents drop out of this round; their failure is logged to
+      // stderr and their result is synthesized as verdict="rework" with
+      // a single blocker so upstream consumers still see the signal.
+      const settled = await Promise.allSettled(this.agents.map((a) => a.review(roundCtx)));
+      const results: ReviewResult[] = [];
+      settled.forEach((s, i) => {
+        if (s.status === "fulfilled") {
+          results.push(s.value);
+          return;
+        }
+        const agent = this.agents[i];
+        if (!agent) return;
+        const err = s.reason instanceof Error ? s.reason : new Error(String(s.reason));
+        process.stderr.write(
+          `Council: ${agent.id} failed in round ${round} — ${err.message.slice(0, 300)}\n`,
+        );
+        results.push({
+          agent: agent.id,
+          verdict: "rework",
+          blockers: [
+            {
+              severity: "major",
+              category: "agent-failure",
+              message: `${agent.displayName} failed: ${err.message.slice(0, 200)}`,
+            },
+          ],
+          summary: `${agent.displayName} errored during round ${round} and was excluded from the tally.`,
+        });
+      });
+      // Throw only if ALL agents failed — otherwise continue with the survivors.
+      const anySucceeded = settled.some((s) => s.status === "fulfilled");
+      if (!anySucceeded) {
+        const reasons = settled
+          .map((s, i) =>
+            s.status === "rejected"
+              ? `${this.agents[i]?.id ?? "?"}: ${s.reason instanceof Error ? s.reason.message : String(s.reason)}`
+              : null,
+          )
+          .filter(Boolean)
+          .join("; ");
+        throw new Error(`Council: all agents failed in round ${round} — ${reasons}`);
+      }
       const tally = this.tally(results);
       roundHistory.push({
         round,

--- a/packages/core/test/council.test.mjs
+++ b/packages/core/test/council.test.mjs
@@ -235,3 +235,61 @@ test("Council: exposes config (agentCount, roundLimit, debateEnabled)", async ()
   const legacy = new Council({ agents: [fakeAgent("a", "approve")], enableDebate: false });
   assert.equal(legacy.debateEnabled, false);
 });
+
+// ---------------------------------------------------------------------
+// Agent-failure isolation (Promise.allSettled — P0 regression test)
+// ---------------------------------------------------------------------
+
+function throwingAgent(id, err) {
+  return {
+    id,
+    displayName: id,
+    review: async () => {
+      throw err instanceof Error ? err : new Error(String(err));
+    },
+  };
+}
+
+test("Council: one agent throwing does NOT kill the rest of the council", async () => {
+  const council = new Council({
+    agents: [
+      throwingAgent("gemini", "429 Too Many Requests (free tier exhausted)"),
+      fakeAgent("claude", "approve"),
+      fakeAgent("openai", "approve"),
+    ],
+  });
+  const outcome = await council.deliberate(ctx);
+  assert.equal(outcome.results.length, 3, "failed agent still surfaces a synthetic result");
+  const failed = outcome.results.find((r) => r.agent === "gemini");
+  assert.ok(failed);
+  assert.equal(failed.verdict, "rework");
+  assert.equal(failed.blockers[0].category, "agent-failure");
+  assert.match(failed.blockers[0].message, /429/);
+});
+
+test("Council: partial failure + mixed verdicts → no consensus, runs full rounds", async () => {
+  const council = new Council({
+    agents: [
+      throwingAgent("gemini", "timeout"),
+      fakeAgent("claude", "approve"),
+      fakeAgent("openai", "rework"),
+    ],
+  });
+  const outcome = await council.deliberate(ctx);
+  // gemini injected as rework → 1 approve + 2 rework → rework, no consensus
+  assert.equal(outcome.verdict, "rework");
+  assert.equal(outcome.consensusReached, false);
+});
+
+test("Council: all agents failing → throws with aggregated reasons", async () => {
+  const council = new Council({
+    agents: [
+      throwingAgent("a", "network unreachable"),
+      throwingAgent("b", "invalid api key"),
+    ],
+  });
+  await assert.rejects(
+    () => council.deliberate(ctx),
+    /all agents failed.*network unreachable.*invalid api key/s,
+  );
+});


### PR DESCRIPTION
P0 surfaced by eventbadge dogfood. Gemini 429 crashed the whole council despite Claude + OpenAI succeeding. Fix: Promise.allSettled with synthesized rework+blocker for failed agents; only throws when ALL fail. 3 new regression tests.