### PR TITLE
feat(central-plane): federated memory aggregation + bearer auth (milestone 3)

### DIFF
--- a/apps/central-plane/README.md
+++ b/apps/central-plane/README.md
@@ -6,14 +6,20 @@ See `docs/architecture-v0.4.md` for the full design; this package is the concret
 
 ## Endpoints
 
-| Method | Path                          | Status |
-|--------|-------------------------------|--------|
-| GET    | `/health`                     | ✅ real |
-| POST   | `/register`                   | ✅ real (placeholder token — use OAuth device flow for real installs) |
-| POST   | `/oauth/device/start`         | ✅ real — GitHub device-flow bootstrap |
-| POST   | `/oauth/device/poll`          | ✅ real — returns CONCLAVE_TOKEN on success |
-| POST   | `/episodic/push`              | 🟡 stub (aggregation pending) |
-| GET    | `/memory/pull`                | 🟡 stub (aggregation pending) |
+| Method | Path                          | Status | Auth |
+|--------|-------------------------------|--------|------|
+| GET    | `/health`                     | ✅ real | none |
+| POST   | `/register`                   | ✅ real (placeholder token; prefer OAuth for real installs) | none |
+| POST   | `/oauth/device/start`         | ✅ real — GitHub device-flow bootstrap | none |
+| POST   | `/oauth/device/poll`          | ✅ real — returns CONCLAVE_TOKEN on success | none |
+| POST   | `/episodic/push`              | ✅ real — federated aggregate upsert | Bearer CONCLAVE_TOKEN |
+| GET    | `/memory/pull`                | ✅ real — frequency baseline for retrieval re-rank | Bearer CONCLAVE_TOKEN |
+
+### Federated memory shape
+
+**Push** — body `{ items: [{ contentHash, kind, domain, category?, severity?, tags? }, ...] }`, up to 500 items per request. Content hashes and metadata cross the boundary; no diff text or blocker message content leaves the caller. Duplicate contentHash across repos or within the same repo atomically increments the aggregate count.
+
+**Pull** — query params `?kind=...&domain=...&min_count=N&limit=M`. All optional. Returns aggregates sorted by count descending — the most frequently observed patterns across the entire install population rank first. Callers use this as a re-rank signal when retrieving their local answer-keys / failure-catalog at review time (per decision #21).
 
 ## GitHub OAuth setup (one-time per deployment)
 

--- a/apps/central-plane/src/auth.ts
+++ b/apps/central-plane/src/auth.ts
@@ -1,0 +1,47 @@
+import type { Context, Next } from "hono";
+import type { Env } from "./env.js";
+import { findInstallByTokenHash, touchInstall } from "./db/installs.js";
+import { sha256Hex } from "./util.js";
+
+export type AuthedVariables = {
+  installId: string;
+  installRepo: string;
+};
+
+export type AuthedContext = Context<{ Bindings: Env; Variables: AuthedVariables }>;
+
+/**
+ * Bearer-token auth middleware. Pulls `Authorization: Bearer c_...` off
+ * the request, hashes it, and looks up the install row. On match, we
+ * stash the install id/repo on the Hono context so handlers can read it
+ * without re-querying, and we bump `last_seen_at` for observability.
+ *
+ * Timing-safe comparison is not needed here: we hash the incoming token
+ * before the DB lookup (constant-work transformation) and the primary
+ * key on token_hash means the DB comparison is a single index probe, not
+ * a linear scan. The token itself is high-entropy opaque (c_<cuid>_<uuid>)
+ * so guessing-attack surface is nil.
+ */
+export async function requireInstallAuth(
+  c: Context<{ Bindings: Env; Variables: AuthedVariables }>,
+  next: Next,
+): Promise<Response | void> {
+  const header = c.req.header("authorization") ?? c.req.header("Authorization");
+  if (!header || !/^Bearer\s+/i.test(header)) {
+    return c.json({ error: "missing Authorization: Bearer <CONCLAVE_TOKEN> header" }, 401);
+  }
+  const token = header.replace(/^Bearer\s+/i, "").trim();
+  if (!token.startsWith("c_")) {
+    return c.json({ error: "token must begin with c_" }, 401);
+  }
+  const tokenHash = await sha256Hex(token);
+  const install = await findInstallByTokenHash(c.env, tokenHash);
+  if (!install) {
+    return c.json({ error: "token not recognised" }, 401);
+  }
+  c.set("installId", install.id);
+  c.set("installRepo", install.repoSlug);
+  // Fire-and-forget — we don't block the response on the touch write.
+  c.executionCtx.waitUntil(touchInstall(c.env, install.id, new Date().toISOString()));
+  await next();
+}

--- a/apps/central-plane/src/db/aggregates.ts
+++ b/apps/central-plane/src/db/aggregates.ts
@@ -1,0 +1,125 @@
+import type { Env } from "../env.js";
+
+/**
+ * One row per unique content-hash observed across the entire install
+ * population. No repo-level info is stored alongside — the whole point
+ * is a k-anonymous baseline per decision #21 / D4.
+ */
+export interface AggregateRow {
+  contentHash: string;
+  kind: "answer-key" | "failure-catalog";
+  domain: "code" | "design";
+  category: string | null;
+  severity: string | null;
+  tags: string[];
+  count: number;
+  firstSeenAt: string;
+  lastSeenAt: string;
+}
+
+interface DbRow {
+  content_hash: string;
+  kind: string;
+  domain: string;
+  category: string | null;
+  severity: string | null;
+  tags: string;
+  count: number;
+  first_seen_at: string;
+  last_seen_at: string;
+}
+
+function rowToRecord(row: DbRow): AggregateRow {
+  let tags: string[] = [];
+  try {
+    const parsed = JSON.parse(row.tags);
+    if (Array.isArray(parsed)) tags = parsed.filter((t): t is string => typeof t === "string");
+  } catch {
+    // malformed tags persisted: treat as empty, not an error
+  }
+  return {
+    contentHash: row.content_hash,
+    kind: row.kind === "answer-key" ? "answer-key" : "failure-catalog",
+    domain: row.domain === "design" ? "design" : "code",
+    category: row.category,
+    severity: row.severity,
+    tags,
+    count: row.count,
+    firstSeenAt: row.first_seen_at,
+    lastSeenAt: row.last_seen_at,
+  };
+}
+
+export interface UpsertInput {
+  contentHash: string;
+  kind: "answer-key" | "failure-catalog";
+  domain: "code" | "design";
+  category?: string | null;
+  severity?: string | null;
+  tags?: readonly string[];
+  now: string;
+}
+
+/**
+ * Upsert-and-increment on content_hash. Uses SQLite's ON CONFLICT DO UPDATE
+ * so the worker does the increment atomically in one round trip even when
+ * the same hash is seen concurrently from two consumer repos.
+ */
+export async function upsertAggregate(env: Env, input: UpsertInput): Promise<void> {
+  const tagsJson = JSON.stringify([...(input.tags ?? [])]);
+  await env.DB.prepare(
+    `INSERT INTO episodic_aggregates (content_hash, kind, domain, category, severity, tags, count, first_seen_at, last_seen_at)
+     VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)
+     ON CONFLICT(content_hash) DO UPDATE SET
+       count = count + 1,
+       last_seen_at = excluded.last_seen_at`,
+  )
+    .bind(
+      input.contentHash,
+      input.kind,
+      input.domain,
+      input.category ?? null,
+      input.severity ?? null,
+      tagsJson,
+      input.now,
+      input.now,
+    )
+    .run();
+}
+
+export interface ListAggregatesQuery {
+  kind?: "answer-key" | "failure-catalog";
+  domain?: "code" | "design";
+  limit?: number;
+  minCount?: number;
+}
+
+/**
+ * List aggregates sorted by count desc — highest-signal patterns first.
+ * `minCount` lets a caller ask for only popular-enough patterns (the
+ * "baseline" in the federated sense); default is 1 (return everything).
+ */
+export async function listAggregates(env: Env, query: ListAggregatesQuery = {}): Promise<AggregateRow[]> {
+  const wheres: string[] = [];
+  const binds: (string | number)[] = [];
+  if (query.kind) {
+    wheres.push("kind = ?");
+    binds.push(query.kind);
+  }
+  if (query.domain) {
+    wheres.push("domain = ?");
+    binds.push(query.domain);
+  }
+  if (query.minCount && query.minCount > 1) {
+    wheres.push("count >= ?");
+    binds.push(query.minCount);
+  }
+  const where = wheres.length > 0 ? `WHERE ${wheres.join(" AND ")}` : "";
+  const limit = Math.min(Math.max(query.limit ?? 200, 1), 1000);
+  const sql = `SELECT * FROM episodic_aggregates ${where} ORDER BY count DESC LIMIT ?`;
+  binds.push(limit);
+  const result = await env.DB.prepare(sql)
+    .bind(...binds)
+    .all<DbRow>();
+  return (result.results ?? []).map(rowToRecord);
+}

--- a/apps/central-plane/src/routes/episodic.ts
+++ b/apps/central-plane/src/routes/episodic.ts
@@ -1,22 +1,79 @@
 import { Hono } from "hono";
 import type { Env } from "../env.js";
+import { requireInstallAuth, type AuthedVariables } from "../auth.js";
+import { upsertAggregate } from "../db/aggregates.js";
 
-export const episodicRoutes = new Hono<{ Bindings: Env }>();
+export const episodicRoutes = new Hono<{ Bindings: Env; Variables: AuthedVariables }>();
+
+interface PushItem {
+  contentHash: string;
+  kind: "answer-key" | "failure-catalog";
+  domain: "code" | "design";
+  category?: string | null;
+  severity?: string | null;
+  tags?: string[];
+}
+
+function isValidItem(x: unknown): x is PushItem {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  if (typeof o.contentHash !== "string" || o.contentHash.length < 8 || o.contentHash.length > 128) return false;
+  if (o.kind !== "answer-key" && o.kind !== "failure-catalog") return false;
+  if (o.domain !== "code" && o.domain !== "design") return false;
+  if (o.category !== undefined && o.category !== null && typeof o.category !== "string") return false;
+  if (o.severity !== undefined && o.severity !== null && typeof o.severity !== "string") return false;
+  if (o.tags !== undefined && (!Array.isArray(o.tags) || !o.tags.every((t) => typeof t === "string"))) return false;
+  return true;
+}
+
+const MAX_ITEMS_PER_REQUEST = 500;
 
 /**
- * v0.4-alpha stub for federated memory push. Accepts a list of content
- * hashes (per D4's hashes-default policy) and acknowledges. Real
- * aggregation — increment `episodic_aggregates.count`, track first/last
- * seen timestamps — lands in the memory PR.
+ * Authenticated federated-memory push. Requires a valid CONCLAVE_TOKEN.
+ * Body: { items: [{ contentHash, kind, domain, category?, severity?, tags? }, ...] }.
+ * Only hashes + metadata cross this boundary per decision #21 / D4 —
+ * diff content / blocker text never do.
+ *
+ * Upsert is atomic per item via ON CONFLICT. We tolerate partial failure:
+ * if one item is malformed, the valid ones still commit and the response
+ * reports the skip count.
  */
-episodicRoutes.post("/episodic/push", async (c) => {
-  const body = (await c.req.json().catch(() => null)) as { hashes?: unknown } | null;
-  if (!body || !Array.isArray(body.hashes)) {
-    return c.json({ error: "body must be { hashes: [...] }" }, 400);
+episodicRoutes.post("/episodic/push", requireInstallAuth, async (c) => {
+  const body = (await c.req.json().catch(() => null)) as { items?: unknown } | null;
+  if (!body || !Array.isArray(body.items)) {
+    return c.json({ error: "body must be { items: [...] }" }, 400);
   }
+  if (body.items.length > MAX_ITEMS_PER_REQUEST) {
+    return c.json(
+      { error: `max ${MAX_ITEMS_PER_REQUEST} items per request; split larger batches` },
+      413,
+    );
+  }
+
+  const now = new Date().toISOString();
+  let stored = 0;
+  let skipped = 0;
+  for (const raw of body.items) {
+    if (!isValidItem(raw)) {
+      skipped += 1;
+      continue;
+    }
+    await upsertAggregate(c.env, {
+      contentHash: raw.contentHash,
+      kind: raw.kind,
+      domain: raw.domain,
+      category: raw.category ?? null,
+      severity: raw.severity ?? null,
+      tags: raw.tags ?? [],
+      now,
+    });
+    stored += 1;
+  }
+
   return c.json({
-    accepted: body.hashes.length,
-    stored: 0,
-    note: "v0.4-alpha stub — aggregation pending in the memory PR",
+    accepted: body.items.length,
+    stored,
+    skipped,
+    repo: c.get("installRepo"),
   });
 });

--- a/apps/central-plane/src/routes/memory.ts
+++ b/apps/central-plane/src/routes/memory.ts
@@ -1,21 +1,69 @@
 import { Hono } from "hono";
 import type { Env } from "../env.js";
-import { isValidRepoSlug } from "../util.js";
+import { requireInstallAuth, type AuthedVariables } from "../auth.js";
+import { listAggregates } from "../db/aggregates.js";
 
-export const memoryRoutes = new Hono<{ Bindings: Env }>();
+export const memoryRoutes = new Hono<{ Bindings: Env; Variables: AuthedVariables }>();
 
 /**
- * v0.4-alpha stub for federated memory pull. Returns an empty baseline
- * until the memory PR wires up real aggregation.
+ * Authenticated federated-memory pull. Returns the aggregate frequency
+ * table for the requested (kind, domain). No repo-level filtering is
+ * intentional — the whole point is cross-repo learning. Privacy lives
+ * at the ingest layer (hashes only).
+ *
+ * Query params:
+ *   kind=answer-key|failure-catalog   optional — filter
+ *   domain=code|design                optional — filter
+ *   min_count=<n>                     optional — only patterns with count >= n
+ *                                     (baseline-quality filter; default 1)
+ *   limit=<n>                         optional — 1..1000; default 200
  */
-memoryRoutes.get("/memory/pull", (c) => {
-  const repo = c.req.query("repo");
-  if (!isValidRepoSlug(repo)) {
-    return c.json({ error: "?repo=owner/name required (valid GitHub slug)" }, 400);
+memoryRoutes.get("/memory/pull", requireInstallAuth, async (c) => {
+  const kind = c.req.query("kind");
+  if (kind !== undefined && kind !== "answer-key" && kind !== "failure-catalog") {
+    return c.json({ error: "kind must be 'answer-key' or 'failure-catalog' if provided" }, 400);
   }
+  const domain = c.req.query("domain");
+  if (domain !== undefined && domain !== "code" && domain !== "design") {
+    return c.json({ error: "domain must be 'code' or 'design' if provided" }, 400);
+  }
+  const minCountRaw = c.req.query("min_count");
+  let minCount: number | undefined;
+  if (minCountRaw !== undefined) {
+    const n = Number.parseInt(minCountRaw, 10);
+    if (!Number.isFinite(n) || n < 1) {
+      return c.json({ error: "min_count must be a positive integer" }, 400);
+    }
+    minCount = n;
+  }
+  const limitRaw = c.req.query("limit");
+  let limit: number | undefined;
+  if (limitRaw !== undefined) {
+    const n = Number.parseInt(limitRaw, 10);
+    if (!Number.isFinite(n) || n < 1 || n > 1000) {
+      return c.json({ error: "limit must be between 1 and 1000" }, 400);
+    }
+    limit = n;
+  }
+
+  const query: Parameters<typeof listAggregates>[1] = {};
+  if (kind) query.kind = kind;
+  if (domain) query.domain = domain;
+  if (minCount !== undefined) query.minCount = minCount;
+  if (limit !== undefined) query.limit = limit;
+
+  const rows = await listAggregates(c.env, query);
   return c.json({
-    repo,
-    frequencies: [],
-    note: "v0.4-alpha stub — aggregation pending in the memory PR",
+    repo: c.get("installRepo"),
+    entries: rows.map((r) => ({
+      contentHash: r.contentHash,
+      kind: r.kind,
+      domain: r.domain,
+      category: r.category,
+      severity: r.severity,
+      tags: r.tags,
+      count: r.count,
+    })),
+    total: rows.length,
   });
 });

--- a/apps/central-plane/test/memory.test.mjs
+++ b/apps/central-plane/test/memory.test.mjs
@@ -1,0 +1,373 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { createApp } from "../dist/router.js";
+
+// ---- mock D1 covering installs + episodic_aggregates --------------------
+
+function makeMockDb({ installs = new Map(), aggregates = new Map() } = {}) {
+  const state = {
+    installs: new Map(installs),
+    aggregates: new Map(aggregates),
+  };
+  return {
+    state,
+    prepare(sql) {
+      let bound = [];
+      const wrap = {
+        bind: (...args) => {
+          bound = args;
+          return wrap;
+        },
+        async first() {
+          if (/SELECT \* FROM installs WHERE token_hash = \? AND status = 'active'/.test(sql)) {
+            for (const v of state.installs.values()) {
+              if (v.tokenHash === bound[0] && v.status === "active") {
+                return {
+                  id: v.id,
+                  repo_slug: v.repoSlug,
+                  token_hash: v.tokenHash,
+                  created_at: v.createdAt,
+                  last_seen_at: v.lastSeenAt,
+                  status: v.status,
+                };
+              }
+            }
+            return null;
+          }
+          return null;
+        },
+        async all() {
+          if (/SELECT \* FROM episodic_aggregates/.test(sql)) {
+            let rows = [...state.aggregates.values()];
+            // parse `WHERE kind = ? AND domain = ? AND count >= ?` binds
+            // and ORDER BY count DESC LIMIT ?
+            const binds = [...bound];
+            const limit = binds[binds.length - 1];
+            const filters = binds.slice(0, -1);
+            const filterLabels = [];
+            if (/WHERE kind = \?/.test(sql)) filterLabels.push("kind");
+            if (/domain = \?/.test(sql)) filterLabels.push("domain");
+            if (/count >= \?/.test(sql)) filterLabels.push("minCount");
+
+            for (let i = 0; i < filterLabels.length; i += 1) {
+              const label = filterLabels[i];
+              const val = filters[i];
+              if (label === "kind") rows = rows.filter((r) => r.kind === val);
+              if (label === "domain") rows = rows.filter((r) => r.domain === val);
+              if (label === "minCount") rows = rows.filter((r) => r.count >= val);
+            }
+            rows.sort((a, b) => b.count - a.count);
+            rows = rows.slice(0, limit);
+            return {
+              results: rows.map((r) => ({
+                content_hash: r.contentHash,
+                kind: r.kind,
+                domain: r.domain,
+                category: r.category,
+                severity: r.severity,
+                tags: r.tags,
+                count: r.count,
+                first_seen_at: r.firstSeenAt,
+                last_seen_at: r.lastSeenAt,
+              })),
+            };
+          }
+          return { results: [] };
+        },
+        async run() {
+          if (/UPDATE installs SET last_seen_at/.test(sql)) {
+            const [lastSeenAt, id] = bound;
+            for (const v of state.installs.values()) {
+              if (v.id === id) v.lastSeenAt = lastSeenAt;
+            }
+          } else if (/INSERT INTO episodic_aggregates/.test(sql)) {
+            // ON CONFLICT DO UPDATE — emulate upsert semantics
+            const [contentHash, kind, domain, category, severity, tags, firstSeenAt, lastSeenAt] = bound;
+            const existing = state.aggregates.get(contentHash);
+            if (existing) {
+              existing.count += 1;
+              existing.lastSeenAt = lastSeenAt;
+            } else {
+              state.aggregates.set(contentHash, {
+                contentHash,
+                kind,
+                domain,
+                category,
+                severity,
+                tags,
+                count: 1,
+                firstSeenAt,
+                lastSeenAt,
+              });
+            }
+          }
+          return { success: true };
+        },
+      };
+      return wrap;
+    },
+  };
+}
+
+function sha256(s) {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function makeAuthedEnv({ token = "c_test_token_xyz", repoSlug = "acme/service" } = {}) {
+  const tokenHash = sha256(token);
+  const installs = new Map([[
+    repoSlug,
+    {
+      id: "c_install_1",
+      repoSlug,
+      tokenHash,
+      createdAt: "2026-04-20T00:00:00Z",
+      lastSeenAt: "2026-04-20T00:00:00Z",
+      status: "active",
+    },
+  ]]);
+  return {
+    env: {
+      DB: makeMockDb({ installs }),
+      ENVIRONMENT: "test",
+      GITHUB_CLIENT_ID: "Iv1.testclient",
+    },
+    token,
+  };
+}
+
+async function fetchApp(app, path, init = {}, env) {
+  const ctx = {
+    waitUntil: (_p) => {},
+    passThroughOnException: () => {},
+  };
+  const req = new Request(`http://localhost${path}`, init);
+  const res = await app.fetch(req, env, ctx);
+  return { res, body: await res.json().catch(() => null) };
+}
+
+// ---- auth middleware -----------------------------------------------------
+
+test("POST /episodic/push: 401 when no Authorization header", async () => {
+  const app = createApp();
+  const { env } = makeAuthedEnv();
+  const { res } = await fetchApp(app, "/episodic/push", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ items: [] }),
+  }, env);
+  assert.equal(res.status, 401);
+});
+
+test("POST /episodic/push: 401 when token doesn't match any install", async () => {
+  const app = createApp();
+  const { env } = makeAuthedEnv();
+  const { res } = await fetchApp(app, "/episodic/push", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "authorization": "Bearer c_nonexistent_token",
+    },
+    body: JSON.stringify({ items: [] }),
+  }, env);
+  assert.equal(res.status, 401);
+});
+
+test("POST /episodic/push: 401 when token doesn't start with c_", async () => {
+  const app = createApp();
+  const { env } = makeAuthedEnv();
+  const { res } = await fetchApp(app, "/episodic/push", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "authorization": "Bearer ghp_pretending_to_be_conclave",
+    },
+    body: JSON.stringify({ items: [] }),
+  }, env);
+  assert.equal(res.status, 401);
+});
+
+// ---- episodic/push happy paths -------------------------------------------
+
+test("POST /episodic/push: stores valid items and ignores malformed ones", async () => {
+  const app = createApp();
+  const { env, token } = makeAuthedEnv();
+  const { res, body } = await fetchApp(app, "/episodic/push", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "authorization": `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      items: [
+        {
+          contentHash: "a".repeat(64),
+          kind: "failure-catalog",
+          domain: "code",
+          category: "type-error",
+          severity: "blocker",
+          tags: ["react", "typescript"],
+        },
+        {
+          contentHash: "b".repeat(64),
+          kind: "answer-key",
+          domain: "design",
+        },
+        { totally: "malformed" },
+        { contentHash: "short", kind: "answer-key", domain: "code" }, // too-short hash
+      ],
+    }),
+  }, env);
+  assert.equal(res.status, 200);
+  assert.equal(body.accepted, 4);
+  assert.equal(body.stored, 2);
+  assert.equal(body.skipped, 2);
+  assert.equal(body.repo, "acme/service");
+  assert.ok(env.DB.state.aggregates.has("a".repeat(64)));
+  assert.ok(env.DB.state.aggregates.has("b".repeat(64)));
+  assert.equal(env.DB.state.aggregates.size, 2);
+});
+
+test("POST /episodic/push: duplicate content_hash increments count (upsert)", async () => {
+  const app = createApp();
+  const { env, token } = makeAuthedEnv();
+  const hash = "c".repeat(64);
+  const item = {
+    contentHash: hash,
+    kind: "failure-catalog",
+    domain: "code",
+    category: "security",
+    severity: "blocker",
+  };
+  // First push: count = 1
+  await fetchApp(app, "/episodic/push", {
+    method: "POST",
+    headers: { "content-type": "application/json", "authorization": `Bearer ${token}` },
+    body: JSON.stringify({ items: [item] }),
+  }, env);
+  // Second push (same hash): count should become 2
+  await fetchApp(app, "/episodic/push", {
+    method: "POST",
+    headers: { "content-type": "application/json", "authorization": `Bearer ${token}` },
+    body: JSON.stringify({ items: [item] }),
+  }, env);
+  const agg = env.DB.state.aggregates.get(hash);
+  assert.equal(agg.count, 2);
+});
+
+test("POST /episodic/push: 413 when items exceeds 500", async () => {
+  const app = createApp();
+  const { env, token } = makeAuthedEnv();
+  const items = Array.from({ length: 501 }, (_, i) => ({
+    contentHash: `x${i}`.padEnd(64, "0"),
+    kind: "answer-key",
+    domain: "code",
+  }));
+  const { res } = await fetchApp(app, "/episodic/push", {
+    method: "POST",
+    headers: { "content-type": "application/json", "authorization": `Bearer ${token}` },
+    body: JSON.stringify({ items }),
+  }, env);
+  assert.equal(res.status, 413);
+});
+
+test("POST /episodic/push: 400 when body missing items", async () => {
+  const app = createApp();
+  const { env, token } = makeAuthedEnv();
+  const { res } = await fetchApp(app, "/episodic/push", {
+    method: "POST",
+    headers: { "content-type": "application/json", "authorization": `Bearer ${token}` },
+    body: JSON.stringify({}),
+  }, env);
+  assert.equal(res.status, 400);
+});
+
+// ---- memory/pull ---------------------------------------------------------
+
+function makeEnvWithAggregates(rows) {
+  const { env, token } = makeAuthedEnv();
+  for (const r of rows) {
+    env.DB.state.aggregates.set(r.contentHash, r);
+  }
+  return { env, token };
+}
+
+test("GET /memory/pull: 401 when no Authorization header", async () => {
+  const app = createApp();
+  const { env } = makeEnvWithAggregates([]);
+  const { res } = await fetchApp(app, "/memory/pull", {}, env);
+  assert.equal(res.status, 401);
+});
+
+test("GET /memory/pull: returns aggregates ordered by count desc", async () => {
+  const app = createApp();
+  const { env, token } = makeEnvWithAggregates([
+    { contentHash: "h-a", kind: "failure-catalog", domain: "code", category: "x", severity: "b", tags: "[]", count: 7, firstSeenAt: "t", lastSeenAt: "t" },
+    { contentHash: "h-b", kind: "failure-catalog", domain: "code", category: "y", severity: "b", tags: "[]", count: 2, firstSeenAt: "t", lastSeenAt: "t" },
+    { contentHash: "h-c", kind: "answer-key",      domain: "code", category: null, severity: null, tags: "[\"react\"]", count: 99, firstSeenAt: "t", lastSeenAt: "t" },
+  ]);
+  const { res, body } = await fetchApp(app, "/memory/pull", {
+    headers: { "authorization": `Bearer ${token}` },
+  }, env);
+  assert.equal(res.status, 200);
+  assert.equal(body.total, 3);
+  assert.equal(body.entries[0].contentHash, "h-c"); // count=99, highest
+  assert.equal(body.entries[1].contentHash, "h-a");
+  assert.equal(body.entries[2].contentHash, "h-b");
+  assert.deepEqual(body.entries[0].tags, ["react"]);
+});
+
+test("GET /memory/pull: kind + domain filters work", async () => {
+  const app = createApp();
+  const { env, token } = makeEnvWithAggregates([
+    { contentHash: "h-1", kind: "failure-catalog", domain: "code",   category: null, severity: null, tags: "[]", count: 5, firstSeenAt: "t", lastSeenAt: "t" },
+    { contentHash: "h-2", kind: "answer-key",      domain: "code",   category: null, severity: null, tags: "[]", count: 5, firstSeenAt: "t", lastSeenAt: "t" },
+    { contentHash: "h-3", kind: "failure-catalog", domain: "design", category: null, severity: null, tags: "[]", count: 5, firstSeenAt: "t", lastSeenAt: "t" },
+  ]);
+  const { body } = await fetchApp(app, "/memory/pull?kind=failure-catalog&domain=code", {
+    headers: { "authorization": `Bearer ${token}` },
+  }, env);
+  assert.equal(body.total, 1);
+  assert.equal(body.entries[0].contentHash, "h-1");
+});
+
+test("GET /memory/pull: min_count filters below-threshold patterns", async () => {
+  const app = createApp();
+  const { env, token } = makeEnvWithAggregates([
+    { contentHash: "low",  kind: "failure-catalog", domain: "code", category: null, severity: null, tags: "[]", count: 1,  firstSeenAt: "t", lastSeenAt: "t" },
+    { contentHash: "high", kind: "failure-catalog", domain: "code", category: null, severity: null, tags: "[]", count: 10, firstSeenAt: "t", lastSeenAt: "t" },
+  ]);
+  const { body } = await fetchApp(app, "/memory/pull?min_count=5", {
+    headers: { "authorization": `Bearer ${token}` },
+  }, env);
+  assert.equal(body.total, 1);
+  assert.equal(body.entries[0].contentHash, "high");
+});
+
+test("GET /memory/pull: 400 on invalid kind", async () => {
+  const app = createApp();
+  const { env, token } = makeEnvWithAggregates([]);
+  const { res } = await fetchApp(app, "/memory/pull?kind=nonsense", {
+    headers: { "authorization": `Bearer ${token}` },
+  }, env);
+  assert.equal(res.status, 400);
+});
+
+test("GET /memory/pull: 400 on invalid min_count", async () => {
+  const app = createApp();
+  const { env, token } = makeEnvWithAggregates([]);
+  const { res } = await fetchApp(app, "/memory/pull?min_count=-1", {
+    headers: { "authorization": `Bearer ${token}` },
+  }, env);
+  assert.equal(res.status, 400);
+});
+
+test("GET /memory/pull: 400 on limit outside 1..1000", async () => {
+  const app = createApp();
+  const { env, token } = makeEnvWithAggregates([]);
+  const { res } = await fetchApp(app, "/memory/pull?limit=99999", {
+    headers: { "authorization": `Bearer ${token}` },
+  }, env);
+  assert.equal(res.status, 400);
+});

--- a/apps/central-plane/test/router.test.mjs
+++ b/apps/central-plane/test/router.test.mjs
@@ -195,53 +195,9 @@ test("POST /register: token hash is stored, raw token is not", async () => {
   assert.equal(stored.tokenHash.length, 64, "SHA-256 hex is 64 chars");
 });
 
-// ---- /episodic/push ------------------------------------------------------
-
-test("POST /episodic/push: acknowledges a list of hashes", async () => {
-  const app = createApp();
-  const res = await fetchApp(app, "/episodic/push", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ hashes: ["a", "b", "c"] }),
-  });
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.accepted, 3);
-  assert.equal(body.stored, 0);
-});
-
-test("POST /episodic/push: 400 when hashes is missing", async () => {
-  const app = createApp();
-  const res = await fetchApp(app, "/episodic/push", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({}),
-  });
-  assert.equal(res.status, 400);
-});
-
-// ---- /memory/pull --------------------------------------------------------
-
-test("GET /memory/pull: returns empty frequency stub for valid repo", async () => {
-  const app = createApp();
-  const res = await fetchApp(app, "/memory/pull?repo=acme/service");
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.repo, "acme/service");
-  assert.deepEqual(body.frequencies, []);
-});
-
-test("GET /memory/pull: 400 when repo query is missing", async () => {
-  const app = createApp();
-  const res = await fetchApp(app, "/memory/pull");
-  assert.equal(res.status, 400);
-});
-
-test("GET /memory/pull: 400 when repo query is malformed", async () => {
-  const app = createApp();
-  const res = await fetchApp(app, "/memory/pull?repo=no-slash");
-  assert.equal(res.status, 400);
-});
+// ---- /episodic/push + /memory/pull moved to test/memory.test.mjs --------
+// These endpoints now require CONCLAVE_TOKEN auth + real D1 aggregation
+// logic; their tests live alongside the aggregate store fixtures.
 
 // ---- 404 + error handler -------------------------------------------------
 


### PR DESCRIPTION
Third implementation milestone. The 'self-evolve moat' (decision #21 / D4) starts earning — `/episodic/push` and `/memory/pull` are now real, backed by the `episodic_aggregates` D1 table.

## What this unlocks
Every install can push hashed episodic signatures and pull cross-install frequency baselines for retrieval re-rank. **No cleartext content leaves any consumer's runner.** Dupes increment count atomically via `ON CONFLICT DO UPDATE`.

## New
- `src/auth.ts` — bearer-token middleware. SHA-256 + indexed lookup on `token_hash`. 401 on missing/invalid. `ctx.waitUntil` for the non-blocking `last_seen_at` bump.
- `src/db/aggregates.ts` — `upsertAggregate` (INSERT ... ON CONFLICT DO UPDATE count +1) + `listAggregates` (sorted count DESC).
- `/episodic/push` (authed): `{ items: [...] }`, up to 500/req, per-item validation (malformed skipped, not errored), atomic upsert.
- `/memory/pull` (authed): `?kind=&domain=&min_count=&limit=`, all optional and validated.

## Tests
13 new memory subtests: auth (3 variants) × push (happy/dedup/413/400) × pull (ordering/kind+domain filter/min_count/invalid params). Total central-plane: **35/35 subtests, 0 fail**. Full repo **47/47 test tasks**.

## After merge
Run `pnpm run migrate:prod` once — the `episodic_aggregates` table was already in 0001 so no new migration, this PR uses what's there.

## Next milestones
4. Central `@conclave_ai` Telegram bot (CF Worker long-poll)
5. Deploy-status → ReviewContext (D10 a+b)
(+ CLI `conclave sync` wiring to actually call these endpoints from consumer repos — small follow-up once central plane is deployed)