### PR TITLE
fix(telegram-bot-runner) 0.3.1: client-side abort timeout prevents callback loss

### DIFF
--- a/packages/telegram-bot-runner/package.json
+++ b/packages/telegram-bot-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/telegram-bot-runner",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Conclave AI Telegram bot-runner — long-polls Telegram callback_query events and dispatches repository_dispatch actions back to the target repo's GH Actions workflows.",
   "license": "MIT",
   "type": "module",

--- a/packages/telegram-bot-runner/src/telegram-client.ts
+++ b/packages/telegram-bot-runner/src/telegram-client.ts
@@ -21,15 +21,40 @@ export class TelegramClient {
   async getUpdates(opts: { offset?: number; timeoutSec?: number }): Promise<unknown[]> {
     const params = new URLSearchParams();
     if (opts.offset !== undefined) params.set("offset", String(opts.offset));
-    params.set("timeout", String(opts.timeoutSec ?? 25));
+    const timeoutSec = opts.timeoutSec ?? 25;
+    params.set("timeout", String(timeoutSec));
     // Narrow what we listen for so we don't rack up updates we don't act on.
     params.set("allowed_updates", JSON.stringify(["callback_query"]));
     const url = `https://api.telegram.org/bot${this.token}/getUpdates?${params.toString()}`;
-    const resp = await this.fetch(url, { method: "GET" });
-    if (!resp.ok) throw new Error(`telegram getUpdates: HTTP ${resp.status} — ${await safeText(resp)}`);
-    const body = (await resp.json()) as { ok?: boolean; result?: unknown[]; description?: string };
-    if (!body.ok) throw new Error(`telegram getUpdates: ${body.description ?? "not ok"}`);
-    return body.result ?? [];
+
+    // Client-side abort timeout set to server long-poll + 10s buffer. Without
+    // this, a hung TCP connection or dropped Telegram response leaves the
+    // caller spinning until the workflow itself is cancelled — and the
+    // cancellation race is what silently loses Bae's clicks (the server
+    // records the updates as delivered on its side, but we never write the
+    // offset locally, so the next poll returns an empty queue). Forcing a
+    // deterministic timeout means we always get EITHER a response (and
+    // advance offset atomically) OR a thrown error (and leave offset alone
+    // so the next cron tick re-requests from the same position).
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(), (timeoutSec + 10) * 1000);
+    try {
+      const resp = await this.fetch(url, { method: "GET", signal: controller.signal });
+      if (!resp.ok) throw new Error(`telegram getUpdates: HTTP ${resp.status} — ${await safeText(resp)}`);
+      const body = (await resp.json()) as { ok?: boolean; result?: unknown[]; description?: string };
+      if (!body.ok) throw new Error(`telegram getUpdates: ${body.description ?? "not ok"}`);
+      return body.result ?? [];
+    } catch (err) {
+      // Wrap abort errors with a message the operator can actually act on.
+      if (err instanceof Error && (err.name === "AbortError" || err.message.toLowerCase().includes("abort"))) {
+        throw new Error(
+          `telegram getUpdates: aborted after ${timeoutSec + 10}s without response (Telegram long-poll hang — retry on next tick)`,
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(abortTimer);
+    }
   }
 
   async answerCallbackQuery(opts: { id: string; text?: string; showAlert?: boolean }): Promise<void> {
@@ -37,12 +62,22 @@ export class TelegramClient {
     const body: Record<string, unknown> = { callback_query_id: opts.id };
     if (opts.text !== undefined) body.text = opts.text;
     if (opts.showAlert !== undefined) body.show_alert = opts.showAlert;
-    const resp = await this.fetch(url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    if (!resp.ok) throw new Error(`telegram answerCallbackQuery: HTTP ${resp.status} — ${await safeText(resp)}`);
+
+    // 10s is already generous for a tiny POST to Telegram. Anything longer
+    // is a network pathology we'd rather surface than swallow.
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(), 10_000);
+    try {
+      const resp = await this.fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!resp.ok) throw new Error(`telegram answerCallbackQuery: HTTP ${resp.status} — ${await safeText(resp)}`);
+    } finally {
+      clearTimeout(abortTimer);
+    }
   }
 }
 

--- a/packages/telegram-bot-runner/src/types.ts
+++ b/packages/telegram-bot-runner/src/types.ts
@@ -24,7 +24,10 @@ export interface FetchResponse {
   text: () => Promise<string>;
 }
 
-export type FetchLike = (url: string, init?: { method?: string; body?: string; headers?: Record<string, string> }) => Promise<FetchResponse>;
+export type FetchLike = (
+  url: string,
+  init?: { method?: string; body?: string; headers?: Record<string, string>; signal?: AbortSignal },
+) => Promise<FetchResponse>;
 
 export interface GhResult {
   stdout: string;

--- a/packages/telegram-bot-runner/test/bot-runner.test.mjs
+++ b/packages/telegram-bot-runner/test/bot-runner.test.mjs
@@ -197,3 +197,32 @@ test("runBotOnce: getUpdates failure is surfaced as a thrown error", async () =>
     /telegram getUpdates.*401/,
   );
 });
