### PR TITLE
feat(agent-worker): new package — turn council blockers into a unified-diff patch

### DIFF
--- a/packages/agent-worker/README.md
+++ b/packages/agent-worker/README.md
@@ -1,0 +1,49 @@
+# @conclave-ai/agent-worker
+
+Worker agent for Conclave AI. Consumes `ReviewResult[]` from the council and emits a unified-diff `WorkerOutcome` ready to be applied with `git apply` and committed back to the PR branch.
+
+Pure with respect to the filesystem — it never reads files or shells out to git. The caller (typically the `conclave rework` CLI) is responsible for reading file snapshots, applying the returned patch, and committing.
+
+## Usage
+
+```ts
+import { ClaudeWorker } from "@conclave-ai/agent-worker";
+import { EfficiencyGate } from "@conclave-ai/core";
+
+const worker = new ClaudeWorker({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+  gate: new EfficiencyGate({ perPrUsd: 5 }),
+});
+
+const outcome = await worker.work({
+  repo: "acme/service",
+  pullNumber: 42,
+  newSha: "abc123",
+  reviews: councilOutcome.results,
+  fileSnapshots: [
+    { path: "src/auth.ts", contents: fs.readFileSync("src/auth.ts", "utf8") },
+  ],
+});
+
+// outcome.patch  → unified diff
+// outcome.message → commit subject
+// outcome.appliedFiles → ["src/auth.ts"]
+```
+
+## Why a separate package
+
+The worker uses the same LLM plumbing as `agent-claude` (tool-use, efficiency gate, pricing table) but emits a fundamentally different artifact — a patch, not a review. Keeping them separate means the `Agent` interface in `@conclave-ai/core` stays clean (review-only) and the worker's commit-loop concerns don't leak into the council.
+
+## Guard integration
+
+The worker itself does not wrap calls in `LoopGuard` / `CircuitBreaker` — the caller is expected to do that, because the "did we already try this" signal lives at the PR/sha level that only the orchestrator can see. Pattern:
+
+```ts
+const loopGuard = new LoopGuard();
+const breaker = new CircuitBreaker();
+
+loopGuard.check(`${ctx.repo}#${ctx.pullNumber}:${ctx.newSha}`);
+const outcome = await breaker.guard("worker", () => worker.work(ctx));
+```
+
+See `@conclave-ai/core` `guards.ts` for the API.

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@conclave-ai/agent-worker",
+  "version": "0.2.2",
+  "description": "Conclave AI Worker agent — turns Council blockers into a unified-diff patch ready to commit back to the PR branch.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@conclave-ai/core": "workspace:*",
+    "@anthropic-ai/sdk": "^0.65.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/agent-worker/src/anthropic-types.ts
+++ b/packages/agent-worker/src/anthropic-types.ts
@@ -1,0 +1,40 @@
+/**
+ * Minimal shape of the Anthropic SDK client that ClaudeWorker needs.
+ * Structurally identical to the one in agent-claude — duplicated here
+ * rather than imported so each agent package can evolve independently
+ * and so tests can inject mocks without pulling the agent-claude build.
+ */
+export interface AnthropicLike {
+  messages: {
+    create(params: AnthropicCreateParams): Promise<AnthropicResponse>;
+  };
+}
+
+export interface AnthropicCreateParams {
+  model: string;
+  max_tokens: number;
+  system?: string | ReadonlyArray<{ type: "text"; text: string; cache_control?: { type: "ephemeral" } }>;
+  messages: ReadonlyArray<{ role: "user" | "assistant"; content: string }>;
+  tools?: ReadonlyArray<{
+    name: string;
+    description: string;
+    input_schema: unknown;
+  }>;
+  tool_choice?: { type: "tool"; name: string } | { type: "auto" } | { type: "any" };
+}
+
+export interface AnthropicResponse {
+  id: string;
+  model: string;
+  content: ReadonlyArray<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; id: string; name: string; input: unknown }
+  >;
+  stop_reason?: string;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}

--- a/packages/agent-worker/src/index.ts
+++ b/packages/agent-worker/src/index.ts
@@ -1,0 +1,13 @@
+export { ClaudeWorker, WORKER_SYSTEM_PROMPT } from "./worker.js";
+export type { ClaudeWorkerOptions } from "./worker.js";
+export { buildWorkerPrompt, buildCacheablePrefix } from "./prompts.js";
+export {
+  PATCH_TOOL_NAME,
+  PATCH_TOOL_DESCRIPTION,
+  PATCH_TOOL_INPUT_SCHEMA,
+} from "./patch-tool.js";
+export { parsePatchToolUse, looksLikeUnifiedDiff, WorkerParseError } from "./patch-parser.js";
+export { actualCost, estimateCallCost, PRICING } from "./pricing.js";
+export type { ModelPricing, UsageBreakdown } from "./pricing.js";
+export type { AnthropicLike, AnthropicCreateParams, AnthropicResponse } from "./anthropic-types.js";
+export type { WorkerContext, WorkerOutcome, FileSnapshot } from "./types.js";

--- a/packages/agent-worker/src/patch-parser.ts
+++ b/packages/agent-worker/src/patch-parser.ts
@@ -1,0 +1,72 @@
+import type { AnthropicResponse } from "./anthropic-types.js";
+import { PATCH_TOOL_NAME } from "./patch-tool.js";
+import type { WorkerOutcome } from "./types.js";
+
+export class WorkerParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkerParseError";
+  }
+}
+
+/**
+ * Parse the Claude tool_use response into a WorkerOutcome.
+ *
+ * Validation rules:
+ * - exactly one `submit_patch` tool_use block must be present
+ * - `commitMessage` and `summary` are strings
+ * - `filesTouched` is an array of strings
+ * - `patch` is a string (may be empty when the worker gives up — we
+ *   preserve that signal instead of throwing, so the caller can decide)
+ * - if `patch` is non-empty, it must look like a unified diff (one of
+ *   `diff --git`, `--- `, or `Index:` at the start of a line) — this
+ *   catches the common failure where the model returns a code snippet
+ *   in prose form instead of a patch
+ */
+export function parsePatchToolUse(response: AnthropicResponse): Omit<WorkerOutcome, "tokensUsed" | "costUsd"> {
+  const toolUse = response.content.find(
+    (block): block is Extract<(typeof response.content)[number], { type: "tool_use" }> =>
+      block.type === "tool_use" && block.name === PATCH_TOOL_NAME,
+  );
+  if (!toolUse) {
+    throw new WorkerParseError(
+      `Worker: response did not include a ${PATCH_TOOL_NAME} tool_use block (stop_reason=${response.stop_reason ?? "?"})`,
+    );
+  }
+
+  const input = toolUse.input as {
+    patch?: unknown;
+    commitMessage?: unknown;
+    filesTouched?: unknown;
+    summary?: unknown;
+  };
+
+  if (typeof input.patch !== "string") {
+    throw new WorkerParseError(`Worker: submit_patch.patch must be a string`);
+  }
+  if (typeof input.commitMessage !== "string" || input.commitMessage.trim().length === 0) {
+    throw new WorkerParseError(`Worker: submit_patch.commitMessage must be a non-empty string`);
+  }
+  if (!Array.isArray(input.filesTouched) || !input.filesTouched.every((f) => typeof f === "string")) {
+    throw new WorkerParseError(`Worker: submit_patch.filesTouched must be an array of strings`);
+  }
+
+  const patch = input.patch;
+  if (patch.length > 0 && !looksLikeUnifiedDiff(patch)) {
+    throw new WorkerParseError(
+      `Worker: submit_patch.patch does not look like a unified diff (expected 'diff --git', '--- ', or 'Index:' header)`,
+    );
+  }
+
+  return {
+    patch,
+    message: input.commitMessage.trim(),
+    appliedFiles: (input.filesTouched as string[]).map((f) => f.trim()).filter((f) => f.length > 0),
+  };
+}
+
+const UNIFIED_DIFF_HEADER = /(^|\n)(diff --git |--- |Index: )/;
+
+export function looksLikeUnifiedDiff(patch: string): boolean {
+  return UNIFIED_DIFF_HEADER.test(patch);
+}

--- a/packages/agent-worker/src/patch-tool.ts
+++ b/packages/agent-worker/src/patch-tool.ts
@@ -1,0 +1,38 @@
+/**
+ * Tool-use schema that forces Claude to emit a structured patch.
+ * Mirrors the single-tool pattern used by agent-claude's `submit_review`
+ * — one tool, `tool_choice: { type: "tool", name }` — so we get reliable
+ * structured output without any regex scraping of free-form text.
+ */
+export const PATCH_TOOL_NAME = "submit_patch";
+
+export const PATCH_TOOL_DESCRIPTION =
+  "Submit a unified-diff patch that fixes every blocker the council raised. Call this exactly once at the end of your analysis.";
+
+export const PATCH_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    patch: {
+      type: "string",
+      description:
+        "A unified diff patch (the exact format `git apply` expects). Must start with `diff --git ` or `--- ` headers. Include full hunks with @@ line ranges. If a fix is impossible, return an empty string and explain in `summary`.",
+    },
+    commitMessage: {
+      type: "string",
+      description:
+        "Single-line commit subject (≤ 72 chars), conventional-commit style when it fits (e.g. `fix(auth): ...`). This becomes the actual git commit message.",
+    },
+    filesTouched: {
+      type: "array",
+      description:
+        "Every file path the patch modifies or creates — repo-relative, forward slashes. Used for post-apply sanity checks.",
+      items: { type: "string" },
+    },
+    summary: {
+      type: "string",
+      description:
+        "One-paragraph rationale: which blockers this patch addresses, which (if any) it could not and why, and any follow-up the reviewer should know about.",
+    },
+  },
+  required: ["patch", "commitMessage", "filesTouched", "summary"],
+} as const;

--- a/packages/agent-worker/src/pricing.ts
+++ b/packages/agent-worker/src/pricing.ts
@@ -1,0 +1,58 @@
+export interface ModelPricing {
+  inputPerMTok: number;
+  cacheWritePerMTok: number;
+  cacheReadPerMTok: number;
+  outputPerMTok: number;
+}
+
+/**
+ * Claude pricing (USD per 1M tokens). Kept in sync with agent-claude's
+ * pricing.ts — duplicated intentionally so each agent package stays
+ * independent. Update when Anthropic announces new tiers.
+ */
+export const PRICING: Record<string, ModelPricing> = {
+  "claude-sonnet-4-6": {
+    inputPerMTok: 3.0,
+    cacheWritePerMTok: 3.75,
+    cacheReadPerMTok: 0.3,
+    outputPerMTok: 15.0,
+  },
+  "claude-haiku-4-5": {
+    inputPerMTok: 0.25,
+    cacheWritePerMTok: 0.3125,
+    cacheReadPerMTok: 0.025,
+    outputPerMTok: 1.25,
+  },
+  "claude-opus-4-7": {
+    inputPerMTok: 15.0,
+    cacheWritePerMTok: 18.75,
+    cacheReadPerMTok: 1.5,
+    outputPerMTok: 75.0,
+  },
+};
+
+export interface UsageBreakdown {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens?: number;
+  cacheReadTokens?: number;
+}
+
+export function actualCost(model: string, usage: UsageBreakdown): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown model "${model}"`);
+  const baseInput = usage.inputTokens - (usage.cacheCreationTokens ?? 0) - (usage.cacheReadTokens ?? 0);
+  return (
+    (Math.max(0, baseInput) * p.inputPerMTok +
+      (usage.cacheCreationTokens ?? 0) * p.cacheWritePerMTok +
+      (usage.cacheReadTokens ?? 0) * p.cacheReadPerMTok +
+      usage.outputTokens * p.outputPerMTok) /
+    1_000_000
+  );
+}
+
+export function estimateCallCost(model: string, estimatedInputTokens: number, maxOutputTokens: number): number {
+  const p = PRICING[model];
+  if (!p) throw new Error(`pricing: unknown model "${model}"`);
+  return (estimatedInputTokens * p.inputPerMTok + maxOutputTokens * p.outputPerMTok) / 1_000_000;
+}

