### PR TITLE
feat(telegram-bot): callback_query → repository_dispatch runner + workflow templates

### DIFF
--- a/examples/github-workflows/README.md
+++ b/examples/github-workflows/README.md
@@ -1,0 +1,18 @@
+# GH Actions workflow templates
+
+Drop-in YAMLs that wire Conclave AI into a repo's CI. Copy any of these into `.github/workflows/` on the target repo.
+
+| File | What it does | Secrets needed |
+|---|---|---|
+| `telegram-bot.yml` | 1-minute cron: long-polls Telegram and fires `repository_dispatch` on button clicks | `TELEGRAM_BOT_TOKEN`, `ORCHESTRATOR_PAT` |
+| `conclave-rework.yml` | Receives `conclave-rework` dispatch → runs `conclave rework` → commits the fix back to the PR branch | `ANTHROPIC_API_KEY`, `ORCHESTRATOR_PAT` |
+| `conclave-merge.yml` | Receives `conclave-merge` dispatch → `gh pr merge --squash` + records outcome | `ORCHESTRATOR_PAT` |
+| `conclave-reject.yml` | Receives `conclave-reject` dispatch → `gh pr close` + records outcome | `ORCHESTRATOR_PAT` |
+
+## Minimal install path
+
+To enable the full Telegram → worker loop on a repo that already has `conclave-review.yml` installed, copy all four files and populate the three secrets above. Branch-protection rules still apply to the merge workflow — Telegram is a convenience, not an authorisation bypass.
+
+## Why `ORCHESTRATOR_PAT` and not `GITHUB_TOKEN`
+
+GH Actions' default `GITHUB_TOKEN` can't trigger subsequent workflow runs. The worker's push to the PR branch has to wake up the review workflow, and the Telegram bot's `repository_dispatch` has to wake up the rework/merge/reject workflows — both require a PAT (or GitHub App token) with the appropriate scopes. A fine-grained PAT with `contents: write` + `actions: write` on the specific repo is usually enough.

--- a/examples/github-workflows/conclave-merge.yml
+++ b/examples/github-workflows/conclave-merge.yml
@@ -1,0 +1,44 @@
+# Triggered by the telegram-bot-runner when a user clicks ✅ Approve.
+# Merges the PR and records the outcome in conclave's episodic store so
+# the answer-key (정답지) generator picks it up.
+#
+# Branch protection rules on the target PR still apply — this workflow
+# cannot force a merge past required reviews / required checks. That's
+# intentional: Telegram is a convenience, not an authorisation bypass.
+name: conclave-merge
+
+on:
+  repository_dispatch:
+    types: [conclave-merge]
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Resolve PR + merge
+        env:
+          GH_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
+          EPISODIC: ${{ github.event.client_payload.episodic }}
+        run: |
+          set -euo pipefail
+          EP_FILE=$(grep -rl "\"id\": \"${EPISODIC}\"" .conclave/episodic 2>/dev/null | head -1)
+          PR=$(jq -r '.pullNumber' "${EP_FILE}")
+          echo "Merging PR ${PR} on behalf of Telegram approval"
+          gh pr merge "${PR}" --squash --delete-branch
+
+      - name: Record outcome = merged
+        env:
+          GH_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
+        run: |
+          npx -y -p @conclave-ai/cli@latest conclave record-outcome \
+            --id ${{ github.event.client_payload.episodic }} \
+            --result merged

--- a/examples/github-workflows/conclave-reject.yml
+++ b/examples/github-workflows/conclave-reject.yml
@@ -1,0 +1,39 @@
+# Triggered by the telegram-bot-runner when a user clicks ❌ Reject.
+# Closes the PR (without merging) and records the outcome so the
+# failure-catalog (오답지) generator picks up the blocker patterns.
+name: conclave-reject
+
+on:
+  repository_dispatch:
+    types: [conclave-reject]
+
+jobs:
+  reject:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Resolve PR + close
+        env:
+          GH_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
+          EPISODIC: ${{ github.event.client_payload.episodic }}
+        run: |
+          set -euo pipefail
+          EP_FILE=$(grep -rl "\"id\": \"${EPISODIC}\"" .conclave/episodic 2>/dev/null | head -1)
+          PR=$(jq -r '.pullNumber' "${EP_FILE}")
+          gh pr close "${PR}" --comment "Closed via conclave Telegram callback (${{ github.event.client_payload.triggeredBy }})."
+
+      - name: Record outcome = rejected
+        env:
+          GH_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
+        run: |
+          npx -y -p @conclave-ai/cli@latest conclave record-outcome \
+            --id ${{ github.event.client_payload.episodic }} \
+            --result rejected

