### PR TITLE
chore(cli): capitalize bot username to @Conclave_ai_bot

### DIFF
--- a/docs/migrate-to-v0.4.md
+++ b/docs/migrate-to-v0.4.md
@@ -40,7 +40,7 @@ v0.4 needs exactly one conclave-owned secret on your repo: `CONCLAVE_TOKEN`. The
 
 **Drop if present:**
 - `ORCHESTRATOR_PAT` — v0.4's central bot fires dispatches server-side using the GitHub token captured during OAuth
-- `TELEGRAM_BOT_TOKEN` — v0.4 uses a single central bot (`@conclave_ai_bot`); you no longer run your own
+- `TELEGRAM_BOT_TOKEN` — v0.4 uses a single central bot (`@Conclave_ai_bot`); you no longer run your own
 - `TELEGRAM_CHAT_ID` — same reason
 
 ```powershell
@@ -83,7 +83,7 @@ The wizard will:
 
 ## Step 5 — Link your Telegram chat
 
-Open Telegram, DM `@conclave_ai_bot`, send:
+Open Telegram, DM `@Conclave_ai_bot`, send:
 
 ```
 /link <the token printed at the end of step 4>
@@ -111,7 +111,7 @@ Open any PR against the default branch. Within ~2 minutes:
 | Surface | v0.3 | v0.4 |
 |---------|------|------|
 | Install steps | ~28 (4 YAMLs + 5 secrets + bot registration + tokens) | 4 prompts via `conclave init` |
-| Telegram bot | Per-repo, user creates via BotFather | One central `@conclave_ai_bot` |
+| Telegram bot | Per-repo, user creates via BotFather | One central `@Conclave_ai_bot` |
 | Memory | Each repo's own `.conclave/` JSON | Federated pool on the central plane (hashes only by default; full content opt-in per D4) |
 | Workflow files | Copy 4 to each repo | One 3-line wrapper |
 | Repo secrets owned by conclave | ORCHESTRATOR_PAT + TELEGRAM_* | `CONCLAVE_TOKEN` |
@@ -143,6 +143,6 @@ The v0.3 workflow templates are frozen at tag `v0.3.3` and will remain installab
 
 **`gh secret set` fails** — either `gh` isn't installed or isn't authenticated for this repo. Install, run `gh auth login`, then re-run `conclave init --reconfigure`.
 
-**Telegram bot doesn't reply to `/link`** — the bot is at `@conclave_ai_bot`. Double-check the handle; if your DM gets no reply within 10 seconds, the central plane's webhook might be down — ping the conclave-ai repo issues.
+**Telegram bot doesn't reply to `/link`** — the bot is at `@Conclave_ai_bot`. Double-check the handle; if your DM gets no reply within 10 seconds, the central plane's webhook might be down — ping the conclave-ai repo issues.
 
 **Review doesn't fire on PR** — confirm `.github/workflows/conclave.yml` exists on the PR's base branch (not just the PR itself). Reusable workflows only dispatch when the call-side workflow is on the default branch.

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -2,7 +2,7 @@
 
 Release date: 2026-04-20
 
-The **Central Control Plane** release. v0.4 collapses the v0.3 per-repo distributed install (4 workflow files + 5 secrets + self-hosted Telegram bot per repo + isolated local memory) into a single `conclave init` command backed by a Cloudflare Worker + D1 + OAuth + a central `@conclave_ai_bot`.
+The **Central Control Plane** release. v0.4 collapses the v0.3 per-repo distributed install (4 workflow files + 5 secrets + self-hosted Telegram bot per repo + isolated local memory) into a single `conclave init` command backed by a Cloudflare Worker + D1 + OAuth + a central `@Conclave_ai_bot`.
 
 ## Highlights
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -10,7 +10,7 @@ import { CentralClient, DEFAULT_CENTRAL_URL } from "./init/central-client.js";
  * `CONCLAVE_BOT_USERNAME` env var if Bae ends up using a different
  * handle after BotFather negotiations.
  */
-const DEFAULT_BOT_USERNAME = process.env["CONCLAVE_BOT_USERNAME"] ?? "conclave_ai_bot";
+const DEFAULT_BOT_USERNAME = process.env["CONCLAVE_BOT_USERNAME"] ?? "Conclave_ai_bot";
 
 const HELP = `conclave init — set up conclave-ai on this repo (v0.4 wizard)
 


### PR DESCRIPTION
## Summary
- BotFather-registered handle is `@Conclave_ai_bot` (capital C); code + docs used lowercase.
- Telegram routing is case-insensitive so runtime behavior is unchanged. Cosmetic fix — user-facing strings now match what's shown in-app when they DM the bot.
- 3 files touched: `DEFAULT_BOT_USERNAME` constant in init.ts, migrate-to-v0.4.md (4 mentions), v0.4.0 release notes (1 mention).

## Test plan
- [x] grep `conclave_ai_bot` (case-insensitive) — all 6 hits now capital C
- [ ] CI build + test green
- [ ] `conclave init` help output shows `@Conclave_ai_bot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)