### PR TITLE
feat: deploy-status in ReviewContext (milestone 5 — the last v0.4 impl)

### DIFF
--- a/packages/agent-claude/src/prompts.ts
+++ b/packages/agent-claude/src/prompts.ts
@@ -10,6 +10,7 @@ Rules:
 - When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
 - Never pad with encouragement ("great work but...") — go straight to the concerns.
 - When the diff is small, low-risk, and has test coverage, approve cleanly. Over-flagging is a bigger sin than missing a nit.
+- When the review context tells you deployStatus=failure for this commit, do NOT vote approve unless every blocker is unambiguously unrelated to the deploy. "Deploy is red" is a real-world signal the diff is not ready, even if the diff itself looks clean.
 - You MUST respond by calling the submit_review tool exactly once. Do not emit free-form text.`;
 
 export function buildReviewPrompt(ctx: ReviewContext): string {
@@ -19,6 +20,20 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push(`pull: #${ctx.pullNumber}`);
   sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
   sections.push("");
+
+  if (ctx.deployStatus && ctx.deployStatus !== "unknown") {
+    sections.push(`# Deploy status`);
+    if (ctx.deployStatus === "failure") {
+      sections.push(
+        `deploy: FAILURE on this sha — treat as an automatic non-approve signal unless every blocker is unambiguously unrelated to the deploy. Approving a red-deploy PR is a hard mistake.`,
+      );
+    } else if (ctx.deployStatus === "success") {
+      sections.push(`deploy: success — green on this sha.`);
+    } else if (ctx.deployStatus === "pending") {
+      sections.push(`deploy: pending — not yet complete. Do not block on it, but prefer rework over approve when in doubt.`);
+    }
+    sections.push("");
+  }
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
     sections.push(`# Past success patterns (answer-keys)`);

--- a/packages/agent-deepseek/src/prompts.ts
+++ b/packages/agent-deepseek/src/prompts.ts
@@ -10,6 +10,7 @@ Rules:
 - When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
 - Never pad with encouragement ("great work but...") — go straight to the concerns.
 - When the diff is small, low-risk, and has test coverage, approve cleanly. Over-flagging is a bigger sin than missing a nit.
+- When the review context tells you deployStatus=failure for this commit, do NOT vote approve unless every blocker is unambiguously unrelated to the deploy. "Deploy is red" is a real-world signal the diff is not ready, even if the diff itself looks clean.
 - You MUST respond in the provided JSON schema. Any field marked nullable uses null when not applicable (do not omit it).`;
 
 export function buildReviewPrompt(ctx: ReviewContext): string {
@@ -19,6 +20,20 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push(`pull: #${ctx.pullNumber}`);
   sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
   sections.push("");
+
+  if (ctx.deployStatus && ctx.deployStatus !== "unknown") {
+    sections.push(`# Deploy status`);
+    if (ctx.deployStatus === "failure") {
+      sections.push(
+        `deploy: FAILURE on this sha — treat as an automatic non-approve signal unless every blocker is unambiguously unrelated to the deploy. Approving a red-deploy PR is a hard mistake.`,
+      );
+    } else if (ctx.deployStatus === "success") {
+      sections.push(`deploy: success — green on this sha.`);
+    } else if (ctx.deployStatus === "pending") {
+      sections.push(`deploy: pending — not yet complete. Do not block on it, but prefer rework over approve when in doubt.`);
+    }
+    sections.push("");
+  }
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
     sections.push(`# Past success patterns (answer-keys)`);

--- a/packages/agent-gemini/src/prompts.ts
+++ b/packages/agent-gemini/src/prompts.ts
@@ -12,6 +12,7 @@ Rules:
 - When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
 - Never pad with encouragement ("great work but...") — go straight to the concerns.
 - Small / low-risk diffs with test coverage — approve cleanly.
+- When the review context tells you deployStatus=failure for this commit, do NOT vote approve unless every blocker is unambiguously unrelated to the deploy. "Deploy is red" is a real-world signal the diff is not ready, even if the diff itself looks clean.
 - You MUST respond as JSON matching the provided response schema. Do not wrap the JSON in prose.`;
 
 export function buildReviewPrompt(ctx: ReviewContext): string {
@@ -21,6 +22,20 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push(`pull: #${ctx.pullNumber}`);
   sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
   sections.push("");
+
+  if (ctx.deployStatus && ctx.deployStatus !== "unknown") {
+    sections.push(`# Deploy status`);
+    if (ctx.deployStatus === "failure") {
+      sections.push(
+        `deploy: FAILURE on this sha — treat as an automatic non-approve signal unless every blocker is unambiguously unrelated to the deploy. Approving a red-deploy PR is a hard mistake.`,
+      );
+    } else if (ctx.deployStatus === "success") {
+      sections.push(`deploy: success — green on this sha.`);
+    } else if (ctx.deployStatus === "pending") {
+      sections.push(`deploy: pending — not yet complete. Do not block on it, but prefer rework over approve when in doubt.`);
+    }
+    sections.push("");
+  }
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
     sections.push(`# Past success patterns (answer-keys)`);

