### PR TITLE
chore(docs+prompts): unify vocabulary to English (drop 정답지/오답지)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,7 +60,7 @@ truth for scaffolding.
 ┌────────────────────────┐  ┌────────────────────────────────┐
 │  Layer 6 —             │  │  Layer 7 — OBSERVABILITY       │
 │  SELF-EVOLVE           │  │  Langfuse self-hosted          │
-│  (정답지 + 오답지)     │  │  per-PR trace                  │
+│  (success + failure)   │  │  per-PR trace                  │
 │  episodic (90d)        │  │  cache hit rate                │
 │  answer-keys (∞)       │  │  cost + tokens per call        │
 │  failure-catalog (∞)   │  │  precision/recall per category │
@@ -71,16 +71,16 @@ truth for scaffolding.
 └────────────────────────┘  └────────────────────────────────┘
 ```
 
-## Self-Evolve Substrate (정답지/오답지 duality — the moat)
+## Self-Evolve Substrate (answer-keys/failure-catalog duality — the moat)
 
 ```
 packages/core/src/memory/
 ├── episodic/                      # raw event log, 90d TTL
 │   └── YYYY-MM-DD/pr-{n}.json
-├── answer-keys/ (정답지)          # ★ SUCCESS PATTERNS
+├── answer-keys/          # ★ SUCCESS PATTERNS
 │   ├── code/{by-pattern,by-user,by-repo}/
 │   └── design/{by-pattern,by-component}/
-├── failure-catalog/ (오답지)      # ★ FAILURE PATTERNS
+├── failure-catalog/      # ★ FAILURE PATTERNS
 │   ├── code/by-category/{type-errors,missing-tests,regression,security,...}
 │   └── design/{accessibility-fails,contrast-fails,...}
 ├── semantic/rules.json            # extracted rules (nightly Haiku compression)
@@ -165,7 +165,7 @@ conclave-ai/
 │   │       ├── agent.ts          # Agent interface
 │   │       ├── council.ts        # Mastra-based N-agent graph
 │   │       ├── schema/           # Zod schemas
-│   │       ├── memory/           # self-evolve 정답지/오답지
+│   │       ├── memory/           # self-evolve answer-keys/failure-catalog
 │   │       ├── efficiency/       # cache/triage/budget/compact/route
 │   │       ├── scoring/          # ported from solo-cto-agent
 │   │       ├── guards.ts         # anti-loop + circuit breaker
@@ -224,12 +224,12 @@ solo-cto-agent 1.4.x stays on npm in maintenance (security fixes only).
 
 - Individual features: 4.5/10 (prior art exists)
 - Architectural sophistication: **8.5/10**
-- Self-evolve as moat (정답지/오답지 duality + federated): **9/10**
+- Self-evolve as moat (answer-keys/failure-catalog duality + federated): **9/10**
 - Overall product thesis: **8.5/10**
 - Execution risk pulls shipped value: TBD
 
 **Differentiators (priority order):**
-1. 정답지 + 오답지 dual catalog as RLHF-like substrate without fine-tuning
+1. answer-keys + failure-catalog dual catalog as RLHF-like substrate without fine-tuning
 2. Efficiency gate built in from day 1 (most multi-agent systems die from cost)
 3. Architectural coherence (all 7 layers woven, not bolted-on)
 4. Pluggable agents including self-hosted Triton-based + local Ollama

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,7 +330,7 @@
 - `@conclave-ai/agent-claude`: Claude agent skeleton implementing `Agent`.
 - `@conclave-ai/cli`: `conclave` binary with `init` and `review` commands (skeleton).
 - `ARCHITECTURE.md`: locked 7-layer design for the council, efficiency gate,
-  self-evolve substrate (정답지 + 오답지), and migration path from solo-cto-agent.
+  self-evolve substrate (answer-keys + failure-catalog), and migration path from solo-cto-agent.
 - GitHub Actions CI: typecheck + build + test on push/PR.
 - **Efficiency Gate** (`@conclave-ai/core/efficiency`) per decision #22 —
   first-class from day 1. Every LLM call must route through
@@ -375,7 +375,7 @@
     wire-format, tool_choice wire-format, missing-key constructor guard,
     metrics aggregation on shared gate.
 - **Memory substrate** (`@conclave-ai/core/memory`) per decision #17 —
-  정답지 / 오답지 dualism as the core primitive.
+  answer-keys dualism as the core primitive.
   - Zod schemas for `EpisodicEntry`, `AnswerKey`, `FailureEntry`, `SemanticRule`
     with enum-validated domains (code / design), severity, and 11 failure categories.
   - `MemoryStore` interface (read + write + list) with a `FileSystemMemoryStore`

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ Council — up to 3 rounds of debate across N agents
   Round 2: each agent sees the others' blockers, can revise
   Round 3: final vote; early-exit the moment all approve OR any reject
   ↓
