### PR TITLE
feat(central-plane): GitHub OAuth device flow (milestone 2)

### DIFF
--- a/apps/central-plane/README.md
+++ b/apps/central-plane/README.md
@@ -4,14 +4,29 @@ Cloudflare Worker that backs conclave-ai's v0.4 centralized install model.
 
 See `docs/architecture-v0.4.md` for the full design; this package is the concrete home for everything labelled "central control plane" in that doc.
 
-## v0.4-alpha endpoints (this PR)
+## Endpoints
 
-| Method | Path              | Status |
-|--------|-------------------|--------|
-| GET    | `/health`         | ✅ real |
-| POST   | `/register`       | ✅ real (placeholder token — OAuth in next PR) |
-| POST   | `/episodic/push`  | 🟡 stub (aggregation pending) |
-| GET    | `/memory/pull`    | 🟡 stub (aggregation pending) |
+| Method | Path                          | Status |
+|--------|-------------------------------|--------|
+| GET    | `/health`                     | ✅ real |
+| POST   | `/register`                   | ✅ real (placeholder token — use OAuth device flow for real installs) |
+| POST   | `/oauth/device/start`         | ✅ real — GitHub device-flow bootstrap |
+| POST   | `/oauth/device/poll`          | ✅ real — returns CONCLAVE_TOKEN on success |
+| POST   | `/episodic/push`              | 🟡 stub (aggregation pending) |
+| GET    | `/memory/pull`                | 🟡 stub (aggregation pending) |
+
+## GitHub OAuth setup (one-time per deployment)
+
+1. Register an OAuth App at https://github.com/settings/developers
+   - Name: `Conclave AI` (or whatever is appropriate for your deployment)
+   - Homepage URL: your worker URL (e.g. `https://conclave-ai.<sub>.workers.dev`)
+   - Authorization callback URL: same as homepage (device flow does not use it, but the GitHub form requires a value)
+   - **Enable device flow**: tick the checkbox
+2. Copy the `Client ID` shown on the OAuth App page
+3. Replace `REPLACE_WITH_GITHUB_OAUTH_APP_CLIENT_ID` in `wrangler.toml` with it (client_id is public; safe to commit)
+4. Re-deploy: `pnpm run ship`
+
+Until step 3 is done, `POST /oauth/device/start` returns `503`. `preflight.mjs` also catches the placeholder and refuses to run migrate/ship.
 
 ## First-time setup
 