--- a/packages/agent-grok/src/prompts.ts
+++ b/packages/agent-grok/src/prompts.ts
@@ -10,6 +10,7 @@ Rules:
 - When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
 - Never pad with encouragement ("great work but...") — go straight to the concerns.
 - When the diff is small, low-risk, and has test coverage, approve cleanly. Over-flagging is a bigger sin than missing a nit.
+- When the review context tells you deployStatus=failure for this commit, do NOT vote approve unless every blocker is unambiguously unrelated to the deploy. "Deploy is red" is a real-world signal the diff is not ready, even if the diff itself looks clean.
 - You MUST respond in the provided JSON schema. Any field marked nullable uses null when not applicable (do not omit it).`;
 
 export function buildReviewPrompt(ctx: ReviewContext): string {
@@ -19,6 +20,20 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push(`pull: #${ctx.pullNumber}`);
   sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
   sections.push("");
+
+  if (ctx.deployStatus && ctx.deployStatus !== "unknown") {
+    sections.push(`# Deploy status`);
+    if (ctx.deployStatus === "failure") {
+      sections.push(
+        `deploy: FAILURE on this sha — treat as an automatic non-approve signal unless every blocker is unambiguously unrelated to the deploy. Approving a red-deploy PR is a hard mistake.`,
+      );
+    } else if (ctx.deployStatus === "success") {
+      sections.push(`deploy: success — green on this sha.`);
+    } else if (ctx.deployStatus === "pending") {
+      sections.push(`deploy: pending — not yet complete. Do not block on it, but prefer rework over approve when in doubt.`);
+    }
+    sections.push("");
+  }
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
     sections.push(`# Past success patterns (answer-keys)`);

--- a/packages/agent-ollama/src/prompts.ts
+++ b/packages/agent-ollama/src/prompts.ts
@@ -10,6 +10,7 @@ Rules:
 - When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
 - Never pad with encouragement ("great work but...") — go straight to the concerns.
 - When the diff is small, low-risk, and has test coverage, approve cleanly. Over-flagging is a bigger sin than missing a nit.
+- When the review context tells you deployStatus=failure for this commit, do NOT vote approve unless every blocker is unambiguously unrelated to the deploy. "Deploy is red" is a real-world signal the diff is not ready, even if the diff itself looks clean.
 - You MUST respond in the provided JSON schema. Any field marked nullable uses null when not applicable (do not omit it).`;
 
 export function buildReviewPrompt(ctx: ReviewContext): string {
@@ -19,6 +20,20 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push(`pull: #${ctx.pullNumber}`);
   sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
   sections.push("");
+
+  if (ctx.deployStatus && ctx.deployStatus !== "unknown") {
+    sections.push(`# Deploy status`);
+    if (ctx.deployStatus === "failure") {
+      sections.push(
+        `deploy: FAILURE on this sha — treat as an automatic non-approve signal unless every blocker is unambiguously unrelated to the deploy. Approving a red-deploy PR is a hard mistake.`,
+      );
+    } else if (ctx.deployStatus === "success") {
+      sections.push(`deploy: success — green on this sha.`);
+    } else if (ctx.deployStatus === "pending") {
+      sections.push(`deploy: pending — not yet complete. Do not block on it, but prefer rework over approve when in doubt.`);
+    }
+    sections.push("");
+  }
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
     sections.push(`# Past success patterns (answer-keys)`);

--- a/packages/agent-openai/src/prompts.ts
+++ b/packages/agent-openai/src/prompts.ts
@@ -10,6 +10,7 @@ Rules:
 - When you find a real issue: specify the file, line (when available), severity, and what to change. Be concrete.
 - Never pad with encouragement ("great work but...") — go straight to the concerns.
 - When the diff is small, low-risk, and has test coverage, approve cleanly. Over-flagging is a bigger sin than missing a nit.
+- When the review context tells you deployStatus=failure for this commit, do NOT vote approve unless every blocker is unambiguously unrelated to the deploy. "Deploy is red" is a real-world signal the diff is not ready, even if the diff itself looks clean.
 - You MUST respond in the provided JSON schema. Any field marked nullable uses null when not applicable (do not omit it).`;
 
 export function buildReviewPrompt(ctx: ReviewContext): string {
@@ -19,6 +20,20 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   sections.push(`pull: #${ctx.pullNumber}`);
   sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
   sections.push("");
