### PR TITLE
feat(secret-guard): pre-apply secret scanner + wire into conclave rework

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,6 +42,7 @@
     "@conclave-ai/platform-render": "workspace:*",
     "@conclave-ai/platform-vercel": "workspace:*",
     "@conclave-ai/scm-github": "workspace:*",
+    "@conclave-ai/secret-guard": "workspace:*",
     "@conclave-ai/visual-review": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cosmiconfig": "^9.0.1",

--- a/packages/cli/src/commands/rework.ts
+++ b/packages/cli/src/commands/rework.ts
@@ -17,6 +17,7 @@ import {
 } from "@conclave-ai/core";
 import { ClaudeWorker, type ClaudeWorkerOptions, type FileSnapshot, type WorkerOutcome } from "@conclave-ai/agent-worker";
 import { fetchPrState, type GhRunner, type PullRequestState } from "@conclave-ai/scm-github";
+import { formatFinding, scanPatch, type ScanResult } from "@conclave-ai/secret-guard";
 import { loadConfig, resolveMemoryRoot, type ConclaveConfig } from "../lib/config.js";
 
 const execFile = promisify(execFileCallback);
@@ -36,6 +37,8 @@ Options:
   --loop-threshold N    Max rework attempts on the same head sha before giving up (default 5).
   --loop-window-ms MS   Rolling window for the loop guard (default 3600000 = 1h).
   --breaker-threshold N Consecutive worker failures before the circuit opens (default 3).
+  --allow-secret <id>   Allow-list a secret-guard rule id (repeatable). Use only after human review.
+  --skip-secret-guard   Disable the pre-apply secret scan (discouraged — use --allow-secret instead).
 
 Environment:
   ANTHROPIC_API_KEY     required — the worker uses Claude.
@@ -58,6 +61,8 @@ export interface ReworkArgs {
   loopThreshold: number;
   loopWindowMs: number;
   breakerThreshold: number;
+  allowSecrets: string[];
+  skipSecretGuard: boolean;
   help: boolean;
 }
 
@@ -69,6 +74,8 @@ export function parseArgv(argv: string[]): ReworkArgs {
     loopThreshold: 5,
     loopWindowMs: 3600_000,
     breakerThreshold: 3,
+    allowSecrets: [],
+    skipSecretGuard: false,
     help: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -98,6 +105,11 @@ export function parseArgv(argv: string[]): ReworkArgs {
       const n = Number.parseInt(argv[i + 1]!, 10);
       if (!Number.isNaN(n) && n > 0) out.breakerThreshold = n;
       i += 1;
+    } else if (a === "--allow-secret" && argv[i + 1]) {
+      out.allowSecrets.push(argv[i + 1]!);
+      i += 1;
+    } else if (a === "--skip-secret-guard") {
+      out.skipSecretGuard = true;
     }
   }
   return out;
