### PR TITLE
feat(core): LoopGuard + CircuitBreaker (architecture spec layer 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+- **`@conclave-ai/core/guards` — `LoopGuard` + `CircuitBreaker` (architecture spec layer 3, now shipped).** Two in-memory primitives with clock-injection for tests:
+  - **`LoopGuard`** — bounded-frequency counter on `(repo, pr, sha)` or any user-chosen key. Throws `LoopDetectedError` when the same key is reviewed more than `threshold` times inside a rolling `windowMs`. Defaults: threshold 5, window 60 min. Prevents the "rework → re-review → rework → …" loop that'll happen once the Worker/Rework agent lands (planned).
+  - **`CircuitBreaker`** — per-provider consecutive-failure counter with cooldown. Wrap each external call with `breaker.guard(providerId, fn)`. After `failureThreshold` consecutive failures (default 3), refuses calls for `cooldownMs` (default 5 min) with `CircuitOpenError`. Success between failures resets the counter. Half-open on next call after cooldown. Providers track independently — Gemini 429 doesn't throttle Claude + OpenAI. Complements the `Promise.allSettled` fix in PR #53: allSettled survives one-round failures; CircuitBreaker stops repeated offenders before they burn budget.
+  - Neither wired into Council / EfficiencyGate by default — callers opt-in through the orchestrator template. Keeps primitives unit-testable and the gate free of deployment-shape assumptions.
+  - 13 tests: threshold math, rolling-window eviction, independent keys/providers, diagnostic error fields, cooldown expiry → half-open → re-open path.
+
 ### Changed
 - **Telegram notification rewritten for non-developer readability (dogfood feedback).** The old per-agent wall-of-technical-jargon format buried the actual action items in paragraphs and repeated the same file:line blocker once per agent. New format:
   - **Plain-language verdict label** — `APPROVE` / `REWORK` / `REJECT` → `Approved` / `Needs changes` / `Rejected`.

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -1,0 +1,185 @@
+/**
+ * Guards — anti-loop + circuit breaker per ARCHITECTURE.md layer 3.
+ *
+ * Two independent primitives, both in-memory + clock-injectable for tests:
+ *
+ *   - `LoopGuard`: bound how many times the same (repo, pr, sha) gets
+ *     reviewed in a rolling window. Prevents infinite rework cycles where
+ *     an agent's patch reopens a review that agents reject, which
+ *     triggers another patch, ad infinitum. Throws `LoopDetectedError`.
+ *
+ *   - `CircuitBreaker`: track consecutive failures per provider. After
+ *     the threshold trips, refuse calls for a cooldown. Prevents burning
+ *     budget on a dead provider while also letting healthy providers
+ *     continue. Wrap each call with `breaker.guard(provider, fn)`.
+ *
+ * Neither guard is wired into Council / EfficiencyGate by default —
+ * callers opt-in via the orchestrator template (`conclave review`
+ * composes them around the Council). Keeps the primitives unit-testable
+ * and the gate free of mandatory behaviour that's only right for one
+ * deployment shape.
+ */
+
+export class LoopDetectedError extends Error {
+  constructor(
+    message: string,
+    readonly key: string,
+    readonly count: number,
+    readonly windowMs: number,
+  ) {
+    super(message);
+    this.name = "LoopDetectedError";
+  }
+}
+
+export class CircuitOpenError extends Error {
+  constructor(
+    message: string,
+    readonly provider: string,
+    readonly openUntil: number,
+  ) {
+    super(message);
+    this.name = "CircuitOpenError";
+  }
+}
+
+export interface LoopGuardOptions {
+  /** Max review attempts per key inside `windowMs`. Default 5. */
+  threshold?: number;
+  /** Rolling-window length in ms. Default 60 minutes. */
+  windowMs?: number;
+  /** Injectable clock (for tests). Default `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * Bounded-frequency counter. `check(key)` records an attempt + throws
+ * when the same key has been seen more than `threshold` times inside
+ * the current rolling window. Purely in-memory — state lives on the
+ * single process running Council.
+ */
+export class LoopGuard {
+  private readonly threshold: number;
+  private readonly windowMs: number;
+  private readonly now: () => number;
+  private readonly attempts: Map<string, number[]> = new Map();
+
+  constructor(opts: LoopGuardOptions = {}) {
+    this.threshold = opts.threshold ?? 5;
+    this.windowMs = opts.windowMs ?? 60 * 60 * 1_000;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  /**
+   * Record an attempt for `key`. Throws `LoopDetectedError` if the
+   * recent attempt count would exceed `threshold` after this record.
+   * Call this at the TOP of every review so the attempt count
+   * accumulates per (repo, pr, sha) or whatever key you pass in.
+   */
+  check(key: string): void {
+    const now = this.now();
+    const cutoff = now - this.windowMs;
+    const prior = (this.attempts.get(key) ?? []).filter((t) => t >= cutoff);
+    prior.push(now);
+    this.attempts.set(key, prior);
+    if (prior.length > this.threshold) {
+      throw new LoopDetectedError(
+        `LoopGuard: ${key} was reviewed ${prior.length} times in the last ${Math.round(this.windowMs / 60_000)} min (threshold ${this.threshold}).`,
+        key,
+        prior.length,
+        this.windowMs,
+      );
+    }
+  }
+
+  /** Test helper — number of live (within-window) attempts for a key. */
+  count(key: string): number {
+    const cutoff = this.now() - this.windowMs;
+    return (this.attempts.get(key) ?? []).filter((t) => t >= cutoff).length;
+  }
+
+  reset(): void {
+    this.attempts.clear();
+  }
+}
+
+export interface CircuitBreakerOptions {
+  /** Consecutive failures that trip the breaker. Default 3. */
+  failureThreshold?: number;
+  /** How long the circuit stays open in ms. Default 5 minutes. */
+  cooldownMs?: number;
+  /** Injectable clock. */
+  now?: () => number;
+}
+
+interface CircuitState {
+  consecutiveFailures: number;
+  openUntil: number | null;
+}
+
+/**
+ * Per-provider circuit breaker. Wrap every external-provider call with
+ * `breaker.guard(providerId, fn)`.
+ *
+ *   closed  → normal, counting failures
+ *   open    → refuses calls, throws `CircuitOpenError` until `openUntil`
+ *   half-open → (implicit, when `openUntil` passes) — the NEXT call
+ *     through is allowed; on success closes + resets, on failure
+ *     re-opens with fresh cooldown.
+ *
+ * Independence across providers means a Gemini 429 doesn't throttle
+ * Claude + OpenAI.
+ */
+export class CircuitBreaker {
+  private readonly failureThreshold: number;
+  private readonly cooldownMs: number;
+  private readonly now: () => number;
+  private readonly states: Map<string, CircuitState> = new Map();
+
+  constructor(opts: CircuitBreakerOptions = {}) {
+    this.failureThreshold = opts.failureThreshold ?? 3;
+    this.cooldownMs = opts.cooldownMs ?? 5 * 60 * 1_000;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  async guard<T>(provider: string, fn: () => Promise<T>): Promise<T> {
+    const state = this.states.get(provider) ?? { consecutiveFailures: 0, openUntil: null };
+
+    if (state.openUntil !== null && this.now() < state.openUntil) {
+      throw new CircuitOpenError(
+        `CircuitBreaker: ${provider} is open until ${new Date(state.openUntil).toISOString()}.`,
+        provider,
+        state.openUntil,
+      );
+    }
+
+    try {
+      const result = await fn();
+      // Success — close the circuit, reset the counter.
+      state.consecutiveFailures = 0;
+      state.openUntil = null;
+      this.states.set(provider, state);
+      return result;
+    } catch (err) {
+      state.consecutiveFailures += 1;
+      if (state.consecutiveFailures >= this.failureThreshold) {
+        state.openUntil = this.now() + this.cooldownMs;
+      }
+      this.states.set(provider, state);
+      throw err;
+    }
+  }
+
+  /** Test helpers. */
+  isOpen(provider: string): boolean {
+    const s = this.states.get(provider);
+    return !!(s && s.openUntil !== null && this.now() < s.openUntil);
+  }
+  failureCount(provider: string): number {
+    return this.states.get(provider)?.consecutiveFailures ?? 0;
+  }
+  reset(provider?: string): void {
+    if (provider) this.states.delete(provider);
+    else this.states.clear();
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,8 @@ export { Council } from "./council.js";
 export type { CouncilOutcome, CouncilOptions, RoundOutcome } from "./council.js";
 export { TieredCouncil } from "./tiered-council.js";
 export type { TieredCouncilOptions, TieredCouncilOutcome } from "./tiered-council.js";
+export { LoopGuard, CircuitBreaker, LoopDetectedError, CircuitOpenError } from "./guards.js";
+export type { LoopGuardOptions, CircuitBreakerOptions } from "./guards.js";
 export { ReviewResultSchema, BlockerSchema } from "./schema.js";
 export type { Notifier, NotifyReviewInput } from "./notifier.js";
 export { resolveFirstPreview } from "./platform.js";

--- a/packages/core/test/guards.test.mjs
+++ b/packages/core/test/guards.test.mjs
@@ -1,0 +1,165 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { LoopGuard, CircuitBreaker, LoopDetectedError, CircuitOpenError } from "../dist/index.js";
+
+// ---------------------------------------------------------------------
+// LoopGuard
+// ---------------------------------------------------------------------
+
+function clock() {
+  let t = 1_700_000_000_000;
+  return {
+    now: () => t,
+    advance(ms) {
+      t += ms;
+    },
+  };
+}
+
+test("LoopGuard: up to threshold is OK", () => {
+  const c = clock();
+  const g = new LoopGuard({ threshold: 5, windowMs: 60_000, now: c.now });
+  for (let i = 0; i < 5; i += 1) g.check("acme/repo#1@abc");
+  assert.equal(g.count("acme/repo#1@abc"), 5);
+});
+
+test("LoopGuard: one-over throws LoopDetectedError", () => {
+  const c = clock();
+  const g = new LoopGuard({ threshold: 3, now: c.now });
+  g.check("k");
+  g.check("k");
+  g.check("k");
+  assert.throws(() => g.check("k"), LoopDetectedError);
+});
+
+test("LoopGuard: stale entries outside window don't count", () => {
+  const c = clock();
+  const g = new LoopGuard({ threshold: 3, windowMs: 60_000, now: c.now });
+  g.check("k");
+  g.check("k");
+  g.check("k");
+  c.advance(120_000); // past the 60s window
+  // All 3 prior entries are now stale — this is the FIRST live attempt
+  g.check("k");
+  assert.equal(g.count("k"), 1);
+});
+
+test("LoopGuard: different keys track independently", () => {
+  const c = clock();
+  const g = new LoopGuard({ threshold: 2, now: c.now });
+  g.check("a");
+  g.check("a");
+  // 'a' is at threshold; 'b' is fresh
+  g.check("b");
+  assert.equal(g.count("a"), 2);
+  assert.equal(g.count("b"), 1);
+});
+
+test("LoopGuard: LoopDetectedError carries diagnostic context", () => {
+  const c = clock();
+  const g = new LoopGuard({ threshold: 2, windowMs: 60_000, now: c.now });
+  g.check("k");
+  g.check("k");
+  try {
+    g.check("k");
+    assert.fail("should have thrown");
+  } catch (err) {
+    assert.ok(err instanceof LoopDetectedError);
+    assert.equal(err.key, "k");
+    assert.equal(err.count, 3);
+    assert.equal(err.windowMs, 60_000);
+  }
+});
+
+test("LoopGuard: reset clears all state", () => {
+  const c = clock();
+  const g = new LoopGuard({ threshold: 2, now: c.now });
+  g.check("a");
+  g.check("a");
+  g.reset();
+  g.check("a");
+  assert.equal(g.count("a"), 1);
+});
+
+// ---------------------------------------------------------------------
+// CircuitBreaker
+// ---------------------------------------------------------------------
+
+test("CircuitBreaker: success path returns result + resets", async () => {
+  const c = clock();
+  const b = new CircuitBreaker({ failureThreshold: 3, now: c.now });
+  const out = await b.guard("openai", async () => "ok");
+  assert.equal(out, "ok");
+  assert.equal(b.failureCount("openai"), 0);
+  assert.equal(b.isOpen("openai"), false);
+});
+
+test("CircuitBreaker: counts consecutive failures up to threshold", async () => {
+  const c = clock();
+  const b = new CircuitBreaker({ failureThreshold: 3, now: c.now });
+  for (let i = 0; i < 2; i += 1) {
+    await assert.rejects(() => b.guard("openai", async () => { throw new Error("nope"); }));
+  }
+  assert.equal(b.failureCount("openai"), 2);
+  assert.equal(b.isOpen("openai"), false);
+});
+
+test("CircuitBreaker: third consecutive failure opens the circuit", async () => {
+  const c = clock();
+  const b = new CircuitBreaker({ failureThreshold: 3, cooldownMs: 300_000, now: c.now });
+  for (let i = 0; i < 3; i += 1) {
+    await assert.rejects(() => b.guard("openai", async () => { throw new Error("nope"); }));
+  }
+  assert.equal(b.isOpen("openai"), true);
+  await assert.rejects(
+    () => b.guard("openai", async () => "never runs"),
+    CircuitOpenError,
+  );
+});
+
+test("CircuitBreaker: success between failures resets the counter", async () => {
+  const c = clock();
+  const b = new CircuitBreaker({ failureThreshold: 3, now: c.now });
+  await assert.rejects(() => b.guard("openai", async () => { throw new Error("1"); }));
+  await assert.rejects(() => b.guard("openai", async () => { throw new Error("2"); }));
+  assert.equal(b.failureCount("openai"), 2);
+  await b.guard("openai", async () => "good");
+  assert.equal(b.failureCount("openai"), 0);
+});
+
+test("CircuitBreaker: different providers track independently", async () => {
+  const c = clock();
+  const b = new CircuitBreaker({ failureThreshold: 2, now: c.now });
+  await assert.rejects(() => b.guard("openai", async () => { throw new Error("x"); }));
+  await assert.rejects(() => b.guard("openai", async () => { throw new Error("x"); }));
+  assert.equal(b.isOpen("openai"), true);
+  assert.equal(b.isOpen("claude"), false);
+  const ok = await b.guard("claude", async () => "ok");
+  assert.equal(ok, "ok");
+});
+
+test("CircuitBreaker: circuit closes after cooldown (half-open on next call)", async () => {
+  const c = clock();
+  const b = new CircuitBreaker({ failureThreshold: 2, cooldownMs: 60_000, now: c.now });
+  await assert.rejects(() => b.guard("openai", async () => { throw new Error("x"); }));
+  await assert.rejects(() => b.guard("openai", async () => { throw new Error("x"); }));
+  assert.equal(b.isOpen("openai"), true);
+  c.advance(61_000);
+  assert.equal(b.isOpen("openai"), false);
+  const ok = await b.guard("openai", async () => "recovered");
+  assert.equal(ok, "recovered");
+});
+
+test("CircuitBreaker: CircuitOpenError carries diagnostics", async () => {
+  const c = clock();
+  const b = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 60_000, now: c.now });
+  await assert.rejects(() => b.guard("gemini", async () => { throw new Error("429"); }));
+  try {
+    await b.guard("gemini", async () => "never");
+    assert.fail("should have thrown");
+  } catch (err) {
+    assert.ok(err instanceof CircuitOpenError);
+    assert.equal(err.provider, "gemini");
+    assert.ok(err.openUntil > c.now());
+  }
+});


### PR DESCRIPTION
Two in-memory primitives, clock-injectable for tests:

- **LoopGuard** — bounded-frequency on user-chosen key (e.g. `repo#pr@sha`). Throws LoopDetectedError past threshold inside rolling window. Primitive for anti-infinite-rework once Worker agent lands.
- **CircuitBreaker** — per-provider consecutive-failure counter + cooldown. Providers independent. Complements PR #53 `Promise.allSettled`.

Neither wired by default; orchestrator opts-in. 13 tests. Full suite 41/41.