-Merged  → success pattern → answer-keys  (정답지)
-Rejected → failure pattern → failure-catalog (오답지)
+Merged  → success pattern → answer-keys 
+Rejected → failure pattern → failure-catalog
   ↓
 Next review reads BOTH catalogs as RAG context → the council gets smarter
 ```
 
 Both signals are first-class. Most ML systems use one (positive OR
-negative); here `정답지 ∥ 오답지` is the primitive — decision #17.
+negative); here `answer-keys ∥ failure-catalog` is the primitive — decision #17.
 
 ## The numbers
 
@@ -68,7 +68,7 @@ negative); here `정답지 ∥ 오답지` is the primitive — decision #17.
 
 | Package | Purpose |
 |---|---|
-| `@conclave-ai/core` | Agent interface, Council (3-round debate), efficiency gate, memory substrate (정답지 + 오답지), scoring (decision #19), federated sync (decision #21) |
+| `@conclave-ai/core` | Agent interface, Council (3-round debate), efficiency gate, memory substrate (answer-keys + failure-catalog), scoring (decision #19), federated sync (decision #21) |
 | `@conclave-ai/agent-claude` | Claude reviewer — tool-use with `submit_review` + prompt caching |
 | `@conclave-ai/agent-openai` | OpenAI reviewer — strict JSON schema + cached-token discount |
 | `@conclave-ai/agent-gemini` | Gemini reviewer — long-context routing tier |

--- a/docs/decision-status.md
+++ b/docs/decision-status.md
@@ -33,7 +33,7 @@ Legend:
 | 14 | Workflow engine → GitHub Actions | ✅ | `.github/workflows/` |
 | 15 | Native pixel diff → odiff | ✅ | `packages/visual-review/src/odiff-diff.ts` (opt-in) |
 | 16 | Config loader → cosmiconfig | ✅ | `packages/cli/src/lib/config.ts` |
-| 17 | Memory dual substrate (정답지 + 오답지) | ✅ | `packages/core/src/memory/` |
+| 17 | Memory dual substrate (answer-keys + failure-catalog) | ✅ | `packages/core/src/memory/` |
 | 18 | Seed from solo-cto-agent catalog | ✅ | `packages/core/src/memory/seeder.ts` |
 | 19 | Agent scoring weights | ✅ | `packages/core/src/scoring.ts` |
 | 20 | Visual review CLI flag | ✅ | `conclave review --visual` |

--- a/examples/github-workflows/conclave-merge.yml
+++ b/examples/github-workflows/conclave-merge.yml
@@ -1,6 +1,6 @@
 # Triggered by the telegram-bot-runner when a user clicks ✅ Approve.
 # Merges the PR and records the outcome in conclave's episodic store so
-# the answer-key (정답지) generator picks it up.
+# the answer-key generator picks it up.
 #
 # Branch protection rules on the target PR still apply — this workflow
 # cannot force a merge past required reviews / required checks. That's

--- a/examples/github-workflows/conclave-reject.yml
+++ b/examples/github-workflows/conclave-reject.yml
@@ -1,6 +1,6 @@
 # Triggered by the telegram-bot-runner when a user clicks ❌ Reject.
 # Closes the PR (without merging) and records the outcome so the
-# failure-catalog (오답지) generator picks up the blocker patterns.
+# failure-catalog generator picks up the blocker patterns.
 name: conclave-reject
 
 on:

--- a/packages/agent-claude/src/prompts.ts
+++ b/packages/agent-claude/src/prompts.ts
@@ -21,7 +21,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push("");
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
-    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(`# Past success patterns (answer-keys)`);
     sections.push(
       `These are reviews that led to merged changes on similar code in this repo. Lean on them as a style + quality bar — match their tolerance for what counts as a blocker.`,
     );
@@ -33,7 +33,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   }
 
   if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
-    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(`# Known failure patterns (failure-catalog)`);
     sections.push(
       `These are patterns that caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
     );

--- a/packages/agent-deepseek/src/prompts.ts
+++ b/packages/agent-deepseek/src/prompts.ts
@@ -21,7 +21,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push("");
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
-    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(`# Past success patterns (answer-keys)`);
     sections.push(
       `These are reviews that led to merged changes on similar code in this repo. Lean on them as a style + quality bar — match their tolerance for what counts as a blocker.`,
     );
@@ -31,7 +31,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   }
 
   if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
-    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(`# Known failure patterns (failure-catalog)`);
     sections.push(
       `These are patterns that caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
     );

--- a/packages/agent-gemini/src/prompts.ts
+++ b/packages/agent-gemini/src/prompts.ts
@@ -23,7 +23,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push("");
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
-    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(`# Past success patterns (answer-keys)`);
     sections.push(
       `These are reviews that led to merged changes on similar code in this repo. Match their tolerance for what counts as a blocker.`,
     );
@@ -33,7 +33,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   }
 
   if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
-    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(`# Known failure patterns (failure-catalog)`);
     sections.push(
       `These patterns caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
     );

--- a/packages/agent-grok/src/prompts.ts
+++ b/packages/agent-grok/src/prompts.ts
@@ -21,7 +21,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push("");
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
-    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(`# Past success patterns (answer-keys)`);
     sections.push(
       `These are reviews that led to merged changes on similar code in this repo. Lean on them as a style + quality bar — match their tolerance for what counts as a blocker.`,
     );
@@ -31,7 +31,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   }
 
   if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