--- a/packages/agent-worker/src/prompts.ts
+++ b/packages/agent-worker/src/prompts.ts
@@ -1,0 +1,109 @@
+import type { Blocker } from "@conclave-ai/core";
+import type { WorkerContext } from "./types.js";
+
+export const WORKER_SYSTEM_PROMPT = `You are the Worker agent on Conclave AI. Your job is to turn council blockers into a concrete code patch.
+
+Upstream context: a multi-agent review council flagged blockers on a pull request. The council's role is to spot problems. Your role is to fix them — produce a unified diff that, when applied with \`git apply\` on top of the PR head commit, resolves the blockers without regressing anything else.
+
+Hard rules:
+- You MUST respond by calling the submit_patch tool exactly once. Do not emit free-form text.
+- The \`patch\` field MUST be a valid unified diff — with \`diff --git\` or \`---\`/\`+++\` headers and \`@@\` hunks — not prose, not a code snippet.
+- Fix ONLY the blockers the council raised. Do not refactor unrelated code, rename things, reformat files, or add features. Scope creep is a worse failure than leaving a minor blocker untouched.
+- Preserve existing public APIs, exports, file paths, import styles, and indentation conventions (tabs vs spaces, quote style) exactly as the source uses them.
+- If a blocker requires information you don't have (a file not included in the snapshots, or ambiguity about intent), skip it and note that in \`summary\`. Never invent file contents you haven't been shown.
+- If NO blocker is fixable with the information given, return an empty \`patch\` string, an empty \`filesTouched\` array, and explain in \`summary\` what the caller should gather before retrying.
+- \`commitMessage\` should be a single line (≤ 72 chars), conventional-commit style where it fits. No trailing period.
+- \`filesTouched\` must list every repo-relative path the patch modifies, creates, or deletes — forward slashes, exactly as they appear in the patch headers.`;
+
+function renderBlockers(reviews: WorkerContext["reviews"]): string {
+  const lines: string[] = [];
+  for (const r of reviews) {
+    if (r.verdict === "approve" || r.blockers.length === 0) continue;
+    lines.push(`## ${r.agent} — verdict: ${r.verdict}`);
+    if (r.summary) lines.push(r.summary);
+    for (const b of r.blockers) {
+      lines.push(`- ${formatBlocker(b)}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n").trim();
+}
+
+function formatBlocker(b: Blocker): string {
+  const loc = b.file ? ` (${b.file}${b.line ? ":" + b.line : ""})` : "";
+  return `[${b.severity}/${b.category}] ${b.message}${loc}`;
+}
+
+export function buildWorkerPrompt(ctx: WorkerContext): string {
+  const sections: string[] = [];
+  sections.push(`# Rework target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`pull: #${ctx.pullNumber}`);
+  sections.push(`head sha: ${ctx.newSha}`);
+  sections.push("");
+
+  const blockerSection = renderBlockers(ctx.reviews);
+  if (blockerSection) {
+    sections.push(`# Blockers to fix`);
+    sections.push(blockerSection);
+    sections.push("");
+  } else {
+    sections.push(`# Blockers to fix`);
+    sections.push(
+      `(None of the council verdicts carry blockers. Return an empty patch and note this in summary — the caller should not have invoked rework.)`,
+    );
+    sections.push("");
+  }
+
+  if (ctx.fileSnapshots.length > 0) {
+    sections.push(`# Current file contents`);
+    sections.push(
+      `These are the files on the PR branch right now, at sha ${ctx.newSha}. Base your patch on these exact contents.`,
+    );
+    sections.push("");
+    for (const snap of ctx.fileSnapshots) {
+      sections.push(`## ${snap.path}`);
+      sections.push("```");
+      sections.push(snap.contents);
+      sections.push("```");
+      sections.push("");
+    }
+  } else {
+    sections.push(
+      `# Current file contents\n(no snapshots provided — return an empty patch and list the files you need in summary)`,
+    );
+    sections.push("");
+  }
+
+  if (ctx.diff) {
+    sections.push(`# Diff that was reviewed`);
+    sections.push(
+      `This is the change that the council ran on. Useful when a blocker cites a line number relative to the diff rather than the current file.`,
+    );
+    sections.push("```diff");
+    sections.push(ctx.diff);
+    sections.push("```");
+    sections.push("");
+  }
+
+  sections.push(
+    `Call submit_patch exactly once with a unified diff, a commit message, the list of files touched, and a one-paragraph summary.`,
+  );
+  return sections.join("\n");
+}
+
+/**
+ * Stable prefix suitable for Anthropic prompt caching. Mirrors the shape
+ * used by agent-claude — system prompt plus any pinned RAG strings that
+ * don't change per call.
+ */
+export function buildCacheablePrefix(ctx: WorkerContext): string {
+  const parts: string[] = [WORKER_SYSTEM_PROMPT];
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
+  }
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    parts.push("failure-catalog:\n" + ctx.failureCatalog.slice(0, 8).join("\n"));
+  }
+  return parts.join("\n---\n");
+}

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -1,0 +1,42 @@
+import type { ReviewResult } from "@conclave-ai/core";
+
+/**
+ * Snapshot of a file as it exists on the PR branch right now.
+ * The caller (e.g. the `conclave rework` CLI) is responsible for reading
+ * these from disk before invoking the worker. The worker itself stays
+ * pure — no filesystem side effects — so it's easy to test and so the
+ * git/commit logic lives in one place (scm-github / CLI) instead of
+ * being split across the LLM layer.
+ */
+export interface FileSnapshot {
+  path: string;
+  contents: string;
+}
+
+/** Everything the worker needs to produce a rework patch. */
+export interface WorkerContext {
+  repo: string;
+  pullNumber: number;
+  /** Head commit of the PR branch that the patch will be applied on top of. */
+  newSha: string;
+  /** Council verdicts from the review round that triggered this rework. */
+  reviews: ReviewResult[];
+  /** Current contents of files the reviewers flagged. */
+  fileSnapshots: FileSnapshot[];
+  /** The diff that was reviewed (optional — useful when blockers reference context lines). */
+  diff?: string;
+  answerKeys?: readonly string[];
+  failureCatalog?: readonly string[];
+}
+
+/** Result of a worker invocation — ready to hand to `git apply` + commit. */
+export interface WorkerOutcome {
+  /** Unified diff patch, applicable with `git apply`. */
+  patch: string;
+  /** Commit message subject (single line, conventional-commit style encouraged). */
+  message: string;
+  /** Files this patch is expected to touch — used for post-apply sanity checking. */
+  appliedFiles: string[];
+  tokensUsed?: number;
+  costUsd?: number;
+}

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -1,0 +1,145 @@
+import { EfficiencyGate, estimateTokens } from "@conclave-ai/core";
+import type { AnthropicCreateParams, AnthropicLike, AnthropicResponse } from "./anthropic-types.js";
+import { PATCH_TOOL_NAME, PATCH_TOOL_DESCRIPTION, PATCH_TOOL_INPUT_SCHEMA } from "./patch-tool.js";
+import { buildWorkerPrompt, buildCacheablePrefix, WORKER_SYSTEM_PROMPT } from "./prompts.js";
+import { parsePatchToolUse } from "./patch-parser.js";
+import { actualCost, estimateCallCost } from "./pricing.js";
+import type { WorkerContext, WorkerOutcome } from "./types.js";
+
+export interface ClaudeWorkerOptions {
+  apiKey?: string;
+  /** Defaults to claude-sonnet-4-6. Gate router may force a different model per call. */
+  model?: string;
+  maxTokens?: number;
+  /** Shared gate (recommended). If omitted, the worker creates its own. */
+  gate?: EfficiencyGate;
+  /** For tests or alternate providers — inject a Messages-compatible client. */
+  client?: AnthropicLike;
+  /** Factory used when `client` is not supplied. Defaults to lazy-loading @anthropic-ai/sdk. */
+  clientFactory?: (apiKey: string) => Promise<AnthropicLike>;
+}
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+/**
+ * Output budget for worker calls is larger than review — a patch with
+ * a few hunks can easily run 4-5K output tokens, and truncating the
+ * patch midway corrupts the diff.
+ */
+const DEFAULT_MAX_TOKENS = 16_384;
+
+async function defaultClientFactory(apiKey: string): Promise<AnthropicLike> {
+  const mod = (await import("@anthropic-ai/sdk")) as unknown as {
+    default: new (opts: { apiKey: string }) => AnthropicLike;
+  };
+  const Ctor = mod.default;
+  return new Ctor({ apiKey });
+}
+
+/**
+ * ClaudeWorker — turns Council blockers into a unified-diff patch.
+ *
+ * Deliberately does NOT implement `Agent` (which is a review-producing
+ * interface). A worker consumes reviews and emits a patch; conflating
+ * the two at the type level would force either side to carry fields
+ * the other doesn't use.
+ *
+ * The worker is pure w.r.t. the filesystem — it never reads files or
+ * shells out to git. The caller (typically the `conclave rework` CLI)
+ * is responsible for reading file snapshots, applying the returned
+ * patch, and committing back to the PR branch. That separation lets
+ * us unit-test the LLM layer without a git fixture.
+ */
+export class ClaudeWorker {
+  readonly id = "worker";
+  readonly displayName = "Worker";
+
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly gate: EfficiencyGate;
+  private readonly clientFactory: (apiKey: string) => Promise<AnthropicLike>;
+  private clientPromise: Promise<AnthropicLike> | null;
+
+  constructor(opts: ClaudeWorkerOptions = {}) {
+    const key = opts.apiKey ?? process.env["ANTHROPIC_API_KEY"] ?? "";
+    if (!key && !opts.client) {
+      throw new Error(
+        "ClaudeWorker: ANTHROPIC_API_KEY not set (pass opts.apiKey, opts.client, or the env var)",
+      );
+    }
+    this.apiKey = key;
+    this.model = opts.model ?? DEFAULT_MODEL;
+    this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.gate = opts.gate ?? new EfficiencyGate();
+    this.clientFactory = opts.clientFactory ?? defaultClientFactory;
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+  }
+
+  private async getClient(): Promise<AnthropicLike> {
+    if (!this.clientPromise) {
+      this.clientPromise = this.clientFactory(this.apiKey);
+    }
+    return this.clientPromise;
+  }
+
+  async work(ctx: WorkerContext): Promise<WorkerOutcome> {
+    const cacheablePrefix = buildCacheablePrefix(ctx);
+    const userPrompt = buildWorkerPrompt(ctx);
+    const inputTokenEstimate = estimateTokens(cacheablePrefix) + estimateTokens(userPrompt);
+    const estimatedCost = estimateCallCost(this.model, inputTokenEstimate, this.maxTokens);
+
+    const outcome = await this.gate.run<Omit<WorkerOutcome, "tokensUsed" | "costUsd">>(
+      {
+        agent: this.id,
+        cacheablePrefix,
+        prompt: cacheablePrefix + "\n" + userPrompt,
+        estimatedCostUsd: estimatedCost,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const params: AnthropicCreateParams = {
+          model,
+          max_tokens: this.maxTokens,
+          system: [{ type: "text", text: cacheablePrefix, cache_control: { type: "ephemeral" } }],
+          messages: [{ role: "user", content: userPrompt }],
+          tools: [
+            {
+              name: PATCH_TOOL_NAME,
+              description: PATCH_TOOL_DESCRIPTION,
+              input_schema: PATCH_TOOL_INPUT_SCHEMA,
+            },
+          ],
+          tool_choice: { type: "tool", name: PATCH_TOOL_NAME },
+        };
+        const response: AnthropicResponse = await client.messages.create(params);
+        const latencyMs = Date.now() - started;
+
+        const parsed = parsePatchToolUse(response);
+        const cost = actualCost(model, {
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          cacheCreationTokens: response.usage.cache_creation_input_tokens,
+          cacheReadTokens: response.usage.cache_read_input_tokens,
+        });
+
+        return {
+          result: parsed,
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          costUsd: cost,
+          latencyMs,
+        };
+      },
+    );
+
+    return {
+      ...outcome.result,
+      tokensUsed: outcome.metric.inputTokens + outcome.metric.outputTokens,
+      costUsd: outcome.metric.costUsd,
+    };
+  }
+}
+
+export { WORKER_SYSTEM_PROMPT };

--- a/packages/agent-worker/test/worker.test.mjs
+++ b/packages/agent-worker/test/worker.test.mjs
@@ -1,0 +1,248 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EfficiencyGate } from "@conclave-ai/core";
+import { ClaudeWorker, looksLikeUnifiedDiff, parsePatchToolUse } from "../dist/index.js";
+
+function makeMockClient(responses) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    messages: {
+      create: async (params) => {
+        calls.push(params);
+        const r = responses[Math.min(i, responses.length - 1)];
+        i += 1;
+        return r;
+      },
+    },
+  };
+}
+
+const VALID_PATCH = `diff --git a/src/x.ts b/src/x.ts
+index 1234567..89abcde 100644
+--- a/src/x.ts
++++ b/src/x.ts
+@@ -1,3 +1,3 @@
+-export const x = 1;
++export const x: number = 1;
+ export const y = 2;
+ export const z = 3;
+`;
+
+function patchResponse({
+  patch = VALID_PATCH,
+  commitMessage = "fix(x): annotate x as number",
+  filesTouched = ["src/x.ts"],
+  summary = "Addresses type-error blocker from Claude.",
+  inputTokens = 2_000,
+  outputTokens = 400,
+  cacheRead = 0,
+} = {}) {
+  return {
+    id: "msg_test",
+    model: "claude-sonnet-4-6",
+    content: [
+      {
+        type: "tool_use",
+        id: "tool_1",
+        name: "submit_patch",
+        input: { patch, commitMessage, filesTouched, summary },
+      },
+    ],
+    stop_reason: "tool_use",
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cache_read_input_tokens: cacheRead,
+    },
+  };
+}
+
+const reviewCtx = {
+  repo: "acme/x",
+  pullNumber: 1,
+  newSha: "abc123",
+  reviews: [
+    {
+      agent: "claude",
+      verdict: "rework",
+      summary: "ts type missing",
+      blockers: [
+        { severity: "blocker", category: "type-error", message: "add explicit type annotation", file: "src/x.ts", line: 1 },
+      ],
+    },
+  ],
+  fileSnapshots: [
+    { path: "src/x.ts", contents: "export const x = 1;\nexport const y = 2;\nexport const z = 3;\n" },
+  ],
+};
+
+test("ClaudeWorker: returns a WorkerOutcome with patch, message, and appliedFiles", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([patchResponse()]);
+  const worker = new ClaudeWorker({ apiKey: "test-key", gate, client });
+  const outcome = await worker.work(reviewCtx);
+  assert.equal(outcome.patch, VALID_PATCH);
+  assert.equal(outcome.message, "fix(x): annotate x as number");
+  assert.deepEqual(outcome.appliedFiles, ["src/x.ts"]);
+  assert.ok(typeof outcome.costUsd === "number" && outcome.costUsd > 0);
+  assert.ok(typeof outcome.tokensUsed === "number" && outcome.tokensUsed === 2_400);
+});
+
+test("ClaudeWorker: preserves empty-patch signal when worker gives up", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([
+    patchResponse({ patch: "", filesTouched: [], summary: "Need the contents of src/other.ts to proceed." }),
+  ]);
+  const worker = new ClaudeWorker({ apiKey: "k", gate, client });
+  const outcome = await worker.work(reviewCtx);
+  assert.equal(outcome.patch, "");
+  assert.deepEqual(outcome.appliedFiles, []);
+});
+
+test("ClaudeWorker: trims whitespace from filesTouched entries and drops empties", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([
+    patchResponse({ filesTouched: ["  src/x.ts  ", "", "src/y.ts"] }),
+  ]);
+  const worker = new ClaudeWorker({ apiKey: "k", gate, client });
+  const outcome = await worker.work(reviewCtx);
+  assert.deepEqual(outcome.appliedFiles, ["src/x.ts", "src/y.ts"]);
+});
+
+test("ClaudeWorker: throws when response has no submit_patch tool_use block", async () => {
+  const client = {
+    calls: [],
+    messages: {
+      create: async () => ({
+        id: "msg",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "here is a patch in prose" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 100, output_tokens: 10 },
+      }),
+    },
+  };
+  const worker = new ClaudeWorker({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => worker.work(reviewCtx), /did not include a submit_patch tool_use/);
+});
+
+test("ClaudeWorker: throws when patch does not look like a unified diff", async () => {
+  const client = makeMockClient([
+    patchResponse({ patch: "just some code, not a diff\nconst x = 1;\n" }),
+  ]);
+  const worker = new ClaudeWorker({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => worker.work(reviewCtx), /does not look like a unified diff/);
+});
+
+test("ClaudeWorker: throws when commitMessage is empty", async () => {
+  const client = makeMockClient([patchResponse({ commitMessage: "   " })]);
+  const worker = new ClaudeWorker({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => worker.work(reviewCtx), /commitMessage must be a non-empty string/);
+});
+
+test("ClaudeWorker: throws when filesTouched is not an array of strings", async () => {
+  const client = makeMockClient([patchResponse({ filesTouched: [42, "src/x.ts"] })]);
+  const worker = new ClaudeWorker({ apiKey: "k", client, gate: new EfficiencyGate({ perPrUsd: 1 }) });
+  await assert.rejects(() => worker.work(reviewCtx), /filesTouched must be an array of strings/);
+});
+
+test("ClaudeWorker: sends system prompt with cache_control ephemeral", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([patchResponse()]);
+  const worker = new ClaudeWorker({ apiKey: "k", gate, client });
+  await worker.work(reviewCtx);
+  const params = client.calls[0];
+  assert.ok(Array.isArray(params.system), "system should be an array of blocks for cache control");
+  assert.equal(params.system[0].cache_control?.type, "ephemeral");
+});
+
+test("ClaudeWorker: forces submit_patch tool via tool_choice", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([patchResponse()]);
+  const worker = new ClaudeWorker({ apiKey: "k", gate, client });
+  await worker.work(reviewCtx);
+  const params = client.calls[0];
+  assert.equal(params.tool_choice.type, "tool");
+  assert.equal(params.tool_choice.name, "submit_patch");
+});
+
+test("ClaudeWorker: records a metric on the shared gate", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([patchResponse({ inputTokens: 5_000, outputTokens: 800 })]);
+  const worker = new ClaudeWorker({ apiKey: "k", gate, client });
+  await worker.work(reviewCtx);
+  const summary = gate.metrics.summary();
+  assert.equal(summary.callCount, 1);
+  assert.equal(summary.byAgent["worker"].calls, 1);
+  assert.ok(summary.totalCostUsd > 0);
+});
+
+test("ClaudeWorker: respects a shared budget cap", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 0.005 });
+  const client = makeMockClient([patchResponse({ inputTokens: 10_000, outputTokens: 1_000 })]);
+  const worker = new ClaudeWorker({ apiKey: "k", gate, client });
+  await assert.rejects(() => worker.work(reviewCtx), /budget/);
+});
+
+test("ClaudeWorker: missing API key AND no injected client throws in constructor", () => {
+  const orig = process.env.ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  try {
+    assert.throws(() => new ClaudeWorker());
+  } finally {
+    if (orig !== undefined) process.env.ANTHROPIC_API_KEY = orig;
+  }
+});
+
+test("ClaudeWorker: prompt includes blocker text and file snapshot contents", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([patchResponse()]);
+  const worker = new ClaudeWorker({ apiKey: "k", gate, client });
+  await worker.work(reviewCtx);
+  const prompt = client.calls[0].messages[0].content;
+  assert.ok(prompt.includes("add explicit type annotation"), "prompt should include blocker text");
+  assert.ok(prompt.includes("export const x = 1;"), "prompt should include file snapshot contents");
+  assert.ok(prompt.includes("src/x.ts"), "prompt should include file path");
+  assert.ok(prompt.includes("abc123"), "prompt should include the head sha");
+});
+
+test("looksLikeUnifiedDiff: accepts common diff header forms", () => {
+  assert.equal(looksLikeUnifiedDiff("diff --git a/x b/x\n"), true);
+  assert.equal(looksLikeUnifiedDiff("--- a/x\n+++ b/x\n"), true);
+  assert.equal(looksLikeUnifiedDiff("Index: src/x.ts\n"), true);
+  assert.equal(looksLikeUnifiedDiff("\n\ndiff --git a/x b/x\n"), true);
+});
+
+test("looksLikeUnifiedDiff: rejects prose and code snippets", () => {
+  assert.equal(looksLikeUnifiedDiff("const x = 1;\n"), false);
+  assert.equal(looksLikeUnifiedDiff("Here's the fix: ...\n"), false);
+  assert.equal(looksLikeUnifiedDiff(""), false);
+});
+
+test("parsePatchToolUse: direct parser happy path (no LLM)", () => {
+  const response = {
+    id: "m",
+    model: "claude-sonnet-4-6",
+    content: [
+      {
+        type: "tool_use",
+        id: "t",
+        name: "submit_patch",
+        input: {
+          patch: VALID_PATCH,
+          commitMessage: "fix: something",
+          filesTouched: ["src/x.ts"],
+          summary: "ok",
+        },
+      },
+    ],
+    stop_reason: "tool_use",
+    usage: { input_tokens: 1, output_tokens: 1 },
+  };
+  const parsed = parsePatchToolUse(response);
+  assert.equal(parsed.patch, VALID_PATCH);
+  assert.equal(parsed.message, "fix: something");
+  assert.deepEqual(parsed.appliedFiles, ["src/x.ts"]);
+});

