### PR TITLE
feat(cli): conclave rework command — worker patch → git apply → commit → push

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@conclave-ai/agent-claude": "workspace:*",
+    "@conclave-ai/agent-worker": "workspace:*",
     "@conclave-ai/agent-deepseek": "workspace:*",
     "@conclave-ai/agent-gemini": "workspace:*",
     "@conclave-ai/agent-grok": "workspace:*",

--- a/packages/cli/src/commands/rework.ts
+++ b/packages/cli/src/commands/rework.ts
@@ -1,0 +1,382 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import { readFile, writeFile, unlink } from "node:fs/promises";
+import path from "node:path";
+import {
+  BudgetTracker,
+  CircuitBreaker,
+  CircuitOpenError,
+  EfficiencyGate,
+  FileSystemMemoryStore,
+  LoopDetectedError,
+  LoopGuard,
+  MetricsRecorder,
+  OutcomeWriter,
+  type EpisodicEntry,
+  type MemoryStore,
+} from "@conclave-ai/core";
+import { ClaudeWorker, type ClaudeWorkerOptions, type FileSnapshot, type WorkerOutcome } from "@conclave-ai/agent-worker";
+import { fetchPrState, type GhRunner, type PullRequestState } from "@conclave-ai/scm-github";
+import { loadConfig, resolveMemoryRoot, type ConclaveConfig } from "../lib/config.js";
+
+const execFile = promisify(execFileCallback);
+
+const HELP = `conclave rework — turn council blockers into a committed fix
+
+Usage:
+  conclave rework --pr N [--episodic <id>] [--cwd <dir>] [--dry-run] [--no-push]
+                  [--loop-threshold N] [--loop-window-ms MS] [--breaker-threshold N]
+
+Options:
+  --pr N                Pull-request number on the current repo to rework. Required unless --episodic is given.
+  --episodic <id>       Explicit episodic id to load (otherwise the latest "pending" episodic for --pr wins).
+  --cwd <dir>           Working directory — must be checked out to the PR branch (default: .).
+  --dry-run             Generate the patch and print it; do not apply, commit, or push.
+  --no-push             Apply + commit locally, skip \`git push\`.
+  --loop-threshold N    Max rework attempts on the same head sha before giving up (default 5).
+  --loop-window-ms MS   Rolling window for the loop guard (default 3600000 = 1h).
+  --breaker-threshold N Consecutive worker failures before the circuit opens (default 3).
+
+Environment:
+  ANTHROPIC_API_KEY     required — the worker uses Claude.
+
+Side effects (unless --dry-run):
+  - \`git apply\` the worker patch on top of the current branch
+  - \`git commit\` with author "conclave-worker[bot] <noreply@conclave.ai>"
+  - \`git push\` (unless --no-push) — assumes current branch tracks a remote
+  - Marks the episodic as "reworked" in the memory store.
+
+The LoopGuard uses \`<repo>#<pr>:<headSha>\` as its key. Running \`rework\` more than --loop-threshold times on the SAME commit within the window aborts with non-zero exit — that's the signal for a human to step in.
+`;
+
+export interface ReworkArgs {
+  pr?: number;
+  episodic?: string;
+  cwd: string;
+  dryRun: boolean;
+  noPush: boolean;
+  loopThreshold: number;
+  loopWindowMs: number;
+  breakerThreshold: number;
+  help: boolean;
+}
+
+export function parseArgv(argv: string[]): ReworkArgs {
+  const out: ReworkArgs = {
+    cwd: ".",
+    dryRun: false,
+    noPush: false,
+    loopThreshold: 5,
+    loopWindowMs: 3600_000,
+    breakerThreshold: 3,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--no-push") out.noPush = true;
+    else if (a === "--pr" && argv[i + 1]) {
+      const n = Number.parseInt(argv[i + 1]!, 10);
+      if (!Number.isNaN(n)) out.pr = n;
+      i += 1;
+    } else if (a === "--episodic" && argv[i + 1]) {
+      out.episodic = argv[i + 1];
+      i += 1;
+    } else if (a === "--cwd" && argv[i + 1]) {
+      out.cwd = argv[i + 1]!;
+      i += 1;
+    } else if (a === "--loop-threshold" && argv[i + 1]) {
+      const n = Number.parseInt(argv[i + 1]!, 10);
+      if (!Number.isNaN(n) && n > 0) out.loopThreshold = n;
+      i += 1;
+    } else if (a === "--loop-window-ms" && argv[i + 1]) {
+      const n = Number.parseInt(argv[i + 1]!, 10);
+      if (!Number.isNaN(n) && n > 0) out.loopWindowMs = n;
+      i += 1;
+    } else if (a === "--breaker-threshold" && argv[i + 1]) {
+      const n = Number.parseInt(argv[i + 1]!, 10);
+      if (!Number.isNaN(n) && n > 0) out.breakerThreshold = n;
+      i += 1;
+    }
+  }
+  return out;
+}
+
+export type Exec = (
+  bin: string,
+  args: readonly string[],
+  opts?: { cwd?: string; input?: string; timeout?: number },
+) => Promise<{ stdout: string; stderr?: string; code?: number }>;
+
+export interface ReworkDeps {
+  /** cosmiconfig loader — override in tests. */
+  loadConfig?: () => Promise<{ config: ConclaveConfig; configDir: string }>;
+  /** Override the memory store (tests). Otherwise built from config. */
+  store?: MemoryStore;
+  /** Override the outcome writer (tests). Otherwise built from the store. */
+  writer?: OutcomeWriter;
+  /** Override the worker instance (tests). Otherwise built from config + env. */
+  worker?: { work: (ctx: Parameters<ClaudeWorker["work"]>[0]) => Promise<WorkerOutcome> };
+  /** gh runner for fetchPrState (same contract as scm-github). */
+  gh?: GhRunner;
+  /** git runner — accepts (args, opts) like execFile. */
+  git?: Exec;
+  /** Reads a file's contents at a path inside cwd. */
+  readFile?: (absPath: string) => Promise<string>;
+  /** Write + delete temp patch file; defaults to fs/promises. */
+  writeTempPatch?: (absPath: string, contents: string) => Promise<void>;
+  removeTempPatch?: (absPath: string) => Promise<void>;
+  /** Stdout / stderr sinks — override in tests. */
+  stdout?: (s: string) => void;
+  stderr?: (s: string) => void;
+  /** LoopGuard — inject for test-time clock control. */
+  loopGuard?: LoopGuard;
+  /** CircuitBreaker — inject for test-time clock control. */
+  breaker?: CircuitBreaker;
+  /** Factory for a real ClaudeWorker when `worker` is not injected. */
+  workerFactory?: (opts: ClaudeWorkerOptions) => { work: (ctx: Parameters<ClaudeWorker["work"]>[0]) => Promise<WorkerOutcome> };
+}
+
+const defaultGit: Exec = async (bin, args, opts) => {
+  try {
+    const { stdout, stderr } = await execFile(bin, args as string[], {
+      ...(opts?.cwd ? { cwd: opts.cwd } : {}),
+      ...(opts?.input ? { input: opts.input } : {}),
+      ...(opts?.timeout ? { timeout: opts.timeout } : {}),
+      maxBuffer: 20 * 1024 * 1024,
+    });
+    return { stdout, stderr, code: 0 };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; code?: number };
+    const out: { stdout: string; stderr?: string; code?: number } = {
+      stdout: e.stdout ?? "",
+    };
+    if (e.stderr !== undefined) out.stderr = e.stderr;
+    if (e.code !== undefined) out.code = typeof e.code === "number" ? e.code : Number(e.code);
+    throw Object.assign(new Error(`${bin} ${args.join(" ")} failed: ${e.stderr ?? e.message}`), out);
+  }
+};
+
+const defaultGh: GhRunner = async (bin, args, opts) => {
+  const { stdout, stderr } = await execFile(bin, args as string[], {
+    ...opts,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return { stdout, stderr };
+};
+
+/**
+ * Resolve which episodic entry to rework. When --episodic is given we
+ * honour it literally (even if the user asks for something non-pending —
+ * operators occasionally want to re-run the worker on an already-recorded
+ * entry, e.g. after tweaking the failure-catalog). When only --pr is given
+ * we pick the most recent pending episodic for that PR.
+ */
+export async function resolveEpisodic(
+  store: MemoryStore,
+  args: Pick<ReworkArgs, "pr" | "episodic">,
+): Promise<EpisodicEntry> {
+  if (args.episodic) {
+    const found = await store.findEpisodic(args.episodic);
+    if (!found) throw new Error(`rework: episodic ${args.episodic} not found in store`);
+    return found;
+  }
+  if (!args.pr) {
+    throw new Error("rework: --pr or --episodic is required");
+  }
+  const all = await store.listEpisodic();
+  const candidates = all
+    .filter((e) => e.pullNumber === args.pr && e.outcome === "pending")
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  if (candidates.length === 0) {
+    throw new Error(`rework: no pending episodic found for PR #${args.pr}`);
+  }
+  return candidates[0]!;
+}
+
+/** Walk `reviews[*].blockers[*].file` and return unique paths (skipping missing). */
+export function collectBlockerFiles(episodic: EpisodicEntry): string[] {
+  const seen = new Set<string>();
+  for (const r of episodic.reviews) {
+    for (const b of r.blockers) {
+      if (b.file && !seen.has(b.file)) seen.add(b.file);
+    }
+  }
+  return [...seen];
+}
+
+export async function runRework(args: ReworkArgs, deps: ReworkDeps = {}): Promise<number> {
+  const stdout = deps.stdout ?? ((s) => process.stdout.write(s));
+  const stderr = deps.stderr ?? ((s) => process.stderr.write(s));
+
+  const cfg = await (deps.loadConfig ?? loadConfig)();
+  const store =
+    deps.store ??
+    new FileSystemMemoryStore({ root: resolveMemoryRoot(cfg.config, cfg.configDir) });
+  const writer = deps.writer ?? new OutcomeWriter({ store });
+
+  const episodic = await resolveEpisodic(store, args);
+
+  const prState: PullRequestState = await fetchPrState(episodic.repo, episodic.pullNumber, { run: deps.gh ?? defaultGh });
+  if (prState.state !== "open") {
+    stderr(`rework: PR ${episodic.repo}#${episodic.pullNumber} is ${prState.state}, not open — nothing to do\n`);
+    return 1;
+  }
+
+  const loopGuard =
+    deps.loopGuard ??
+    new LoopGuard({ threshold: args.loopThreshold, windowMs: args.loopWindowMs });
+  const breaker =
+    deps.breaker ?? new CircuitBreaker({ failureThreshold: args.breakerThreshold });
+
+  const loopKey = `${episodic.repo}#${episodic.pullNumber}:${prState.headSha}`;
+  try {
+    loopGuard.check(loopKey);
+  } catch (err) {
+    if (err instanceof LoopDetectedError) {
+      stderr(
+        `rework: loop guard tripped on ${loopKey} (${err.count} attempts in ${err.windowMs}ms) — human needed\n`,
+      );
+      return 2;
+    }
+    throw err;
+  }
+
+  const git = deps.git ?? defaultGit;
+  const read = deps.readFile ?? ((p: string) => readFile(p, "utf8"));
+  const blockerFiles = collectBlockerFiles(episodic);
+
+  const fileSnapshots: FileSnapshot[] = [];
+  for (const relPath of blockerFiles) {
+    const abs = path.isAbsolute(relPath) ? relPath : path.join(args.cwd, relPath);
+    try {
+      const contents = await read(abs);
+      fileSnapshots.push({ path: relPath, contents });
+    } catch {
+      stderr(`rework: could not read ${relPath} — worker will proceed without it\n`);
+    }
+  }
+
+  const worker = deps.worker ?? buildWorker(deps, cfg.config);
+
+  let outcome: WorkerOutcome;
+  try {
+    outcome = await breaker.guard("worker", () =>
+      worker.work({
+        repo: episodic.repo,
+        pullNumber: episodic.pullNumber,
+        newSha: prState.headSha,
+        reviews: episodic.reviews,
+        fileSnapshots,
+      }),
+    );
+  } catch (err) {
+    if (err instanceof CircuitOpenError) {
+      stderr(`rework: circuit breaker open for worker (until ${new Date(err.openUntil).toISOString()}) — human needed\n`);
+      return 2;
+    }
+    throw err;
+  }
+
+  if (!outcome.patch) {
+    stderr(`rework: worker could not produce a patch — no changes applied\n`);
+    return 1;
+  }
+
+  stdout(
+    `rework: worker proposed patch (${outcome.appliedFiles.length} file${
+      outcome.appliedFiles.length === 1 ? "" : "s"
+    }, ${outcome.patch.length} bytes)\n`,
+  );
+  stdout(`rework: commit message: ${outcome.message}\n`);
+
+  if (args.dryRun) {
+    stdout(`---\n${outcome.patch}\n---\n`);
+    stdout(`rework: --dry-run, not applying\n`);
+    return 0;
+  }
+
+  const patchPath = path.join(args.cwd, ".conclave-rework.patch");
+  const writeTemp = deps.writeTempPatch ?? ((p: string, c: string) => writeFile(p, c, "utf8"));
+  const removeTemp = deps.removeTempPatch ?? ((p: string) => unlink(p));
+
+  await writeTemp(patchPath, outcome.patch);
+
+  try {
+    await git("git", ["apply", "--check", patchPath], { cwd: args.cwd });
+  } catch (err) {
+    await removeTemp(patchPath).catch(() => undefined);
+    const msg = err instanceof Error ? err.message : String(err);
+    stderr(`rework: patch does not apply cleanly — ${msg}\n`);
+    return 1;
+  }
+
+  await git("git", ["apply", patchPath], { cwd: args.cwd });
+  await removeTemp(patchPath).catch(() => undefined);
+
+  if (outcome.appliedFiles.length > 0) {
+    await git("git", ["add", "--", ...outcome.appliedFiles], { cwd: args.cwd });
+  } else {
+    await git("git", ["add", "-A"], { cwd: args.cwd });
+  }
+
+  await git(
+    "git",
+    [
+      "-c",
+      "user.name=conclave-worker[bot]",
+      "-c",
+      "user.email=noreply@conclave.ai",
+      "commit",
+      "-m",
+      outcome.message,
+      "--author",
+      "conclave-worker[bot] <noreply@conclave.ai>",
+    ],
+    { cwd: args.cwd },
+  );
+
+  if (!args.noPush) {
+    await git("git", ["push"], { cwd: args.cwd });
+  }
+
+  await writer.recordOutcome({ episodicId: episodic.id, outcome: "reworked" });
+
+  stdout(
+    `rework: applied${args.noPush ? " (local only)" : " + pushed"} — ${outcome.appliedFiles.join(", ") || "(none listed)"}\n`,
+  );
+  stdout(`rework: episodic ${episodic.id} recorded as reworked\n`);
+  return 0;
+}
+
+function buildWorker(deps: ReworkDeps, config: ConclaveConfig): { work: (ctx: Parameters<ClaudeWorker["work"]>[0]) => Promise<WorkerOutcome> } {
+  const perPrUsd = config.budget?.perPrUsd ?? 0.5;
+  const gate = new EfficiencyGate({
+    budget: new BudgetTracker({ perPrUsd }),
+    metrics: new MetricsRecorder(),
+  });
+  const apiKey = process.env["ANTHROPIC_API_KEY"];
+  if (!apiKey) {
+    throw new Error(
+      "rework: ANTHROPIC_API_KEY is not set (the worker agent needs it; pass --dry-run only after setting the key)",
+    );
+  }
+  const factory = deps.workerFactory ?? ((opts: ClaudeWorkerOptions) => new ClaudeWorker(opts));
+  return factory({ apiKey, gate });
+}
+
+export async function rework(argv: string[]): Promise<void> {
+  const args = parseArgv(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  if (args.pr === undefined && !args.episodic) {
+    process.stderr.write(`conclave rework: --pr or --episodic is required\n\n${HELP}`);
+    process.exit(2);
+    return;
+  }
+  const code = await runRework(args);
+  if (code !== 0) process.exit(code);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { init } from "./commands/init.js";
 import { review } from "./commands/review.js";
 import { recordOutcome } from "./commands/record-outcome.js";
+import { rework } from "./commands/rework.js";
 import { pollOutcomesCommand } from "./commands/poll-outcomes.js";
 import { seed } from "./commands/seed.js";
 import { migrate } from "./commands/migrate.js";
@@ -16,6 +17,7 @@ Usage:
 Commands:
   init                  Set up conclave in the current repo (config + skeleton)
   review                Run a council review on the current branch
+  rework                Apply a worker-generated patch for a pending council "rework" verdict
   record-outcome        Record a PR's merge/reject/rework outcome manually
   poll-outcomes         Auto-classify pending reviews against live GitHub PR state
   seed                  Bootstrap failure-catalog from a legacy source (default: bundled solo-cto-agent)
@@ -29,6 +31,7 @@ Commands:
 Examples:
   conclave init
   conclave review --pr 42 --visual
+  conclave rework --pr 42                 # apply worker patch for the latest pending review on PR 42
   conclave record-outcome --id ep-... --result merged
   conclave poll-outcomes                 # cron-friendly automatic outcome capture
   conclave seed                           # one-time bootstrap from the bundled solo-cto-agent catalog
@@ -55,6 +58,9 @@ export async function run(argv: string[]): Promise<void> {
       return;
     case "review":
       await review(rest);
+      return;
+    case "rework":
+      await rework(rest);
       return;
     case "record-outcome":
       await recordOutcome(rest);

--- a/packages/cli/test/rework.test.mjs
+++ b/packages/cli/test/rework.test.mjs
@@ -1,0 +1,511 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseArgv,
+  collectBlockerFiles,
+  resolveEpisodic,
+  runRework,
+} from "../dist/commands/rework.js";
+import { LoopGuard, CircuitBreaker } from "@conclave-ai/core";
+
+// ---- parseArgv ------------------------------------------------------------
+
+test("parseArgv: defaults + --pr", () => {
+  const a = parseArgv(["--pr", "42"]);
+  assert.equal(a.pr, 42);
+  assert.equal(a.episodic, undefined);
+  assert.equal(a.cwd, ".");
+  assert.equal(a.dryRun, false);
+  assert.equal(a.noPush, false);
+  assert.equal(a.loopThreshold, 5);
+  assert.equal(a.loopWindowMs, 3600_000);
+  assert.equal(a.breakerThreshold, 3);
+  assert.equal(a.help, false);
+});
+
+test("parseArgv: --episodic wins over --pr semantically but both can coexist", () => {
+  const a = parseArgv(["--pr", "9", "--episodic", "ep-123"]);
+  assert.equal(a.pr, 9);
+  assert.equal(a.episodic, "ep-123");
+});
+
+test("parseArgv: flags", () => {
+  const a = parseArgv(["--dry-run", "--no-push", "--cwd", "/repo", "--loop-threshold", "2"]);
+  assert.equal(a.dryRun, true);
+  assert.equal(a.noPush, true);
+  assert.equal(a.cwd, "/repo");
+  assert.equal(a.loopThreshold, 2);
+});
+
+test("parseArgv: --help", () => {
+  assert.equal(parseArgv(["--help"]).help, true);
+  assert.equal(parseArgv(["-h"]).help, true);
+});
+
+test("parseArgv: rejects non-numeric --pr silently (leaves undefined)", () => {
+  const a = parseArgv(["--pr", "abc"]);
+  assert.equal(a.pr, undefined);
+});
+
+// ---- collectBlockerFiles --------------------------------------------------
+
+test("collectBlockerFiles: dedupes paths across reviews", () => {
+  const ep = {
+    reviews: [
+      {
+        agent: "claude", verdict: "rework", summary: "", blockers: [
+          { severity: "blocker", category: "x", message: "m", file: "a.ts" },
+          { severity: "major", category: "y", message: "m", file: "b.ts" },
+        ],
+      },
+      {
+        agent: "openai", verdict: "rework", summary: "", blockers: [
+          { severity: "blocker", category: "x", message: "m", file: "a.ts" },
+          { severity: "minor", category: "z", message: "m" },
+        ],
+      },
+    ],
+  };
+  assert.deepEqual(collectBlockerFiles(ep), ["a.ts", "b.ts"]);
+});
+
+test("collectBlockerFiles: handles empty reviews", () => {
+  assert.deepEqual(collectBlockerFiles({ reviews: [] }), []);
+});
+
+// ---- resolveEpisodic ------------------------------------------------------
+
+function makeStore(entries) {
+  return {
+    async listEpisodic() { return entries; },
+    async findEpisodic(id) { return entries.find((e) => e.id === id) ?? null; },
+  };
+}
+
+test("resolveEpisodic: --episodic id success", async () => {
+  const store = makeStore([{ id: "ep-1", pullNumber: 1, outcome: "pending", createdAt: "t" }]);
+  const e = await resolveEpisodic(store, { episodic: "ep-1" });
+  assert.equal(e.id, "ep-1");
+});
+
+test("resolveEpisodic: --episodic id not found throws", async () => {
+  const store = makeStore([]);
+  await assert.rejects(() => resolveEpisodic(store, { episodic: "ep-missing" }), /not found/);
+});
+
+test("resolveEpisodic: --pr picks most recent pending", async () => {
+  const store = makeStore([
+    { id: "ep-old", pullNumber: 42, outcome: "pending", createdAt: "2026-04-18T00:00:00Z" },
+    { id: "ep-new", pullNumber: 42, outcome: "pending", createdAt: "2026-04-20T00:00:00Z" },
+    { id: "ep-merged", pullNumber: 42, outcome: "merged", createdAt: "2026-04-21T00:00:00Z" },
+    { id: "ep-other", pullNumber: 7, outcome: "pending", createdAt: "2026-04-22T00:00:00Z" },
+  ]);
+  const e = await resolveEpisodic(store, { pr: 42 });
+  assert.equal(e.id, "ep-new");
+});
+
+test("resolveEpisodic: --pr with no pending throws", async () => {
+  const store = makeStore([{ id: "ep", pullNumber: 1, outcome: "merged", createdAt: "t" }]);
+  await assert.rejects(() => resolveEpisodic(store, { pr: 1 }), /no pending episodic/);
+});
+
+test("resolveEpisodic: neither arg throws", async () => {
+  const store = makeStore([]);
+  await assert.rejects(() => resolveEpisodic(store, {}), /--pr or --episodic/);
+});
+
+// ---- runRework integration ------------------------------------------------
+
+function makeEpisodic(overrides = {}) {
+  return {
+    id: "ep-abc",
+    createdAt: "2026-04-20T00:00:00Z",
+    repo: "acme/x",
+    pullNumber: 1,
+    sha: "old-sha",
+    diffSha256: "a".repeat(64),
+    councilVerdict: "rework",
+    outcome: "pending",
+    costUsd: 0.01,
+    reviews: [
+      {
+        agent: "claude", verdict: "rework", summary: "s",
+        blockers: [
+          { severity: "blocker", category: "type-error", message: "fix type", file: "src/x.ts", line: 1 },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeWorker({ patch = "diff --git a/src/x.ts b/src/x.ts\n@@\n-a\n+b\n", message = "fix: x", appliedFiles = ["src/x.ts"] } = {}) {
+  const calls = [];
+  return {
+    calls,
+    work: async (ctx) => {
+      calls.push(ctx);
+      return { patch, message, appliedFiles, tokensUsed: 100, costUsd: 0.01 };
+    },
+  };
+}
+
+function makeGit() {
+  const calls = [];
+  return {
+    calls,
+    exec: async (bin, args, _opts) => {
+      calls.push({ bin, args: [...args] });
+      return { stdout: "", stderr: "" };
+    },
+  };
+}
+
+function makeGh(headSha = "head-sha-1", state = "OPEN") {
+  return async (_bin, _args, _opts) => ({
+    stdout: JSON.stringify({ state, headRefOid: headSha, updatedAt: "2026-04-20T00:00:00Z" }),
+  });
+}
+
+function makeWriter() {
+  const recorded = [];
+  return {
+    recorded,
+    recordOutcome: async (input) => {
+      recorded.push(input);
+      return { answerKeys: [], failures: [] };
+    },
+  };
+}
+
+const fakeConfig = {
+  config: { version: 1, agents: ["claude"], budget: { perPrUsd: 0.5 } },
+  configDir: "/tmp/fake",
+};
+
+const baseArgs = {
+  cwd: "/repo",
+  dryRun: false,
+  noPush: false,
+  loopThreshold: 5,
+  loopWindowMs: 3600_000,
+  breakerThreshold: 3,
+  help: false,
+};
+
+test("runRework: happy path — applies patch, commits, pushes, records outcome", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const git = makeGit();
+  const fileReads = [];
+  const stdout = [];
+  const stderr = [];
+  const tempWrites = [];
+  const tempRemoves = [];
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1 },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh("head-sha-1"),
+      git: git.exec,
+      readFile: async (p) => {
+        fileReads.push(p);
+        return "export const x = 1;\n";
+      },
+      writeTempPatch: async (p, c) => { tempWrites.push({ p, c }); },
+      removeTempPatch: async (p) => { tempRemoves.push(p); },
+      stdout: (s) => stdout.push(s),
+      stderr: (s) => stderr.push(s),
+    },
+  );
+
+  assert.equal(code, 0, stderr.join(""));
+  assert.equal(worker.calls.length, 1);
+  assert.equal(worker.calls[0].newSha, "head-sha-1");
+  assert.equal(worker.calls[0].repo, "acme/x");
+  assert.equal(worker.calls[0].fileSnapshots.length, 1);
+  assert.equal(worker.calls[0].fileSnapshots[0].path, "src/x.ts");
+  assert.equal(tempWrites.length, 1);
+  const gitCmds = git.calls.map((c) => c.args.join(" "));
+  assert.ok(gitCmds.some((c) => c.startsWith("apply --check")), `git apply --check missing: ${gitCmds.join(" | ")}`);
+  assert.ok(gitCmds.some((c) => c === `apply ${tempWrites[0].p}`), "git apply missing");
+  assert.ok(gitCmds.some((c) => c.startsWith("add -- src/x.ts")), "git add missing");
+  assert.ok(gitCmds.some((c) => c.includes("commit")), "git commit missing");
+  assert.ok(gitCmds.some((c) => c === "push"), "git push missing");
+  assert.equal(writer.recorded.length, 1);
+  assert.equal(writer.recorded[0].outcome, "reworked");
+  assert.equal(writer.recorded[0].episodicId, "ep-abc");
+});
+
+test("runRework: --dry-run skips git apply/commit/push and does not record outcome", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const git = makeGit();
+  const stdout = [];
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1, dryRun: true },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh(),
+      git: git.exec,
+      readFile: async () => "x",
+      stdout: (s) => stdout.push(s),
+      stderr: () => {},
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.equal(git.calls.length, 0, "no git commands should run on dry-run");
+  assert.equal(writer.recorded.length, 0, "no outcome should be recorded on dry-run");
+  assert.ok(stdout.join("").includes("--dry-run, not applying"));
+});
+
+test("runRework: --no-push applies + commits but does not push", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const git = makeGit();
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1, noPush: true },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh(),
+      git: git.exec,
+      readFile: async () => "x",
+      writeTempPatch: async () => {},
+      removeTempPatch: async () => {},
+      stdout: () => {},
+      stderr: () => {},
+    },
+  );
+
+  assert.equal(code, 0);
+  const gitCmds = git.calls.map((c) => c.args.join(" "));
+  assert.ok(gitCmds.some((c) => c.includes("commit")), "commit should run");
+  assert.ok(!gitCmds.some((c) => c === "push"), "push should NOT run");
+  assert.equal(writer.recorded.length, 1);
+});
+
+test("runRework: PR not open returns exit 1", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const stderr = [];
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1 },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh("x", "MERGED"),
+      git: makeGit().exec,
+      readFile: async () => "x",
+      stdout: () => {},
+      stderr: (s) => stderr.push(s),
+    },
+  );
+
+  assert.equal(code, 1);
+  assert.ok(stderr.join("").includes("not open"));
+  assert.equal(worker.calls.length, 0);
+});
+
+test("runRework: LoopGuard trip returns exit 2", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const stderr = [];
+  const guard = new LoopGuard({ threshold: 2, windowMs: 10 * 60_000 });
+  // Pre-fill to trip immediately
+  guard.check("acme/x#1:head-sha-1");
+  guard.check("acme/x#1:head-sha-1");
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1 },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh("head-sha-1"),
+      git: makeGit().exec,
+      readFile: async () => "x",
+      loopGuard: guard,
+      stdout: () => {},
+      stderr: (s) => stderr.push(s),
+    },
+  );
+
+  assert.equal(code, 2);
+  assert.ok(stderr.join("").includes("loop guard"));
+  assert.equal(worker.calls.length, 0);
+});
+
+test("runRework: CircuitBreaker open returns exit 2", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const stderr = [];
+  const breaker = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 60_000 });
+  // Trip the breaker manually
+  await breaker
+    .guard("worker", async () => { throw new Error("boom"); })
+    .catch(() => {});
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1 },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh(),
+      git: makeGit().exec,
+      readFile: async () => "x",
+      breaker,
+      stdout: () => {},
+      stderr: (s) => stderr.push(s),
+    },
+  );
+
+  assert.equal(code, 2);
+  assert.ok(stderr.join("").includes("circuit breaker"));
+});
+
+test("runRework: empty patch (worker gave up) returns exit 1", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker({ patch: "", appliedFiles: [] });
+  const git = makeGit();
+  const stderr = [];
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1 },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh(),
+      git: git.exec,
+      readFile: async () => "x",
+      stdout: () => {},
+      stderr: (s) => stderr.push(s),
+    },
+  );
+
+  assert.equal(code, 1);
+  assert.equal(git.calls.length, 0);
+  assert.equal(writer.recorded.length, 0);
+  assert.ok(stderr.join("").includes("could not produce a patch"));
+});
+
+test("runRework: git apply --check failure returns exit 1 and does NOT record outcome", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const stderr = [];
+
+  const git = async (_bin, args, _opts) => {
+    if (args[0] === "apply" && args[1] === "--check") {
+      throw new Error("error: patch does not apply");
+    }
+    return { stdout: "", stderr: "" };
+  };
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1 },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh(),
+      git,
+      readFile: async () => "x",
+      writeTempPatch: async () => {},
+      removeTempPatch: async () => {},
+      stdout: () => {},
+      stderr: (s) => stderr.push(s),
+    },
+  );
+
+  assert.equal(code, 1);
+  assert.equal(writer.recorded.length, 0);
+  assert.ok(stderr.join("").includes("does not apply cleanly"));
+});
+
+test("runRework: missing blocker file is noted on stderr but worker still runs", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const stderr = [];
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1 },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh(),
+      git: makeGit().exec,
+      readFile: async () => { throw new Error("ENOENT"); },
+      writeTempPatch: async () => {},
+      removeTempPatch: async () => {},
+      stdout: () => {},
+      stderr: (s) => stderr.push(s),
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.ok(stderr.join("").includes("could not read src/x.ts"));
+  // Worker was still invoked, but with zero snapshots
+  assert.equal(worker.calls[0].fileSnapshots.length, 0);
+});
+
+test("runRework: commit is authored as conclave-worker[bot]", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const git = makeGit();
+
+  await runRework(
+    { ...baseArgs, pr: 1 },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh(),
+      git: git.exec,
+      readFile: async () => "x",
+      writeTempPatch: async () => {},
+      removeTempPatch: async () => {},
+      stdout: () => {},
+      stderr: () => {},
+    },
+  );
+
+  const commit = git.calls.find((c) => c.args.includes("commit"));
+  assert.ok(commit, "commit call should exist");
+  const joined = commit.args.join(" ");
+  assert.ok(joined.includes("conclave-worker[bot]"), `author missing: ${joined}`);
+  assert.ok(joined.includes("noreply@conclave.ai"), `email missing: ${joined}`);
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,6 +9,7 @@
   "references": [
     { "path": "../core" },
     { "path": "../agent-claude" },
+    { "path": "../agent-worker" },
     { "path": "../agent-deepseek" },
     { "path": "../agent-gemini" },
     { "path": "../agent-grok" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@conclave-ai/agent-openai':
         specifier: workspace:*
         version: link:../agent-openai
+      '@conclave-ai/agent-worker':
+        specifier: workspace:*
+        version: link:../agent-worker
       '@conclave-ai/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary
Closes the Worker / Rework loop end-to-end. The LLM layer landed in #56; this PR gives it a command-line entry point. The README's "Blockers → auto-rework commits back to your PR" claim is now live.

## Flow
1. Resolve episodic — `--episodic <id>` wins; otherwise pick the latest `pending` for `--pr`
2. `fetchPrState` via `gh` → verify still open + read `headSha`
3. `LoopGuard.check(\`<repo>#<pr>:<headSha>\`, threshold=5, window=1h)` — trip → exit 2
4. Collect unique files from `reviews[*].blockers[*].file`, read snapshots from `--cwd` (missing files warned to stderr, worker runs without them)
5. `CircuitBreaker.guard("worker", () => worker.work(ctx))` — open → exit 2
6. Empty patch → exit 1 (worker gave up)
7. `git apply --check` → `git apply` → `git add -- <appliedFiles>` → `git commit` (author \`conclave-worker[bot] <noreply@conclave.ai>\`) → `git push`
8. `writer.recordOutcome(episodic.id, "reworked")` — self-evolve loop closed

Flags: \`--dry-run\`, \`--no-push\`, \`--cwd\`, \`--loop-threshold\`, \`--loop-window-ms\`, \`--breaker-threshold\`.

## Why no explicit re-review trigger
The \`git push\` step naturally causes the existing review workflow's \`pull_request: synchronize\` event to fire — GH Actions runs \`conclave review\` again on the new sha. Adding a direct re-review call would duplicate that and risk double-runs. The LoopGuard key \`<repo>#<pr>:<headSha>\` is what actually prevents infinite ping-pong between worker and council.

## Not in this PR
- \`secret-guard\` pre-apply gate — next PR. Scans the worker's patch + file snapshots for API-key patterns before \`git apply\`. Real risk: worker could slurp a token from a snapshot and commit it.
- \`telegram-bot-runner\` — PR after that. Turns the decorative 🔧/✅/🚫 buttons into \`repository_dispatch\` events that trigger \`conclave rework\` / merge / close.

## Test plan
- [x] \`pnpm build\` — 22/22 (unchanged)
- [x] \`pnpm test\` — 43/43 tasks (was 42, cli grew from 45 to 74 subtests). All green.
- [x] Dependency injection: \`runRework(args, deps)\` accepts store/writer/worker/gh/git/readFile/writeTempPatch/stdout/stderr/loopGuard/breaker overrides for pure unit tests. No spawning in tests.
- [x] Covered: happy path, --dry-run, --no-push, PR closed/merged, LoopGuard trip, CircuitBreaker open, empty patch, git apply --check failure, missing blocker file, commit author identity, all parseArgv forms, all resolveEpisodic paths.
- [ ] Manual dogfood smoke after merge — run against a real eventbadge PR with a known blocker.