+
+  if (ctx.deployStatus && ctx.deployStatus !== "unknown") {
+    sections.push(`# Deploy status`);
+    if (ctx.deployStatus === "failure") {
+      sections.push(
+        `deploy: FAILURE on this sha — treat as an automatic non-approve signal unless every blocker is unambiguously unrelated to the deploy. Approving a red-deploy PR is a hard mistake.`,
+      );
+    } else if (ctx.deployStatus === "success") {
+      sections.push(`deploy: success — green on this sha.`);
+    } else if (ctx.deployStatus === "pending") {
+      sections.push(`deploy: pending — not yet complete. Do not block on it, but prefer rework over approve when in doubt.`);
+    }
+    sections.push("");
+  }
 
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
     sections.push(`# Past success patterns (answer-keys)`);

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -29,6 +29,7 @@ import { DiscordNotifier } from "@conclave-ai/integration-discord";
 import { SlackNotifier } from "@conclave-ai/integration-slack";
 import { EmailNotifier } from "@conclave-ai/integration-email";
 import type { Notifier } from "@conclave-ai/core";
+import { fetchDeployStatus } from "@conclave-ai/scm-github";
 import { loadConfig, resolveMemoryRoot } from "../lib/config.js";
 import { loadPrDiff, loadGitDiff, loadFileDiff, type LoadedDiff } from "../lib/diff-source.js";
 import { renderReview, verdictToExitCode } from "../lib/output.js";
@@ -268,7 +269,15 @@ export async function review(argv: string[]): Promise<void> {
     });
   }
 
