### PR TITLE
chore(release): cli + agent-worker 0.3.2 (fixes broken workspace:* deps in 0.3.1)

### DIFF
--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-worker",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Conclave AI Worker agent — turns Council blockers into a unified-diff patch ready to commit back to the PR branch.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
v0.3.1 is broken on npm — published with `npm publish` which left `workspace:*` deps literal. Any consumer hits `Unsupported URL Type workspace:` on install.

Observed: eventbadge dogfood run 24634973573.

Fix: bump to 0.3.2. On publish side **use `pnpm publish`** (NOT `npm publish`) so workspaces get rewritten to concrete versions.

```
cd packages/cli;          pnpm publish --access public --no-git-checks
cd packages/agent-worker; pnpm publish --access public --no-git-checks
```

And deprecate 0.3.1 so no one installs it by accident:
```
npm deprecate @conclave-ai/cli@0.3.1          'broken: workspace:* not resolved; use >=0.3.2'
npm deprecate @conclave-ai/agent-worker@0.3.1 'broken: workspace:* not resolved; use >=0.3.2'
```

No code changes — version strings only.