--- a/packages/agent-worker/tsconfig.json
+++ b/packages/agent-worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,19 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/agent-worker:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.65.0
+        version: 0.65.0(zod@3.25.76)
+      '@conclave-ai/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/cli:
     dependencies:
       '@conclave-ai/agent-claude':


### PR DESCRIPTION
## Summary
- New `@conclave-ai/agent-worker` package. `ClaudeWorker.work(ctx)` consumes `ReviewResult[]` + `FileSnapshot[]` and returns `WorkerOutcome { patch, message, appliedFiles }` ready for `git apply` + commit.
- First half of the Worker / Rework engine promised in README + ARCHITECTURE.md pipeline steps 4+6. Closes the biggest claim-vs-reality gap: council could flag blockers but nothing produced a fix.
- Pure w.r.t. the filesystem — caller handles snapshot reads + commit + guard wrapping (LoopGuard/CircuitBreaker live at the orchestrator level where sha is visible).

## Design notes
- `ClaudeWorker` does NOT implement the `Agent` interface. Reviews and patches are different artifacts; conflating would leak commit concerns into `@conclave-ai/core`.
- `submit_patch` tool_choice mirrors `submit_review` — one tool, forced, reliable structured output without regex scraping.
- Patch validated with a unified-diff header check (`diff --git `, `--- `, or `Index:`) — catches the common "model returned prose instead of a patch" failure.
- `DEFAULT_MAX_TOKENS = 16_384` (vs. 8_192 for review) — diffs with a few hunks easily exceed the review budget and truncation corrupts the patch.
- Pricing table duplicated from `agent-claude` (matches the established per-agent-package pattern — agent-openai, agent-gemini each keep their own).