--- a/examples/github-workflows/conclave-rework.yml
+++ b/examples/github-workflows/conclave-rework.yml
@@ -1,0 +1,75 @@
+# Triggered by the telegram-bot-runner when a user clicks 🔧 Rework.
+# Runs `conclave rework --episodic <id>` on the PR branch, which invokes
+# the Worker agent, applies the generated patch, and pushes back to the
+# PR branch. The pull_request:synchronize event then re-runs the council
+# review automatically.
+#
+# Copy into `.github/workflows/conclave-rework.yml`. Requires secrets:
+#   - ANTHROPIC_API_KEY : the Worker uses Claude
+#   - ORCHESTRATOR_PAT  : a PAT with contents:write (to push the fix commit)
+name: conclave-rework
+
+on:
+  repository_dispatch:
+    types: [conclave-rework]
+
+concurrency:
+  # One rework at a time per episodic — avoids two Telegram clicks racing.
+  group: conclave-rework-${{ github.event.client_payload.episodic }}
+  cancel-in-progress: false
+
+jobs:
+  rework:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Find the PR from the episodic
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
+          EPISODIC: ${{ github.event.client_payload.episodic }}
+        run: |
+          set -euo pipefail
+          # Expect the episodic store to live at .conclave/episodic/**/ep-*.json
+          # on the default branch. Shallow-clone to find it.
+          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" repo
+          cd repo
+          EP_FILE=$(grep -rl "\"id\": \"${EPISODIC}\"" .conclave/episodic 2>/dev/null | head -1 || true)
+          if [ -z "${EP_FILE}" ]; then
+            echo "::error::No episodic file found for id ${EPISODIC}"
+            exit 1
+          fi
+          PR=$(jq -r '.pullNumber' "${EP_FILE}")
+          echo "pr=${PR}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          # Check out the PR branch so `conclave rework` can apply + push.
+          ref: refs/pull/${{ steps.resolve.outputs.pr }}/head
+          fetch-depth: 0
+          token: ${{ secrets.ORCHESTRATOR_PAT }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Switch to the PR's actual branch (not detached HEAD)
+        env:
+          GH_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
+          PR: ${{ steps.resolve.outputs.pr }}
+        run: |
+          set -euo pipefail
+          BRANCH=$(gh pr view "$PR" --repo ${{ github.repository }} --json headRefName -q .headRefName)
+          git checkout -B "$BRANCH"
+          git branch --set-upstream-to="origin/${BRANCH}" "$BRANCH" || true
+
+      - name: Run conclave rework
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
+        run: |
+          npx -y -p @conclave-ai/cli@latest conclave rework \
+            --pr ${{ steps.resolve.outputs.pr }} \
+            --episodic ${{ github.event.client_payload.episodic }}

--- a/examples/github-workflows/telegram-bot.yml
+++ b/examples/github-workflows/telegram-bot.yml
@@ -1,0 +1,58 @@
+# Copy into `.github/workflows/telegram-bot.yml` on the repo that runs
+# conclave review. Requires repo secrets:
+#   - TELEGRAM_BOT_TOKEN : the bot that integration-telegram posts as
+#   - ORCHESTRATOR_PAT   : a PAT with actions:write on this repo (used by
+#     gh CLI to fire the repository_dispatch events for conclave-rework /
+#     conclave-merge / conclave-reject)
+name: conclave-telegram-bot
+
+on:
+  schedule:
+    - cron: '*/1 * * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: conclave-telegram-bot
+  cancel-in-progress: false
+
+jobs:
+  poll:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Persist the Telegram getUpdates offset between runs so we don't
+      # double-process callbacks. The cache key is static — GH Actions
+      # cache writes are eventually consistent, which is acceptable here
+      # because Telegram is happy to repeat an already-answered update
+      # (answerCallbackQuery is idempotent within a short window).
+      - name: Restore offset
+        uses: actions/cache/restore@v4
+        with:
+          path: .telegram-bot-offset.json
+          key: conclave-telegram-bot-offset
+
+      - name: Poll Telegram + dispatch
+        run: |
+          npx -y -p @conclave-ai/telegram-bot-runner@latest \
+            conclave-telegram-bot \
+              --repo ${{ github.repository }} \
+              --offset-file .telegram-bot-offset.json \
+              --poll-timeout 25
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
+
+      - name: Save offset
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .telegram-bot-offset.json
+          key: conclave-telegram-bot-offset

--- a/packages/telegram-bot-runner/README.md
+++ b/packages/telegram-bot-runner/README.md
@@ -1,0 +1,79 @@
+# @conclave-ai/telegram-bot-runner
+
+Long-polls Telegram `callback_query` updates (the 🔧 Rework / ✅ Approve / ❌ Reject buttons that `@conclave-ai/integration-telegram` renders) and dispatches `repository_dispatch` events back to the target repo's GH Actions workflows.
+
+Closes the final gap documented in `next_session_kickoff.md`: the notifier already emits action buttons, but until now clicking them did nothing.
+
+## How it fits together
+
+```
+Telegram user clicks 🔧 Rework
+   → callback_query (update_id N, data="ep:<id>:reworked")
+   → runBotOnce() reads it via getUpdates
+   → gh api repos/<repo>/dispatches -f event_type=conclave-rework
+        -f client_payload='{"episodic":"<id>", ...}'
+   → GH Actions `rework.yml` workflow fires
+   → workflow checks out the PR branch, runs `conclave rework --episodic <id>`
+   → worker agent generates patch → commit + push → review re-runs automatically
+```
+
+Merge / reject map the same way — the bot-runner only dispatches, it never touches PR state directly. That keeps the token blast radius small: it needs `actions: write` on the target repo, nothing more.
+
+## Running as a GH Actions cron
+
+```yaml
+# .github/workflows/telegram-bot.yml
+name: conclave-telegram-bot
+on:
+  schedule:
+    - cron: '*/1 * * * *'
+  workflow_dispatch:
+
+jobs:
+  poll:
+    runs-on: ubuntu-latest
+    permissions: { contents: read, actions: write }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - uses: actions/cache@v4
+        with:
+          path: .telegram-bot-offset.json
+          key: telegram-bot-offset
+      - run: npx -p @conclave-ai/telegram-bot-runner conclave-telegram-bot --repo ${{ github.repository }}
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
+```
+
+The offset file is cached across runs so consecutive polls don't double-process the same callback. `--poll-timeout 25` means each tick blocks for up to 25 seconds on the Telegram side — the job typically finishes in under 30 seconds even when nothing is queued.
+
+## API (for embedding)
+
+```ts
+import { runBotOnce } from "@conclave-ai/telegram-bot-runner";
+
+const result = await runBotOnce({
+  botToken: process.env.TELEGRAM_BOT_TOKEN!,
+  repo: "acme/service",
+  offset: savedOffset,         // persisted between runs
+  pollTimeoutSec: 25,
+  allowOutcomes: ["reworked"], // e.g. disable auto-merge from Telegram
+});
+
+// result.parsed:     every callback we saw
+// result.dispatched: the ones we actually fired repository_dispatch for
+// result.errors:     per-update errors (non-fatal)
+// result.nextOffset: persist this and pass as `offset` next call
+```
+
+## Trust model
+
+- The bot runs on GH Actions with `ORCHESTRATOR_PAT`. Anyone who can click the Telegram button can trigger a dispatch. **Telegram does not authenticate users beyond "they're in the chat."** That means the chat ACL is the authorisation surface — keep the chat private, invite only people who are allowed to rework/merge/reject PRs.
+- The dispatcher never shells out `gh pr merge` itself — the target repo's workflow does, behind its own branch protection rules. So even a spoofed callback can't merge a PR that doesn't otherwise meet the repo's requirements.
+- The bot's `answerCallbackQuery` shows the user what happened (`✓ conclave-rework dispatched` or `⚠ dispatch failed`) so they know the button did something.
+
+## Zero runtime dependencies
+
+Uses only `globalThis.fetch` (Node 18+) and the `gh` CLI. No Telegram SDK, no Octokit.

--- a/packages/telegram-bot-runner/package.json
+++ b/packages/telegram-bot-runner/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@conclave-ai/telegram-bot-runner",
+  "version": "0.2.2",
+  "description": "Conclave AI Telegram bot-runner — long-polls Telegram callback_query events and dispatches repository_dispatch actions back to the target repo's GH Actions workflows.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "conclave-telegram-bot": "./dist/bin/bot.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/telegram-bot-runner/src/bin/bot.ts
+++ b/packages/telegram-bot-runner/src/bin/bot.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { runBotOnce } from "../bot-runner.js";
+import type { Outcome } from "../types.js";
+
+const HELP = `conclave-telegram-bot — one-shot long-poll → repository_dispatch runner
+
+Usage:
+  conclave-telegram-bot --repo <owner/name> [--offset-file <path>] [--poll-timeout <seconds>]
+                        [--allow merged,reworked,rejected] [--no-ack]
+
+Flags:
+  --repo <owner/name>     Required. Destination repo for repository_dispatch events.
+  --offset-file <path>    JSON file used to persist the last-seen update_id. Default: ./.telegram-bot-offset.json
+  --poll-timeout <s>      Long-poll timeout passed to getUpdates. Default: 25.
+  --allow <list>          Comma-separated allow-list of outcomes (merged, reworked, rejected).
+  --no-ack                Skip Telegram's answerCallbackQuery step (useful in dry-run).
+  --help, -h              Show this message.
+
+Environment:
+  TELEGRAM_BOT_TOKEN      Required. The bot that users click the inline buttons on.
+  GH_TOKEN / GITHUB_TOKEN Required for \`gh api\` — a token with actions:write on the target repo.
+
+Design note: this process runs for one cycle and exits. Schedule it with
+GH Actions (\`schedule: */1 * * * *\`) so each minute picks up whatever's
+queued. The offset is persisted to a small JSON file so consecutive runs
+don't double-process the same update.
+`;
+
+interface BinArgs {
+  repo?: string;
+  offsetFile: string;
+  pollTimeoutSec: number;
+  allow?: Outcome[];
+  ack: boolean;
+  help: boolean;
+}
+
+function parse(argv: string[]): BinArgs {
+  const out: BinArgs = { offsetFile: ".telegram-bot-offset.json", pollTimeoutSec: 25, ack: true, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--repo" && argv[i + 1]) { out.repo = argv[i + 1]; i += 1; }
+    else if (a === "--offset-file" && argv[i + 1]) { out.offsetFile = argv[i + 1]!; i += 1; }
+    else if (a === "--poll-timeout" && argv[i + 1]) {
+      const n = Number.parseInt(argv[i + 1]!, 10);
+      if (!Number.isNaN(n)) out.pollTimeoutSec = n;
+      i += 1;
+    }
+    else if (a === "--allow" && argv[i + 1]) {
+      out.allow = argv[i + 1]!
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s): s is Outcome => s === "merged" || s === "reworked" || s === "rejected");
+      i += 1;
+    }
+    else if (a === "--no-ack") out.ack = false;
+  }
+  return out;
+}
+
+async function readOffset(filePath: string): Promise<number | undefined> {
+  try {
+    const raw = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw) as { offset?: unknown };
+    return typeof parsed.offset === "number" ? parsed.offset : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeOffset(filePath: string, offset: number): Promise<void> {
+  await mkdir(path.dirname(filePath) || ".", { recursive: true });
+  await writeFile(filePath, JSON.stringify({ offset }, null, 2) + "\n", "utf8");
+}
+
+async function main(): Promise<void> {
+  const args = parse(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  if (!args.repo || !args.repo.includes("/")) {
+    process.stderr.write(`conclave-telegram-bot: --repo <owner/name> is required\n\n${HELP}`);
+    process.exit(2);
+  }
+  const botToken = process.env["TELEGRAM_BOT_TOKEN"];
+  if (!botToken) {
+    process.stderr.write("conclave-telegram-bot: TELEGRAM_BOT_TOKEN env var is not set\n");
+    process.exit(2);
+  }
+
+  const offset = await readOffset(args.offsetFile);
+  const result = await runBotOnce({
+    botToken: botToken!,
+    repo: args.repo!,
+    ...(offset !== undefined ? { offset } : {}),
+    pollTimeoutSec: args.pollTimeoutSec,
+    ackCallbacks: args.ack,
+    ...(args.allow ? { allowOutcomes: args.allow } : {}),
+  });
+
+  if (result.nextOffset !== undefined && result.nextOffset !== offset) {
+    await writeOffset(args.offsetFile, result.nextOffset);
+  }
+
+  process.stdout.write(
+    `conclave-telegram-bot: parsed=${result.parsed.length} dispatched=${result.dispatched.length} errors=${result.errors.length} nextOffset=${result.nextOffset ?? "(unchanged)"}\n`,
+  );
+  for (const e of result.errors) {
+    process.stderr.write(`  update ${e.updateId}: ${e.message}\n`);
+  }
+  if (result.errors.length > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  process.stderr.write(`conclave-telegram-bot: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/telegram-bot-runner/src/bot-runner.ts
+++ b/packages/telegram-bot-runner/src/bot-runner.ts
@@ -1,0 +1,101 @@
+import { extractCallback } from "./callback-parser.js";
+import { TelegramClient } from "./telegram-client.js";
+import { defaultEventTypeFor, defaultGh, dispatchRepositoryEvent } from "./dispatcher.js";
+import type { BotCallback, DispatchedAction, RunBotOnceOptions, RunBotOnceResult } from "./types.js";
+
+// One poll cycle. Caller runs this on a schedule (GH Actions cron every
+// minute with pollTimeoutSec: 25 is the recommended pattern — each job
+// finishes inside a minute, ticks overlap gracefully).
+//
+// Caller responsibilities:
+//   - persist result.nextOffset between runs (e.g. cache artifact);
+//   - provide a repo-scoped GitHub token with actions:write so
+//     repository_dispatch succeeds;
+//   - rate-limit — 1/min is fine; /10s across many repos will hit Telegram
+//     bot limits.
+export async function runBotOnce(opts: RunBotOnceOptions): Promise<RunBotOnceResult> {
+  if (!opts.botToken) throw new Error("runBotOnce: botToken is required");
+  if (!opts.repo || !opts.repo.includes("/")) {
+    throw new Error(`runBotOnce: repo must be "owner/name" (got ${JSON.stringify(opts.repo)})`);
+  }
+
+  const telegram = new TelegramClient({
+    token: opts.botToken,
+    ...(opts.fetch ? { fetch: opts.fetch } : {}),
+  });
+  const gh = opts.gh ?? defaultGh;
+  const ack = opts.ackCallbacks ?? true;
+  const allow = new Set(opts.allowOutcomes ?? (["merged", "reworked", "rejected"] as const));
+  const eventTypeFor = opts.eventTypeFor ?? defaultEventTypeFor;
+
+  const updates = await telegram.getUpdates({
+    ...(opts.offset !== undefined ? { offset: opts.offset } : {}),
+    timeoutSec: opts.pollTimeoutSec ?? 25,
+  });
+
+  const parsed: BotCallback[] = [];
+  const dispatched: DispatchedAction[] = [];
+  const errors: RunBotOnceResult["errors"] = [];
+  let maxUpdateId = opts.offset !== undefined ? opts.offset - 1 : -1;
+
+  for (const u of updates) {
+    const cb = extractCallback(u);
+    if (!cb) {
+      // Not a recognised callback — still advance the offset so we don't
+      // re-fetch it forever. Telegram gives us the update_id on every
+      // shape, so pull it defensively.
+      const uid = pickUpdateId(u);
+      if (uid !== null && uid > maxUpdateId) maxUpdateId = uid;
+      continue;
+    }
+    parsed.push(cb);
+    if (cb.updateId > maxUpdateId) maxUpdateId = cb.updateId;
+
+    if (!allow.has(cb.outcome)) {
+      if (ack) {
+        await telegram
+          .answerCallbackQuery({ id: cb.callbackQueryId, text: `outcome "${cb.outcome}" is disabled on this bot` })
+          .catch((e) => errors.push({ updateId: cb.updateId, message: `ack: ${String(e)}` }));
+      }
+      continue;
+    }
+
+    try {
+      const eventType = eventTypeFor(cb.outcome);
+      const clientPayload: Record<string, unknown> = {
+        episodic: cb.episodicId,
+        outcome: cb.outcome,
+      };
+      if (cb.user) clientPayload.triggeredBy = cb.user;
+      await dispatchRepositoryEvent(gh, opts.repo, eventType, clientPayload);
+      dispatched.push({ eventType, repo: opts.repo, clientPayload, callback: cb });
+      if (ack) {
+        await telegram
+          .answerCallbackQuery({ id: cb.callbackQueryId, text: `✓ ${eventType} dispatched` })
+          .catch((e) => errors.push({ updateId: cb.updateId, message: `ack: ${String(e)}` }));
+      }
+    } catch (err) {
+      errors.push({ updateId: cb.updateId, message: err instanceof Error ? err.message : String(err) });
+      if (ack) {
+        await telegram
+          .answerCallbackQuery({
+            id: cb.callbackQueryId,
+            text: `⚠ dispatch failed — see bot logs`,
+            showAlert: true,
+          })
+          .catch((e) => errors.push({ updateId: cb.updateId, message: `ack: ${String(e)}` }));
+      }
+    }
+  }
+
+  const result: RunBotOnceResult = { parsed, dispatched, errors };
+  if (maxUpdateId >= 0) result.nextOffset = maxUpdateId + 1;
+  return result;
+}
+
+function pickUpdateId(u: unknown): number | null {
+  if (u && typeof u === "object" && typeof (u as { update_id?: unknown }).update_id === "number") {
+    return (u as { update_id: number }).update_id;
+  }
+  return null;
+}

--- a/packages/telegram-bot-runner/src/callback-parser.ts
+++ b/packages/telegram-bot-runner/src/callback-parser.ts
@@ -1,0 +1,58 @@
+import type { BotCallback, Outcome } from "./types.js";
+
+/**
+ * Parse the `callback_data` string that integration-telegram stamps on
+ * its inline buttons. Format: `ep:<episodicId>:<outcome>`. Anything else
+ * returns null — we log+skip rather than throw, because malformed updates
+ * are not our problem to crash over (could be an old button from a
+ * previous schema version).
+ */
+export function parseCallbackData(data: string | undefined | null): { episodicId: string; outcome: Outcome } | null {
+  if (!data) return null;
+  // "ep:<id>:<outcome>" — the id itself can't contain ":" because
+  // integration-telegram generates ids from UUIDv4 (no colons), but we
+  // still handle it defensively by splitting on the LAST colon.
+  if (!data.startsWith("ep:")) return null;
+  const lastColon = data.lastIndexOf(":");
+  if (lastColon <= 3) return null; // no room for both id and outcome
+  const episodicId = data.slice(3, lastColon);
+  const outcome = data.slice(lastColon + 1);
+  if (outcome !== "merged" && outcome !== "reworked" && outcome !== "rejected") return null;
+  if (episodicId.length === 0) return null;
+  return { episodicId, outcome };
+}
+
+/**
+ * Pull a BotCallback out of a Telegram `Update` object. Returns null for
+ * non-callback updates or for callbacks we don't recognise.
+ */
+export function extractCallback(update: unknown): BotCallback | null {
+  if (!update || typeof update !== "object") return null;
+  const u = update as { update_id?: unknown; callback_query?: unknown };
+  if (typeof u.update_id !== "number") return null;
+  const cq = u.callback_query;
+  if (!cq || typeof cq !== "object") return null;
+  const q = cq as {
+    id?: unknown;
+    data?: unknown;
+    from?: { username?: unknown; first_name?: unknown };
+    message?: { chat?: { id?: unknown }; message_id?: unknown };
+  };
+  if (typeof q.id !== "string") return null;
+  const parsed = parseCallbackData(typeof q.data === "string" ? q.data : undefined);
+  if (!parsed) return null;
+
+  const result: BotCallback = {
+    episodicId: parsed.episodicId,
+    outcome: parsed.outcome,
+    callbackQueryId: q.id,
+    updateId: u.update_id,
+  };
+  const chatId = q.message?.chat?.id;
+  if (typeof chatId === "number") result.chatId = chatId;
+  const messageId = q.message?.message_id;
+  if (typeof messageId === "number") result.messageId = messageId;
+  const user = typeof q.from?.username === "string" ? q.from.username : typeof q.from?.first_name === "string" ? q.from.first_name : undefined;
+  if (user) result.user = user;
+  return result;
+}

--- a/packages/telegram-bot-runner/src/dispatcher.ts
+++ b/packages/telegram-bot-runner/src/dispatcher.ts
@@ -1,0 +1,45 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import type { GhLike, Outcome } from "./types.js";
+
+const execFile = promisify(execFileCallback);
+
+export function defaultEventTypeFor(outcome: Outcome): string {
+  switch (outcome) {
+    case "merged":
+      return "conclave-merge";
+    case "reworked":
+      return "conclave-rework";
+    case "rejected":
+      return "conclave-reject";
+  }
+}
+
+export const defaultGh: GhLike = async (bin, args, opts) => {
+  const { stdout, stderr } = await execFile(bin, args as string[], {
+    ...(opts?.timeout ? { timeout: opts.timeout } : {}),
+    ...(opts?.input ? { input: opts.input } : {}),
+    maxBuffer: 5 * 1024 * 1024,
+  });
+  return { stdout, stderr };
+};
+
+/**
+ * Fire a `repository_dispatch` event on `repo` with `event_type` and the
+ * given client_payload. Uses gh CLI so authentication flows through the
+ * already-configured token (ORCHESTRATOR_PAT in the conclave GH Actions
+ * context) without us having to handle HTTPS ourselves.
+ *
+ * Invokes: gh api repos/:owner/:repo/dispatches -f event_type=... --input -
+ * with the payload piped on stdin. That lets us pass arbitrarily nested
+ * JSON client_payloads without fighting gh's -F/-f escaping.
+ */
+export async function dispatchRepositoryEvent(
+  gh: GhLike,
+  repo: string,
+  eventType: string,
+  clientPayload: Record<string, unknown>,
+): Promise<void> {
+  const body = JSON.stringify({ event_type: eventType, client_payload: clientPayload });
+  await gh("gh", ["api", `repos/${repo}/dispatches`, "--method", "POST", "--input", "-"], { input: body });
+}

--- a/packages/telegram-bot-runner/src/index.ts
+++ b/packages/telegram-bot-runner/src/index.ts
@@ -1,0 +1,15 @@
+export { runBotOnce } from "./bot-runner.js";
+export { parseCallbackData, extractCallback } from "./callback-parser.js";
+export { TelegramClient } from "./telegram-client.js";
+export { defaultEventTypeFor, dispatchRepositoryEvent } from "./dispatcher.js";
+export type {
+  Outcome,
+  BotCallback,
+  DispatchedAction,
+  FetchLike,
+  FetchResponse,
+  GhLike,
+  GhResult,
+  RunBotOnceOptions,
+  RunBotOnceResult,
+} from "./types.js";

--- a/packages/telegram-bot-runner/src/telegram-client.ts
+++ b/packages/telegram-bot-runner/src/telegram-client.ts
@@ -1,0 +1,55 @@
+import type { FetchLike } from "./types.js";
+
+/**
+ * Minimal Telegram Bot API client. Intentionally narrower than a general
+ * wrapper — only the two endpoints this package actually needs. Keeping
+ * it small means no runtime deps and no SDK churn.
+ */
+export class TelegramClient {
+  private readonly token: string;
+  private readonly fetch: FetchLike;
+
+  constructor(opts: { token: string; fetch?: FetchLike }) {
+    if (!opts.token) throw new Error("TelegramClient: token is required");
+    this.token = opts.token;
+    const fallback = (globalThis as unknown as { fetch?: FetchLike }).fetch;
+    const f = opts.fetch ?? fallback;
+    if (!f) throw new Error("TelegramClient: no fetch implementation available (Node 18+ required, or pass opts.fetch)");
+    this.fetch = f;
+  }
+
+  async getUpdates(opts: { offset?: number; timeoutSec?: number }): Promise<unknown[]> {
+    const params = new URLSearchParams();
+    if (opts.offset !== undefined) params.set("offset", String(opts.offset));
+    params.set("timeout", String(opts.timeoutSec ?? 25));
+    // Narrow what we listen for so we don't rack up updates we don't act on.
+    params.set("allowed_updates", JSON.stringify(["callback_query"]));
+    const url = `https://api.telegram.org/bot${this.token}/getUpdates?${params.toString()}`;
+    const resp = await this.fetch(url, { method: "GET" });
+    if (!resp.ok) throw new Error(`telegram getUpdates: HTTP ${resp.status} — ${await safeText(resp)}`);
+    const body = (await resp.json()) as { ok?: boolean; result?: unknown[]; description?: string };
+    if (!body.ok) throw new Error(`telegram getUpdates: ${body.description ?? "not ok"}`);
+    return body.result ?? [];
+  }
+
+  async answerCallbackQuery(opts: { id: string; text?: string; showAlert?: boolean }): Promise<void> {
+    const url = `https://api.telegram.org/bot${this.token}/answerCallbackQuery`;
+    const body: Record<string, unknown> = { callback_query_id: opts.id };
+    if (opts.text !== undefined) body.text = opts.text;
+    if (opts.showAlert !== undefined) body.show_alert = opts.showAlert;
+    const resp = await this.fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) throw new Error(`telegram answerCallbackQuery: HTTP ${resp.status} — ${await safeText(resp)}`);
+  }
+}
+
+async function safeText(resp: { text: () => Promise<string> }): Promise<string> {
+  try {
+    return (await resp.text()).slice(0, 500);
+  } catch {
+    return "<no body>";
+  }
+}

--- a/packages/telegram-bot-runner/src/types.ts
+++ b/packages/telegram-bot-runner/src/types.ts
@@ -1,0 +1,69 @@
+export type Outcome = "merged" | "reworked" | "rejected";
+
+export interface BotCallback {
+  episodicId: string;
+  outcome: Outcome;
+  callbackQueryId: string;
+  updateId: number;
+  chatId?: number;
+  messageId?: number;
+  user?: string;
+}
+
+export interface DispatchedAction {
+  eventType: string;
+  repo: string;
+  clientPayload: Record<string, unknown>;
+  callback: BotCallback;
+}
+
+export interface FetchResponse {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+}
+
+export type FetchLike = (url: string, init?: { method?: string; body?: string; headers?: Record<string, string> }) => Promise<FetchResponse>;
+
+export interface GhResult {
+  stdout: string;
+  stderr?: string;
+}
+
+export type GhLike = (bin: string, args: readonly string[], opts?: { timeout?: number; input?: string }) => Promise<GhResult>;
+
+export interface RunBotOnceOptions {
+  /** Telegram bot token (required). */
+  botToken: string;
+  /** Target repo in "owner/name" form — the repo that will receive the repository_dispatch events. */
+  repo: string;
+  /** Last-seen update_id + 1. If omitted, Telegram returns all pending updates since the bot was last polled. */
+  offset?: number;
+  /** Long-poll timeout in seconds. Default 25. Telegram max 50. Set 0 for a pure non-blocking poll in tests. */
+  pollTimeoutSec?: number;
+  /** Injected fetch — defaults to globalThis.fetch. */
+  fetch?: FetchLike;
+  /** Injected gh CLI runner — defaults to spawning `gh` via execFile. */
+  gh?: GhLike;
+  /**
+   * If true (default) the bot calls Telegram's answerCallbackQuery to clear
+   * the button's loading spinner after dispatching. Set false in dry-run
+   * / tests where you don't want to touch Telegram.
+   */
+  ackCallbacks?: boolean;
+  /** Allow-list — only these outcomes are dispatched. Defaults to all three. */
+  allowOutcomes?: readonly Outcome[];
+  /** Map outcome → GH Actions event_type. Defaults: merged→conclave-merge, reworked→conclave-rework, rejected→conclave-reject. */
+  eventTypeFor?: (outcome: Outcome) => string;
+}
+
+export interface RunBotOnceResult {
+  /** Every callback we parsed (including ones we skipped due to allow-list). */
+  parsed: BotCallback[];
+  /** Actions that were successfully dispatched. */
+  dispatched: DispatchedAction[];
+  errors: Array<{ updateId: number; message: string }>;
+  /** New offset to persist. Undefined = caller should keep the current offset (we saw nothing actionable). */
+  nextOffset?: number;
+}

--- a/packages/telegram-bot-runner/test/bot-runner.test.mjs
+++ b/packages/telegram-bot-runner/test/bot-runner.test.mjs
@@ -1,0 +1,199 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runBotOnce } from "../dist/index.js";
+
+function makeFetch(responses) {
+  const calls = [];
+  let i = 0;
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: async () => r.body,
+      text: async () => JSON.stringify(r.body ?? ""),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function makeGh() {
+  const calls = [];
+  const fn = async (bin, args, opts) => {
+    calls.push({ bin, args: [...args], input: opts?.input });
+    return { stdout: "", stderr: "" };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function updatesResponse(result) {
+  return { ok: true, status: 200, body: { ok: true, result } };
+}
+
+const update = (updateId, { episodicId = "ep-1", outcome = "reworked", cqId = "cq" } = {}) => ({
+  update_id: updateId,
+  callback_query: {
+    id: cqId,
+    data: `ep:${episodicId}:${outcome}`,
+    from: { username: "bae" },
+    message: { chat: { id: 1 }, message_id: updateId },
+  },
+});
+
+test("runBotOnce: rejects missing botToken or malformed repo", async () => {
+  await assert.rejects(() => runBotOnce({ botToken: "", repo: "acme/x" }), /botToken is required/);
+  await assert.rejects(() => runBotOnce({ botToken: "t", repo: "no-slash" }), /owner\/name/);
+});
+
+test("runBotOnce: dispatches a repository_dispatch event for each recognised callback", async () => {
+  const fetch = makeFetch([
+    updatesResponse([update(100), update(101, { outcome: "merged", episodicId: "ep-2", cqId: "cq2" })]),
+    { ok: true, body: { ok: true } }, // answerCallbackQuery #1
+    { ok: true, body: { ok: true } }, // answerCallbackQuery #2
+  ]);
+  const gh = makeGh();
+
+  const r = await runBotOnce({ botToken: "tok", repo: "acme/x", fetch, gh, pollTimeoutSec: 0 });
+  assert.equal(r.parsed.length, 2);
+  assert.equal(r.dispatched.length, 2);
+  assert.equal(r.errors.length, 0);
+  assert.equal(r.nextOffset, 102);
+
+  // 2 dispatches fired through gh
+  const dispatches = gh.calls.filter((c) => c.args.some((a) => a.includes("/dispatches")));
+  assert.equal(dispatches.length, 2);
+  const [d1, d2] = dispatches;
+  assert.ok(d1.input.includes("conclave-rework"));
+  assert.ok(d1.input.includes("ep-1"));
+  assert.ok(d2.input.includes("conclave-merge"));
+  assert.ok(d2.input.includes("ep-2"));
+});
+
+test("runBotOnce: non-callback updates still advance the offset", async () => {
+  const fetch = makeFetch([
+    updatesResponse([
+      { update_id: 50, message: { text: "hello" } },
+      { update_id: 51, my_chat_member: {} },
+    ]),
+  ]);
+  const gh = makeGh();
+  const r = await runBotOnce({ botToken: "t", repo: "a/b", fetch, gh, pollTimeoutSec: 0 });
+  assert.equal(r.parsed.length, 0);
+  assert.equal(r.dispatched.length, 0);
+  assert.equal(r.nextOffset, 52);
+  assert.equal(gh.calls.length, 0);
+});
+
+test("runBotOnce: allowOutcomes filters out disallowed outcomes but still acks them", async () => {
+  const fetch = makeFetch([
+    updatesResponse([update(200, { outcome: "merged" })]),
+    { ok: true, body: { ok: true } }, // answerCallbackQuery
+  ]);
+  const gh = makeGh();
+  const r = await runBotOnce({
+    botToken: "t",
+    repo: "a/b",
+    fetch,
+    gh,
+    allowOutcomes: ["reworked"],
+    pollTimeoutSec: 0,
+  });
+  assert.equal(r.parsed.length, 1);
+  assert.equal(r.dispatched.length, 0);
+  assert.equal(gh.calls.length, 0);
+  // Still acked so the user sees "disabled"
+  const ackCalls = fetch.calls.filter((c) => c.url.includes("answerCallbackQuery"));
+  assert.equal(ackCalls.length, 1);
+  assert.ok(JSON.parse(ackCalls[0].init.body).text.includes("disabled"));
+});
+
+test("runBotOnce: dispatch error records per-update error but does not throw", async () => {
+  const fetch = makeFetch([
+    updatesResponse([update(300)]),
+    { ok: true, body: { ok: true } }, // answerCallbackQuery showing warning
+  ]);
+  const gh = async (_bin, _args, _opts) => {
+    throw new Error("gh api boom");
+  };
+  const r = await runBotOnce({ botToken: "t", repo: "a/b", fetch, gh, pollTimeoutSec: 0 });
+  assert.equal(r.parsed.length, 1);
+  assert.equal(r.dispatched.length, 0);
+  assert.equal(r.errors.length, 1);
+  assert.equal(r.errors[0].updateId, 300);
+  assert.ok(r.errors[0].message.includes("gh api boom"));
+  // Offset still advances so we don't re-attempt forever
+  assert.equal(r.nextOffset, 301);
+});
+
+test("runBotOnce: --no-ack (ackCallbacks:false) never calls answerCallbackQuery", async () => {
+  const fetch = makeFetch([updatesResponse([update(1)])]);
+  const gh = makeGh();
+  const r = await runBotOnce({
+    botToken: "t",
+    repo: "a/b",
+    fetch,
+    gh,
+    ackCallbacks: false,
+    pollTimeoutSec: 0,
+  });
+  assert.equal(r.dispatched.length, 1);
+  const ackCalls = fetch.calls.filter((c) => c.url.includes("answerCallbackQuery"));
+  assert.equal(ackCalls.length, 0);
+});
+
+test("runBotOnce: empty getUpdates result leaves offset unchanged", async () => {
+  const fetch = makeFetch([updatesResponse([])]);
+  const gh = makeGh();
+  const r = await runBotOnce({ botToken: "t", repo: "a/b", fetch, gh, offset: 500, pollTimeoutSec: 0 });
+  assert.equal(r.parsed.length, 0);
+  assert.equal(r.dispatched.length, 0);
+  // When offset is provided, we pass it through unchanged rather than omitting
+  assert.equal(r.nextOffset, 500);
+  const updatesCall = fetch.calls.find((c) => c.url.includes("getUpdates"));
+  assert.ok(updatesCall.url.includes("offset=500"));
+});
+
+test("runBotOnce: custom eventTypeFor is honoured", async () => {
+  const fetch = makeFetch([
+    updatesResponse([update(700)]),
+    { ok: true, body: { ok: true } },
+  ]);
+  const gh = makeGh();
+  await runBotOnce({
+    botToken: "t",
+    repo: "a/b",
+    fetch,
+    gh,
+    eventTypeFor: (o) => `custom-${o}`,
+    pollTimeoutSec: 0,
+  });
+  const dispatch = gh.calls.find((c) => c.args.some((a) => a.includes("/dispatches")));
+  assert.ok(dispatch.input.includes("custom-reworked"));
+});
+
+test("runBotOnce: client_payload includes triggeredBy when user is known", async () => {
+  const fetch = makeFetch([
+    updatesResponse([update(900)]),
+    { ok: true, body: { ok: true } },
+  ]);
+  const gh = makeGh();
+  await runBotOnce({ botToken: "t", repo: "a/b", fetch, gh, pollTimeoutSec: 0 });
+  const dispatch = gh.calls.find((c) => c.args.some((a) => a.includes("/dispatches")));
+  const body = JSON.parse(dispatch.input);
+  assert.equal(body.client_payload.triggeredBy, "bae");
+  assert.equal(body.client_payload.episodic, "ep-1");
+  assert.equal(body.client_payload.outcome, "reworked");
+});
+
+test("runBotOnce: getUpdates failure is surfaced as a thrown error", async () => {
+  const fetch = makeFetch([{ ok: false, status: 401, body: { ok: false, description: "unauthorized" } }]);
+  const gh = makeGh();
+  await assert.rejects(
+    () => runBotOnce({ botToken: "t", repo: "a/b", fetch, gh, pollTimeoutSec: 0 }),
+    /telegram getUpdates.*401/,
+  );
+});

--- a/packages/telegram-bot-runner/test/parser.test.mjs
+++ b/packages/telegram-bot-runner/test/parser.test.mjs
@@ -1,0 +1,95 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseCallbackData, extractCallback, defaultEventTypeFor } from "../dist/index.js";
+
+// ---- parseCallbackData ----------------------------------------------------
+
+test("parseCallbackData: parses valid ep:<id>:<outcome>", () => {
+  assert.deepEqual(parseCallbackData("ep:abc123:merged"), { episodicId: "abc123", outcome: "merged" });
+  assert.deepEqual(parseCallbackData("ep:x:reworked"), { episodicId: "x", outcome: "reworked" });
+  assert.deepEqual(parseCallbackData("ep:id-with-dashes:rejected"), { episodicId: "id-with-dashes", outcome: "rejected" });
+});
+
+test("parseCallbackData: rejects missing prefix", () => {
+  assert.equal(parseCallbackData("abc:def:merged"), null);
+});
+
+test("parseCallbackData: rejects unknown outcome", () => {
+  assert.equal(parseCallbackData("ep:abc:shipit"), null);
+  assert.equal(parseCallbackData("ep:abc:approve"), null); // approve is a verdict, not an outcome
+});
+
+test("parseCallbackData: rejects empty id", () => {
+  assert.equal(parseCallbackData("ep::merged"), null);
+});
+
+test("parseCallbackData: handles id with colons by splitting on LAST", () => {
+  assert.deepEqual(parseCallbackData("ep:id:with:colons:merged"), {
+    episodicId: "id:with:colons",
+    outcome: "merged",
+  });
+});
+
+test("parseCallbackData: rejects null/undefined/empty", () => {
+  assert.equal(parseCallbackData(undefined), null);
+  assert.equal(parseCallbackData(null), null);
+  assert.equal(parseCallbackData(""), null);
+});
+
+// ---- extractCallback ------------------------------------------------------
+
+test("extractCallback: pulls a full BotCallback from a realistic update", () => {
+  const update = {
+    update_id: 12345,
+    callback_query: {
+      id: "cq-1",
+      data: "ep:abc123:reworked",
+      from: { username: "bae", first_name: "Bae" },
+      message: { chat: { id: 987 }, message_id: 42 },
+    },
+  };
+  const cb = extractCallback(update);
+  assert.deepEqual(cb, {
+    episodicId: "abc123",
+    outcome: "reworked",
+    callbackQueryId: "cq-1",
+    updateId: 12345,
+    chatId: 987,
+    messageId: 42,
+    user: "bae",
+  });
+});
+
+test("extractCallback: falls back to first_name when username is missing", () => {
+  const cb = extractCallback({
+    update_id: 1,
+    callback_query: {
+      id: "cq",
+      data: "ep:x:merged",
+      from: { first_name: "Anonymous" },
+    },
+  });
+  assert.equal(cb.user, "Anonymous");
+});
+
+test("extractCallback: returns null for non-callback updates", () => {
+  assert.equal(extractCallback({ update_id: 1, message: { text: "hi" } }), null);
+  assert.equal(extractCallback({}), null);
+  assert.equal(extractCallback(null), null);
+});
+
+test("extractCallback: returns null for unrecognised callback data", () => {
+  const cb = extractCallback({
+    update_id: 1,
+    callback_query: { id: "cq", data: "something-else" },
+  });
+  assert.equal(cb, null);
+});
+
+// ---- defaultEventTypeFor --------------------------------------------------
+
+test("defaultEventTypeFor: maps each outcome to a distinct event type", () => {
+  assert.equal(defaultEventTypeFor("merged"), "conclave-merge");
+  assert.equal(defaultEventTypeFor("reworked"), "conclave-rework");
+  assert.equal(defaultEventTypeFor("rejected"), "conclave-reject");
+});

--- a/packages/telegram-bot-runner/tsconfig.json
+++ b/packages/telegram-bot-runner/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,12 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/telegram-bot-runner:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/visual-review:
     dependencies:
       '@anthropic-ai/sdk':


### PR DESCRIPTION
## Summary
Turns the existing 🔧 / ✅ / ❌ Telegram inline buttons into actual PR operations. Closes the dogfood gap from \`next_session_kickoff.md\` — Bae clicked rework in the eventbadge test and got silence because the buttons were decorative. Not anymore.

Finishes the T1 Worker / Rework engine arc: #56 (agent-worker) → #57 (rework CLI) → #58 (secret-guard) → **this PR (telegram bot runner)**.

## @conclave-ai/telegram-bot-runner
- \`runBotOnce()\` — one long-poll cycle. Reads getUpdates, parses \`ep:<id>:<outcome>\` callbacks, dispatches \`repository_dispatch\` events, ACKs via \`answerCallbackQuery\`. Returns \`{ parsed, dispatched, errors, nextOffset }\`.
- Event-type mapping: \`merged → conclave-merge\`, \`reworked → conclave-rework\`, \`rejected → conclave-reject\`. Override via \`eventTypeFor\`.
- Dispatch errors are per-update and non-fatal. Offset still advances so a poisoned update can't block the queue.
- Binary \`conclave-telegram-bot\` persists offset between runs in a JSON file.
- Zero runtime deps — just \`fetch\` (Node 18+) and the \`gh\` CLI.
- 21 tests green.

## Workflow templates — examples/github-workflows/
Drop-in YAMLs ready to copy to any repo:
- \`telegram-bot.yml\` — 1-minute cron wrapper around the bot-runner, with offset caching across runs
- \`conclave-rework.yml\` — receives dispatch, resolves PR from episodic, runs \`conclave rework --episodic <id>\`, lets the push trigger the next review
- \`conclave-merge.yml\` — \`gh pr merge --squash\` + record-outcome=merged
- \`conclave-reject.yml\` — \`gh pr close\` + record-outcome=rejected
- README with the secret matrix and a note on why \`ORCHESTRATOR_PAT\` is required (default \`GITHUB_TOKEN\` can't wake follow-up workflows)

## Trust model
Documented in the package README. Telegram does NOT authenticate users beyond "they're in the chat" — the chat ACL IS the authorisation surface. Branch protection still gates merges — Telegram is a convenience, not an authorisation bypass. The bot-runner only dispatches, never touches PR state directly; all git operations happen in the target repo's own workflows behind its own rules.

## Deploying to eventbadge
All three required secrets (\`TELEGRAM_BOT_TOKEN\`, \`TELEGRAM_CHAT_ID\`, \`ORCHESTRATOR_PAT\`) are already present per \`state_ai_conclave_v2.md\`. Installation after merge = copy 4 YAMLs into \`eventbadge/.github/workflows/\`. I can prepare that PR next if you want.

## Test plan
- [x] \`pnpm build\` — 24/24 (was 23)
- [x] \`pnpm test\` — 46/46 tasks green (was 45). telegram-bot-runner: 21/21 subtests.
- [x] Covered: callback-data parsing (valid / malformed / colon-in-id / wrong-outcome), update extraction (full / no-username / non-callback / unknown data), default event-type mapping, full-cycle dispatch with multiple callbacks, non-callback updates advancing offset, \`allowOutcomes\` filter + "disabled" ack, dispatch failure propagation, \`--no-ack\` suppression, empty-updates offset behaviour, custom \`eventTypeFor\`, \`triggeredBy\` threading, getUpdates HTTP-error surfaces.
- [ ] End-to-end dogfood on eventbadge after merging + copying the workflows.