--- a/apps/central-plane/migrations/0002_oauth_devices.sql
+++ b/apps/central-plane/migrations/0002_oauth_devices.sql
@@ -1,0 +1,19 @@
+-- v0.4-alpha OAuth device flow. Transient records — one row per in-flight
+-- CLI authorisation. `device_code` is a secret that never leaves the
+-- Worker; we return the short user_code (public) + our own device_code_id
+-- (opaque pointer) to the CLI so it can poll without handling the raw
+-- GitHub device_code itself.
+
+CREATE TABLE IF NOT EXISTS oauth_devices (
+  device_code_id TEXT PRIMARY KEY,                -- c_<time36>_<rand16>
+  device_code    TEXT NOT NULL,                    -- GitHub-issued; secret
+  user_code      TEXT NOT NULL,                    -- short public code user types
+  repo_slug      TEXT NOT NULL,                    -- what they're registering
+  interval_sec   INTEGER NOT NULL DEFAULT 5,       -- GitHub-recommended poll interval
+  expires_at     TEXT NOT NULL,                    -- ISO-8601; GitHub's 15-min default
+  created_at     TEXT NOT NULL,
+  consumed       INTEGER NOT NULL DEFAULT 0        -- 0=pending  1=succeeded  2=denied/expired
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_devices_expires ON oauth_devices(expires_at);
+CREATE INDEX IF NOT EXISTS idx_oauth_devices_consumed ON oauth_devices(consumed);

--- a/apps/central-plane/src/db/oauth.ts
+++ b/apps/central-plane/src/db/oauth.ts
@@ -1,0 +1,77 @@
+import type { Env } from "../env.js";
+
+export interface OAuthDevice {
+  deviceCodeId: string;
+  deviceCode: string;
+  userCode: string;
+  repoSlug: string;
+  intervalSec: number;
+  expiresAt: string;
+  createdAt: string;
+  consumed: 0 | 1 | 2;
+}
+
+interface Row {
+  device_code_id: string;
+  device_code: string;
+  user_code: string;
+  repo_slug: string;
+  interval_sec: number;
+  expires_at: string;
+  created_at: string;
+  consumed: number;
+}
+
+function rowToRecord(row: Row): OAuthDevice {
+  const c = row.consumed;
+  return {
+    deviceCodeId: row.device_code_id,
+    deviceCode: row.device_code,
+    userCode: row.user_code,
+    repoSlug: row.repo_slug,
+    intervalSec: row.interval_sec,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+    consumed: (c === 1 ? 1 : c === 2 ? 2 : 0),
+  };
+}
+
+export async function createDevice(
+  env: Env,
+  input: {
+    deviceCodeId: string;
+    deviceCode: string;
+    userCode: string;
+    repoSlug: string;
+    intervalSec: number;
+    expiresAt: string;
+    createdAt: string;
+  },
+): Promise<void> {
+  await env.DB.prepare(
+    "INSERT INTO oauth_devices (device_code_id, device_code, user_code, repo_slug, interval_sec, expires_at, created_at, consumed) VALUES (?, ?, ?, ?, ?, ?, ?, 0)",
+  )
+    .bind(
+      input.deviceCodeId,
+      input.deviceCode,
+      input.userCode,
+      input.repoSlug,
+      input.intervalSec,
+      input.expiresAt,
+      input.createdAt,
+    )
+    .run();
+}
+
+export async function findDevice(env: Env, deviceCodeId: string): Promise<OAuthDevice | null> {
+  const row = await env.DB.prepare("SELECT * FROM oauth_devices WHERE device_code_id = ?")
+    .bind(deviceCodeId)
+    .first<Row>();
+  return row ? rowToRecord(row) : null;
+}
+
+export async function markDeviceConsumed(env: Env, deviceCodeId: string, flag: 1 | 2): Promise<void> {
+  await env.DB.prepare("UPDATE oauth_devices SET consumed = ? WHERE device_code_id = ?")
+    .bind(flag, deviceCodeId)
+    .run();
+}

--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -6,4 +6,10 @@
 export interface Env {
   DB: D1Database;
   ENVIRONMENT: string;
+  /**
+   * Public GitHub OAuth App client_id (vars, not secret — it's public by nature).
+   * Required by the /oauth/device/* routes. Leave empty / set to placeholder
+   * while the central plane is run without OAuth integration.
+   */
+  GITHUB_CLIENT_ID?: string;
 }

--- a/apps/central-plane/src/github.ts
+++ b/apps/central-plane/src/github.ts
@@ -1,0 +1,103 @@
+/**
+ * Thin GitHub API client — only the three endpoints v0.4 OAuth uses.
+ * Injectable fetch so the route tests stay hermetic without monkey-
+ * patching globalThis.fetch.
+ */
+
+export type FetchLike = typeof fetch;
+
+export interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+/** POST https://github.com/login/device/code — kick off device flow. */
+export async function requestDeviceCode(
+  clientId: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<DeviceCodeResponse> {
+  const resp = await fetchImpl("https://github.com/login/device/code", {
+    method: "POST",
+    headers: { accept: "application/json", "content-type": "application/json" },
+    body: JSON.stringify({ client_id: clientId, scope: "repo" }),
+  });
+  if (!resp.ok) {
+    throw new Error(`github device code: HTTP ${resp.status}`);
+  }
+  return (await resp.json()) as DeviceCodeResponse;
+}
+
+export type DeviceTokenPoll =
+  | { kind: "pending" }
+  | { kind: "slow_down" }
+  | { kind: "expired" }
+  | { kind: "denied" }
+  | { kind: "success"; accessToken: string; scope: string }
+  | { kind: "error"; message: string };
+
+/** POST https://github.com/login/oauth/access_token — poll for the token. */
+export async function pollDeviceToken(
+  clientId: string,
+  deviceCode: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<DeviceTokenPoll> {
+  const resp = await fetchImpl("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: { accept: "application/json", "content-type": "application/json" },
+    body: JSON.stringify({
+      client_id: clientId,
+      device_code: deviceCode,
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    }),
+  });
+  const body = (await resp.json().catch(() => ({}))) as {
+    error?: string;
+    access_token?: string;
+    scope?: string;
+  };
+  if (body.access_token) {
+    return { kind: "success", accessToken: body.access_token, scope: body.scope ?? "" };
+  }
+  switch (body.error) {
+    case "authorization_pending":
+      return { kind: "pending" };
+    case "slow_down":
+      return { kind: "slow_down" };
+    case "expired_token":
+      return { kind: "expired" };
+    case "access_denied":
+      return { kind: "denied" };
+    default:
+      return { kind: "error", message: body.error ?? `HTTP ${resp.status}` };
+  }
+}
+
+export interface RepoPermissions {
+  admin: boolean;
+  maintain?: boolean;
+  push: boolean;
+  triage?: boolean;
+  pull?: boolean;
+}
+
+/** GET https://api.github.com/repos/:slug — used to verify repo access. */
+export async function fetchRepoPermissions(
+  slug: string,
+  githubToken: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<RepoPermissions | null> {
+  const resp = await fetchImpl(`https://api.github.com/repos/${slug}`, {
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${githubToken}`,
+      "user-agent": "conclave-ai-central-plane",
+    },
+  });
+  if (resp.status === 404 || resp.status === 403) return null;
+  if (!resp.ok) throw new Error(`github repo api: HTTP ${resp.status}`);
+  const body = (await resp.json()) as { permissions?: RepoPermissions };
+  return body.permissions ?? null;
+}

--- a/apps/central-plane/src/router.ts
+++ b/apps/central-plane/src/router.ts
@@ -4,13 +4,16 @@ import { healthRoutes } from "./routes/health.js";
 import { registerRoutes } from "./routes/register.js";
 import { episodicRoutes } from "./routes/episodic.js";
 import { memoryRoutes } from "./routes/memory.js";
+import { createOAuthRoutes } from "./routes/oauth.js";
+import type { FetchLike } from "./github.js";
 
-export function createApp(): Hono<{ Bindings: Env }> {
+export function createApp(opts: { fetch?: FetchLike } = {}): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
   app.route("/", healthRoutes);
   app.route("/", registerRoutes);
   app.route("/", episodicRoutes);
   app.route("/", memoryRoutes);
+  app.route("/", createOAuthRoutes(opts.fetch));
   app.onError((err, c) => {
     console.error("central-plane error:", err);
     return c.json({ error: err.message || "internal error" }, 500);

--- a/apps/central-plane/src/routes/oauth.ts
+++ b/apps/central-plane/src/routes/oauth.ts
@@ -1,0 +1,141 @@
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import { isValidRepoSlug, newId, sha256Hex } from "../util.js";
+import { createDevice, findDevice, markDeviceConsumed } from "../db/oauth.js";
+import { createInstall, findInstallBySlug } from "../db/installs.js";
+import { fetchRepoPermissions, pollDeviceToken, requestDeviceCode, type FetchLike } from "../github.js";
+
+/**
+ * Factory so tests can inject a mock fetch; production gets globalThis.fetch.
+ */
+export function createOAuthRoutes(fetchImpl: FetchLike = fetch): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+
+  app.post("/oauth/device/start", async (c) => {
+    const body = (await c.req.json().catch(() => null)) as { repo?: unknown } | null;
+    if (!body || !isValidRepoSlug(body.repo)) {
+      return c.json({ error: "body must be { repo: 'owner/name' }" }, 400);
+    }
+    const clientId = c.env.GITHUB_CLIENT_ID;
+    if (!clientId || clientId.startsWith("REPLACE_WITH_")) {
+      return c.json(
+        {
+          error: "central plane not configured — GITHUB_CLIENT_ID unset. Register an OAuth App first; see README.",
+        },
+        503,
+      );
+    }
+
+    let gh;
+    try {
+      gh = await requestDeviceCode(clientId, fetchImpl);
+    } catch (err) {
+      return c.json({ error: `upstream: ${(err as Error).message}` }, 502);
+    }
+
+    const deviceCodeId = newId();
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + gh.expires_in * 1000).toISOString();
+    await createDevice(c.env, {
+      deviceCodeId,
+      deviceCode: gh.device_code,
+      userCode: gh.user_code,
+      repoSlug: body.repo,
+      intervalSec: gh.interval,
+      expiresAt,
+      createdAt: now.toISOString(),
+    });
+
+    return c.json({
+      device_code_id: deviceCodeId,
+      user_code: gh.user_code,
+      verification_uri: gh.verification_uri,
+      interval_sec: gh.interval,
+      expires_at: expiresAt,
+    });
+  });
+
+  app.post("/oauth/device/poll", async (c) => {
+    const body = (await c.req.json().catch(() => null)) as { device_code_id?: unknown } | null;
+    if (!body || typeof body.device_code_id !== "string") {
+      return c.json({ error: "body must be { device_code_id: string }" }, 400);
+    }
+
+    const device = await findDevice(c.env, body.device_code_id);
+    if (!device) return c.json({ error: "device_code_id not found" }, 404);
+
+    if (device.consumed === 1) return c.json({ status: "already_succeeded" });
+    if (device.consumed === 2) return c.json({ status: "expired" });
+    if (new Date(device.expiresAt).getTime() < Date.now()) {
+      await markDeviceConsumed(c.env, device.deviceCodeId, 2);
+      return c.json({ status: "expired" });
+    }
+
+    const clientId = c.env.GITHUB_CLIENT_ID;
+    if (!clientId) return c.json({ error: "central plane not configured" }, 503);
+
+    const poll = await pollDeviceToken(clientId, device.deviceCode, fetchImpl);
+
+    switch (poll.kind) {
+      case "pending":
+        return c.json({ status: "pending", interval_sec: device.intervalSec });
+      case "slow_down":
+        return c.json({ status: "slow_down", interval_sec: device.intervalSec + 5 });
+      case "expired":
+        await markDeviceConsumed(c.env, device.deviceCodeId, 2);
+        return c.json({ status: "expired" });
+      case "denied":
+        await markDeviceConsumed(c.env, device.deviceCodeId, 2);
+        return c.json({ status: "denied" });
+      case "error":
+        return c.json({ status: "error", message: poll.message }, 500);
+      case "success": {
+        // Verify the authorising user actually has write access to the repo they
+        // claimed. Repo owner mismatch / no-push-rights → deny hard.
+        const perms = await fetchRepoPermissions(device.repoSlug, poll.accessToken, fetchImpl).catch(
+          () => null,
+        );
+        if (!perms || (!perms.admin && !perms.push)) {
+          await markDeviceConsumed(c.env, device.deviceCodeId, 2);
+          return c.json(
+            { status: "denied", reason: "authorised user has no push access to the repo they registered" },
+            403,
+          );
+        }
+
+        // Mint CONCLAVE_TOKEN (opaque). Store hash only — raw token is in the
+        // response once, never retrievable again.
+        const conclaveToken = `c_${newId().slice(2)}_${crypto.randomUUID().replace(/-/g, "")}`;
+        const tokenHash = await sha256Hex(conclaveToken);
+        const now = new Date().toISOString();
+
+        const existing = await findInstallBySlug(c.env, device.repoSlug);
+        if (existing) {
+          // Rotate: update token_hash + last_seen_at in place. Install id stays stable.
+          await c.env.DB.prepare("UPDATE installs SET token_hash = ?, last_seen_at = ? WHERE id = ?")
+            .bind(tokenHash, now, existing.id)
+            .run();
+        } else {
+          await createInstall(c.env, {
+            id: newId(),
+            repoSlug: device.repoSlug,
+            tokenHash,
+            now,
+          });
+        }
+
+        await markDeviceConsumed(c.env, device.deviceCodeId, 1);
+
+        return c.json({
+          status: "success",
+          token: conclaveToken,
+          repo: device.repoSlug,
+          rotated: Boolean(existing),
+          note: "CONCLAVE_TOKEN — set this as the GitHub repo secret CONCLAVE_TOKEN immediately; it is not retrievable.",
+        });
+      }
+    }
+  });
+
+  return app;
+}

--- a/apps/central-plane/test/oauth.test.mjs
+++ b/apps/central-plane/test/oauth.test.mjs
@@ -1,0 +1,404 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../dist/router.js";
+
+// ---- mock D1 + oauth_devices table ---------------------------------------
+
+function makeMockDb(installsSeed = new Map(), devicesSeed = new Map()) {
+  const state = {
+    installs: new Map(installsSeed),
+    devices: new Map(devicesSeed),
+  };
+  return {
+    state,
+    prepare(sql) {
+      let bound = [];
+      return {
+        bind: (...args) => {
+          bound = args;
+          return {
+            async first() {
+              if (/SELECT \* FROM installs WHERE repo_slug = \?/.test(sql)) {
+                const row = state.installs.get(bound[0]);
+                return row ? toInstallRow(row) : null;
+              }
+              if (/SELECT \* FROM oauth_devices WHERE device_code_id = \?/.test(sql)) {
+                const row = state.devices.get(bound[0]);
+                return row ? toDeviceRow(row) : null;
+              }
+              return null;
+            },
+            async run() {
+              if (/INSERT INTO installs/.test(sql)) {
+                const [id, repoSlug, tokenHash, createdAt, lastSeenAt] = bound;
+                state.installs.set(repoSlug, {
+                  id, repoSlug, tokenHash, createdAt, lastSeenAt, status: "active",
+                });
+              } else if (/UPDATE installs SET token_hash/.test(sql)) {
+                const [tokenHash, lastSeenAt, id] = bound;
+                for (const v of state.installs.values()) {
+                  if (v.id === id) {
+                    v.tokenHash = tokenHash;
+                    v.lastSeenAt = lastSeenAt;
+                  }
+                }
+              } else if (/INSERT INTO oauth_devices/.test(sql)) {
+                const [deviceCodeId, deviceCode, userCode, repoSlug, intervalSec, expiresAt, createdAt] = bound;
+                state.devices.set(deviceCodeId, {
+                  deviceCodeId, deviceCode, userCode, repoSlug, intervalSec, expiresAt, createdAt, consumed: 0,
+                });
+              } else if (/UPDATE oauth_devices SET consumed = \?/.test(sql)) {
+                const [flag, id] = bound;
+                const d = state.devices.get(id);
+                if (d) d.consumed = flag;
+              }
+              return { success: true };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function toInstallRow(r) {
+  return {
+    id: r.id, repo_slug: r.repoSlug, token_hash: r.tokenHash,
+    created_at: r.createdAt, last_seen_at: r.lastSeenAt, status: r.status,
+  };
+}
+
+function toDeviceRow(r) {
+  return {
+    device_code_id: r.deviceCodeId, device_code: r.deviceCode, user_code: r.userCode,
+    repo_slug: r.repoSlug, interval_sec: r.intervalSec, expires_at: r.expiresAt,
+    created_at: r.createdAt, consumed: r.consumed,
+  };
+}
+
+function makeEnv(overrides = {}) {
+  return {
+    DB: makeMockDb(),
+    ENVIRONMENT: "test",
+    GITHUB_CLIENT_ID: "Iv1.testclient",
+    ...overrides,
+  };
+}
+
+// ---- mock GitHub fetch ----------------------------------------------------
+
+function makeFetch(handlers) {
+  const calls = [];
+  const fn = async (url, init = {}) => {
+    const urlStr = typeof url === "string" ? url : url.url;
+    calls.push({ url: urlStr, init });
+    for (const h of handlers) {
+      if (h.match(urlStr, init)) {
+        return h.respond(urlStr, init);
+      }
+    }
+    throw new Error(`unexpected fetch: ${urlStr}`);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function jsonResponse(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function fetchApp(app, path, init = {}, env = makeEnv()) {
+  const req = new Request(`http://localhost${path}`, init);
+  const res = await app.fetch(req, env);
+  return { res, body: await res.json().catch(() => null) };
+}
+
+// ---- /oauth/device/start -------------------------------------------------
+
+test("POST /oauth/device/start: returns user_code + verification_uri + device_code_id", async () => {
+  const fetchMock = makeFetch([
+    {
+      match: (u) => u === "https://github.com/login/device/code",
+      respond: () => jsonResponse(200, {
+        device_code: "gh-device-1234",
+        user_code: "ABCD-EFGH",
+        verification_uri: "https://github.com/login/device",
+        expires_in: 900,
+        interval: 5,
+      }),
+    },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const env = makeEnv();
+  const { res, body } = await fetchApp(app, "/oauth/device/start", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ repo: "acme/service" }),
+  }, env);
+  assert.equal(res.status, 200);
+  assert.equal(body.user_code, "ABCD-EFGH");
+  assert.equal(body.verification_uri, "https://github.com/login/device");
+  assert.ok(body.device_code_id.startsWith("c_"));
+  assert.equal(body.interval_sec, 5);
+  // Device row stored with GitHub device_code (secret) NOT returned
+  const stored = env.DB.state.devices.get(body.device_code_id);
+  assert.ok(stored);
+  assert.equal(stored.deviceCode, "gh-device-1234");
+  assert.equal(stored.repoSlug, "acme/service");
+  assert.notEqual(body.device_code_id, stored.deviceCode, "internal pointer must not equal GitHub device_code");
+});
+
+test("POST /oauth/device/start: 400 on malformed slug", async () => {
+  const fetchMock = makeFetch([]);
+  const app = createApp({ fetch: fetchMock });
+  const { res } = await fetchApp(app, "/oauth/device/start", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ repo: "../evil" }),
+  });
+  assert.equal(res.status, 400);
+  assert.equal(fetchMock.calls.length, 0, "GitHub must not be called for malformed input");
+});
+
+test("POST /oauth/device/start: 503 when GITHUB_CLIENT_ID is placeholder", async () => {
+  const app = createApp({ fetch: makeFetch([]) });
+  const { res, body } = await fetchApp(app, "/oauth/device/start", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ repo: "acme/service" }),
+  }, makeEnv({ GITHUB_CLIENT_ID: "REPLACE_WITH_GITHUB_OAUTH_APP_CLIENT_ID" }));
+  assert.equal(res.status, 503);
+  assert.ok(/GITHUB_CLIENT_ID/.test(body.error));
+});
+
+// ---- /oauth/device/poll --------------------------------------------------
+
+test("POST /oauth/device/poll: pending status while user hasn't authorized yet", async () => {
+  const fetchMock = makeFetch([
+    {
+      match: (u) => u === "https://github.com/login/oauth/access_token",
+      respond: () => jsonResponse(200, { error: "authorization_pending" }),
+    },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const env = makeEnv({
+    DB: makeMockDb(new Map(), new Map([["c_dev_1", {
+      deviceCodeId: "c_dev_1", deviceCode: "gh-xyz", userCode: "ABCD-EFGH",
+      repoSlug: "acme/x", intervalSec: 5,
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      createdAt: new Date().toISOString(), consumed: 0,
+    }]])),
+  });
+  const { res, body } = await fetchApp(app, "/oauth/device/poll", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ device_code_id: "c_dev_1" }),
+  }, env);
+  assert.equal(res.status, 200);
+  assert.equal(body.status, "pending");
+});
+
+test("POST /oauth/device/poll: slow_down bumps interval", async () => {
+  const fetchMock = makeFetch([
+    {
+      match: (u) => u === "https://github.com/login/oauth/access_token",
+      respond: () => jsonResponse(200, { error: "slow_down" }),
+    },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const env = makeEnv({
+    DB: makeMockDb(new Map(), new Map([["c_dev_2", {
+      deviceCodeId: "c_dev_2", deviceCode: "gh-xyz", userCode: "X",
+      repoSlug: "acme/x", intervalSec: 5,
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      createdAt: "t", consumed: 0,
+    }]])),
+  });
+  const { body } = await fetchApp(app, "/oauth/device/poll", {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ device_code_id: "c_dev_2" }),
+  }, env);
+  assert.equal(body.status, "slow_down");
+  assert.equal(body.interval_sec, 10);
+});
+
+test("POST /oauth/device/poll: expired token marks device consumed=2", async () => {
+  const fetchMock = makeFetch([
+    {
+      match: (u) => u === "https://github.com/login/oauth/access_token",
+      respond: () => jsonResponse(200, { error: "expired_token" }),
+    },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const env = makeEnv({
+    DB: makeMockDb(new Map(), new Map([["c_dev_3", {
+      deviceCodeId: "c_dev_3", deviceCode: "gh-xyz", userCode: "X",
+      repoSlug: "acme/x", intervalSec: 5,
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      createdAt: "t", consumed: 0,
+    }]])),
+  });
+  const { body } = await fetchApp(app, "/oauth/device/poll", {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ device_code_id: "c_dev_3" }),
+  }, env);
+  assert.equal(body.status, "expired");
+  assert.equal(env.DB.state.devices.get("c_dev_3").consumed, 2);
+});
+
+test("POST /oauth/device/poll: success creates install and returns CONCLAVE_TOKEN", async () => {
+  const fetchMock = makeFetch([
+    {
+      match: (u) => u === "https://github.com/login/oauth/access_token",
+      respond: () => jsonResponse(200, { access_token: "gho_abcd", scope: "repo" }),
+    },
+    {
+      match: (u) => u === "https://api.github.com/repos/acme/service",
+      respond: () => jsonResponse(200, { permissions: { admin: true, push: true } }),
+    },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const env = makeEnv({
+    DB: makeMockDb(new Map(), new Map([["c_dev_4", {
+      deviceCodeId: "c_dev_4", deviceCode: "gh-xyz", userCode: "X",
+      repoSlug: "acme/service", intervalSec: 5,
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      createdAt: "t", consumed: 0,
+    }]])),
+  });
+  const { res, body } = await fetchApp(app, "/oauth/device/poll", {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ device_code_id: "c_dev_4" }),
+  }, env);
+  assert.equal(res.status, 200);
+  assert.equal(body.status, "success");
+  assert.ok(body.token.startsWith("c_"));
+  assert.equal(body.repo, "acme/service");
+  assert.equal(body.rotated, false);
+  // Install row created with token_hash
+  const install = env.DB.state.installs.get("acme/service");
+  assert.ok(install);
+  assert.equal(install.tokenHash.length, 64);
+  assert.notEqual(install.tokenHash, body.token);
+  // Device marked consumed=1
+  assert.equal(env.DB.state.devices.get("c_dev_4").consumed, 1);
+});
+
+test("POST /oauth/device/poll: success on existing repo rotates the token (same install id)", async () => {
+  const fetchMock = makeFetch([
+    {
+      match: (u) => u === "https://github.com/login/oauth/access_token",
+      respond: () => jsonResponse(200, { access_token: "gho_new", scope: "repo" }),
+    },
+    {
+      match: (u) => u === "https://api.github.com/repos/acme/service",
+      respond: () => jsonResponse(200, { permissions: { admin: true, push: true } }),
+    },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const env = makeEnv({
+    DB: makeMockDb(
+      new Map([["acme/service", {
+        id: "c_existing", repoSlug: "acme/service", tokenHash: "old-hash",
+        createdAt: "2026-01-01T00:00:00Z", lastSeenAt: "2026-01-01T00:00:00Z", status: "active",
+      }]]),
+      new Map([["c_dev_5", {
+        deviceCodeId: "c_dev_5", deviceCode: "gh-xyz", userCode: "X",
+        repoSlug: "acme/service", intervalSec: 5,
+        expiresAt: new Date(Date.now() + 600_000).toISOString(),
+        createdAt: "t", consumed: 0,
+      }]]),
+    ),
+  });
+  const { body } = await fetchApp(app, "/oauth/device/poll", {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ device_code_id: "c_dev_5" }),
+  }, env);
+  assert.equal(body.status, "success");
+  assert.equal(body.rotated, true);
+  const install = env.DB.state.installs.get("acme/service");
+  assert.equal(install.id, "c_existing", "install id must be stable across rotation");
+  assert.notEqual(install.tokenHash, "old-hash", "tokenHash must be updated on rotation");
+});
+
+test("POST /oauth/device/poll: success but no repo push access → 403 denied", async () => {
+  const fetchMock = makeFetch([
+    {
+      match: (u) => u === "https://github.com/login/oauth/access_token",
+      respond: () => jsonResponse(200, { access_token: "gho_read_only", scope: "repo" }),
+    },
+    {
+      match: (u) => u === "https://api.github.com/repos/other/secure",
+      respond: () => jsonResponse(200, { permissions: { admin: false, push: false, pull: true } }),
+    },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const env = makeEnv({
+    DB: makeMockDb(new Map(), new Map([["c_dev_6", {
+      deviceCodeId: "c_dev_6", deviceCode: "gh-xyz", userCode: "X",
+      repoSlug: "other/secure", intervalSec: 5,
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      createdAt: "t", consumed: 0,
+    }]])),
+  });
+  const { res, body } = await fetchApp(app, "/oauth/device/poll", {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ device_code_id: "c_dev_6" }),
+  }, env);
+  assert.equal(res.status, 403);
+  assert.equal(body.status, "denied");
+  assert.equal(env.DB.state.installs.has("other/secure"), false, "no install created when denied");
+  assert.equal(env.DB.state.devices.get("c_dev_6").consumed, 2);
+});
+
+test("POST /oauth/device/poll: already-succeeded returns stable response", async () => {
+  const fetchMock = makeFetch([]);
+  const app = createApp({ fetch: fetchMock });
+  const env = makeEnv({
+    DB: makeMockDb(new Map(), new Map([["c_dev_7", {
+      deviceCodeId: "c_dev_7", deviceCode: "gh-xyz", userCode: "X",
+      repoSlug: "acme/x", intervalSec: 5,
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      createdAt: "t", consumed: 1,
+    }]])),
+  });
+  const { body } = await fetchApp(app, "/oauth/device/poll", {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ device_code_id: "c_dev_7" }),
+  }, env);
+  assert.equal(body.status, "already_succeeded");
+  assert.equal(fetchMock.calls.length, 0, "must not re-poll GitHub for consumed devices");
+});
+
+test("POST /oauth/device/poll: locally-expired device returns expired without calling GitHub", async () => {
+  const fetchMock = makeFetch([]);
+  const app = createApp({ fetch: fetchMock });
+  const env = makeEnv({
+    DB: makeMockDb(new Map(), new Map([["c_dev_8", {
+      deviceCodeId: "c_dev_8", deviceCode: "gh-xyz", userCode: "X",
+      repoSlug: "acme/x", intervalSec: 5,
+      expiresAt: new Date(Date.now() - 1000).toISOString(),  // already expired
+      createdAt: "t", consumed: 0,
+    }]])),
+  });
+  const { body } = await fetchApp(app, "/oauth/device/poll", {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ device_code_id: "c_dev_8" }),
+  }, env);
+  assert.equal(body.status, "expired");
+  assert.equal(fetchMock.calls.length, 0);
+  assert.equal(env.DB.state.devices.get("c_dev_8").consumed, 2);
+});
+
+test("POST /oauth/device/poll: 404 for unknown device_code_id", async () => {
+  const fetchMock = makeFetch([]);
+  const app = createApp({ fetch: fetchMock });
+  const { res } = await fetchApp(app, "/oauth/device/poll", {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ device_code_id: "c_missing" }),
+  });
+  assert.equal(res.status, 404);
+});