+
+test("TelegramClient.getUpdates: passes an AbortSignal on the fetch init", async () => {
+  // We receive the fetch init and check that `signal` is present and is an
+  // AbortSignal — this is the contract that prevents the cancellation-
+  // consumes-callbacks bug (run 24634355279 on eventbadge).
+  const fetch = makeFetch([updatesResponse([])]);
+  const gh = makeGh();
+  await runBotOnce({ botToken: "t", repo: "a/b", fetch, gh, pollTimeoutSec: 0 });
+  const getUpdatesCall = fetch.calls.find((c) => c.url.includes("getUpdates"));
+  assert.ok(getUpdatesCall, "getUpdates was not called");
+  assert.ok(getUpdatesCall.init?.signal, "fetch init is missing an AbortSignal");
+  assert.equal(typeof getUpdatesCall.init.signal.aborted, "boolean", "signal doesn't look like an AbortSignal");
+});
+
+test("TelegramClient.getUpdates: translates fetch AbortError into an actionable message", async () => {
+  // Simulate a fetch that throws AbortError (e.g. because the client-side
+  // timeout fired). The caller should see a wrapped error that names what
+  // happened so the workflow log is legible, not a raw AbortError stack.
+  const fetchThatAborts = async (_url, _init) => {
+    const err = new Error("The user aborted a request.");
+    err.name = "AbortError";
+    throw err;
+  };
+  const gh = makeGh();
+  await assert.rejects(
+    () => runBotOnce({ botToken: "t", repo: "a/b", fetch: fetchThatAborts, gh, pollTimeoutSec: 0 }),
+    /aborted after \d+s without response/,
+  );
+});


### PR DESCRIPTION
## Root cause
Eventbadge run 24634355279 (2026-04-20): bot's getUpdates hung for 8+ minutes with no response, workflow was cancelled, Telegram considered the updates 'delivered' on its side but our local offset was never written. Next poll came back empty — Bae's 🔧 Rework click silently lost.

## Fix
`AbortController` around every fetch call:
- `getUpdates`: `pollTimeoutSec + 10s` budget (server long-poll + network + JSON parse)
- `answerCallbackQuery`: hard 10s (tiny POST, anything longer is pathological)

On abort, throw a wrapped error the workflow log can read. Offset is never advanced on error, so the next cron tick re-requests from the same position.

## Doesn't fix
The narrower race where Telegram *does* respond but the workflow is SIGKILL'd between response receipt and offset write — unrecoverable without webhook mode. Out of scope.

## Test plan
- [x] 23/23 telegram-bot-runner subtests pass, including new: `getUpdates must pass a signal` + `AbortError translates to a human message`
- [x] Full repo 46/46 tasks green
- [x] `FetchLike` type gained optional `signal?: AbortSignal` — backwards-compatible
- [ ] Manual smoke on eventbadge after publish: trigger a click, cancel bot mid-run, verify next tick picks up the same update (not silently consumed)

## Version
telegram-bot-runner 0.3.0 → 0.3.1. Publish with `pnpm publish` (never npm).