### PR TITLE
fix(cli+agent-worker): git apply --recount for LLM patches (v0.3.1)

### DIFF
--- a/packages/agent-claude/package.json
+++ b/packages/agent-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-claude",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Claude agent — wraps @anthropic-ai/claude-agent-sdk.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-deepseek/package.json
+++ b/packages/agent-deepseek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-deepseek",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Deepseek agent — OpenAI-wire-compatible, routes to api.deepseek.com with strict-JSON-schema structured output.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-gemini/package.json
+++ b/packages/agent-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-gemini",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Gemini agent — wraps @google/genai with responseSchema structured output. Long-context slot per decision #10.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-grok/package.json
+++ b/packages/agent-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-grok",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Grok agent — OpenAI-wire-compatible, routes to xAI's api.x.ai/v1 with strict-JSON-schema structured output.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-ollama/package.json
+++ b/packages/agent-ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-ollama",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Ollama agent — local inference via Ollama's OpenAI-compatible endpoint. Zero cost, zero API key.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-openai/package.json
+++ b/packages/agent-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-openai",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI OpenAI agent — wraps the OpenAI SDK with strict-JSON-schema structured output.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-worker",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "description": "Conclave AI Worker agent — turns Council blockers into a unified-diff patch ready to commit back to the PR branch.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-worker/src/prompts.ts
+++ b/packages/agent-worker/src/prompts.ts
@@ -13,7 +13,8 @@ Hard rules:
 - If a blocker requires information you don't have (a file not included in the snapshots, or ambiguity about intent), skip it and note that in \`summary\`. Never invent file contents you haven't been shown.
 - If NO blocker is fixable with the information given, return an empty \`patch\` string, an empty \`filesTouched\` array, and explain in \`summary\` what the caller should gather before retrying.
 - \`commitMessage\` should be a single line (≤ 72 chars), conventional-commit style where it fits. No trailing period.
-- \`filesTouched\` must list every repo-relative path the patch modifies, creates, or deletes — forward slashes, exactly as they appear in the patch headers.`;
+- \`filesTouched\` must list every repo-relative path the patch modifies, creates, or deletes — forward slashes, exactly as they appear in the patch headers.
+- The caller applies your patch with \`git apply --recount\`, so the line counts in your \`@@ -A,B +C,D @@\` headers DO NOT need to be exact — they will be recomputed from the actual hunk content. Focus on correct \`-\`/\`+\`/context lines; don't agonise over the header numbers.`;
 
 function renderBlockers(reviews: WorkerContext["reviews"]): string {
   const lines: string[] = [];

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/commands/rework.ts
+++ b/packages/cli/src/commands/rework.ts
@@ -335,7 +335,13 @@ export async function runRework(args: ReworkArgs, deps: ReworkDeps = {}): Promis
   await writeTemp(patchPath, outcome.patch);
 
   try {
-    await git("git", ["apply", "--check", patchPath], { cwd: args.cwd });
+    // --recount lets git apply recompute the @@ hunk header line counts from
+    // the actual hunk content. LLMs (Claude, GPT, Gemini) routinely get those
+    // counts wrong — the hunk body is correct but the header claims e.g.
+    // "7 lines" when only 3 are present, which `git apply` would otherwise
+    // reject as "corrupt patch at line N". --recount is the official git
+    // option designed for exactly this case.
+    await git("git", ["apply", "--check", "--recount", patchPath], { cwd: args.cwd });
   } catch (err) {
     await removeTemp(patchPath).catch(() => undefined);
     const msg = err instanceof Error ? err.message : String(err);
@@ -343,7 +349,7 @@ export async function runRework(args: ReworkArgs, deps: ReworkDeps = {}): Promis
     return 1;
   }
 
-  await git("git", ["apply", patchPath], { cwd: args.cwd });
+  await git("git", ["apply", "--recount", patchPath], { cwd: args.cwd });
   await removeTemp(patchPath).catch(() => undefined);
 
   if (outcome.appliedFiles.length > 0) {

--- a/packages/cli/test/rework.test.mjs
+++ b/packages/cli/test/rework.test.mjs
@@ -240,8 +240,8 @@ test("runRework: happy path — applies patch, commits, pushes, records outcome"
   assert.equal(worker.calls[0].fileSnapshots[0].path, "src/x.ts");
   assert.equal(tempWrites.length, 1);
   const gitCmds = git.calls.map((c) => c.args.join(" "));
-  assert.ok(gitCmds.some((c) => c.startsWith("apply --check")), `git apply --check missing: ${gitCmds.join(" | ")}`);
-  assert.ok(gitCmds.some((c) => c === `apply ${tempWrites[0].p}`), "git apply missing");
+  assert.ok(gitCmds.some((c) => c.startsWith("apply --check --recount")), `git apply --check --recount missing: ${gitCmds.join(" | ")}`);
+  assert.ok(gitCmds.some((c) => c === `apply --recount ${tempWrites[0].p}`), "git apply --recount missing");
   assert.ok(gitCmds.some((c) => c.startsWith("add -- src/x.ts")), "git add missing");
   assert.ok(gitCmds.some((c) => c.includes("commit")), "git commit missing");
   assert.ok(gitCmds.some((c) => c === "push"), "git push missing");

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/core",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI core — Agent interface, council orchestration, self-evolve substrate, efficiency gate.",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-discord/package.json
+++ b/packages/integration-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-discord",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Discord notifier — posts review outcomes to a Discord channel via incoming webhook.",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-email/package.json
+++ b/packages/integration-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-email",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI email notifier — pluggable transport (Resend default; SMTP/SES/nodemailer drop-ins).",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-slack/package.json
+++ b/packages/integration-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-slack",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Slack notifier — posts review outcomes to a Slack channel via incoming webhook.",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-telegram/package.json
+++ b/packages/integration-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-telegram",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Telegram notifier — posts review outcomes to a Telegram chat via Bot API.",
   "license": "MIT",
   "type": "module",

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/observability-langfuse",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI observability sink — forwards efficiency-gate metrics to Langfuse (self-hosted per decision #13).",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-cloudflare",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Cloudflare Pages adapter — resolve preview URL for a commit SHA via Cloudflare API.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-deployment-status/package.json
+++ b/packages/platform-deployment-status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-deployment-status",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI generic platform adapter — resolves preview URL via GitHub Deployments API, works with any host that reports back.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-netlify/package.json
+++ b/packages/platform-netlify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-netlify",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Netlify adapter — resolve preview URL for a commit SHA via Netlify API.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-railway/package.json
+++ b/packages/platform-railway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-railway",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Railway adapter — resolve preview URL for a commit SHA via Railway's GraphQL API.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-render/package.json
+++ b/packages/platform-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-render",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Render adapter — resolve deploy URL for a commit SHA via Render's REST API.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-vercel/package.json
+++ b/packages/platform-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-vercel",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Vercel adapter — resolve preview URL for a commit SHA via Vercel REST API.",
   "license": "MIT",
   "type": "module",

--- a/packages/scm-github/package.json
+++ b/packages/scm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/scm-github",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI SCM adapter for GitHub — resolve PR state for automatic outcome capture.",
   "license": "MIT",
   "type": "module",

--- a/packages/secret-guard/package.json
+++ b/packages/secret-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/secret-guard",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI secret-guard — scans patches + file content for API keys, tokens, and private keys before the worker commits them.",
   "license": "MIT",
   "type": "module",

--- a/packages/telegram-bot-runner/package.json
+++ b/packages/telegram-bot-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/telegram-bot-runner",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI Telegram bot-runner — long-polls Telegram callback_query events and dispatches repository_dispatch actions back to the target repo's GH Actions workflows.",
   "license": "MIT",
   "type": "module",

--- a/packages/visual-review/package.json
+++ b/packages/visual-review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/visual-review",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Conclave AI visual review — Playwright screenshots + pixel diff for before/after design review.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Root cause (from eventbadge dogfood)
Worker produces unified diffs where the `@@ -A,B +C,D @@` line counts are routinely wrong — hunk body is correct, header arithmetic is not. Every frontier LLM does this; it's not a Claude-specific regression. `git apply` rejects as 'corrupt patch at line N'.

Observed on 3 consecutive eventbadge rework dispatches (runs 24634562759, 24634645144, 24634750724). Dry-run dump confirmed the patch content was a valid fix — only headers broke.

## Fix
Pass `--recount` to both `git apply --check` and `git apply`. Official git option for exactly this case. Zero downside on hand-written patches with correct headers.

Also adds a worker prompt hint: 'headers will be recounted, don't agonise over them.' Defence-in-depth + cheaper tokens from the model skipping arithmetic it gets wrong anyway.

## Versioning
- `@conclave-ai/cli` 0.3.0 → 0.3.1 (the fix)
- `@conclave-ai/agent-worker` 0.3.0 → 0.3.1 (prompt)
- Others stay at 0.3.0

## Test plan
- [x] pnpm build — 24/24
- [x] pnpm test — 46/46 tasks, cli 79/79 subtests (assertions updated for `--recount`)
- [ ] Merge → publish both at 0.3.1 → rerun eventbadge rework dispatch → worker commit should finally land