### PR TITLE
fix(cli+agent-worker) 0.3.3: git add -A + no-new-files rule

### DIFF
--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-worker",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Conclave AI Worker agent — turns Council blockers into a unified-diff patch ready to commit back to the PR branch.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-worker/src/prompts.ts
+++ b/packages/agent-worker/src/prompts.ts
@@ -9,6 +9,7 @@ Hard rules:
 - You MUST respond by calling the submit_patch tool exactly once. Do not emit free-form text.
 - The \`patch\` field MUST be a valid unified diff — with \`diff --git\` or \`---\`/\`+++\` headers and \`@@\` hunks — not prose, not a code snippet.
 - Fix ONLY the blockers the council raised. Do not refactor unrelated code, rename things, reformat files, or add features. Scope creep is a worse failure than leaving a minor blocker untouched.
+- Modify EXISTING files only. Do NOT create new files (including test files, documentation, scripts, or config files) unless a blocker explicitly names a missing file as the defect. Adding a test file "just to cover the fix" counts as scope creep and is forbidden — the human reviewer adds tests, not the worker.
 - Preserve existing public APIs, exports, file paths, import styles, and indentation conventions (tabs vs spaces, quote style) exactly as the source uses them.
 - If a blocker requires information you don't have (a file not included in the snapshots, or ambiguity about intent), skip it and note that in \`summary\`. Never invent file contents you haven't been shown.
 - If NO blocker is fixable with the information given, return an empty \`patch\` string, an empty \`filesTouched\` array, and explain in \`summary\` what the caller should gather before retrying.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/commands/rework.ts
+++ b/packages/cli/src/commands/rework.ts
@@ -352,11 +352,14 @@ export async function runRework(args: ReworkArgs, deps: ReworkDeps = {}): Promis
   await git("git", ["apply", "--recount", patchPath], { cwd: args.cwd });
   await removeTemp(patchPath).catch(() => undefined);
 
-  if (outcome.appliedFiles.length > 0) {
-    await git("git", ["add", "--", ...outcome.appliedFiles], { cwd: args.cwd });
-  } else {
-    await git("git", ["add", "-A"], { cwd: args.cwd });
-  }
+  // `git add -A` stages every change the apply actually produced — tracked
+  // modifications AND untracked new files. Using `outcome.appliedFiles`
+  // as the pathspec was fragile: the worker can report a file it meant
+  // to create whose hunk `git apply --recount` didn't actually materialise
+  // (common with new-file hunks), and `git add -- <missing>` then fails
+  // with "did not match any files". Trusting git's view of the workspace
+  // post-apply is more robust than the worker's self-report.
+  await git("git", ["add", "-A"], { cwd: args.cwd });
 
   await git(
     "git",

--- a/packages/cli/test/rework.test.mjs
+++ b/packages/cli/test/rework.test.mjs
@@ -242,7 +242,7 @@ test("runRework: happy path — applies patch, commits, pushes, records outcome"
   const gitCmds = git.calls.map((c) => c.args.join(" "));
   assert.ok(gitCmds.some((c) => c.startsWith("apply --check --recount")), `git apply --check --recount missing: ${gitCmds.join(" | ")}`);
   assert.ok(gitCmds.some((c) => c === `apply --recount ${tempWrites[0].p}`), "git apply --recount missing");
-  assert.ok(gitCmds.some((c) => c.startsWith("add -- src/x.ts")), "git add missing");
+  assert.ok(gitCmds.some((c) => c === "add -A"), "git add -A missing");
   assert.ok(gitCmds.some((c) => c.includes("commit")), "git commit missing");
   assert.ok(gitCmds.some((c) => c === "push"), "git push missing");
   assert.equal(writer.recorded.length, 1);


### PR DESCRIPTION
Follow-up to #60 (git apply --recount). Third dogfood run (24635117457) on eventbadge got past apply but failed at:
`git add -- lib/pagination.js lib/pagination.test.js: pathspec 'lib/pagination.test.js' did not match any files`

Worker claimed to create a test file but the new-file hunk never materialised on disk (known edge with `--recount` + `@@ -0,0 +1,N @@`).

**Fix 1 (rework.ts):** `git add -A` instead of pathspec-based add. Trusts git's view of the workspace, not the worker's self-report. If a claimed file wasn't actually created, it simply isn't staged — tracked modifications still picked up.

**Fix 2 (worker prompt):** 'Modify EXISTING files only. Do NOT create new files (tests, docs, config) unless a blocker explicitly names a missing file.' Defence-in-depth vs scope creep — the worker kept trying to add tests even though `Fix ONLY the blockers the council raised` was already there.

**Versioning:** cli + agent-worker 0.3.2 → 0.3.3. Others stay at 0.3.0.

**Test plan:** pnpm build 24/24, pnpm test 46/46 (cli 79 subtests, add -A assertion updated). Merge → `pnpm publish` (NOT npm publish) cli + agent-worker → rerun rework dispatch → worker commit finally lands.