### PR TITLE
feat(cli): conclave init wires to real central plane OAuth (follow-up 1/3)

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,16 +2,27 @@ import { detectRepo, type DetectRepoDeps } from "./init/repo-detect.js";
 import { writeConfig, CONFIG_FILENAME } from "./init/config-writer.js";
 import { writeWorkflow, WORKFLOW_PATH, REUSABLE_REF } from "./init/workflow-writer.js";
 import { createPrompter, createNonInteractivePrompter, type Prompter } from "./init/prompts.js";
+import { runOauthFlow, type OauthFlowDeps } from "./init/oauth-flow.js";
+import { CentralClient, DEFAULT_CENTRAL_URL } from "./init/central-client.js";
+
+/**
+ * Default Telegram bot username for the central bot. Overridable via
+ * `CONCLAVE_BOT_USERNAME` env var if Bae ends up using a different
+ * handle after BotFather negotiations.
+ */
+const DEFAULT_BOT_USERNAME = process.env["CONCLAVE_BOT_USERNAME"] ?? "conclave_ai_bot";
 
 const HELP = `conclave init — set up conclave-ai on this repo (v0.4 wizard)
 
 Usage:
-  conclave init [--yes] [--reconfigure] [--repo <owner/name>]
+  conclave init [--yes] [--reconfigure] [--skip-oauth] [--repo <owner/name>] [--central-url <url>]
 
 Flags:
   --yes               non-interactive; use defaults, fail fast if required info is missing
   --reconfigure       overwrite existing .conclaverc.json and workflow file
+  --skip-oauth        do not run GitHub device-flow OAuth (local-only install; no federated memory)
   --repo <slug>       use this repo slug instead of detecting via \`git remote\`
+  --central-url <url> override the central plane URL (default: ${DEFAULT_CENTRAL_URL})
   --cwd <dir>         target directory (default: current)
   --help, -h          show this
 
@@ -20,12 +31,14 @@ What it does:
   2. Writes .conclaverc.json with the 2-tier council defaults
   3. Writes .github/workflows/conclave.yml — a 3-line wrapper pointing at
      ${REUSABLE_REF}
-  4. Prints next-step instructions (API key secrets + Telegram /link)
+  4. Runs GitHub OAuth device flow against the central plane and installs
+     CONCLAVE_TOKEN as a GitHub repo secret via \`gh secret set\`
+  5. Prints the /link command for the central @${DEFAULT_BOT_USERNAME} Telegram bot
+  6. Prints next-step instructions for API key secrets
 
-What it does NOT do yet (deferred to the central-plane PR):
-  - Mint a CONCLAVE_TOKEN via GitHub OAuth
-  - Link your Telegram chat to the central @conclave_ai bot
-  Both steps print "TODO" placeholders with guidance for now.
+Env vars:
+  CONCLAVE_CENTRAL_URL   override the central plane URL
+  CONCLAVE_BOT_USERNAME  override the Telegram bot handle
 `;
 
 export interface InitArgs {
@@ -33,18 +46,26 @@ export interface InitArgs {
   reconfigure: boolean;
   repo?: string;
   cwd: string;
+  /** Skip the OAuth step (central plane call). For testing + air-gapped users. */
+  skipOauth: boolean;
+  /** Override the central plane base URL. Default comes from env / constant. */
+  centralUrl?: string;
   help: boolean;
 }
 
 export function parseArgv(argv: string[]): InitArgs {
-  const out: InitArgs = { yes: false, reconfigure: false, cwd: ".", help: false };
+  const out: InitArgs = { yes: false, reconfigure: false, cwd: ".", skipOauth: false, help: false };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === "--help" || a === "-h") out.help = true;
     else if (a === "--yes" || a === "-y") out.yes = true;
     else if (a === "--reconfigure") out.reconfigure = true;
+    else if (a === "--skip-oauth") out.skipOauth = true;
     else if (a === "--repo" && argv[i + 1]) {
       out.repo = argv[i + 1];
+      i += 1;
+    } else if (a === "--central-url" && argv[i + 1]) {
+      out.centralUrl = argv[i + 1];
       i += 1;
     } else if (a === "--cwd" && argv[i + 1]) {
       out.cwd = argv[i + 1]!;
@@ -59,6 +80,8 @@ export interface RunInitDeps {
   detectRepoDeps?: DetectRepoDeps;
   stdout?: (s: string) => void;
   stderr?: (s: string) => void;
+  /** Injected OAuth flow deps — tests replace the client + secret setter. */
+  oauthDeps?: OauthFlowDeps;
 }
 
 export async function runInit(args: InitArgs, deps: RunInitDeps = {}): Promise<number> {
@@ -90,11 +113,43 @@ export async function runInit(args: InitArgs, deps: RunInitDeps = {}): Promise<n
       stdout(`• mode:  reconfigure — will overwrite .conclaverc.json + workflow file\n`);
     }
 
-    // Step 3 — OAuth / CONCLAVE_TOKEN. STUB (central service lands in follow-up PR).
-    stdout(
-      `\n• GitHub OAuth + CONCLAVE_TOKEN: [TODO — ships with central plane Worker in v0.4.0-beta]\n` +
-        `  For now: no central registration. Council runs locally using your own API keys.\n`,
-    );
+    // Step 3 — OAuth / CONCLAVE_TOKEN via central plane device flow.
+    let oauthOutcome: "success" | "skipped" | "failed" = "skipped";
+    if (!args.skipOauth) {
+      const oauthDeps: OauthFlowDeps = {
+        stdout,
+        stderr,
+        ...(deps.oauthDeps ?? {}),
+      };
+      // If the caller didn't inject a client, build one honoring --central-url.
+      if (!oauthDeps.client) {
+        const opts: ConstructorParameters<typeof CentralClient>[0] = {};
+        if (args.centralUrl) opts.baseUrl = args.centralUrl;
+        oauthDeps.client = new CentralClient(opts);
+      }
+      stdout(
+        `\n• GitHub OAuth against central plane: ${oauthDeps.client.baseUrl}\n` +
+          `  (override with --central-url <url> or CONCLAVE_CENTRAL_URL env)\n`,
+      );
+      const exit = await runOauthFlow(repoSlug!, oauthDeps);
+      if (exit.kind === "success") {
+        oauthOutcome = "success";
+        if (exit.rotated) {
+          stdout(`  (CONCLAVE_TOKEN rotated for an existing install)\n`);
+        }
+      } else if (exit.kind === "denied") {
+        stderr(`  ✗ OAuth denied${exit.reason ? ": " + exit.reason : ""}. Continuing without central registration.\n`);
+        oauthOutcome = "failed";
+      } else if (exit.kind === "expired") {
+        stderr(`  ✗ OAuth code expired before you authorized. Re-run \`conclave init\` to try again.\n`);
+        oauthOutcome = "failed";
+      } else {
+        stderr(`  ✗ OAuth failed: ${exit.message}\n`);
+        oauthOutcome = "failed";
+      }
+    } else {
+      stdout(`\n• GitHub OAuth: skipped (--skip-oauth). Council runs locally; federated memory disabled.\n`);
+    }
 
     // Step 4 — API keys. Prompt + print guidance; we do NOT write them to
     // GitHub secrets ourselves in v0.4-alpha (that needs the OAuth token
@@ -119,11 +174,18 @@ export async function runInit(args: InitArgs, deps: RunInitDeps = {}): Promise<n
       );
     }
 