--- a/apps/central-plane/wrangler.toml
+++ b/apps/central-plane/wrangler.toml
@@ -12,6 +12,10 @@ database_id = "28be7ec4-9c46-4b78-8d07-11f344021dd0"
 
 [vars]
 ENVIRONMENT = "production"
+# Public GitHub OAuth App client_id. Register at https://github.com/settings/developers
+# (type: OAuth App, enable device flow). Leave the placeholder if OAuth is not
+# yet configured — /oauth/device/* endpoints will return 503 until this is real.
+GITHUB_CLIENT_ID = "REPLACE_WITH_GITHUB_OAUTH_APP_CLIENT_ID"
 
 # Observability. Logs retained 3 days on free tier, sufficient for v0.4-alpha.
 [observability]


### PR DESCRIPTION
Second implementation milestone of v0.4 central plane. Replaces the placeholder /register token with a real GitHub device-flow OAuth handshake — ideal for CLI installs (no callback server needed, user reads short code off terminal).

## Flow
1. CLI POSTs `/oauth/device/start { repo: 'owner/name' }` → Worker starts GitHub device flow, returns `{ user_code, verification_uri, device_code_id, interval_sec, expires_at }`
2. CLI prints: `Open https://github.com/login/device and enter: ABCD-EFGH`
3. CLI polls `/oauth/device/poll { device_code_id }` every `interval_sec`
4. On success: Worker verifies the authorising user has push access to the claimed repo, mints an opaque CONCLAVE_TOKEN, stores SHA-256 hash only, returns raw token once

