### PR TITLE
fix(cli): read --version from package.json (v0.4.1 hotfix)

### DIFF
--- a/docs/releases/v0.4.1.md
+++ b/docs/releases/v0.4.1.md
@@ -1,0 +1,21 @@
+# Conclave AI v0.4.1
+
+Release date: 2026-04-20
+
+Hotfix release — fixes `conclave --version` output.
+
+## Fixes
+
+- **`conclave --version` now reports the real version** — previously hardcoded to `0.0.0` (regression from pre-release scaffolding). Reads from package.json via `createRequire` at runtime, so future bumps don't need code edits.
+- **MCP server reports real version** — same root cause; `conclave mcp-server` now advertises its real version to MCP clients instead of `0.0.0`.
+
+## Notes
+
+- No other packages touched. `@conclave-ai/core`, agents, platforms, integrations remain at `0.4.0`.
+- `workspace:*` resolution in published tarball unchanged — pnpm still rewrites to `^0.4.0` on publish.
+- Reusable workflow tag `v0.4` still points to main HEAD; consumer repos see no change.
+
+## Dogfood E2E status
+
+- D1 migrations must be applied to production Worker (`wrangler d1 migrations apply conclave-ai --remote`) before `conclave init`'s OAuth step succeeds. See migration catalog for details.
+- `@Conclave_ai_bot` (capital C) is the BotFather-registered handle; `conclave init` help text and migration docs reflect this from main HEAD `ef33ecf`. Consumer repos picking up the reusable workflow at `@v0.4` automatically get the capitalized form.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/commands/mcp-server.ts
+++ b/packages/cli/src/commands/mcp-server.ts
@@ -50,9 +50,10 @@ export async function mcpServer(argv: string[]): Promise<void> {
   );
   const { z } = await import("zod");
 
+  const { CLI_VERSION } = await import("../version.js");
   const server = new McpServer({
     name: "conclave-ai",
-    version: "0.0.0",
+    version: CLI_VERSION,
   });
 
   server.registerTool(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import { migrate } from "./commands/migrate.js";
 import { scores } from "./commands/scores.js";
 import { sync } from "./commands/sync.js";
 import { mcpServer } from "./commands/mcp-server.js";
+import { CLI_VERSION } from "./version.js";
 
 const HELP = `conclave — Conclave AI CLI
 
@@ -48,7 +49,7 @@ export async function run(argv: string[]): Promise<void> {
   }
 
   if (cmd === "--version" || cmd === "-v") {
-    process.stdout.write("0.0.0\n");
+    process.stdout.write(`${CLI_VERSION}\n`);
     return;
   }
 

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,6 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+
+export const CLI_VERSION: string = pkg.version;

--- a/packages/cli/test/smoke.test.mjs
+++ b/packages/cli/test/smoke.test.mjs
@@ -1,12 +1,18 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { run } from "../dist/index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8"));
 
 test("cli: run is exported", () => {
   assert.equal(typeof run, "function");
 });
 
-test("cli: --version prints 0.0.0 to stdout", async () => {
+test("cli: --version prints package.json version to stdout", async () => {
   const chunks = [];
   const origWrite = process.stdout.write.bind(process.stdout);
   process.stdout.write = (c) => {
@@ -18,5 +24,5 @@ test("cli: --version prints 0.0.0 to stdout", async () => {
   } finally {
     process.stdout.write = origWrite;
   }
-  assert.match(chunks.join(""), /0\.0\.0/);
+  assert.equal(chunks.join("").trim(), pkg.version);
 });


### PR DESCRIPTION
## Summary
- **Bug**: `conclave --version` printed `0.0.0` (hardcoded in `packages/cli/src/index.ts:51`). MCP server advertised same stub.
- **Fix**: new `src/version.ts` reads `package.json` via `createRequire` at runtime. Both `--version` and `McpServer({ version })` consume it.
- **Bump**: `@conclave-ai/cli` → 0.4.1. No other packages touched — only CLI binary changed.
- Release notes: [`docs/releases/v0.4.1.md`](../blob/claude/v0.4.1-version-string/docs/releases/v0.4.1.md).

## Discovered during v0.4 E2E smoke
Bae ran `conclave --version` after `npm install -g @conclave-ai/cli@0.4.0` — output was `0.0.0`. Ship this then re-publish as 0.4.1.

Separate bug found (D1 `oauth_devices` table missing) is a Worker deployment fix, not a CLI change — tracked separately.

## Test plan
- [x] `packages/cli/src/version.ts` compiles (tsc accepts createRequire relative path to published package.json)
- [ ] CI typecheck + test green
- [ ] After publish: `npm install -g @conclave-ai/cli@0.4.1 && conclave --version` → `0.4.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)