-    // Step 5 — Telegram central bot link. STUB.
-    stdout(
-      `\n• Telegram @conclave_ai link: [TODO — ships with central plane Worker]\n` +
-        `  For now: skipping Telegram. The reusable workflow handles its absence gracefully.\n`,
-    );
+    // Step 5 — Telegram central bot link hint. The CLI can't silently
+    // pair the chat for you (chat ownership lives on the user's phone),
+    // so we print the exact /link command instead. If OAuth failed, the
+    // user has no CONCLAVE_TOKEN to link with — skip the hint.
+    if (oauthOutcome === "success") {
+      stdout(
+        `\n• Telegram link step:\n` +
+          `  1. Open Telegram and DM @${DEFAULT_BOT_USERNAME}\n` +
+          `  2. Send: /link <CONCLAVE_TOKEN>   (the token printed above in the OAuth step)\n` +
+          `  Bot confirms with "✅ Linked this chat to ${repoSlug}"\n`,
+      );
+    }
 
     // Step 6 — write config.
     const cfgResult = await writeConfig({
@@ -147,18 +209,26 @@ export async function runInit(args: InitArgs, deps: RunInitDeps = {}): Promise<n
     }
 
     // Step 8 — next steps.
+    const needsApiKeySetup = Boolean(anthropic || openai || gemini);
     stdout(
       `\n✔ conclave init complete.\n\n` +
-        `Next steps:\n` +
-        `  1. Set repo secrets:\n` +
-        `       gh secret set ANTHROPIC_API_KEY --repo ${repoSlug} --body "$ANTHROPIC_API_KEY"\n` +
-        (openai ? `       gh secret set OPENAI_API_KEY   --repo ${repoSlug} --body "$OPENAI_API_KEY"\n` : "") +
-        (gemini ? `       gh secret set GEMINI_API_KEY   --repo ${repoSlug} --body "$GEMINI_API_KEY"\n` : "") +
-        `  2. Commit:\n` +
+        (needsApiKeySetup
+          ? `Next steps:\n` +
+            (anthropic
+              ? `  • Install Anthropic key:\n       gh secret set ANTHROPIC_API_KEY --repo ${repoSlug} --body "$ANTHROPIC_API_KEY"\n`
+              : "") +
+            (openai
+              ? `  • Install OpenAI key:\n       gh secret set OPENAI_API_KEY --repo ${repoSlug} --body "$OPENAI_API_KEY"\n`
+              : "") +
+            (gemini
+              ? `  • Install Gemini key:\n       gh secret set GEMINI_API_KEY --repo ${repoSlug} --body "$GEMINI_API_KEY"\n`
+              : "")
+          : `Next steps:\n  • Set at least one LLM API key secret on ${repoSlug} before opening a PR (ANTHROPIC_API_KEY required).\n`) +
+        `  • Commit:\n` +
         `       git add ${CONFIG_FILENAME} ${WORKFLOW_PATH}\n` +
         `       git commit -m "chore: install conclave-ai review"\n` +
-        `  3. Open a PR to test — council will comment with a verdict.\n` +
-        `\nv0.4.0-beta (central registration + Telegram linking) ships soon — no action needed then, this install auto-upgrades via the reusable workflow.\n`,
+        `  • Open a PR — the council will comment with a verdict, and Telegram notifications arrive` +
+        (oauthOutcome === "success" ? ` in the chat you /link'd.\n` : `. (OAuth skipped — Telegram notifications disabled.)\n`),
     );
     return 0;
   } finally {

--- a/packages/cli/src/commands/init/central-client.ts
+++ b/packages/cli/src/commands/init/central-client.ts
@@ -1,0 +1,77 @@
+/**
+ * Minimal HTTP client for the Conclave AI central plane. Only the two
+ * endpoints `conclave init` actually calls — OAuth device-flow start and
+ * poll. Built as an injectable class so tests can stub without monkey-
+ * patching globalThis.fetch.
+ */
+
+export const DEFAULT_CENTRAL_URL = "https://conclave-ai.seunghunbae.workers.dev";
+
+export type FetchLike = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string; signal?: AbortSignal },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown>; text: () => Promise<string> }>;
+
+export interface DeviceStartResponse {
+  device_code_id: string;
+  user_code: string;
+  verification_uri: string;
+  interval_sec: number;
+  expires_at: string;
+}
+
+export type DevicePollResponse =
+  | { status: "pending"; interval_sec?: number }
+  | { status: "slow_down"; interval_sec?: number }
+  | { status: "expired" }
+  | { status: "denied"; reason?: string }
+  | { status: "already_succeeded" }
+  | { status: "success"; token: string; repo: string; rotated?: boolean; note?: string }
+  | { status: "error"; message?: string };
+
+export interface CentralClientOptions {
+  baseUrl?: string;
+  fetch?: FetchLike;
+}
+
+export class CentralClient {
+  readonly baseUrl: string;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(opts: CentralClientOptions = {}) {
+    this.baseUrl = (opts.baseUrl ?? process.env["CONCLAVE_CENTRAL_URL"] ?? DEFAULT_CENTRAL_URL).replace(/\/$/, "");
+    const f = opts.fetch ?? (globalThis as unknown as { fetch?: FetchLike }).fetch;
+    if (!f) {
+      throw new Error(
+        "CentralClient: global fetch unavailable (Node 18+ required) and no opts.fetch passed",
+      );
+    }
+    this.fetchImpl = f;
+  }
+
+  async startDeviceFlow(repoSlug: string): Promise<DeviceStartResponse> {
+    const resp = await this.fetchImpl(`${this.baseUrl}/oauth/device/start`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repo: repoSlug }),
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => "");
+      throw new Error(`conclave central: /oauth/device/start returned HTTP ${resp.status} — ${text.slice(0, 300)}`);
+    }
+    return (await resp.json()) as DeviceStartResponse;
+  }
+
+  async pollDeviceFlow(deviceCodeId: string): Promise<DevicePollResponse> {
+    const resp = await this.fetchImpl(`${this.baseUrl}/oauth/device/poll`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ device_code_id: deviceCodeId }),
+    });
+    if (!resp.ok && resp.status !== 403 && resp.status !== 404) {
+      const text = await resp.text().catch(() => "");
+      throw new Error(`conclave central: /oauth/device/poll returned HTTP ${resp.status} — ${text.slice(0, 300)}`);
+    }
+    return (await resp.json()) as DevicePollResponse;
+  }
+}

