### PR TITLE
fix(cli): mask API key input + print /link token (v0.4.2 hotfix)

### DIFF
--- a/docs/releases/v0.4.2.md
+++ b/docs/releases/v0.4.2.md
@@ -1,0 +1,20 @@
+# Conclave AI v0.4.2
+
+Release date: 2026-04-20
+
+CLI UX hotfix — removes two footguns discovered during v0.4 E2E smoke.
+
+## Fixes
+
+- **API key prompts now mask input.** `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY` prompts in `conclave init` were echoing the user's typed key in plaintext. Keys ended up in PowerShell history / screen scrollback / any shared terminal output. `conclave init` now shows `*` per character in TTY mode; non-TTY (piped) input is not echoed by the source anyway.
+- **`/link <token>` hint now prints the actual token.** The "Telegram link step" block previously said *"the token printed above in the OAuth step"* — but nothing ever printed the token. The OAuth flow stored it as a repo secret and discarded the value from the CLI's local scope. The Telegram `/link` command was therefore unreachable without querying the central plane directly. Now the block prints the raw `/link <TOKEN>` command for copy-paste.
+
+## Upgrade notes
+
+- The token shown by `conclave init` is sensitive (it authenticates the install to the central plane and the Telegram bot). Do not paste it into public chats / screenshots / issue trackers. `--reconfigure` rotates it.
+- No config-file format changes. No reusable-workflow changes. Downstream repos on `@v0.4` continue to work unchanged.
+
+## Known issues still in 0.4
+
+- Reusable `review.yml` still expects `TELEGRAM_BOT_TOKEN` (v0.3 style), so Telegram notifier skips during PR review even after `/link`. Tracked separately — v0.4.3 will route notifier through the central plane.
+- `Gemini` agent in default config participates in tier-1 but not tier-2. This is by design (decision #7's escalation debate uses top-2 agents). The rendered verdict shows tier-2 only, so Gemini's tier-1 verdict is not individually surfaced. Follow-up: surface tier-1 breakdown in verdict output.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -115,6 +115,7 @@ export async function runInit(args: InitArgs, deps: RunInitDeps = {}): Promise<n
 
     // Step 3 — OAuth / CONCLAVE_TOKEN via central plane device flow.
     let oauthOutcome: "success" | "skipped" | "failed" = "skipped";
+    let oauthToken: string | undefined;
     if (!args.skipOauth) {
       const oauthDeps: OauthFlowDeps = {
         stdout,
@@ -134,6 +135,7 @@ export async function runInit(args: InitArgs, deps: RunInitDeps = {}): Promise<n
       const exit = await runOauthFlow(repoSlug!, oauthDeps);
       if (exit.kind === "success") {
         oauthOutcome = "success";
+        oauthToken = exit.token;
         if (exit.rotated) {
           stdout(`  (CONCLAVE_TOKEN rotated for an existing install)\n`);
         }
@@ -154,14 +156,15 @@ export async function runInit(args: InitArgs, deps: RunInitDeps = {}): Promise<n
     // Step 4 — API keys. Prompt + print guidance; we do NOT write them to
     // GitHub secrets ourselves in v0.4-alpha (that needs the OAuth token
     // from step 3). Users currently set secrets via \`gh secret set\`.
-    const anthropic = await prompter.ask(
+    // Input is masked so keys don't end up in terminal scrollback.
+    const anthropic = await prompter.askSecret(
       "ANTHROPIC_API_KEY (required, not stored — used only for a one-time gh secret set hint)",
       { required: false },
     );
-    const openai = await prompter.ask("OPENAI_API_KEY (optional, press Enter to skip)", {
+    const openai = await prompter.askSecret("OPENAI_API_KEY (optional, press Enter to skip)", {
       required: false,
     });
-    const gemini = await prompter.ask("GEMINI_API_KEY (optional, press Enter to skip)", {
+    const gemini = await prompter.askSecret("GEMINI_API_KEY (optional, press Enter to skip)", {
       required: false,
     });
     const selectedAgents: string[] = [];
@@ -178,11 +181,12 @@ export async function runInit(args: InitArgs, deps: RunInitDeps = {}): Promise<n
     // pair the chat for you (chat ownership lives on the user's phone),
     // so we print the exact /link command instead. If OAuth failed, the
     // user has no CONCLAVE_TOKEN to link with — skip the hint.
-    if (oauthOutcome === "success") {
+    if (oauthOutcome === "success" && oauthToken) {
       stdout(
         `\n• Telegram link step:\n` +
           `  1. Open Telegram and DM @${DEFAULT_BOT_USERNAME}\n` +
-          `  2. Send: /link <CONCLAVE_TOKEN>   (the token printed above in the OAuth step)\n` +
+          `  2. Send this command (copy + paste, token is shown only here):\n` +
+          `       /link ${oauthToken}\n` +
           `  Bot confirms with "✅ Linked this chat to ${repoSlug}"\n`,
       );
     }

--- a/packages/cli/src/commands/init/prompts.ts
+++ b/packages/cli/src/commands/init/prompts.ts
@@ -3,6 +3,12 @@ import { stdin as input, stdout as output } from "node:process";
 
 export interface Prompter {
   ask(question: string, opts?: { default?: string; required?: boolean }): Promise<string>;
+  /**
+   * Prompt for a sensitive value (API key, token). Input is not echoed;
+   * each character shows as `*` so the user can see the length.
+   * Falls back to `ask` when stdin is not a TTY (CI, piped input).
+   */
+  askSecret(question: string, opts?: { required?: boolean }): Promise<string>;
   confirm(question: string, opts?: { default?: boolean }): Promise<boolean>;
   close(): void;
 }
@@ -26,6 +32,15 @@ export function createPrompter(): Prompter {
         output.write("  required — please enter a value\n");
       }
     },
+    async askSecret(question, opts = {}) {
+      const required = opts.required ?? false;
+      while (true) {
+        const ans = (await readMaskedLine(`${question}: `)).trim();
+        if (ans) return ans;
+        if (!required) return "";
+        output.write("  required — please enter a value\n");
+      }
+    },
     async confirm(question, opts = {}) {
       const defaultY = opts.default ?? true;
       const suffix = defaultY ? "[Y/n]" : "[y/N]";
@@ -37,6 +52,73 @@ export function createPrompter(): Prompter {
       rl.close();
     },
   };
+}
+
+/**
+ * Read a line from stdin with each character echoed as `*`. Uses raw
+ * mode for masked input. Falls back to plain readline when stdin is
+ * not a TTY (CI piped input) — in that case the input is still not
+ * echoed (since the source isn't a terminal), so no leakage.
+ */
+function readMaskedLine(prompt: string): Promise<string> {
+  output.write(prompt);
+  const isTTY = input.isTTY === true;
+  if (!isTTY) {
+    return new Promise<string>((resolve) => {
+      let buf = "";
+      const onData = (chunk: Buffer | string) => {
+        buf += chunk.toString("utf8");
+        const nl = buf.indexOf("\n");
+        if (nl >= 0) {
+          input.removeListener("data", onData);
+          input.pause();
+          resolve(buf.slice(0, nl).replace(/\r$/, ""));
+        }
+      };
+      input.resume();
+      input.on("data", onData);
+    });
+  }
+  return new Promise<string>((resolve) => {
+    let buffer = "";
+    const originalRaw = input.isRaw ?? false;
+    input.setRawMode(true);
+    input.resume();
+    input.setEncoding("utf8");
+    const finish = () => {
+      input.removeListener("data", onData);
+      input.setRawMode(originalRaw);
+      input.pause();
+      output.write("\n");
+      resolve(buffer);
+    };
+    const onData = (ch: string) => {
+      for (const c of ch) {
+        if (c === "\r" || c === "\n") {
+          finish();
+          return;
+        }
+        if (c === "\u0003") {
+          input.setRawMode(originalRaw);
+          process.exit(130);
+        }
+        if (c === "\u0004" && buffer.length === 0) {
+          finish();
+          return;
+        }
+        if (c === "\u007f" || c === "\b") {
+          if (buffer.length > 0) {
+            buffer = buffer.slice(0, -1);
+            output.write("\b \b");
+          }
+          continue;
+        }
+        buffer += c;
+        output.write("*");
+      }
+    };
+    input.on("data", onData);
+  });
 }
 
 /**
@@ -52,6 +134,12 @@ export function createNonInteractivePrompter(env: Record<string, string | undefi
       if (!opts.required) return "";
       throw new Error(
         `conclave init --yes: "${question}" has no default and no value was supplied via env/flag; aborting`,
+      );
+    },
+    async askSecret(question, opts = {}) {
+      if (!opts.required) return "";
+      throw new Error(
+        `conclave init --yes: secret "${question}" has no value; set it via env/flag before running`,
       );
     },
     async confirm(_question, opts = {}) {

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -208,12 +208,59 @@ function makePrompter(answers = {}) {
       calls.push(q);
       return answers[calls.length - 1] ?? "";
     },
+    async askSecret(q) {
+      calls.push(q);
+      return answers[calls.length - 1] ?? "";
+    },
     async confirm() {
       return true;
     },
     close() {},
   };
 }
+
+test("runInit: OAuth success prints CONCLAVE_TOKEN in Telegram /link hint", async () => {
+  const dir = await mkTmpDir("conclave-init-");
+  const stdout = [];
+  const stderr = [];
+  const TOKEN = "ct_live_abc123xyz";
+  const fakeClient = {
+    baseUrl: "https://example.invalid",
+    async startDeviceFlow() {
+      return {
+        device_code_id: "c_dev_1",
+        user_code: "ABCD-EFGH",
+        verification_uri: "https://github.com/login/device",
+        interval_sec: 5,
+        expires_at: new Date(Date.now() + 900_000).toISOString(),
+      };
+    },
+    async pollDeviceFlow() {
+      return { status: "success", token: TOKEN };
+    },
+  };
+  try {
+    const code = await runInit(
+      { yes: true, reconfigure: false, repo: "acme/service", cwd: dir, skipOauth: false, help: false },
+      {
+        prompter: makePrompter(),
+        stdout: (s) => stdout.push(s),
+        stderr: (s) => stderr.push(s),
+        oauthDeps: {
+          client: fakeClient,
+          setGhSecret: async () => {},
+          sleep: () => Promise.resolve(),
+        },
+      },
+    );
+    assert.equal(code, 0, stderr.join(""));
+    const out = stdout.join("");
+    assert.ok(out.includes("Telegram link step"), "should print Telegram link step block");
+    assert.ok(out.includes(`/link ${TOKEN}`), `should include literal '/link ${TOKEN}' — got: ${out}`);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
 
 test("runInit: happy path with explicit --repo, no keys → all stubs, files written", async () => {
   const dir = await mkTmpDir("conclave-init-");


### PR DESCRIPTION
## Summary

Two CLI footguns found during v0.4 E2E smoke on a fresh private repo.

### 1. API key input was echoed in plaintext
`conclave init` prompts for `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` via readline which echoes by default. On PowerShell the keys landed in command history + scrollback. A user testing the smoke flow leaked 3 live keys this way.

**Fix**: `Prompter.askSecret()` method. TTY input shows `*` per char (Ctrl+C/backspace handled). Non-TTY input isn't echoed by the source, so no extra work needed.

### 2. Telegram `/link` step said "use the token printed above" but nothing printed the token
OAuth flow returned `{ kind: "success", token, rotated }` from `runOauthFlow`. init.ts stored the token as a repo secret and discarded the value. The Telegram `/link <token>` hint was therefore unreachable — the token exists only on the central plane (hashed) and in the GitHub secret (write-only).

**Fix**: init.ts captures `exit.token`, prints `/link <token>` verbatim in the Telegram step block.

## Test plan
- [x] new integration test: OAuth success path → assert `/link <TOKEN>` appears in stdout
- [x] makePrompter helper updated to include askSecret
- [ ] CI typecheck + test green
- [ ] manual: `conclave init` shows `*****` when typing API keys, prints raw token in Telegram block

## Not in this PR
- Telegram notifier still v0.3 style (`TELEGRAM_BOT_TOKEN`-based in reusable workflow). Follow-up: route through central plane → v0.4.3.
- Gemini tier-2 absence is by design (decision #7). Follow-up: surface tier-1 agent breakdown in verdict output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)