### PR TITLE
fix(central-plane): rename deploy→ship (pnpm collision) + preflight check

### DIFF
--- a/apps/central-plane/README.md
+++ b/apps/central-plane/README.md
@@ -13,33 +13,42 @@ See `docs/architecture-v0.4.md` for the full design; this package is the concret
 | POST   | `/episodic/push`  | 🟡 stub (aggregation pending) |
 | GET    | `/memory/pull`    | 🟡 stub (aggregation pending) |
 
-## Local development
+## First-time setup
 
-Requires `wrangler` + a Cloudflare account. The Worker runs against a local D1 emulator:
-
-```bash
+```powershell
+# from repo root
 pnpm install
+
 cd apps/central-plane
-pnpm wrangler d1 create conclave-ai    # one-time — copy the database_id into wrangler.toml
-pnpm migrate:local                       # apply schema to the local D1
-pnpm dev                                 # http://localhost:8787
+pnpm wrangler login                    # browser auth, once per CF account
+pnpm wrangler d1 create conclave-ai    # prints a UUID on success — COPY IT
+```
+
+Then edit `wrangler.toml` and replace `REPLACE_WITH_wrangler_d1_create_OUTPUT` with the UUID from the previous step. Preflight (see below) will refuse to run until you do this.
+
+## Apply schema + local dev
+
+```powershell
+pnpm run migrate:local   # schema → local D1 emulator
+pnpm run dev             # http://localhost:8787
 ```
 
 Then:
-
-```bash
+```powershell
 curl http://localhost:8787/health
-curl -X POST http://localhost:8787/register -H 'content-type: application/json' -d '{"repo":"acme/service"}'
+curl -X POST http://localhost:8787/register -H 'content-type: application/json' -d '{\"repo\":\"acme/service\"}'
 ```
 
 ## Deploy
 
-```bash
-pnpm migrate:prod   # one-time per schema change
-pnpm deploy
+```powershell
+pnpm run migrate:prod    # one-time per schema change; runs preflight first
+pnpm run ship            # deploys — name chosen to avoid pnpm's builtin `deploy` command
 ```
 
-Deploys to `https://conclave-ai.<your-cf-subdomain>.workers.dev` by default. Custom domain (`conclave.ai` once we own it) is a `wrangler.toml` `[[routes]]` block away — deferred until the repo is public and user signal justifies it.
+Use `pnpm run <name>` (not bare `pnpm <name>`) for these — pnpm reserves `pnpm deploy` / `pnpm publish` / etc. as builtins, hence the script is named `ship` instead of `deploy`.
+
+Deploys to `https://conclave-ai.<your-cf-subdomain>.workers.dev` by default. Custom domain deferred per v0.4 architecture doc (§D2) — ship and iterate on user signal first.
 
 ## Testing
 

--- a/apps/central-plane/package.json
+++ b/apps/central-plane/package.json
@@ -9,12 +9,12 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "ship": "node scripts/preflight.mjs && wrangler deploy",
     "test": "node --test test/*.test.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "clean": "rm -rf dist .tsbuildinfo",
     "migrate:local": "wrangler d1 execute conclave-ai --local --file=./migrations/0001_initial.sql",
-    "migrate:prod": "wrangler d1 execute conclave-ai --remote --file=./migrations/0001_initial.sql"
+    "migrate:prod": "node scripts/preflight.mjs && wrangler d1 execute conclave-ai --remote --file=./migrations/0001_initial.sql"
   },
   "dependencies": {
     "hono": "^4.6.14"

--- a/apps/central-plane/scripts/preflight.mjs
+++ b/apps/central-plane/scripts/preflight.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Preflight check for migrate / ship scripts. Catches the common footgun
+ * where `wrangler.toml` still has the placeholder `database_id` because the
+ * operator skipped `wrangler d1 create` or forgot to paste the output.
+ *
+ * We'd rather fail with a pointed error than hand a 500 "import failed" to
+ * the user from the Cloudflare API.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const wranglerPath = path.resolve(here, "..", "wrangler.toml");
+
+const PLACEHOLDER_RE = /REPLACE_WITH_/;
+
+try {
+  const content = await readFile(wranglerPath, "utf8");
+  if (PLACEHOLDER_RE.test(content)) {
+    const lines = content
+      .split(/\r?\n/)
+      .map((line, i) => ({ line, idx: i }))
+      .filter(({ line }) => PLACEHOLDER_RE.test(line))
+      .map(({ line, idx }) => `  line ${idx + 1}: ${line.trim()}`);
+    process.stderr.write(
+      [
+        "",
+        "conclave central-plane preflight: wrangler.toml has placeholder values.",
+        "",
+        ...lines,
+        "",
+        "Fix:",
+        "  1. wrangler d1 create conclave-ai         # one-time, prints a UUID",
+        "  2. edit wrangler.toml, replace REPLACE_WITH_... with the UUID",
+        "  3. retry your command",
+        "",
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+} catch (err) {
+  process.stderr.write(`conclave preflight: could not read ${wranglerPath}: ${(err && err.message) || err}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
Two footguns Bae hit while deploying the Worker:

1. `pnpm deploy` = pnpm builtin. Script was silently shadowed. Fix: rename to `ship` → `pnpm ship` and `pnpm run ship` both work.
2. Placeholder `REPLACE_WITH_wrangler_d1_create_OUTPUT` in wrangler.toml → confusing 404 from Cloudflare API. Fix: `scripts/preflight.mjs` fails loud with exact remediation, wired in front of `migrate:prod` + `ship`.

README updated with the cold-start sequence.