-    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(`# Known failure patterns (failure-catalog)`);
     sections.push(
       `These are patterns that caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
     );

--- a/packages/agent-ollama/src/prompts.ts
+++ b/packages/agent-ollama/src/prompts.ts
@@ -21,7 +21,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push("");
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
-    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(`# Past success patterns (answer-keys)`);
     sections.push(
       `These are reviews that led to merged changes on similar code in this repo. Lean on them as a style + quality bar — match their tolerance for what counts as a blocker.`,
     );
@@ -31,7 +31,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   }
 
   if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
-    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(`# Known failure patterns (failure-catalog)`);
     sections.push(
       `These are patterns that caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
     );

--- a/packages/agent-openai/src/prompts.ts
+++ b/packages/agent-openai/src/prompts.ts
@@ -21,7 +21,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push("");
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
-    sections.push(`# Past success patterns (answer-keys / 정답지)`);
+    sections.push(`# Past success patterns (answer-keys)`);
     sections.push(
       `These are reviews that led to merged changes on similar code in this repo. Lean on them as a style + quality bar — match their tolerance for what counts as a blocker.`,
     );
@@ -31,7 +31,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   }
 
   if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
-    sections.push(`# Known failure patterns (failure-catalog / 오답지)`);
+    sections.push(`# Known failure patterns (failure-catalog)`);
     sections.push(
       `These are patterns that caused real incidents in the past. Flag them aggressively if you see them in this diff.`,
     );

--- a/packages/cli/src/commands/mcp-server.ts
+++ b/packages/cli/src/commands/mcp-server.ts
@@ -76,7 +76,7 @@ export async function mcpServer(argv: string[]): Promise<void> {
     {
       title: "Retrieve answer-keys and failures",
       description:
-        "BM25-style retrieval over the local memory substrate. Returns the top-K answer-keys (정답지) and failures (오답지) matching `query`.",
+        "BM25-style retrieval over the local memory substrate. Returns the top-K answer-keys and failures matching `query`.",
       inputSchema: {
         query: z.string().min(1).describe("Free-text query — typically a diff summary or blocker category"),
         k: z.number().int().positive().max(32).optional().describe("Max per bucket, default 8"),

--- a/packages/cli/src/commands/record-outcome.ts
+++ b/packages/cli/src/commands/record-outcome.ts
@@ -6,8 +6,8 @@ const HELP = `conclave record-outcome — close the self-evolve loop
 Usage:
   conclave record-outcome --id <episodic-id> --result merged|rejected|reworked
 
-On merged PRs, a new answer-key (정답지) is derived from the review summary.
-On rejected / reworked PRs, a failure-catalog entry (오답지) is derived per
+On merged PRs, a new answer-key is derived from the review summary.
+On rejected / reworked PRs, a failure-catalog entry is derived per
 unique blocker (ignoring nits).
 `;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,7 +12,7 @@ export type { Platform, PreviewResolution, ResolvePreviewInput } from "./platfor
 export { computeAgentScore, computeAllAgentScores, AGENT_SCORE_WEIGHTS } from "./scoring.js";
 export type { AgentScore, AgentScoreComponents } from "./scoring.js";
 
-// Memory substrate (decision #17: 정답지 + 오답지 duality as core primitive).
+// Memory substrate (decision #17: answer-keys + failure-catalog duality as core primitive).
 // Re-exported here for convenience; dedicated subpath at @conclave-ai/core/memory.
 export {
   FileSystemMemoryStore,

--- a/packages/core/src/memory/schema.ts
+++ b/packages/core/src/memory/schema.ts
@@ -21,7 +21,7 @@ export const EpisodicEntrySchema = z.object({
 export type EpisodicEntry = z.infer<typeof EpisodicEntrySchema>;
 
 /**
- * AnswerKey (정답지) — a SUCCESS PATTERN. Written when a PR merges.
+ * AnswerKey — a SUCCESS PATTERN. Written when a PR merges.
  * Retrieved at review time so future reviews match the repo's tolerance
  * for what counts as a blocker and what counts as polish.
  */
@@ -44,7 +44,7 @@ export const AnswerKeySchema = z.object({
 export type AnswerKey = z.infer<typeof AnswerKeySchema>;
 
 /**
- * FailureEntry (오답지) — a FAILURE PATTERN. Written on reject or rework.
+ * FailureEntry — a FAILURE PATTERN. Written on reject or rework.
  * Seeded from solo-cto-agent's failure-catalog.json (ERR-001~) per
  * decision #18 — do not start from zero.
  */


### PR DESCRIPTION
Bae's request: 'all references should be in English so the baseline is consistent.'

Strips `(정답지)` and `(오답지)` parentheticals and rewrites standalone uses → their already-present English equivalents (`answer-keys` / `failure-catalog`). No schema, function, or file-path renames — only human-facing labels change.

16 files touched: 6 agent prompts, schema + index in core, 2 CLI commands, ARCHITECTURE.md (incl. one ASCII diagram realigned), README, CHANGELOG, decision-status, 2 example workflows.

46/46 test tasks still green. No code paths touched.