@@ -136,6 +148,8 @@ export interface ReworkDeps {
   breaker?: CircuitBreaker;
   /** Factory for a real ClaudeWorker when `worker` is not injected. */
   workerFactory?: (opts: ClaudeWorkerOptions) => { work: (ctx: Parameters<ClaudeWorker["work"]>[0]) => Promise<WorkerOutcome> };
+  /** Patch scanner — defaults to `scanPatch` from @conclave-ai/secret-guard. */
+  secretScan?: (patch: string, opts?: { allow?: readonly string[] }) => ScanResult;
 }
 
 const defaultGit: Exec = async (bin, args, opts) => {
@@ -290,6 +304,23 @@ export async function runRework(args: ReworkArgs, deps: ReworkDeps = {}): Promis
     }, ${outcome.patch.length} bytes)\n`,
   );
   stdout(`rework: commit message: ${outcome.message}\n`);
+
+  if (!args.skipSecretGuard) {
+    const scan = (deps.secretScan ?? scanPatch)(outcome.patch, { allow: args.allowSecrets });
+    if (scan.blocked) {
+      stderr(
+        `rework: secret-guard blocked the patch — ${scan.findings.length} high-confidence finding(s):\n`,
+      );
+      for (const f of scan.findings) stderr(`  ${formatFinding(f)}\n`);
+      stderr(
+        `rework: run with --allow-secret <ruleId> only after a human confirms the match is a false positive\n`,
+      );
+      return 1;
+    }
+    if (scan.findings.length > 0) {
+      stdout(`rework: secret-guard saw ${scan.findings.length} low/medium finding(s), not blocking\n`);
+    }
+  }
 
   if (args.dryRun) {
     stdout(`---\n${outcome.patch}\n---\n`);

--- a/packages/cli/test/rework.test.mjs
+++ b/packages/cli/test/rework.test.mjs
@@ -37,6 +37,12 @@ test("parseArgv: flags", () => {
   assert.equal(a.loopThreshold, 2);
 });
 
+test("parseArgv: --allow-secret is repeatable and --skip-secret-guard toggles", () => {
+  const a = parseArgv(["--allow-secret", "openai-key", "--allow-secret", "aws-access-key", "--skip-secret-guard"]);
+  assert.deepEqual(a.allowSecrets, ["openai-key", "aws-access-key"]);
+  assert.equal(a.skipSecretGuard, true);
+});
+
 test("parseArgv: --help", () => {
   assert.equal(parseArgv(["--help"]).help, true);
   assert.equal(parseArgv(["-h"]).help, true);
@@ -190,6 +196,8 @@ const baseArgs = {
   loopThreshold: 5,
   loopWindowMs: 3600_000,
   breakerThreshold: 3,
+  allowSecrets: [],
+  skipSecretGuard: false,
   help: false,
 };
 
@@ -478,6 +486,150 @@ test("runRework: missing blocker file is noted on stderr but worker still runs",
   assert.ok(stderr.join("").includes("could not read src/x.ts"));
   // Worker was still invoked, but with zero snapshots
   assert.equal(worker.calls[0].fileSnapshots.length, 0);
+});
+
+test("runRework: secret-guard blocks when worker patch contains a secret", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const git = makeGit();
+  const stderr = [];
+
+  // Return a "blocked" scan result regardless of patch contents.
+  const fakeScan = (_patch, _opts) => ({
+    blocked: true,
+    findings: [{
+      ruleId: "openai-key",
+      ruleName: "OpenAI API Key",
+      confidence: "high",
+      line: 3,
+      column: 12,
+      preview: "sk-a…89AB",
+      file: "src/x.ts",
+    }],
+  });
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1 },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh(),
+      git: git.exec,
+      readFile: async () => "x",
+      writeTempPatch: async () => {},
+      removeTempPatch: async () => {},
+      secretScan: fakeScan,
+      stdout: () => {},
+      stderr: (s) => stderr.push(s),
+    },
+  );
+
+  assert.equal(code, 1);
+  assert.equal(git.calls.length, 0, "git should never run when secret-guard blocks");
+  assert.equal(writer.recorded.length, 0, "no outcome should be recorded when blocked");
+  const err = stderr.join("");
+  assert.ok(err.includes("secret-guard blocked"));
+  assert.ok(err.includes("openai-key"));
+  assert.ok(err.includes("--allow-secret"));
+});
+
+test("runRework: --allow-secret forwards to the scanner", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const git = makeGit();
+  const seenAllow = [];
+  const fakeScan = (_patch, opts) => {
+    seenAllow.push(opts?.allow ?? []);
+    return { blocked: false, findings: [] };
+  };
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1, allowSecrets: ["openai-key", "aws-access-key"] },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh(),
+      git: git.exec,
+      readFile: async () => "x",
+      writeTempPatch: async () => {},
+      removeTempPatch: async () => {},
+      secretScan: fakeScan,
+      stdout: () => {},
+      stderr: () => {},
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.deepEqual([...seenAllow[0]], ["openai-key", "aws-access-key"]);
+});
+
+test("runRework: --skip-secret-guard does not invoke the scanner at all", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const git = makeGit();
+  let scanCalls = 0;
+  const fakeScan = () => { scanCalls += 1; return { blocked: true, findings: [] }; };
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1, skipSecretGuard: true },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh(),
+      git: git.exec,
+      readFile: async () => "x",
+      writeTempPatch: async () => {},
+      removeTempPatch: async () => {},
+      secretScan: fakeScan,
+      stdout: () => {},
+      stderr: () => {},
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.equal(scanCalls, 0, "scanner must NOT be invoked when --skip-secret-guard is set");
+});
+
+test("runRework: low-confidence-only scan findings do NOT block", async () => {
+  const store = makeStore([makeEpisodic()]);
+  const writer = makeWriter();
+  const worker = makeWorker();
+  const git = makeGit();
+  const stdout = [];
+  const fakeScan = () => ({
+    blocked: false,
+    findings: [{ ruleId: "generic-password-assignment", ruleName: "x", confidence: "low", line: 1, column: 1, preview: "[redacted]" }],
+  });
+
+  const code = await runRework(
+    { ...baseArgs, pr: 1 },
+    {
+      loadConfig: async () => fakeConfig,
+      store,
+      writer,
+      worker,
+      gh: makeGh(),
+      git: git.exec,
+      readFile: async () => "x",
+      writeTempPatch: async () => {},
+      removeTempPatch: async () => {},
+      secretScan: fakeScan,
+      stdout: (s) => stdout.push(s),
+      stderr: () => {},
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.ok(stdout.join("").includes("low/medium finding"));
 });
 
 test("runRework: commit is authored as conclave-worker[bot]", async () => {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -27,6 +27,7 @@
     { "path": "../platform-vercel" },
     { "path": "../visual-review" },
     { "path": "../observability-langfuse" },
-    { "path": "../scm-github" }
+    { "path": "../scm-github" },
+    { "path": "../secret-guard" }
   ]
 }

--- a/packages/secret-guard/README.md
+++ b/packages/secret-guard/README.md
@@ -1,0 +1,31 @@
+# @conclave-ai/secret-guard
+
+Pre-commit secret scanner. Takes a unified diff or raw text, returns a list of findings plus a `blocked` flag.
+
+Used by `conclave rework` before `git apply` — if the worker's patch contains an API key lifted from a file snapshot, the commit is refused.
+
+## Usage
+
+```ts
+import { scanPatch } from "@conclave-ai/secret-guard";
+
+const result = scanPatch(workerOutcome.patch);
+if (result.blocked) {
+  for (const f of result.findings) console.error(formatFinding(f));
+  throw new Error("secret-guard: worker patch contains secrets");
+}
+```
+
+## Design
+
+- **High-confidence rules block by default.** AWS keys, Anthropic/OpenAI keys, GitHub PATs, Slack/Discord/Telegram webhook URLs, PEM private keys — every one a format where a match is almost certainly a real secret.
+- **Medium / low confidence rules are opt-in** via `includeLowConfidence: true`. JWTs are medium (sometimes public); generic `password = "…"` is low (huge false-positive surface).
+- **Patches scan only added lines.** Context lines and deletions can't introduce a new secret, and flagging them would spam any PR that touches a file containing an existing token.
+- **Findings are redacted by default.** Only the first 4 + last 4 chars of the match survive — no finding ever has to be stringified with the raw secret.
+- **Zero runtime dependencies.** Pure regex + string split. Tests are deterministic.
+
+## Adding a rule
+
+Append to `DEFAULT_RULES` in `src/rules.ts`. Rules have stable `id`s — callers can allow-list with `{ allow: ["id-to-skip"] }`.
+
+Rules must NOT use `/g`, `/y`, or `/m` flags (the scanner iterates itself). If your pattern needs to name the secret (labelled assignment), put the raw secret in capture group 1 — the scanner uses it for redaction.

--- a/packages/secret-guard/package.json
+++ b/packages/secret-guard/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@conclave-ai/secret-guard",
+  "version": "0.2.2",
+  "description": "Conclave AI secret-guard — scans patches + file content for API keys, tokens, and private keys before the worker commits them.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/secret-guard/src/index.ts
+++ b/packages/secret-guard/src/index.ts
@@ -1,0 +1,3 @@
+export { scanText, scanPatch, formatFinding, redact } from "./scanner.js";
+export { DEFAULT_RULES } from "./rules.js";
+export type { SecretRule, SecretFinding, ScanOptions, ScanResult } from "./types.js";

--- a/packages/secret-guard/src/rules.ts
+++ b/packages/secret-guard/src/rules.ts
@@ -1,0 +1,130 @@
+import type { SecretRule } from "./types.js";
+
+/**
+ * Default rule set. Kept deliberately narrow: every rule is a pattern we
+ * can explain in one line and where a match almost always means "this is
+ * a real secret." Broader heuristic patterns (entropy checks, generic
+ * base64 strings) go behind `confidence: "medium" | "low"` so the worker
+ * never blocks a commit on a false positive.
+ *
+ * Rule authors: do NOT add /g, /y, or /m flags — the scanner drives the
+ * iteration. Trailing word-boundary anchors are the recommended way to
+ * end a fixed-width match.
+ */
+export const DEFAULT_RULES: readonly SecretRule[] = [
+  {
+    id: "aws-access-key",
+    name: "AWS Access Key ID",
+    pattern: /\bAKIA[0-9A-Z]{16}\b/,
+    confidence: "high",
+    description: "IAM access key (format AKIA + 16 uppercase alnum)",
+  },
+  {
+    id: "aws-secret-access-key-labeled",
+    name: "AWS Secret Access Key (labeled)",
+    // Only catch when the line clearly names it — the raw 40-char base64
+    // pattern is too false-positive-heavy for a `high` rule.
+    pattern: /aws_secret_access_key\s*[:=]\s*['"]?([A-Za-z0-9/+=]{40})['"]?/i,
+    confidence: "high",
+    description: "A line literally labelled aws_secret_access_key followed by a 40-char value",
+  },
+  {
+    id: "openai-key",
+    name: "OpenAI API Key",
+    pattern: /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/,
+    confidence: "high",
+    description: "OpenAI API or project key (sk- / sk-proj- prefix)",
+  },
+  {
+    id: "anthropic-key",
+    name: "Anthropic API Key",
+    pattern: /\bsk-ant-api03-[A-Za-z0-9_-]{50,}\b/,
+    confidence: "high",
+    description: "Anthropic Claude API key (sk-ant-api03- prefix)",
+  },
+  {
+    id: "github-pat-classic",
+    name: "GitHub Personal Access Token (classic)",
+    pattern: /\bghp_[A-Za-z0-9]{36}\b/,
+    confidence: "high",
+    description: "GitHub PAT classic (ghp_ prefix, 36 alnum)",
+  },
+  {
+    id: "github-pat-fine-grained",
+    name: "GitHub Fine-Grained PAT",
+    pattern: /\bgithub_pat_[A-Za-z0-9_]{60,}\b/,
+    confidence: "high",
+    description: "GitHub fine-grained PAT (github_pat_ prefix)",
+  },
+  {
+    id: "github-app-token",
+    name: "GitHub App / OAuth Token",
+    pattern: /\bgh[oasu]_[A-Za-z0-9]{36}\b/,
+    confidence: "high",
+    description: "GitHub OAuth/App/Server/User token (gho_/ghs_/ghu_/gha_ prefix)",
+  },
+  {
+    id: "slack-webhook",
+    name: "Slack Incoming Webhook URL",
+    pattern: /https:\/\/hooks\.slack\.com\/services\/T[A-Z0-9]+\/B[A-Z0-9]+\/[A-Za-z0-9]+/,
+    confidence: "high",
+    description: "Slack incoming webhook — full URL including signing segment",
+  },
+  {
+    id: "discord-webhook",
+    name: "Discord Webhook URL",
+    pattern: /https:\/\/(?:canary\.|ptb\.)?discord(?:app)?\.com\/api\/webhooks\/\d+\/[\w-]{40,}/,
+    confidence: "high",
+    description: "Discord webhook URL",
+  },
+  {
+    id: "telegram-bot-token",
+    name: "Telegram Bot Token",
+    pattern: /\b\d{8,10}:[A-Za-z0-9_-]{35}\b/,
+    confidence: "high",
+    description: "Telegram bot API token (bot id + 35-char signing segment)",
+  },
+  {
+    id: "google-api-key",
+    name: "Google API Key",
+    pattern: /\bAIza[0-9A-Za-z_-]{35}\b/,
+    confidence: "high",
+    description: "Google Cloud / Firebase / Maps API key (AIza prefix)",
+  },
+  {
+    id: "npm-token",
+    name: "npm Access Token",
+    pattern: /\bnpm_[A-Za-z0-9]{36}\b/,
+    confidence: "high",
+    description: "npm automation / publish token (npm_ prefix)",
+  },
+  {
+    id: "stripe-live-key",
+    name: "Stripe Live Secret Key",
+    pattern: /\b(?:sk|rk)_live_[A-Za-z0-9]{24,}\b/,
+    confidence: "high",
+    description: "Stripe live-mode secret or restricted key",
+  },
+  {
+    id: "private-key-block",
+    name: "PEM Private Key Block",
+    pattern: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED |PGP )?PRIVATE KEY-----/,
+    confidence: "high",
+    description: "Any PEM-encoded private key header",
+  },
+  {
+    id: "jwt",
+    name: "JSON Web Token",
+    // JWTs are sometimes public (signed but not secret) — medium only.
+    pattern: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+    confidence: "medium",
+    description: "JWT-shaped string (3 dot-delimited base64url segments)",
+  },
+  {
+    id: "generic-password-assignment",
+    name: "Generic password assignment",
+    pattern: /\b(?:password|passwd|api[_-]?key|secret)\s*[:=]\s*['"][^'"\n]{8,}['"]/i,
+    confidence: "low",
+    description: "A variable named password/api_key/secret with a string literal value (high FP rate)",
+  },
+];

--- a/packages/secret-guard/src/scanner.ts
+++ b/packages/secret-guard/src/scanner.ts
@@ -1,0 +1,125 @@
+import { DEFAULT_RULES } from "./rules.js";
+import type { ScanOptions, ScanResult, SecretFinding, SecretRule } from "./types.js";
+
+/**
+ * Redact a match so the finding can be logged / stored safely. Keeps the
+ * first 4 characters (usually a prefix like `sk-` / `AKIA` / `ghp_` that
+ * is helpful for triage) and the last 4 of tokens 12 chars or longer.
+ * For shorter matches, returns `[redacted]`.
+ */
+export function redact(match: string): string {
+  if (match.length < 12) return "[redacted]";
+  return `${match.slice(0, 4)}…${match.slice(-4)}`;
+}
+
+function shouldSurface(rule: SecretRule, opts: ScanOptions): boolean {
+  if (rule.confidence === "high") return true;
+  if (rule.confidence === "medium") return Boolean(opts.includeLowConfidence);
+  return Boolean(opts.includeLowConfidence);
+}
+
+/**
+ * Scan an arbitrary text blob. Returns every finding (ordered by line)
+ * and a `blocked` flag that is true iff any high-confidence rule matched.
+ */
+export function scanText(text: string, opts: ScanOptions = {}): ScanResult {
+  const rules = opts.rules ?? DEFAULT_RULES;
+  const allow = new Set(opts.allow ?? []);
+  const findings: SecretFinding[] = [];
+
+  // Line/column tracking: we walk the text line by line so each finding's
+  // line number is stable even if the file contains multiline content.
+  const lines = text.split(/\r?\n/);
+  for (let lineIdx = 0; lineIdx < lines.length; lineIdx += 1) {
+    const line = lines[lineIdx]!;
+    for (const rule of rules) {
+      if (allow.has(rule.id)) continue;
+      if (!shouldSurface(rule, opts)) continue;
+      const m = line.match(rule.pattern);
+      if (!m || m.index === undefined) continue;
+      // Full match is index 0; labeled-rules capture group 1 is the actual
+      // secret, so prefer it for redaction when present.
+      const secret = m[1] ?? m[0];
+      const finding: SecretFinding = {
+        ruleId: rule.id,
+        ruleName: rule.name,
+        confidence: rule.confidence,
+        line: lineIdx + 1,
+        column: m.index,
+        preview: redact(secret),
+      };
+      if (opts.file) finding.file = opts.file;
+      findings.push(finding);
+    }
+  }
+
+  const blocked = findings.some((f) => f.confidence === "high");
+  return { findings, blocked };
+}
+
+/**
+ * Scan a unified-diff patch. Only "added" lines (lines starting with `+`
+ * but not `+++` headers) are considered — context lines and deletions
+ * can't introduce new secrets, so flagging them would spam false positives
+ * on PRs that merely touched a file containing an existing token.
+ *
+ * Line numbers are relative to the *patch*, not the post-apply file —
+ * that's accurate for the context where this scanner runs (pre-apply).
+ * The `file` field is populated from the `+++ b/<path>` header so
+ * consumers can attribute findings back to the right file in a multi-file
+ * patch without doing the parsing themselves.
+ */
+export function scanPatch(patch: string, opts: ScanOptions = {}): ScanResult {
+  const rules = opts.rules ?? DEFAULT_RULES;
+  const allow = new Set(opts.allow ?? []);
+  const findings: SecretFinding[] = [];
+
+  const lines = patch.split(/\r?\n/);
+  let currentFile: string | undefined = opts.file;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    if (line.startsWith("+++ ")) {
+      // `+++ b/path/to/file` — strip the `b/` prefix if present. Git uses
+      // `/dev/null` to indicate a deleted file.
+      const raw = line.slice(4).trim();
+      if (raw === "/dev/null") {
+        currentFile = opts.file;
+      } else {
+        currentFile = raw.startsWith("b/") ? raw.slice(2) : raw;
+      }
+      continue;
+    }
+    if (line.startsWith("---") || line.startsWith("diff ") || line.startsWith("@@") || line.startsWith("index ")) continue;
+    if (!line.startsWith("+")) continue;
+    const added = line.slice(1);
+    for (const rule of rules) {
+      if (allow.has(rule.id)) continue;
+      if (!shouldSurface(rule, opts)) continue;
+      const m = added.match(rule.pattern);
+      if (!m || m.index === undefined) continue;
+      const secret = m[1] ?? m[0];
+      const finding: SecretFinding = {
+        ruleId: rule.id,
+        ruleName: rule.name,
+        confidence: rule.confidence,
+        line: i + 1,
+        column: m.index + 1, // account for the leading `+`
+        preview: redact(secret),
+      };
+      if (currentFile) finding.file = currentFile;
+      findings.push(finding);
+    }
+  }
+
+  const blocked = findings.some((f) => f.confidence === "high");
+  return { findings, blocked };
+}
+
+/**
+ * One-line summary of a finding, safe to log. Mirrors the format used by
+ * the conclave CLI when a pre-apply scan blocks a rework commit.
+ */
+export function formatFinding(f: SecretFinding): string {
+  const loc = f.file ? `${f.file}:${f.line}:${f.column}` : `line ${f.line}:${f.column}`;
+  return `[${f.confidence}] ${f.ruleName} (${f.ruleId}) @ ${loc} → ${f.preview}`;
+}

--- a/packages/secret-guard/src/types.ts
+++ b/packages/secret-guard/src/types.ts
@@ -1,0 +1,57 @@
+export interface SecretRule {
+  /**
+   * Stable identifier — used for `--allow <ruleId>` and for suppression
+   * comments. Don't rename after release; callers may pin to specific ids.
+   */
+  id: string;
+  /** Human-friendly name shown in findings. */
+  name: string;
+  /**
+   * Regex pattern. Authors must NOT set sticky/global flags here — the
+   * scanner controls iteration itself. Case sensitivity is on by default
+   * because most real secrets are case-specific (`AKIA` prefix, etc).
+   */
+  pattern: RegExp;
+  /**
+   * Confidence the match is a real secret. "high" patterns block by
+   * default; "medium" are reported but don't block unless the caller
+   * opts in; "low" are reported only on explicit request.
+   */
+  confidence: "high" | "medium" | "low";
+  /** One-line description for CLI/UI rendering. */
+  description: string;
+}
+
+export interface SecretFinding {
+  ruleId: string;
+  ruleName: string;
+  confidence: "high" | "medium" | "low";
+  /** 1-based line number within the scanned text. */
+  line: number;
+  /** 0-based column of the first character of the match. */
+  column: number;
+  /** Redacted preview — never the raw secret. */
+  preview: string;
+  /** Repo-relative file path, when the caller provided one. */
+  file?: string;
+}
+
+export interface ScanOptions {
+  /** Optional repo-relative path, threaded into the finding for UX. */
+  file?: string;
+  /** Rule ids to skip (allow-list). */
+  allow?: readonly string[];
+  /** Rule overrides — defaults to DEFAULT_RULES. */
+  rules?: readonly SecretRule[];
+  /**
+   * When false (default), medium- and low-confidence rules are evaluated
+   * but their findings are not returned. Set to true to surface them.
+   */
+  includeLowConfidence?: boolean;
+}
+
+export interface ScanResult {
+  findings: SecretFinding[];
+  /** True iff at least one high-confidence finding was returned. */
+  blocked: boolean;
+}

--- a/packages/secret-guard/test/scanner.test.mjs
+++ b/packages/secret-guard/test/scanner.test.mjs
@@ -1,0 +1,229 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { scanText, scanPatch, formatFinding, redact, DEFAULT_RULES } from "../dist/index.js";
+
+// These are SYNTHETIC values crafted to match the patterns for testing only.
+// They are not real secrets. Prefix each with a test marker so scanners of
+// this file (including our own) can allow-list them out in the future.
+const FIXTURE = {
+  aws: "AKIAIOSFODNN7EXAMPLE",
+  openai: "sk-abcdefghijklmnopqrstuvwxyz01234567890A",
+  openaiProj: "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH",
+  anthropic: "sk-ant-api03-" + "a".repeat(60),
+  ghPat: "ghp_" + "a".repeat(36),
+  ghFine: "github_pat_" + "a".repeat(65),
+  ghOAuth: "gho_" + "a".repeat(36),
+  slack: "https://hooks.slack.com/services/T01234567/B01234567/aBcDeFgHiJkLmN",
+  discord: "https://discord.com/api/webhooks/123456789012345678/" + "a".repeat(60),
+  telegram: "123456789:AAEabcdefghijklmnopqrstuvwxyz012345",
+  google: "AIza" + "a".repeat(35),
+  npm: "npm_" + "a".repeat(36),
+  stripe: "sk_live_" + "a".repeat(32),
+  jwt: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+};
+
+// ---------- redact ---------------------------------------------------------
+
+test("redact: short strings become [redacted]", () => {
+  assert.equal(redact("abc"), "[redacted]");
+  assert.equal(redact("abcdefghijk"), "[redacted]"); // 11 chars, just under 12
+});
+
+test("redact: longer strings keep 4+4 chars with ellipsis", () => {
+  const out = redact("AKIAIOSFODNN7EXAMPLE");
+  assert.equal(out, "AKIA…MPLE");
+  assert.ok(!out.includes("IOSFODNN7EX"));
+});
+
+// ---------- scanText: high-confidence rules --------------------------------
+
+for (const [name, sample] of Object.entries(FIXTURE)) {
+  test(`scanText: detects ${name}`, () => {
+    // scanText needs to surface the rule; JWT is medium, rest are high.
+    const opts = name === "jwt" ? { includeLowConfidence: true } : {};
+    const result = scanText(`token = "${sample}"`, opts);
+    assert.ok(result.findings.length >= 1, `no finding for ${name}: ${JSON.stringify(result)}`);
+    if (name !== "jwt") assert.equal(result.blocked, true);
+  });
+}
+
+test("scanText: file option is threaded into findings", () => {
+  const result = scanText(`x = "${FIXTURE.ghPat}"`, { file: "src/config.ts" });
+  assert.equal(result.findings[0].file, "src/config.ts");
+});
+
+test("scanText: no findings on clean text", () => {
+  const result = scanText("export const x = 1;\nfunction foo() {}\n");
+  assert.equal(result.findings.length, 0);
+  assert.equal(result.blocked, false);
+});
+
+test("scanText: line numbers are 1-based and accurate", () => {
+  const text = `line one\nline two\nkey = "${FIXTURE.openai}"\nline four`;
+  const result = scanText(text);
+  assert.equal(result.findings[0].line, 3);
+});
+
+test("scanText: allow-list suppresses findings by rule id", () => {
+  const result = scanText(`x = "${FIXTURE.aws}"`, { allow: ["aws-access-key"] });
+  assert.equal(result.findings.length, 0);
+  assert.equal(result.blocked, false);
+});
+
+test("scanText: medium confidence (JWT) hidden by default, surfaced on opt-in", () => {
+  const clean = scanText(FIXTURE.jwt);
+  assert.equal(clean.findings.length, 0);
+  const loud = scanText(FIXTURE.jwt, { includeLowConfidence: true });
+  assert.equal(loud.findings.length, 1);
+  assert.equal(loud.blocked, false); // medium alone must not block
+});
+
+test("scanText: low-confidence password= only on opt-in, never blocks", () => {
+  const text = `password = "hunter2-classic"`;
+  assert.equal(scanText(text).findings.length, 0);
+  const loud = scanText(text, { includeLowConfidence: true });
+  assert.ok(loud.findings.some((f) => f.ruleId === "generic-password-assignment"));
+  assert.equal(loud.blocked, false);
+});
+
+test("scanText: AWS-secret labeled rule captures the value, not the label", () => {
+  const secret40 = "A".repeat(40);
+  const text = `aws_secret_access_key = "${secret40}"`;
+  const result = scanText(text);
+  const f = result.findings.find((x) => x.ruleId === "aws-secret-access-key-labeled");
+  assert.ok(f, "should detect labeled AWS secret");
+  // Preview should come from the capture group (the value), not the label.
+  assert.equal(f.preview, "AAAA…AAAA");
+});
+
+test("scanText: PEM private key block", () => {
+  const result = scanText("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIB...");
+  assert.ok(result.findings.some((f) => f.ruleId === "private-key-block"));
+  assert.equal(result.blocked, true);
+});
+
+test("scanText: custom rules replace the defaults", () => {
+  const result = scanText('prefix MY-TOKEN-1234', {
+    rules: [{ id: "my", name: "My Token", pattern: /MY-TOKEN-\d+/, confidence: "high", description: "" }],
+  });
+  assert.equal(result.findings.length, 1);
+  assert.equal(result.findings[0].ruleId, "my");
+});
+
+// ---------- scanPatch ------------------------------------------------------
+
+test("scanPatch: flags added lines, ignores context and deletions", () => {
+  const patch = `diff --git a/src/x.ts b/src/x.ts
+--- a/src/x.ts
++++ b/src/x.ts
+@@ -1,3 +1,3 @@
+ const keep = "harmless";
+-const old = "${FIXTURE.aws}";
++const fresh = "${FIXTURE.ghPat}";
+`;
+  const result = scanPatch(patch);
+  // The removed line (starts with -) must NOT produce a finding; only the
+  // added line (starts with +) should.
+  assert.equal(result.findings.length, 1);
+  assert.equal(result.findings[0].ruleId, "github-pat-classic");
+  assert.equal(result.findings[0].file, "src/x.ts");
+  assert.equal(result.blocked, true);
+});
+
+test("scanPatch: attributes findings to the right file in a multi-file patch", () => {
+  const patch = `diff --git a/src/a.ts b/src/a.ts
+--- a/src/a.ts
++++ b/src/a.ts
+@@ -0,0 +1 @@
++const a = "${FIXTURE.openai}";
+diff --git a/src/b.ts b/src/b.ts
+--- a/src/b.ts
++++ b/src/b.ts
+@@ -0,0 +1 @@
++const b = "${FIXTURE.slack}";
+`;
+  const result = scanPatch(patch);
+  const a = result.findings.find((f) => f.file === "src/a.ts");
+  const b = result.findings.find((f) => f.file === "src/b.ts");
+  assert.ok(a, "src/a.ts finding missing");
+  assert.ok(b, "src/b.ts finding missing");
+  assert.equal(a.ruleId, "openai-key");
+  assert.equal(b.ruleId, "slack-webhook");
+});
+
+test("scanPatch: ignores /dev/null destination (file deletion)", () => {
+  const patch = `diff --git a/old.ts b/old.ts
+--- a/old.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-const old = "${FIXTURE.aws}";
+`;
+  const result = scanPatch(patch);
+  assert.equal(result.findings.length, 0);
+});
+
+test("scanPatch: no findings on clean patch", () => {
+  const patch = `diff --git a/x b/x
+--- a/x
++++ b/x
+@@ -1 +1,2 @@
+ existing line
++added clean line
+`;
+  const result = scanPatch(patch);
+  assert.equal(result.findings.length, 0);
+  assert.equal(result.blocked, false);
+});
+
+test("scanPatch: allow-list still honoured", () => {
+  const patch = `+++ b/src/x.ts
++const key = "${FIXTURE.aws}";
+`;
+  const result = scanPatch(patch, { allow: ["aws-access-key"] });
+  assert.equal(result.findings.length, 0);
+});
+
+// ---------- formatFinding --------------------------------------------------
+
+test("formatFinding: includes confidence, rule, location, and preview", () => {
+  const f = {
+    ruleId: "openai-key",
+    ruleName: "OpenAI API Key",
+    confidence: "high",
+    line: 42,
+    column: 8,
+    preview: "sk-a…89AB",
+    file: "src/config.ts",
+  };
+  const s = formatFinding(f);
+  assert.match(s, /\[high\]/);
+  assert.match(s, /OpenAI API Key/);
+  assert.match(s, /openai-key/);
+  assert.match(s, /src\/config\.ts:42:8/);
+  assert.match(s, /sk-a…89AB/);
+});
+
+test("formatFinding: omits file segment when absent", () => {
+  const f = {
+    ruleId: "aws-access-key",
+    ruleName: "AWS Access Key ID",
+    confidence: "high",
+    line: 3,
+    column: 5,
+    preview: "AKIA…MPLE",
+  };
+  assert.match(formatFinding(f), /line 3:5/);
+});
+
+// ---------- DEFAULT_RULES integrity ----------------------------------------
+
+test("DEFAULT_RULES: every rule has unique id and no banned regex flags", () => {
+  const ids = new Set();
+  for (const rule of DEFAULT_RULES) {
+    assert.ok(!ids.has(rule.id), `duplicate rule id: ${rule.id}`);
+    ids.add(rule.id);
+    assert.equal(rule.pattern.global, false, `rule ${rule.id}: pattern must not use /g`);
+    assert.equal(rule.pattern.sticky, false, `rule ${rule.id}: pattern must not use /y`);
+    assert.equal(rule.pattern.multiline, false, `rule ${rule.id}: pattern must not use /m`);
+  }
+});

--- a/packages/secret-guard/tsconfig.json
+++ b/packages/secret-guard/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       '@conclave-ai/scm-github':
         specifier: workspace:*
         version: link:../scm-github
+      '@conclave-ai/secret-guard':
+        specifier: workspace:*
+        version: link:../secret-guard
       '@conclave-ai/visual-review':
         specifier: workspace:*
         version: link:../visual-review
@@ -316,6 +319,12 @@ importers:
       '@conclave-ai/core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/secret-guard:
     devDependencies:
       typescript:
         specifier: ^5.7.0


### PR DESCRIPTION
## Summary
New \`@conclave-ai/secret-guard\` package + wired into \`conclave rework\` as a pre-apply gate. Closes a real risk introduced by #57: the worker reads file snapshots and commits patches unsupervised — without a scanner it could publish an API key on auto-pilot.

## Package: @conclave-ai/secret-guard
- Zero runtime deps. Pure regex + string split.
- **16 default rules.** High-confidence (block): AWS access key, labeled AWS secret, OpenAI, Anthropic, GitHub PAT (classic/fine/app), Slack/Discord/Telegram webhooks, Google API key, npm token, Stripe live key, PEM private key blocks. Medium: JWT. Low: generic \`password/api_key/secret = "…"\` assignment.
- **Medium + low hidden by default**, surfaced with \`includeLowConfidence: true\`. Medium alone never blocks — only high findings set \`result.blocked = true\`.
- \`scanPatch()\` inspects only \`+\`-prefixed added lines, so touching a file that already contains a secret never false-positives.
- Findings are redacted (\`abcd…wxyz\`) before any log/store write.
- Per-rule allow-list via \`opts.allow: string[]\`; stable ruleIds.
- 33 tests green.

## CLI integration
- \`conclave rework\` invokes \`scanPatch\` after \`worker.work()\`, before \`git apply\`. High-confidence → exit 1, no git ops, no \`recordOutcome\`.
- New flags: \`--allow-secret <ruleId>\` (repeatable) + \`--skip-secret-guard\` (escape hatch; discouraged).
- Non-blocking low/medium findings get stdout'd so operators see them.
- \`deps.secretScan\` override keeps rework tests hermetic — 4 new rework tests cover block / allow-list forwarding / skip / low-only pass.

## Why this instead of gitleaks/trufflehog
- Runs inline in the worker loop — no new process spawn, no extra CI dependency, no signup.
- Single-purpose: we only care about *new* additions in the worker's patch, not a full repo sweep. \`scanPatch\` is tight around that use case.
- Rule set is intentionally narrow — every pattern is one where a match is almost certainly a real secret. Easy to audit, easy to extend.

## Test plan
- [x] \`pnpm build\` — 23/23 (was 22)
- [x] \`pnpm test\` — 45/45 tasks (was 43). secret-guard subtests: 33/33. cli rework subtests grew from 29 to 33, all green.
- [x] Covered: every default rule's positive case + clean-text negative, file threading, line/column accuracy, patch diff awareness (+/context/-/dev-null), allow-list, confidence gating, rule-set integrity (unique ids, no banned flags), format + redact helpers.
- [ ] Manual smoke after merge — intentionally paste an AKIA... into a test PR snapshot, confirm worker patch is blocked.