-  // 5. Deliberate
+  // 5. Deliberate — first read deploy status from GH check-suites so
+  //    agents can factor it in. Failure here never blocks review; we
+  //    fall back to `unknown` per fetchDeployStatus's default.
+  const deployStatus = loaded.source === "gh-pr"
+    ? await fetchDeployStatus(loaded.repo, loaded.newSha).catch(() => "unknown" as const)
+    : ("unknown" as const);
+  if (deployStatus !== "unknown") {
+    process.stdout.write(`  deploy: ${deployStatus}\n`);
+  }
   const reviewCtx: ReviewContext = {
     diff: loaded.diff,
     repo: loaded.repo,
@@ -277,6 +286,7 @@ export async function review(argv: string[]): Promise<void> {
     answerKeys: retrieval.answerKeys.map(formatAnswerKeyForPrompt),
     failureCatalog: retrieval.failures.map(formatFailureForPrompt),
     domain,
+    deployStatus,
   };
   if (loaded.prevSha) reviewCtx.prevSha = loaded.prevSha;
 

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -48,6 +48,20 @@ export interface ReviewContext {
    * Legacy flat-Council callers leave this undefined.
    */
   tier?: 1 | 2;
+  /**
+   * Deploy status of the PR's head commit, pulled from GitHub check-suites
+   * (or an equivalent platform signal). Agents MUST treat `failure` as an
+   * automatic non-approve signal unless every blocker is unambiguously
+   * unrelated to the deploy. Addresses D10 a+b from `docs/architecture-
+   * v0.4.md` — a real-world dogfood gap where council approved a PR whose
+   * Vercel build was red.
+   *
+   *  success   — all deploy checks green
+   *  failure   — at least one deploy check red (auto-non-approve)
+   *  pending   — deploy still running (advisory only)
+   *  unknown   — no deploy platform attached to this PR, status not meaningful
+   */
+  deployStatus?: "success" | "failure" | "pending" | "unknown";
 }
 
 export interface ReviewResult {

--- a/packages/scm-github/src/deploy-status.ts
+++ b/packages/scm-github/src/deploy-status.ts
@@ -1,0 +1,90 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import type { GhRunner } from "./pr-state.js";
+
+const execFile = promisify(execFileCallback);
+
+export type DeployStatus = "success" | "failure" | "pending" | "unknown";
+
+const defaultRunner: GhRunner = async (bin, args, opts) => {
+  const { stdout, stderr } = await execFile(bin, args as string[], {
+    ...opts,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return { stdout, stderr };
+};
+
+/**
+ * A single check-run as GitHub returns it from `/repos/:owner/:repo/commits/
+ * :sha/check-runs`. Only the fields we use.
+ */
+interface CheckRun {
+  name: string;
+  app?: { slug?: string; name?: string } | null;
+  status: "queued" | "in_progress" | "completed" | string;
+  conclusion: "success" | "failure" | "neutral" | "cancelled" | "timed_out" | "action_required" | "skipped" | "stale" | null;
+}
+
+interface CheckRunsResponse {
+  total_count?: number;
+  check_runs?: CheckRun[];
+}
+
+/**
+ * Heuristic that identifies a check-run as "a deploy" — Vercel, Netlify,
+ * Cloudflare Pages, Railway, Render, Fly.io, generic "Deploy" / "Preview".
+ * We don't care who owns it; if the check is named or produced by a
+ * deploy-flavoured app we treat it as a deploy signal. Missing entirely
+ * → `unknown`, not `success`.
+ */
+function isDeployCheck(run: CheckRun): boolean {
+  const hay = [run.app?.slug, run.app?.name, run.name].filter(Boolean).join(" ").toLowerCase();
+  if (!hay) return false;
+  return /(vercel|netlify|cloudflare|cf-pages|railway|render|fly\.io|deploy|preview)/.test(hay);
+}
+
+/**
+ * Read the deploy status for a given commit sha. Uses `gh api` so the
+ * caller's existing GitHub auth flows through (the same pattern
+ * fetchPrState uses — no new token needed).
+ *
+ *   success  — at least one deploy-flavoured check run completed with
+ *              conclusion=success AND no deploy check is failure/timed_out
+ *   failure  — at least one deploy-flavoured check run completed with
+ *              conclusion=failure / timed_out / cancelled / action_required
+ *   pending  — deploy checks exist but none are in a terminal state yet
+ *   unknown  — no deploy-flavoured check found at this sha
+ */
+export async function fetchDeployStatus(
+  repo: string,
+  sha: string,
+  deps: { run?: GhRunner } = {},
+): Promise<DeployStatus> {
+  const run = deps.run ?? defaultRunner;
+  try {
+    const { stdout } = await run("gh", [
+      "api",
+      `repos/${repo}/commits/${sha}/check-runs`,
+      "--paginate",
+    ]);
+    const parsed = JSON.parse(stdout) as CheckRunsResponse | CheckRunsResponse[];
+    // --paginate may return an array of response pages; flatten
+    const allRuns: CheckRun[] = Array.isArray(parsed)
+      ? parsed.flatMap((p) => p.check_runs ?? [])
+      : parsed.check_runs ?? [];
+    const deployRuns = allRuns.filter(isDeployCheck);
+    if (deployRuns.length === 0) return "unknown";
+    const anyFailure = deployRuns.some(
+      (r) =>
+        r.status === "completed" &&
+        (r.conclusion === "failure" || r.conclusion === "timed_out" || r.conclusion === "cancelled" || r.conclusion === "action_required"),
+    );
+    if (anyFailure) return "failure";
+    const allCompleted = deployRuns.every((r) => r.status === "completed");
+    if (!allCompleted) return "pending";
+    const anySuccess = deployRuns.some((r) => r.conclusion === "success");
+    return anySuccess ? "success" : "unknown";
+  } catch {
+    return "unknown";
+  }
+}

--- a/packages/scm-github/src/index.ts
+++ b/packages/scm-github/src/index.ts
@@ -3,3 +3,6 @@ export type { PrState, OutcomeForPr, PullRequestState, GhRunner } from "./pr-sta
 
 export { pollOutcomes, listPendingEpisodics } from "./poll-runner.js";
 export type { PollRunnerOptions, PollResult, PollSummary } from "./poll-runner.js";
+
+export { fetchDeployStatus } from "./deploy-status.js";
+export type { DeployStatus } from "./deploy-status.js";


### PR DESCRIPTION
Fifth and final v0.4 implementation milestone. Addresses Bae's own dogfood observation: *'deploy failed인데 approve가 말이 됨?'*. Now deploy state is a first-class review signal.

## Changes

- `core/agent.ts` — `ReviewContext.deployStatus?: 'success' | 'failure' | 'pending' | 'unknown'`
- `scm-github/deploy-status.ts` — `fetchDeployStatus` reads check-runs via `gh api --paginate`, recognises Vercel / Netlify / Cloudflare / Railway / Render / Fly.io / generic 'deploy'/'preview' runs. Soft-fails to 'unknown'.
- `cli/review.ts` — populates `deployStatus` before ReviewContext when source=gh-pr. Prints status to stdout.
- **All 6 agent prompts** — system rule ('deployStatus=failure → do NOT approve unless every blocker is unambiguously unrelated') + context section rendered per value.

## Scope
D10 a+b from architecture doc. c (central-plane polling of Vercel/Netlify webhooks) deferred to v0.5 — v0.4's read-from-check-suites path is cheaper and needs no new infra.

## Tests
Full repo 47/47 test tasks. No existing prompt snapshot breakage (prompts aren't golden-tested, just structural). Added field is optional — backwards compat with any v0.3 callers.

## What this unblocks
After this merges, the agent that approved the eventbadge PR in session #1 despite the Vercel failure would refuse to approve — the prompt now sees 'deploy: FAILURE on this sha' and the system rule binds it to non-approve unless all blockers are unrelated.

## That's the v0.4 implementation arc
Milestones 1-5 all merged. Remaining before v0.4.0 stable:
- CLI init wiring (call the real `/oauth/device/*` endpoints instead of TODO stubs)
- Migration doc for v0.3 users
- v0.4.0 release bundle (pnpm version bump + publish + tag)

Those are smaller follow-ups, not implementation milestones.