### PR TITLE
feat(telegram): friendly, summarized notification (non-dev readable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Changed
+- **Telegram notification rewritten for non-developer readability (dogfood feedback).** The old per-agent wall-of-technical-jargon format buried the actual action items in paragraphs and repeated the same file:line blocker once per agent. New format:
+  - **Plain-language verdict label** — `APPROVE` / `REWORK` / `REJECT` → `Approved` / `Needs changes` / `Rejected`.
+  - **Cross-agent blocker deduplication** — blockers pointing at the same `file:line` merge into one entry with an `"Claude + OpenAI agree"` marker so consensus is obvious.
+  - **Humanized category labels** — `workflow-security` → `CI workflow security`, `secrets-exposure` → `Possible secret leak`, `supply-chain` → `Supply-chain risk`, `type-error` → `Type mismatch`, plus ~10 more. Unknown categories pass through verbatim so custom tags aren't rewritten.
+  - **Top-3 distinct blockers** across all agents (was: top-3 per agent, so 9 with 3 agents and massive overlap). Remainder shown as `"+ N more issues"`.
+  - **Compact footer** — `💰 $0.37 · agents: 3` instead of `cost: 0.3664 · episodic: ep-abc…`. Episodic id kept on its own line for ops lookup.
+  - `approve` verdict gets a friendly single-line blessing (`All agents agreed the change is ready to ship`) instead of empty per-agent blocks.
+  - 11 tests cover verdict labels, category humanization, cross-agent merge, severity ordering, truncation at the 4096-char Telegram limit, HTML escape.
+
 ### Fixed
 - **P0: `Council.deliberate()` no longer dies when one agent throws.** `Promise.all` → `Promise.allSettled`. Previously, any single agent 4xx/5xx/network error (e.g. Gemini free-tier 429, provider timeout, invalid key) killed the entire round and surfaced as a top-level CLI crash. Now failed agents drop out of the tally with a synthesized `rework` result carrying a `category: "agent-failure"` blocker explaining the cause. Only throws when ALL agents fail (aggregated reasons in the message). Dogfood on eventbadge PR surfaced this: Gemini 429 crashed Claude + OpenAI's otherwise-successful tier-1 pass. 3 new regression tests.
 

--- a/packages/integration-telegram/src/format.ts
+++ b/packages/integration-telegram/src/format.ts
@@ -1,9 +1,15 @@
-import type { NotifyReviewInput } from "@conclave-ai/core";
+import type { Blocker, NotifyReviewInput, ReviewResult } from "@conclave-ai/core";
 
 const VERDICT_EMOJI: Record<"approve" | "rework" | "reject", string> = {
   approve: "✅",
   rework: "🔧",
   reject: "❌",
+};
+
+const VERDICT_LABEL: Record<"approve" | "rework" | "reject", string> = {
+  approve: "Approved",
+  rework: "Needs changes",
+  reject: "Rejected",
 };
 
 const SEVERITY_EMOJI: Record<"blocker" | "major" | "minor" | "nit", string> = {
@@ -13,65 +19,167 @@ const SEVERITY_EMOJI: Record<"blocker" | "major" | "minor" | "nit", string> = {
   nit: "💬",
 };
 
+/**
+ * Humanize our internal `category` strings into a label a non-developer
+ * can read. Unknown categories pass through as-is so domain-specific
+ * tags don't get rewritten.
+ */
+const CATEGORY_LABEL: Record<string, string> = {
+  "workflow-security": "CI workflow security",
+  "secrets-exposure": "Possible secret leak",
+  "supply-chain": "Supply-chain risk",
+  security: "Security",
+  "type-error": "Type mismatch",
+  "missing-test": "Missing test coverage",
+  regression: "Possible regression",
+  accessibility: "Accessibility",
+  contrast: "Colour contrast",
+  performance: "Performance",
+  "dead-code": "Unused code",
+  "api-misuse": "API misuse",
+  "schema-drift": "Schema drift",
+  "agent-failure": "Agent runtime error",
+  other: "Other",
+};
+
+function humanCategory(cat: string): string {
+  return CATEGORY_LABEL[cat] ?? cat;
+}
+
 /** Telegram HTML mode allows <b>, <i>, <code>, <pre>, <a href>. Escape &, <, >. */
 function esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-/**
- * Render a NotifyReviewInput into a Telegram HTML-mode message body.
- *
- * Contract:
- *   - Max length 4096 chars per Telegram (longer → truncated with ellipsis).
- *   - Per-agent sections, each capped to the top-3 blockers by severity.
- *   - Repo + PR link line at the top if `prUrl` is set.
- *   - Cost + episodic id in a footer for ops visibility.
- */
-export function formatReviewForTelegram(input: NotifyReviewInput): string {
-  const { outcome, ctx, totalCostUsd, prUrl, episodicId } = input;
-  const lines: string[] = [];
-
-  const verdictBadge = `${VERDICT_EMOJI[outcome.verdict]} <b>${outcome.verdict.toUpperCase()}</b>`;
-  const header = prUrl
-    ? `${verdictBadge} — <a href="${esc(prUrl)}">${esc(ctx.repo)} #${ctx.pullNumber}</a>`
-    : `${verdictBadge} — <b>${esc(ctx.repo)}${ctx.pullNumber ? ` #${ctx.pullNumber}` : ""}</b>`;
-  lines.push(header);
-  if (!outcome.consensusReached) lines.push("<i>no consensus reached</i>");
-  lines.push("");
-
-  for (const result of outcome.results) {
-    lines.push(
-      `<b>${esc(result.agent)}</b> → ${VERDICT_EMOJI[result.verdict]} <i>${result.verdict}</i>`,
-    );
-    if (result.blockers.length === 0) {
-      lines.push("  (no blockers)");
-    } else {
-      const sorted = [...result.blockers]
-        .sort((a, b) => severityOrder(a.severity) - severityOrder(b.severity))
-        .slice(0, 3);
-      for (const b of sorted) {
-        const where = b.file ? ` <code>${esc(b.file)}${b.line ? `:${b.line}` : ""}</code>` : "";
-        lines.push(
-          `  ${SEVERITY_EMOJI[b.severity]} <b>${b.severity}</b> (${esc(b.category)})${where}`,
-        );
-        lines.push(`    ${esc(b.message)}`);
-      }
-      if (result.blockers.length > 3) lines.push(`  … +${result.blockers.length - 3} more`);
-    }
-    if (result.summary) lines.push(`  <i>${esc(truncate(result.summary, 240))}</i>`);
-    lines.push("");
-  }
-
-  lines.push(`<i>cost: $${totalCostUsd.toFixed(4)} · episodic: <code>${esc(episodicId)}</code></i>`);
-
-  const message = lines.join("\n");
-  return message.length <= 4090 ? message : message.slice(0, 4085) + "\n…";
-}
-
-function severityOrder(s: "blocker" | "major" | "minor" | "nit"): number {
+function severityOrder(s: Blocker["severity"]): number {
   return { blocker: 0, major: 1, minor: 2, nit: 3 }[s];
 }
 
 function truncate(s: string, max: number): string {
   return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}
+
+interface MergedBlocker {
+  severity: Blocker["severity"];
+  category: string;
+  message: string;
+  file?: string;
+  line?: number;
+  agreeingAgents: string[];
+}
+
+/**
+ * Merge blockers across agents that point at the same file:line.
+ * Keeps the highest severity, the longest message (usually most
+ * informative), and the list of agents that flagged it — so the
+ * summary can show "Claude + OpenAI agree" as a consensus cue.
+ */
+function mergeBlockers(results: readonly ReviewResult[]): MergedBlocker[] {
+  const byKey = new Map<string, MergedBlocker>();
+  const unkeyed: MergedBlocker[] = [];
+
+  for (const r of results) {
+    for (const b of r.blockers) {
+      const key = b.file ? `${b.file}:${b.line ?? ""}` : null;
+      if (!key) {
+        unkeyed.push({
+          severity: b.severity,
+          category: b.category,
+          message: b.message,
+          agreeingAgents: [r.agent],
+        });
+        continue;
+      }
+      const existing = byKey.get(key);
+      if (!existing) {
+        const merged: MergedBlocker = {
+          severity: b.severity,
+          category: b.category,
+          message: b.message,
+          agreeingAgents: [r.agent],
+        };
+        if (b.file) merged.file = b.file;
+        if (b.line !== undefined) merged.line = b.line;
+        byKey.set(key, merged);
+        continue;
+      }
+      // Higher severity wins (lower enum index).
+      if (severityOrder(b.severity) < severityOrder(existing.severity)) {
+        existing.severity = b.severity;
+        existing.category = b.category;
+      }
+      // Keep the longer message — typically more informative.
+      if (b.message.length > existing.message.length) existing.message = b.message;
+      if (!existing.agreeingAgents.includes(r.agent)) existing.agreeingAgents.push(r.agent);
+    }
+  }
+
+  return [...byKey.values(), ...unkeyed].sort(
+    (a, b) => severityOrder(a.severity) - severityOrder(b.severity),
+  );
+}
+
+/**
+ * Render a NotifyReviewInput into a Telegram HTML-mode message body.
+ *
+ * Designed for non-developer readability:
+ *   - Verdict + repo link on one header line
+ *   - Cross-agent deduplication: same file:line → single entry with
+ *     "agreeing agents" footer (e.g. "Claude + OpenAI agree")
+ *   - Top 3 DISTINCT blockers (highest severity first)
+ *   - Humanized category labels (workflow-security → "CI workflow security")
+ *   - Compact footer: cost + agent count, episodic id on its own line
+ *
+ * Max 4096 chars per Telegram; truncates with ellipsis.
+ */
+export function formatReviewForTelegram(input: NotifyReviewInput): string {
+  const { outcome, ctx, totalCostUsd, prUrl, episodicId } = input;
+  const lines: string[] = [];
+
+  const repoLabel = `${ctx.repo}${ctx.pullNumber ? ` #${ctx.pullNumber}` : ""}`;
+  const repoDisplay = prUrl ? `<a href="${esc(prUrl)}">${esc(repoLabel)}</a>` : `<b>${esc(repoLabel)}</b>`;
+  const verdictLine = `${VERDICT_EMOJI[outcome.verdict]} <b>${VERDICT_LABEL[outcome.verdict]}</b>`;
+  const consensusTag = outcome.consensusReached ? "" : " · <i>no consensus</i>";
+  lines.push(`🏛️ Conclave AI — ${repoDisplay}`);
+  lines.push(verdictLine + consensusTag);
+  lines.push("");
+
+  if (outcome.verdict === "approve") {
+    lines.push("<i>All agents agreed the change is ready to ship.</i>");
+  } else {
+    const merged = mergeBlockers(outcome.results);
+    const top = merged.slice(0, 3);
+    const rest = merged.length - top.length;
+
+    if (top.length === 0) {
+      lines.push("<i>No specific blockers named, but agents did not approve.</i>");
+    } else {
+      lines.push(`<b>Top issues to fix</b> (${merged.length} total)`);
+      lines.push("");
+      top.forEach((b, i) => {
+        const head = `${i + 1}. ${SEVERITY_EMOJI[b.severity]} <b>${esc(humanCategory(b.category))}</b>`;
+        lines.push(head);
+        lines.push(`   ${esc(truncate(b.message, 220))}`);
+        if (b.file) {
+          const where = `${esc(b.file)}${b.line ? `:${b.line}` : ""}`;
+          lines.push(`   <code>${where}</code>`);
+        }
+        if (b.agreeingAgents.length > 1) {
+          const joined = b.agreeingAgents.map((a) => a[0]?.toUpperCase() + a.slice(1)).join(" + ");
+          lines.push(`   <i>${joined} agree</i>`);
+        }
+        lines.push("");
+      });
+      if (rest > 0) lines.push(`<i>+ ${rest} more issue${rest === 1 ? "" : "s"}</i>`);
+    }
+  }
+
+  lines.push("");
+  lines.push(
+    `<i>💰 $${totalCostUsd.toFixed(2)} · agents: ${outcome.results.length}</i>`,
+  );
+  lines.push(`<i>ref: <code>${esc(episodicId)}</code></i>`);
+
+  const message = lines.join("\n");
+  return message.length <= 4090 ? message : message.slice(0, 4085) + "\n…";
 }

--- a/packages/integration-telegram/test/format.test.mjs
+++ b/packages/integration-telegram/test/format.test.mjs
@@ -22,11 +22,11 @@ function mkInput(overrides = {}) {
   };
 }
 
-test("formatReviewForTelegram: approve with HTML emoji header", () => {
+test("formatReviewForTelegram: approve uses plain-language verdict label", () => {
   const msg = formatReviewForTelegram(mkInput());
-  assert.match(msg, /✅ <b>APPROVE<\/b>/);
+  assert.match(msg, /✅ <b>Approved<\/b>/);
   assert.match(msg, /acme\/app.*#42/);
-  assert.match(msg, /LGTM/);
+  assert.match(msg, /All agents agreed/);
 });
 
 test("formatReviewForTelegram: link to prUrl when supplied", () => {
@@ -56,16 +56,15 @@ test("formatReviewForTelegram: escapes HTML-special chars in content", () => {
   );
   assert.ok(!msg.includes("<never>"), "raw angle brackets must be escaped");
   assert.match(msg, /&lt;never&gt;/);
-  assert.match(msg, /a &amp; b/);
 });
 
-test("formatReviewForTelegram: severity-sorts blockers and caps at 3", () => {
+test("formatReviewForTelegram: severity-sorts distinct blockers and caps at top 3", () => {
   const blockers = [
-    { severity: "nit", category: "style", message: "nit 1" },
-    { severity: "blocker", category: "security", message: "block 1" },
-    { severity: "minor", category: "dead-code", message: "minor 1" },
-    { severity: "major", category: "regression", message: "major 1" },
-    { severity: "blocker", category: "type-error", message: "block 2" },
+    { severity: "nit", category: "style", message: "nit 1", file: "a.ts", line: 1 },
+    { severity: "blocker", category: "security", message: "block 1", file: "b.ts", line: 2 },
+    { severity: "minor", category: "dead-code", message: "minor 1", file: "c.ts", line: 3 },
+    { severity: "major", category: "regression", message: "major 1", file: "d.ts", line: 4 },
+    { severity: "blocker", category: "type-error", message: "block 2", file: "e.ts", line: 5 },
   ];
   const msg = formatReviewForTelegram(
     mkInput({
@@ -77,15 +76,15 @@ test("formatReviewForTelegram: severity-sorts blockers and caps at 3", () => {
       },
     }),
   );
-  // Top-3 by severity: block 1, block 2, major 1
+  // Top-3 by severity: block 1, block 2, major 1 — should appear in that order
   const order = ["block 1", "block 2", "major 1"];
   let lastIdx = -1;
   for (const label of order) {
     const idx = msg.indexOf(label);
-    assert.ok(idx > lastIdx, `expected "${label}" to appear in order`);
+    assert.ok(idx > lastIdx, `expected "${label}" to appear in order, instead got index ${idx}`);
     lastIdx = idx;
   }
-  assert.match(msg, /\+2 more/); // 5 blockers minus 3 shown = 2 more
+  assert.match(msg, /\+ 2 more issues/);
 });
 
 test("formatReviewForTelegram: no-consensus tag", () => {
@@ -102,36 +101,96 @@ test("formatReviewForTelegram: no-consensus tag", () => {
   assert.match(msg, /no consensus/);
 });
 
-test("formatReviewForTelegram: footer includes cost + episodic id", () => {
-  const msg = formatReviewForTelegram(mkInput({ totalCostUsd: 0.0345, episodicId: "ep-xyz" }));
-  assert.match(msg, /\$0\.0345/);
+test("formatReviewForTelegram: footer shows cost (2 decimals) + episodic ref", () => {
+  const msg = formatReviewForTelegram(mkInput({ totalCostUsd: 0.3664, episodicId: "ep-xyz" }));
+  assert.match(msg, /\$0\.37/); // rounded to 2 decimals
   assert.match(msg, /ep-xyz/);
 });
 
 test("formatReviewForTelegram: truncates if longer than 4096 chars", () => {
-  const huge = "x".repeat(12_000);
+  // Per-blocker messages are 220-char capped; force overflow via a
+  // giant repo slug so the envelope alone exceeds the 4096 cap.
+  const hugeRepo = "acme/" + "x".repeat(5000);
   const msg = formatReviewForTelegram(
     mkInput({
-      outcome: {
-        verdict: "rework",
-        rounds: 1,
-        consensusReached: true,
-        results: [
-          {
-            agent: "claude",
-            verdict: "rework",
-            blockers: [{ severity: "blocker", category: "security", message: huge }],
-            summary: "",
-          },
-        ],
-      },
+      ctx: { diff: "", repo: hugeRepo, pullNumber: 42, newSha: "abc" },
     }),
   );
   assert.ok(msg.length <= 4096, `expected ≤ 4096 chars, got ${msg.length}`);
   assert.ok(msg.endsWith("…"));
 });
 
-test("formatReviewForTelegram: (no blockers) placeholder when empty", () => {
-  const msg = formatReviewForTelegram(mkInput());
-  assert.match(msg, /no blockers/);
+test("formatReviewForTelegram: humanizes technical category labels", () => {
+  const msg = formatReviewForTelegram(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: false,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [
+              { severity: "major", category: "secrets-exposure", message: "key may leak", file: "x.yml", line: 12 },
+              { severity: "major", category: "workflow-security", message: "PR secret access", file: "x.yml", line: 5 },
+              { severity: "minor", category: "supply-chain", message: "unpinned dep", file: "x.yml", line: 30 },
+            ],
+            summary: "",
+          },
+        ],
+      },
+    }),
+  );
+  assert.match(msg, /Possible secret leak/);
+  assert.match(msg, /CI workflow security/);
+  assert.match(msg, /Supply-chain risk/);
+  // Original technical keys should NOT appear in the rendered text
+  assert.ok(!msg.includes("secrets-exposure"));
+  assert.ok(!msg.includes("workflow-security"));
+});
+
+test("formatReviewForTelegram: merges cross-agent blockers at same file:line", () => {
+  const shared = { severity: "major", category: "security", file: "app.ts", line: 42 };
+  const msg = formatReviewForTelegram(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: false,
+        results: [
+          {
+            agent: "claude",
+            verdict: "rework",
+            blockers: [{ ...shared, message: "Claude: auth check missing" }],
+            summary: "",
+          },
+          {
+            agent: "openai",
+            verdict: "rework",
+            blockers: [{ ...shared, message: "OpenAI: missing auth check (slightly longer)" }],
+            summary: "",
+          },
+        ],
+      },
+    }),
+  );
+  // Merged — only one entry for app.ts:42
+  assert.equal(msg.match(/app\.ts:42/g)?.length, 1);
+  // Agreement marker shown
+  assert.match(msg, /Claude \+ Openai agree|Claude \+ OpenAI agree/i);
+});
+
+test("formatReviewForTelegram: no blockers named but not approved → fallback notice", () => {
+  const msg = formatReviewForTelegram(
+    mkInput({
+      outcome: {
+        verdict: "rework",
+        rounds: 1,
+        consensusReached: false,
+        results: [{ agent: "claude", verdict: "rework", blockers: [], summary: "" }],
+      },
+    }),
+  );
+  assert.match(msg, /No specific blockers named/);
 });

--- a/packages/integration-telegram/test/notifier.test.mjs
+++ b/packages/integration-telegram/test/notifier.test.mjs
@@ -63,7 +63,7 @@ test("TelegramNotifier: notifyReview posts HTML + disable_web_page_preview", asy
   await n.notifyReview(baseInput);
   assert.equal(f.calls[0].body.parse_mode, "HTML");
   assert.equal(f.calls[0].body.disable_web_page_preview, true);
-  assert.match(f.calls[0].body.text, /APPROVE/);
+  assert.match(f.calls[0].body.text, /Approved/);
 });
 
 test("TelegramNotifier: includes inline action keyboard by default", async () => {


### PR DESCRIPTION
Dogfood feedback — the v0.2.1 Telegram output buried action items in technical jargon. Rewrite:

- Plain labels (Approved / Needs changes / Rejected)
- **Cross-agent dedup**: same file:line → one entry with 'Claude + OpenAI agree' marker
- Humanized categories (workflow-security → 'CI workflow security', secrets-exposure → 'Possible secret leak', etc.)
- Top-3 DISTINCT blockers, not per-agent repeat
- Compact footer: `💰 $0.37 · agents: 3`

11 tests. 41/41 tasks green.