## Not in this PR
- `conclave rework --pr N --episodic ep-...` CLI command — follow-up. Loads episodic, reads file snapshots, invokes worker, applies patch with `git apply`, commits + pushes to the PR branch, triggers re-review (wrapped in LoopGuard + CircuitBreaker).
- `@conclave-ai/telegram-bot-runner` — long-poll bot that turns the existing decorative 🔧 rework / ✅ merge / 🚫 reject callback_query buttons into actual `repository_dispatch` events.

Splitting this way keeps the PR reviewable and lets the CLI/bot layers evolve independently once the LLM surface is locked.

## Test plan
- [x] `pnpm build` — 22/22 tasks (was 21, +agent-worker)
- [x] `pnpm test` — 42/42 tasks (was 41, +agent-worker with 16/16 subtests green)
- [x] Worker tests cover: happy path, empty-patch signal (model gives up), whitespace/empty filtering, no-tool-use failure, non-diff patch rejection, empty commit message rejection, non-string filesTouched rejection, cache_control ephemeral, tool_choice forcing, gate metric recording, budget cap, constructor key validation, prompt content assertions, parser happy path, and the `looksLikeUnifiedDiff` helper.
- [ ] Manual smoke after CLI PR lands: invoke `conclave rework` against a real PR with a flagged type-error blocker.