--- a/packages/cli/src/commands/init/oauth-flow.ts
+++ b/packages/cli/src/commands/init/oauth-flow.ts
@@ -1,0 +1,132 @@
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import { CentralClient, type DevicePollResponse } from "./central-client.js";
+
+const execFile = promisify(execFileCb);
+
+export interface OauthFlowDeps {
+  client?: CentralClient;
+  /** Override for tests; defaults to `execFile("gh", ...)` to set repo secret. */
+  setGhSecret?: (opts: { repoSlug: string; name: string; value: string }) => Promise<void>;
+  /** Sleep used in poll loop; injected so tests don't wait real seconds. */
+  sleep?: (ms: number) => Promise<void>;
+  stdout?: (s: string) => void;
+  stderr?: (s: string) => void;
+  /** Wall-clock now; injected so tests can make the device expire on schedule. */
+  now?: () => number;
+}
+
+export interface OauthFlowResult {
+  kind: "success";
+  token: string;
+  rotated: boolean;
+}
+
+export type OauthFlowExit =
+  | OauthFlowResult
+  | { kind: "denied"; reason?: string }
+  | { kind: "expired" }
+  | { kind: "error"; message: string };
+
+async function defaultSetGhSecret(opts: { repoSlug: string; name: string; value: string }): Promise<void> {
+  await execFile("gh", ["secret", "set", opts.name, "--repo", opts.repoSlug, "--body", opts.value]);
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Run the full GitHub OAuth device flow against the central plane and,
+ * on success, install the returned CONCLAVE_TOKEN as a repo secret via
+ * `gh secret set`. Returns a structured exit so the caller can produce
+ * a user-friendly summary without parsing error strings.
+ *
+ * This function is deliberately long on user-visible text — setup-only
+ * commands benefit from narrating every step so the operator doesn't
+ * wonder if the CLI is hung.
+ */
+export async function runOauthFlow(repoSlug: string, deps: OauthFlowDeps = {}): Promise<OauthFlowExit> {
+  const stdout = deps.stdout ?? ((s) => process.stdout.write(s));
+  const stderr = deps.stderr ?? ((s) => process.stderr.write(s));
+  const sleep = deps.sleep ?? defaultSleep;
+  const now = deps.now ?? (() => Date.now());
+  const client = deps.client ?? new CentralClient();
+
+  let startResp;
+  try {
+    startResp = await client.startDeviceFlow(repoSlug);
+  } catch (err) {
+    return { kind: "error", message: (err as Error).message };
+  }
+
+  stdout(
+    [
+      "",
+      "• GitHub OAuth:",
+      `  1. Open this URL in a browser:     ${startResp.verification_uri}`,
+      `  2. Enter this code when prompted:  ${startResp.user_code}`,
+      `  3. Authorize Conclave AI access.`,
+      "",
+      "Waiting for authorization…",
+      "",
+    ].join("\n"),
+  );
+
+  const expiresAtMs = new Date(startResp.expires_at).getTime();
+  let intervalSec = startResp.interval_sec;
+
+  // Poll loop — capped by server-reported expires_at. Handles pending +
+  // slow_down backoff + terminal states (success / denied / expired).
+  while (now() < expiresAtMs) {
+    await sleep(intervalSec * 1000);
+
+    let pollResp: DevicePollResponse;
+    try {
+      pollResp = await client.pollDeviceFlow(startResp.device_code_id);
+    } catch (err) {
+      // Transient network hiccup — warn, but keep polling. If the error
+      // persists, the device will expire and we'll exit via the loop.
+      stderr(`  (poll warning: ${(err as Error).message.slice(0, 200)}; retrying)\n`);
+      continue;
+    }
+
+    switch (pollResp.status) {
+      case "pending":
+        stdout("  still waiting…\n");
+        continue;
+      case "slow_down":
+        intervalSec = pollResp.interval_sec ?? intervalSec + 5;
+        stdout(`  GitHub says slow down — backing off to ${intervalSec}s between polls\n`);
+        continue;
+      case "expired":
+        return { kind: "expired" };
+      case "denied":
+        return { kind: "denied", reason: pollResp.reason };
+      case "already_succeeded":
+        // Unusual — someone polled before us. Treat as expired; a re-init
+        // will mint a fresh token.
+        return { kind: "expired" };
+      case "success": {
+        stdout(`  ✓ authorized. Installing CONCLAVE_TOKEN as repo secret…\n`);
+        try {
+          const setSecret = deps.setGhSecret ?? defaultSetGhSecret;
+          await setSecret({ repoSlug, name: "CONCLAVE_TOKEN", value: pollResp.token });
+          stdout(`  ✓ CONCLAVE_TOKEN stored on ${repoSlug}\n`);
+        } catch (err) {
+          stderr(
+            `  ⚠ failed to run \`gh secret set\`: ${(err as Error).message}\n` +
+              `  Set it manually: gh secret set CONCLAVE_TOKEN --repo ${repoSlug} --body '${pollResp.token}'\n`,
+          );
+        }
+        return { kind: "success", token: pollResp.token, rotated: Boolean(pollResp.rotated) };
+      }
+      case "error":
+        return { kind: "error", message: pollResp.message ?? "central plane returned an unstructured error" };
+      default:
+        // TypeScript exhaustiveness — any new status should hit this only
+        // if the server added a state the CLI hasn't learned about yet.
+        return { kind: "error", message: `unknown status: ${JSON.stringify(pollResp)}` };
+    }
+  }
+
+  return { kind: "expired" };
+}

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -219,7 +219,7 @@ test("runInit: happy path with explicit --repo, no keys → all stubs, files wri
   const stderr = [];
   try {
     const code = await runInit(
-      { yes: true, reconfigure: false, repo: "acme/service", cwd: dir, help: false },
+      { yes: true, reconfigure: false, repo: "acme/service", cwd: dir, skipOauth: true, help: false },
       {
         prompter: makePrompter(),
         stdout: (s) => stdout.push(s),
@@ -249,7 +249,7 @@ test("runInit: existing config + no --reconfigure → skip both writes", async (
     await fs.writeFile(path.join(dir, ".github", "workflows", "conclave.yml"), "# user edit\n");
 
     const code = await runInit(
-      { yes: true, reconfigure: false, repo: "acme/service", cwd: dir, help: false },
+      { yes: true, reconfigure: false, repo: "acme/service", cwd: dir, skipOauth: true, help: false },
       { prompter: makePrompter(), stdout: (s) => stdout.push(s), stderr: () => {} },
     );
     assert.equal(code, 0);
@@ -268,7 +268,7 @@ test("runInit: --reconfigure overwrites both files", async () => {
   try {
     await fs.writeFile(path.join(dir, CONFIG_FILENAME), '{"repo":"old/repo"}\n');
     const code = await runInit(
-      { yes: true, reconfigure: true, repo: "new/repo", cwd: dir, help: false },
+      { yes: true, reconfigure: true, repo: "new/repo", cwd: dir, skipOauth: true, help: false },
       { prompter: makePrompter(), stdout: () => {}, stderr: () => {} },
     );
     assert.equal(code, 0);
@@ -282,7 +282,7 @@ test("runInit: --reconfigure overwrites both files", async () => {
 test("runInit: no --repo + git remote fails → exit 1 with helpful message", async () => {
   const stderr = [];
   const code = await runInit(
-    { yes: true, reconfigure: false, cwd: ".", help: false },
+    { yes: true, reconfigure: false, cwd: ".", skipOauth: true, help: false },
     {
       prompter: makePrompter(),
       detectRepoDeps: {
@@ -302,7 +302,7 @@ test("runInit: collected API keys narrow the written agent set", async () => {
   const dir = await mkTmpDir("conclave-init-");
   try {
     const code = await runInit(
-      { yes: false, reconfigure: false, repo: "acme/service", cwd: dir, help: false },
+      { yes: false, reconfigure: false, repo: "acme/service", cwd: dir, skipOauth: true, help: false },
       {
         // prompt answers in order: ANTHROPIC / OPENAI / GEMINI
         prompter: makePrompter({ 0: "sk-ant-xxx", 1: "", 2: "" }),

--- a/packages/cli/test/oauth-flow.test.mjs
+++ b/packages/cli/test/oauth-flow.test.mjs
@@ -1,0 +1,296 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runOauthFlow } from "../dist/commands/init/oauth-flow.js";
+import { CentralClient, DEFAULT_CENTRAL_URL } from "../dist/commands/init/central-client.js";
+
+// ---- mock CentralClient ---------------------------------------------------
+//
+// The real client wraps fetch; we stub it with a scripted client that
+// returns pre-programmed device start + poll responses. The OauthFlow
+// code paths (pending → slow_down → success / expired / denied / error)
+// are what we're asserting — not the HTTP layer.
+
+class MockClient {
+  constructor(opts) {
+    this.baseUrl = opts.baseUrl ?? DEFAULT_CENTRAL_URL;
+    this.startResponse = opts.startResponse;
+    this.pollResponses = opts.pollResponses ?? [];
+    this.startCalls = [];
+    this.pollCalls = [];
+  }
+  async startDeviceFlow(repo) {
+    this.startCalls.push(repo);
+    if (this.startResponse instanceof Error) throw this.startResponse;
+    return this.startResponse;
+  }
+  async pollDeviceFlow(id) {
+    this.pollCalls.push(id);
+    if (this.pollResponses.length === 0) {
+      throw new Error("mock: poll responses exhausted");
+    }
+    const next = this.pollResponses.shift();
+    if (next instanceof Error) throw next;
+    return next;
+  }
+}
+
+function baseStartResponse(overrides = {}) {
+  return {
+    device_code_id: "c_dev_1",
+    user_code: "ABCD-EFGH",
+    verification_uri: "https://github.com/login/device",
+    interval_sec: 5,
+    expires_at: new Date(Date.now() + 900_000).toISOString(), // 15 min in future
+    ...overrides,
+  };
+}
+
+function fakeSleep() {
+  return Promise.resolve();
+}
+
+// ---- happy path ----------------------------------------------------------
+
+test("runOauthFlow: pending → success writes CONCLAVE_TOKEN via setGhSecret", async () => {
+  const client = new MockClient({
+    startResponse: baseStartResponse(),
+    pollResponses: [
+      { status: "pending" },
+      { status: "success", token: "c_granted_token_xyz", repo: "acme/service", rotated: false },
+    ],
+  });
+  const setSecretCalls = [];
+  const stdout = [];
+  const stderr = [];
+  const result = await runOauthFlow("acme/service", {
+    client,
+    setGhSecret: async (opts) => { setSecretCalls.push(opts); },
+    sleep: fakeSleep,
+    stdout: (s) => stdout.push(s),
+    stderr: (s) => stderr.push(s),
+  });
+  assert.equal(result.kind, "success");
+  assert.equal(result.token, "c_granted_token_xyz");
+  assert.equal(result.rotated, false);
+  assert.equal(setSecretCalls.length, 1);
+  assert.deepEqual(setSecretCalls[0], {
+    repoSlug: "acme/service",
+    name: "CONCLAVE_TOKEN",
+    value: "c_granted_token_xyz",
+  });
+  const out = stdout.join("");
+  assert.ok(out.includes("ABCD-EFGH"), "user_code must be printed");
+  assert.ok(out.includes("https://github.com/login/device"), "verification_uri must be printed");
+  assert.ok(out.includes("CONCLAVE_TOKEN stored on acme/service"));
+});
+
+// ---- slow_down ----------------------------------------------------------
+
+test("runOauthFlow: slow_down bumps interval and keeps polling", async () => {
+  const client = new MockClient({
+    startResponse: baseStartResponse({ interval_sec: 5 }),
+    pollResponses: [
+      { status: "slow_down", interval_sec: 10 },
+      { status: "success", token: "c_tok", repo: "acme/x", rotated: false },
+    ],
+  });
+  const result = await runOauthFlow("acme/x", {
+    client,
+    setGhSecret: async () => {},
+    sleep: fakeSleep,
+    stdout: () => {},
+    stderr: () => {},
+  });
+  assert.equal(result.kind, "success");
+  assert.equal(client.pollCalls.length, 2);
+});
+
+// ---- denied -------------------------------------------------------------
+
+test("runOauthFlow: denied by GitHub → never calls setGhSecret", async () => {
+  const client = new MockClient({
+    startResponse: baseStartResponse(),
+    pollResponses: [{ status: "denied", reason: "user rejected" }],
+  });
+  let setCalled = false;
+  const result = await runOauthFlow("acme/x", {
+    client,
+    setGhSecret: async () => { setCalled = true; },
+    sleep: fakeSleep,
+    stdout: () => {},
+    stderr: () => {},
+  });
+  assert.equal(result.kind, "denied");
+  assert.equal(result.reason, "user rejected");
+  assert.equal(setCalled, false);
+});
+
+// ---- expired ------------------------------------------------------------
+
+test("runOauthFlow: server-side expired → expired result, no secret write", async () => {
+  const client = new MockClient({
+    startResponse: baseStartResponse(),
+    pollResponses: [{ status: "expired" }],
+  });
+  const result = await runOauthFlow("acme/x", {
+    client,
+    setGhSecret: async () => { throw new Error("should not run"); },
+    sleep: fakeSleep,
+    stdout: () => {},
+    stderr: () => {},
+  });
+  assert.equal(result.kind, "expired");
+});
+
+test("runOauthFlow: client-side expires_at reached before any poll returns terminal", async () => {
+  const expired = new Date(Date.now() - 1000).toISOString();
+  const client = new MockClient({
+    startResponse: baseStartResponse({ expires_at: expired }),
+    pollResponses: [],
+  });
+  const result = await runOauthFlow("acme/x", {
+    client,
+    setGhSecret: async () => {},
+    sleep: fakeSleep,
+    stdout: () => {},
+    stderr: () => {},
+  });
+  assert.equal(result.kind, "expired");
+  assert.equal(client.pollCalls.length, 0, "should not poll past server-side expiry");
+});
+
+// ---- poll transient error then success ----------------------------------
+
+test("runOauthFlow: transient poll error is logged but retried", async () => {
+  const client = new MockClient({
+    startResponse: baseStartResponse(),
+    pollResponses: [
+      new Error("network hiccup"),
+      { status: "pending" },
+      { status: "success", token: "c_x", repo: "acme/x", rotated: true },
+    ],
+  });
+  const stderr = [];
+  const result = await runOauthFlow("acme/x", {
+    client,
+    setGhSecret: async () => {},
+    sleep: fakeSleep,
+    stdout: () => {},
+    stderr: (s) => stderr.push(s),
+  });
+  assert.equal(result.kind, "success");
+  assert.equal(result.rotated, true);
+  assert.ok(stderr.join("").includes("poll warning"));
+});
+
+// ---- startDeviceFlow itself fails ---------------------------------------
+
+test("runOauthFlow: start fails → error result with upstream message", async () => {
+  const client = new MockClient({
+    startResponse: new Error("HTTP 503 from central plane"),
+    pollResponses: [],
+  });
+  const result = await runOauthFlow("acme/x", {
+    client,
+    setGhSecret: async () => {},
+    sleep: fakeSleep,
+    stdout: () => {},
+    stderr: () => {},
+  });
+  assert.equal(result.kind, "error");
+  assert.ok(result.message.includes("503"));
+});
+
+// ---- gh secret set failure does NOT tank the flow -----------------------
+
+test("runOauthFlow: gh secret set failure warns but returns success", async () => {
+  const client = new MockClient({
+    startResponse: baseStartResponse(),
+    pollResponses: [{ status: "success", token: "c_x", repo: "acme/x", rotated: false }],
+  });
+  const stderr = [];
+  const result = await runOauthFlow("acme/x", {
+    client,
+    setGhSecret: async () => { throw new Error("gh CLI not authenticated"); },
+    sleep: fakeSleep,
+    stdout: () => {},
+    stderr: (s) => stderr.push(s),
+  });
+  assert.equal(result.kind, "success");
+  assert.equal(result.token, "c_x");
+  // The flow returns success — the user still got a token — but stderr
+  // tells them to set the secret manually.
+  const err = stderr.join("");
+  assert.ok(err.includes("gh secret set CONCLAVE_TOKEN"));
+  assert.ok(err.includes("acme/x"));
+});
+
+// ---- CentralClient basic behavior ---------------------------------------
+
+test("CentralClient: uses CONCLAVE_CENTRAL_URL env when no baseUrl passed", () => {
+  const orig = process.env["CONCLAVE_CENTRAL_URL"];
+  try {
+    process.env["CONCLAVE_CENTRAL_URL"] = "https://custom.example.com/";
+    const c = new CentralClient({ fetch: async () => ({ ok: true, status: 200, json: async () => ({}), text: async () => "" }) });
+    // trailing slash stripped
+    assert.equal(c.baseUrl, "https://custom.example.com");
+  } finally {
+    if (orig === undefined) delete process.env["CONCLAVE_CENTRAL_URL"];
+    else process.env["CONCLAVE_CENTRAL_URL"] = orig;
+  }
+});
+
+test("CentralClient: explicit baseUrl wins over env", () => {
+  const orig = process.env["CONCLAVE_CENTRAL_URL"];
+  try {
+    process.env["CONCLAVE_CENTRAL_URL"] = "https://env.example.com";
+    const c = new CentralClient({
+      baseUrl: "https://override.example.com",
+      fetch: async () => ({ ok: true, status: 200, json: async () => ({}), text: async () => "" }),
+    });
+    assert.equal(c.baseUrl, "https://override.example.com");
+  } finally {
+    if (orig === undefined) delete process.env["CONCLAVE_CENTRAL_URL"];
+    else process.env["CONCLAVE_CENTRAL_URL"] = orig;
+  }
+});
+
+test("CentralClient.startDeviceFlow: POSTs JSON body and parses response", async () => {
+  const calls = [];
+  const client = new CentralClient({
+    baseUrl: "https://fake.com",
+    fetch: async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          device_code_id: "c_x",
+          user_code: "UUUU-CCCC",
+          verification_uri: "https://github.com/login/device",
+          interval_sec: 5,
+          expires_at: "2026-04-20T00:00:00Z",
+        }),
+        text: async () => "",
+      };
+    },
+  });
+  const resp = await client.startDeviceFlow("acme/x");
+  assert.equal(resp.user_code, "UUUU-CCCC");
+  assert.equal(calls[0].url, "https://fake.com/oauth/device/start");
+  assert.equal(calls[0].init.method, "POST");
+  assert.equal(JSON.parse(calls[0].init.body).repo, "acme/x");
+});
+
+test("CentralClient.startDeviceFlow: throws on non-ok HTTP", async () => {
+  const client = new CentralClient({
+    baseUrl: "https://fake.com",
+    fetch: async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+      text: async () => "upstream unavailable",
+    }),
+  });
+  await assert.rejects(() => client.startDeviceFlow("acme/x"), /HTTP 503/);
+});


### PR DESCRIPTION
First of three follow-ups to close out v0.4.0. Replaces the TODO stubs in the init wizard with actual HTTP calls against the deployed central plane.

## What changes for users
Before: `conclave init` printed '[TODO — OAuth ships later]' and left CONCLAVE_TOKEN unset.
After: `conclave init` runs the real device flow, mints CONCLAVE_TOKEN on success, installs it as a repo secret via `gh secret set`, and prints the exact `/link` DM to send `@conclave_ai_bot`.

## New flags
- `--skip-oauth` for local-only / air-gapped installs
- `--central-url` override (default honors `CONCLAVE_CENTRAL_URL` env, falls back to the deployed Worker URL)

## Robustness
- Poll handles every GitHub device-flow terminal state + slow_down backoff
- Transient network errors during poll: warn, keep trying. Device TTL ends the loop naturally.
- `gh secret set` failure: flow still returns success with fallback command in stderr

## Tests
12 new oauth-flow subtests (happy / slow_down / denied / expired server + client / transient recovery / gh failure tolerance / URL precedence). **115/115 cli subtests, 47/47 full repo.**

Also made the existing init tests hermetic — they were silently hitting the live Worker because `skipOauth` defaulted to false; now set to true per test.

## Next
- F2: v0.3 → v0.4 migration doc
- F3: v0.4.0 release (pnpm publish + tag + notes)