### PR TITLE
chore(release): v0.4.0 — central control plane (follow-up 3/3)

### DIFF
--- a/apps/central-plane/package.json
+++ b/apps/central-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/central-plane",
-  "version": "0.4.0-alpha.1",
+  "version": "0.4.0",
   "private": true,
   "description": "Conclave AI central control plane — Cloudflare Worker + D1 backing the v0.4 install model.",
   "license": "MIT",

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,66 @@
+# Conclave AI v0.4.0
+
+Release date: 2026-04-20
+
+The **Central Control Plane** release. v0.4 collapses the v0.3 per-repo distributed install (4 workflow files + 5 secrets + self-hosted Telegram bot per repo + isolated local memory) into a single `conclave init` command backed by a Cloudflare Worker + D1 + OAuth + a central `@conclave_ai_bot`.
+
+## Highlights
+
+- **`conclave init` wizard** — one command registers a repo via GitHub OAuth device flow, writes `.conclaverc.json` + a 3-line wrapper workflow, installs `CONCLAVE_TOKEN` as a repo secret, and prints the exact Telegram `/link` command.
+- **Reusable workflow** — consumer repos point at `conclave-ai/conclave-ai/.github/workflows/review.yml@v0.4`. Pipeline updates ship to every install the next time their PR CI fires.
+- **Central control plane** (`apps/central-plane`) — Cloudflare Worker on Hono + D1 (SQLite). Endpoints: `/health`, `/register`, `/oauth/device/*`, `/episodic/push`, `/memory/pull`, `/telegram/webhook`.
+- **Federated memory** — every install pushes hashed episodic signatures to a shared pool; every review pulls cross-install frequency baselines to re-rank retrieval. Hashes only by default (decision #21 / D4); full-content sharing is opt-in per repo.
+- **One `@conclave_ai` Telegram bot** — no more BotFather per repo. DM `/link <token>` once, 🔧/✅/❌ button clicks dispatch real actions via the user's OAuth-granted GitHub token.
+- **Deploy-status in ReviewContext** — `conclave review` reads Vercel / Netlify / Cloudflare / Railway / Render / Fly.io check-runs on the PR's head sha and injects the status into agent prompts. All six agent prompts bind `deployStatus=failure` to auto-non-approve unless blockers are unambiguously unrelated.
+- **16 new ERR entries** in the seeded failure-catalog including dogfood-derived patterns (`git apply --recount`, `workspace:* in published tarballs`, `pathspec mismatch after apply`).
+
+## Breaking changes (v0.3 → v0.4)
+
+See [`docs/migrate-to-v0.4.md`](../migrate-to-v0.4.md) for the full walkthrough.
+
+- Delete the 4 workflow files v0.3 installed (`conclave-review.yml`, `conclave-rework.yml`, `conclave-merge.yml`, `conclave-reject.yml`, `conclave-telegram-bot.yml`). `conclave init` writes a single `conclave.yml` wrapper in their place.
+- Repo secrets: drop `ORCHESTRATOR_PAT`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`. Keep your LLM keys. Add nothing — `CONCLAVE_TOKEN` gets installed automatically by the wizard.
+- Local `.conclave/` directory: no longer consulted at review time. Federated pool replaces it. Archive if you want; nothing reads it.
+- No automatic `conclave migrate` CLI. Re-running `conclave init` does the work.
+
+## Architecture + decision record
+
+- [`docs/architecture-v0.4.md`](../architecture-v0.4.md) — the 12 decisions (D1–D12) locked in the v0.4 design review, including Telegram cost math + v0.5 transition triggers.
+
+## New / changed packages
+
+| Package | v0.3 → v0.4 change |
+|---------|-------------------|
+| `@conclave-ai/cli` | Rewrote `conclave init` as the device-flow wizard; added `--skip-oauth`, `--central-url`, `--reconfigure` flags. `conclave review` now populates `ReviewContext.deployStatus`. |
+| `@conclave-ai/core` | `ReviewContext.deployStatus?: 'success' \| 'failure' \| 'pending' \| 'unknown'` |
+| `@conclave-ai/scm-github` | New `fetchDeployStatus(repo, sha)` reading GH check-runs with deploy-flavoured filtering. |
+| `@conclave-ai/agent-{claude,openai,gemini,grok,deepseek,ollama}` | System prompts: `deployStatus=failure` blocks auto-approve. Prompt builders inject a `# Deploy status` section. |
+| `@conclave-ai/secret-guard` | 3 new rules from 2026-04-20 dogfood (ERR-016..018). |
+| **New: `@conclave-ai/central-plane`** | Cloudflare Worker on Hono + D1. Not published to npm — private ops-only app. |
+
+## Published npm versions
+
+All workspace packages at `0.4.0`. `@conclave-ai/central-plane` is marked `"private": true` and not published. Breaking changes merit a 0.x.0 bump under [semver 0.x cadence](https://semver.org/#spec-item-4).
+
+## Upgrade command
+
+For consumer repos:
+
+```powershell
+# 1. Follow docs/migrate-to-v0.4.md steps 1-3 (delete old files + secrets + .conclave/)
+# 2. then:
+npm install -g @conclave-ai/cli@latest
+conclave init
+```
+
+## Deferrals (v0.5+)
+
+- Dashboard web UI
+- LLM proxy / paid subscription tier
+- Self-hosted enterprise control plane
+- i18n (Telegram button labels etc. — see `feedback_conclave_ux_i18n.md`)
+- Nightly memory classification scheduler
+- Central plane polling of Vercel/Netlify webhooks (D10c)
+- `conclave migrate` CLI (D9)
+- Field-level encryption of GitHub access tokens in D1 (plaintext in 0.4-alpha storage, per migration 0003 comment)
+- Design-specialist agent — Claude Design (Anthropic Labs, 2026-04-17) is UI-only / no API, so the v0.5 approach is Claude vision + before/after screenshot diffs on CSS/component PRs. The `@conclave-ai/visual-review` package already has the rendering + diff infrastructure.

--- a/packages/agent-claude/package.json
+++ b/packages/agent-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-claude",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Claude agent — wraps @anthropic-ai/claude-agent-sdk.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-deepseek/package.json
+++ b/packages/agent-deepseek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-deepseek",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Deepseek agent — OpenAI-wire-compatible, routes to api.deepseek.com with strict-JSON-schema structured output.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-gemini/package.json
+++ b/packages/agent-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-gemini",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Gemini agent — wraps @google/genai with responseSchema structured output. Long-context slot per decision #10.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-grok/package.json
+++ b/packages/agent-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-grok",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Grok agent — OpenAI-wire-compatible, routes to xAI's api.x.ai/v1 with strict-JSON-schema structured output.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-ollama/package.json
+++ b/packages/agent-ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-ollama",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Ollama agent — local inference via Ollama's OpenAI-compatible endpoint. Zero cost, zero API key.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-openai/package.json
+++ b/packages/agent-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-openai",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI OpenAI agent — wraps the OpenAI SDK with strict-JSON-schema structured output.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-worker",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Conclave AI Worker agent — turns Council blockers into a unified-diff patch ready to commit back to the PR branch.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI core — Agent interface, council orchestration, self-evolve substrate, efficiency gate.",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-discord/package.json
+++ b/packages/integration-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-discord",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Discord notifier — posts review outcomes to a Discord channel via incoming webhook.",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-email/package.json
+++ b/packages/integration-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-email",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI email notifier — pluggable transport (Resend default; SMTP/SES/nodemailer drop-ins).",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-slack/package.json
+++ b/packages/integration-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-slack",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Slack notifier — posts review outcomes to a Slack channel via incoming webhook.",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-telegram/package.json
+++ b/packages/integration-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-telegram",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Telegram notifier — posts review outcomes to a Telegram chat via Bot API.",
   "license": "MIT",
   "type": "module",

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/observability-langfuse",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI observability sink — forwards efficiency-gate metrics to Langfuse (self-hosted per decision #13).",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-cloudflare",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Cloudflare Pages adapter — resolve preview URL for a commit SHA via Cloudflare API.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-deployment-status/package.json
+++ b/packages/platform-deployment-status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-deployment-status",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI generic platform adapter — resolves preview URL via GitHub Deployments API, works with any host that reports back.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-netlify/package.json
+++ b/packages/platform-netlify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-netlify",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Netlify adapter — resolve preview URL for a commit SHA via Netlify API.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-railway/package.json
+++ b/packages/platform-railway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-railway",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Railway adapter — resolve preview URL for a commit SHA via Railway's GraphQL API.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-render/package.json
+++ b/packages/platform-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-render",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Render adapter — resolve deploy URL for a commit SHA via Render's REST API.",
   "license": "MIT",
   "type": "module",

--- a/packages/platform-vercel/package.json
+++ b/packages/platform-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/platform-vercel",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI Vercel adapter — resolve preview URL for a commit SHA via Vercel REST API.",
   "license": "MIT",
   "type": "module",

--- a/packages/scm-github/package.json
+++ b/packages/scm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/scm-github",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI SCM adapter for GitHub — resolve PR state for automatic outcome capture.",
   "license": "MIT",
   "type": "module",

--- a/packages/secret-guard/package.json
+++ b/packages/secret-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/secret-guard",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI secret-guard — scans patches + file content for API keys, tokens, and private keys before the worker commits them.",
   "license": "MIT",
   "type": "module",

--- a/packages/telegram-bot-runner/package.json
+++ b/packages/telegram-bot-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/telegram-bot-runner",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Conclave AI Telegram bot-runner — long-polls Telegram callback_query events and dispatches repository_dispatch actions back to the target repo's GH Actions workflows.",
   "license": "MIT",
   "type": "module",

--- a/packages/visual-review/package.json
+++ b/packages/visual-review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/visual-review",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Conclave AI visual review — Playwright screenshots + pixel diff for before/after design review.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
All 24 workspace packages + central-plane bumped from 0.3.x → 0.4.0. v0.4 is a breaking minor (per D9) — the install pattern fundamentally changed.

[docs/releases/v0.4.0.md](./docs/releases/v0.4.0.md) = the full release notes.

## After merge — Bae publishes

```powershell
cd C:\Users\ADMIN\Desktop\Desktop\Cowork_Outputs_Organized\기타_Misc\ai-conclave
git checkout main; git pull
pnpm install; pnpm build

# ⚠⚠⚠ pnpm publish, NOT npm publish (ERR-017 from session #1) ⚠⚠⚠
pnpm -r publish --access public --no-git-checks

# Tag the release + re-point the floating major
git tag v0.4.0
git push origin v0.4.0
git tag -f v0.4 main
git push -f origin v0.4
```

`apps/central-plane` is marked private: true so pnpm skips it on publish.

## Test plan
- [x] All 24 package.jsons on 0.4.0
- [x] pnpm build — 25/25 tasks (included fresh install of version change)
- [x] pnpm test — 47/47 tasks green
- [ ] After publish: `npm view @conclave-ai/cli version` returns 0.4.0
- [ ] `conclave init` in a throwaway repo installs 0.4.0, runs OAuth against the live central plane

Closes the v0.4 arc. What's left is runtime validation (Bae already ran migrate:prod + ship + OAuth App + bot setup earlier today, so the central plane is already accepting traffic).