### PR TITLE
fix(cli): wrapper workflow grants pull-requests:write (v0.4.2 hotfix)

### DIFF
--- a/packages/cli/src/commands/init/workflow-writer.ts
+++ b/packages/cli/src/commands/init/workflow-writer.ts
@@ -31,6 +31,9 @@ on:
 jobs:
   conclave:
     uses: ${REUSABLE_REF}
+    permissions:
+      contents: read
+      pull-requests: write
     secrets: inherit
 `;
 

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -160,6 +160,8 @@ test("writeWorkflow: creates file with reusable-workflow ref", async () => {
     assert.ok(body.includes(REUSABLE_REF), `workflow body missing ref: ${REUSABLE_REF}`);
     assert.ok(body.includes("secrets: inherit"), "workflow body missing secrets: inherit");
     assert.ok(body.includes("pull_request"), "workflow body missing pull_request trigger");
+    assert.ok(body.includes("pull-requests: write"), "workflow body missing pull-requests: write permission");
+    assert.ok(body.includes("contents: read"), "workflow body missing contents: read permission");
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

**Bug**: `conclave init` generates a wrapper workflow without a `permissions:` block. Private-repo consumers default to `pull-requests: none`, which makes the reusable `review.yml` fail at startup:

> Error calling workflow 'seunghunbae-3svs/conclave-ai/.github/workflows/review.yml@v0.4'. The nested job 'review' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.

**Fix**: generated wrapper now includes
```yaml
permissions:
  contents: read
  pull-requests: write
```
matching the reusable workflow's declared needs.

## Discovered during v0.4 E2E smoke
Bae ran `conclave init` on a fresh private smoke repo, opened PR #1 → workflow startup failed before any job ran. Error message pulled from the repo's Actions annotations.

## Test plan
- [x] test updated to assert both permission keys present in emitted YAML
- [ ] CI typecheck + test green
- [ ] after publish: fresh `conclave init` → open PR → council runs (no startup_failure)

## Release bundling
Ship alongside #80 (`--version` fix) as v0.4.2. Order: merge #80 first, rebase this PR, bump cli/package.json to 0.4.2, publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)