## Security posture
- GitHub `device_code` (secret) never leaves the Worker. CLI gets an opaque `device_code_id` pointer instead
- Repo-permission check catches bait-and-switch: authorising as A then claiming repo B's install
- CONCLAVE_TOKEN rotation via same flow keeps install `id` stable (same row, new hash)
- Locally-expired device records fail early without burning a GitHub call
- `consumed=1` devices can't be re-polled — prevents token farming from a single auth

## Tests
12 new OAuth subtests covering every branch of the device-flow state machine: pending / slow_down / expired (locally + GitHub-side) / denied / success (new install) / success (rotation) / already-succeeded / 404 / 400 / 503-when-unconfigured. Hermetic — fetch injected via `createApp({ fetch })`.

Central-plane total: **26/26 subtests green**. Full repo: **25/25 build, 47/47 test tasks**.

## Bae setup after merge
1. Register OAuth App at https://github.com/settings/developers (enable device flow)
2. Paste client_id into `wrangler.toml` `GITHUB_CLIENT_ID`
3. `pnpm run migrate:prod` (applies 0002_oauth_devices)
4. `pnpm run ship`

## Next milestones
3. Federated memory aggregation (`/episodic/push` + `/memory/pull` become real)
4. Central `@conclave_ai` Telegram bot
5. Deploy-status → ReviewContext
(+ CLI `conclave init` wiring to call these OAuth endpoints instead of stubbing — small follow-up PR)