### PR TITLE
feat(agent-design): vision-based design-specialist agent (v0.5.0-alpha.1)

### DIFF
--- a/docs/releases/v0.5.0-alpha.md
+++ b/docs/releases/v0.5.0-alpha.md
@@ -1,0 +1,66 @@
+# v0.5.0-alpha
+
+The v0.5 release bundles three independent deliverables the project needs
+before it can prove itself as a best-in-class multi-agent code review
+system. Each lands on its own PR so merge order stays flexible; this
+release-notes file is the shared changelog entry.
+
+## C — Design-specialist agent (`@conclave-ai/agent-design`)
+
+**Ships as**: `v0.5.0-alpha.1`.
+
+A new primary agent, `DesignAgent`, that reviews UI changes by reasoning
+over before/after screenshots of the affected routes. Implements the same
+`Agent` interface as `ClaudeAgent` / `OpenAIAgent` / `GeminiAgent`, so
+`Council` and `TieredCouncil` debate loops treat it identically — no
+special-case plumbing.
+
+**What changed:**
+
+- New package `@conclave-ai/agent-design` (version `0.5.0`).
+  Structurally mirrors `@conclave-ai/agent-claude`. Depends on
+  `@conclave-ai/core`, `@conclave-ai/visual-review`, and
+  `@anthropic-ai/sdk`.
+- New optional field `ReviewContext.visualArtifacts` in
+  `@conclave-ai/core` — array of `{ before, after, route }` screenshot
+  pairs. Existing code compiles unchanged; the field is purely additive.
+- CLI `review` command wires `DesignAgent` behind the `design` agent id.
+  Requires `ANTHROPIC_API_KEY` (reuses the Claude key — no new
+  credential). When the env var is missing the agent is skipped with a
+  stderr warning, consistent with other agent init paths.
+- `.conclaverc.json` default written by `conclave init` now lists
+  `design` as the lead agent on the `design` domain for both tier-1 and
+  tier-2. Claude stays on as the text-backup. Per-tier model overrides
+  default to `claude-haiku-4-5` (tier-1 draft) and `claude-opus-4-7`
+  (tier-2 authoritative).
+- Zod config schema learns the `design` agent id in both the flat
+  `agents` enum and the tiered `domains.*.tier1` / `tier2` enums.
+
+**Graceful fallback:** when no `visualArtifacts` are present on the
+context (today's production state — the screenshot capture pipeline has
+not yet been wired into `conclave review`), `DesignAgent.review` returns
+a clean `approve` verdict with a summary flagging the missing artifacts.
+It never throws. A follow-up PR will bind the existing
+`@conclave-ai/visual-review` capture to the review command so the
+artifacts flow end-to-end; until then the agent is safe to run in CI.
+
+**Relationship to `ClaudeVisionJudge`:** complementary, not overlapping.
+`ClaudeVisionJudge` (in `@conclave-ai/visual-review`) classifies
+pixel-diff regions semantically after a pixel diff runs — it's a helper
+in the visual-diff pipeline. `DesignAgent` is a first-class Council
+participant: it takes the before/after images as input, produces a
+standard `ReviewResult`, and votes on the verdict alongside the
+text-reviewers. Both stay.
+
+**Tests:** `@conclave-ai/agent-design` ships 6 Node test-runner cases
+covering the skip-path, the happy-path (vision content shape + tool_use
+parse), two error paths (missing tool_use, invalid verdict), the
+constructor-error path, and base64-string artifact input.
+
+## F — i18n (forthcoming)
+
+*(This section will be populated by the F PR.)*
+
+## H — D1 token encryption (forthcoming)
+
+*(This section will be populated by the H PR.)*

--- a/packages/agent-design/README.md
+++ b/packages/agent-design/README.md
@@ -1,0 +1,35 @@
+# @conclave-ai/agent-design
+
+Design-specialist agent for Conclave AI — implements the `Agent` interface
+from `@conclave-ai/core` and reviews design changes by reasoning over
+before/after screenshot pairs supplied on `ReviewContext.visualArtifacts`.
+
+This agent is **primary**: it returns a standard `ReviewResult` (verdict +
+blockers + summary) so the Council debate loop treats it identically to the
+text-based `ClaudeAgent` / `OpenAIAgent` / `GeminiAgent`. It complements
+`@conclave-ai/visual-review`'s `ClaudeVisionJudge` (a helper that classifies
+pixel-diff regions), not replaces it.
+
+When no `visualArtifacts` are present on the context, the agent returns a
+graceful `approve` verdict with a summary noting the missing artifacts —
+never throws. This keeps the v0.5.0-alpha useful even before the screenshot
+capture pipeline is wired into the review command.
+
+## Install
+
+```bash
+pnpm add @conclave-ai/agent-design @conclave-ai/core
+```
+
+## Usage
+
+```ts
+import { DesignAgent } from "@conclave-ai/agent-design";
+import { TieredCouncil } from "@conclave-ai/core";
+
+const design = new DesignAgent({ model: "claude-opus-4-7" });
+const council = new TieredCouncil({
+  tier1Agents: [design],
+  tier2Agents: [design],
+});
+```

--- a/packages/agent-design/package.json
+++ b/packages/agent-design/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@conclave-ai/agent-design",
+  "version": "0.5.0",
+  "description": "Conclave AI design-specialist agent — vision-based review over before/after screenshots.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test test/*.test.mjs",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@conclave-ai/core": "workspace:*",
+    "@conclave-ai/visual-review": "workspace:*",
+    "@anthropic-ai/sdk": "^0.65.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/agent-design/src/design-agent.ts
+++ b/packages/agent-design/src/design-agent.ts
@@ -1,0 +1,358 @@
+import type { Agent, Blocker, ReviewContext, ReviewResult } from "@conclave-ai/core";
+import { EfficiencyGate, estimateTokens } from "@conclave-ai/core";
+import {
+  REVIEW_TOOL_NAME,
+  REVIEW_TOOL_DESCRIPTION,
+  REVIEW_TOOL_INPUT_SCHEMA,
+  SYSTEM_PROMPT,
+  buildUserPrompt,
+} from "./prompts.js";
+
+/**
+ * Minimal shape of the Anthropic vision-capable messages API. Narrowed so
+ * tests can inject a mock without loading the SDK.
+ */
+export interface AnthropicLike {
+  messages: {
+    create(params: AnthropicCreateParams): Promise<AnthropicResponse>;
+  };
+}
+
+export interface AnthropicCreateParams {
+  model: string;
+  max_tokens: number;
+  system?: string | ReadonlyArray<{ type: "text"; text: string; cache_control?: { type: "ephemeral" } }>;
+  messages: ReadonlyArray<{
+    role: "user" | "assistant";
+    content:
+      | string
+      | ReadonlyArray<
+          | { type: "text"; text: string }
+          | {
+              type: "image";
+              source: { type: "base64"; media_type: "image/png" | "image/jpeg"; data: string };
+            }
+        >;
+  }>;
+  tools?: ReadonlyArray<{
+    name: string;
+    description: string;
+    input_schema: unknown;
+  }>;
+  tool_choice?: { type: "tool"; name: string } | { type: "auto" } | { type: "any" };
+}
+
+export interface AnthropicResponse {
+  id?: string;
+  model?: string;
+  content: ReadonlyArray<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; id: string; name: string; input: unknown }
+  >;
+  stop_reason?: string;
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}
+
+export interface DesignAgentOptions {
+  apiKey?: string;
+  /** Override the vision model. Defaults to `claude-opus-4-7` (authoritative tier). */
+  model?: string;
+  maxTokens?: number;
+  /** Shared efficiency gate. If omitted, the agent creates its own. */
+  gate?: EfficiencyGate;
+  /** For tests / alternate providers — inject a Messages-compatible client. */
+  client?: AnthropicLike;
+  /** Factory used when `client` is not supplied. Defaults to lazy-loading @anthropic-ai/sdk. */
+  clientFactory?: (apiKey: string) => Promise<AnthropicLike>;
+}
+
+const DEFAULT_MODEL = "claude-opus-4-7";
+const DEFAULT_MAX_TOKENS = 4_096;
+
+async function defaultClientFactory(apiKey: string): Promise<AnthropicLike> {
+  const mod = (await import("@anthropic-ai/sdk")) as unknown as {
+    default: new (opts: { apiKey: string }) => AnthropicLike;
+  };
+  const Ctor = mod.default;
+  return new Ctor({ apiKey });
+}
+
+/**
+ * DesignAgent — primary visual design reviewer. Consumes
+ * `ctx.visualArtifacts` (before/after PNG pairs), sends them to a
+ * vision-capable Claude model, and returns a standard `ReviewResult`
+ * so the Council debate loop treats it identically to the text-based
+ * reviewers.
+ *
+ * When no artifacts are attached to `ctx`, returns a graceful
+ * `approve` verdict with a summary flagging the missing artifacts —
+ * never throws. This keeps design domain useful during v0.5.0-alpha
+ * before the screenshot capture pipeline lands on `review`.
+ */
+export class DesignAgent implements Agent {
+  readonly id = "design";
+  readonly displayName = "Design";
+
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly gate: EfficiencyGate;
+  private readonly clientFactory: (apiKey: string) => Promise<AnthropicLike>;
+  private clientPromise: Promise<AnthropicLike> | null;
+
+  constructor(opts: DesignAgentOptions = {}) {
+    const key = opts.apiKey ?? process.env["ANTHROPIC_API_KEY"] ?? "";
+    if (!key && !opts.client) {
+      throw new Error(
+        "DesignAgent: ANTHROPIC_API_KEY not set (pass opts.apiKey, opts.client, or the env var)",
+      );
+    }
+    this.apiKey = key;
+    this.model = opts.model ?? DEFAULT_MODEL;
+    this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.gate = opts.gate ?? new EfficiencyGate();
+    this.clientFactory = opts.clientFactory ?? defaultClientFactory;
+    this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
+  }
+
+  private async getClient(): Promise<AnthropicLike> {
+    if (!this.clientPromise) {
+      this.clientPromise = this.clientFactory(this.apiKey);
+    }
+    return this.clientPromise;
+  }
+
+  async review(ctx: ReviewContext): Promise<ReviewResult> {
+    const artifacts = ctx.visualArtifacts ?? [];
+    if (artifacts.length === 0) {
+      return {
+        agent: this.id,
+        verdict: "approve",
+        blockers: [],
+        summary:
+          "skipped — no visual artifacts captured for this PR. Design agent cannot infer visual regressions from the text diff alone; approving by default. (Follow-up: wire screenshot capture into the review pipeline.)",
+      };
+    }
+
+    const routes = artifacts.map((a) => a.route);
+    const userText = buildUserPrompt(ctx, routes);
+    // Rough token estimate for budget reservation. Images cost ~1.5k tokens
+    // each for Anthropic vision; we over-estimate to stay safe.
+    const perImageTokens = 1_500;
+    const inputTokenEstimate =
+      estimateTokens(SYSTEM_PROMPT) +
+      estimateTokens(userText) +
+      artifacts.length * 2 * perImageTokens;
+    // Rough pre-flight cost. EfficiencyGate only uses this to reserve
+    // against the per-PR budget; it does not gate on the exact number.
+    // We pick a conservative USD/1M-input-tokens figure for Opus vision.
+    const estimatedCostUsd = (inputTokenEstimate * 15) / 1_000_000 + (this.maxTokens * 75) / 1_000_000;
+
+    const outcome = await this.gate.run<ReviewResult>(
+      {
+        agent: this.id,
+        cacheablePrefix: SYSTEM_PROMPT,
+        prompt: SYSTEM_PROMPT + "\n" + userText,
+        estimatedCostUsd,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const content = buildVisionContent(userText, artifacts);
+        const response = await client.messages.create({
+          model,
+          max_tokens: this.maxTokens,
+          system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
+          messages: [{ role: "user", content }],
+          tools: [
+            {
+              name: REVIEW_TOOL_NAME,
+              description: REVIEW_TOOL_DESCRIPTION,
+              input_schema: REVIEW_TOOL_INPUT_SCHEMA,
+            },
+          ],
+          tool_choice: { type: "tool", name: REVIEW_TOOL_NAME },
+        });
+        const latencyMs = Date.now() - started;
+
+        const parsed = parseReviewResponse(response, this.id);
+        const usage = response.usage ?? { input_tokens: 0, output_tokens: 0 };
+        const costUsd = estimateActualCost(model, usage);
+
+        return {
+          result: {
+            ...parsed,
+            tokensUsed: usage.input_tokens + usage.output_tokens,
+            costUsd,
+          },
+          inputTokens: usage.input_tokens,
+          outputTokens: usage.output_tokens,
+          costUsd,
+          latencyMs,
+        };
+      },
+    );
+
+    return outcome.result;
+  }
+}
+
+/**
+ * Turn each (before, after) pair into an interleaved text + image block
+ * sequence, prefaced by the textual prompt. Anthropic's vision API
+ * accepts multiple images per user message; we clearly label each so the
+ * model doesn't confuse ordering.
+ */
+function buildVisionContent(
+  userText: string,
+  artifacts: ReadonlyArray<{ before: Buffer | string; after: Buffer | string; route: string }>,
+): Array<
+  | { type: "text"; text: string }
+  | { type: "image"; source: { type: "base64"; media_type: "image/png"; data: string } }
+> {
+  const blocks: Array<
+    | { type: "text"; text: string }
+    | { type: "image"; source: { type: "base64"; media_type: "image/png"; data: string } }
+  > = [{ type: "text", text: userText }];
+  for (const art of artifacts) {
+    blocks.push({ type: "text", text: `--- Route: ${art.route} — BEFORE ---` });
+    blocks.push({
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: toBase64(art.before) },
+    });
+    blocks.push({ type: "text", text: `--- Route: ${art.route} — AFTER ---` });
+    blocks.push({
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: toBase64(art.after) },
+    });
+  }
+  blocks.push({
+    type: "text",
+    text: "Respond by calling submit_review exactly once.",
+  });
+  return blocks;
+}
+
+function toBase64(input: Buffer | string): string {
+  if (typeof input === "string") {
+    // Treat the string as already-base64. Stripping whitespace/newlines
+    // guards against accidental pretty-printing.
+    return input.replace(/\s+/g, "");
+  }
+  return Buffer.from(input).toString("base64");
+}
+
+function parseReviewResponse(response: AnthropicResponse, agentId: string): ReviewResult {
+  const toolUse = response.content.find(
+    (block): block is Extract<(typeof response.content)[number], { type: "tool_use" }> =>
+      block.type === "tool_use" && block.name === REVIEW_TOOL_NAME,
+  );
+  if (!toolUse) {
+    return errorResult(
+      agentId,
+      `design agent: response did not include a ${REVIEW_TOOL_NAME} tool_use block (stop_reason=${response.stop_reason ?? "?"}).`,
+    );
+  }
+  const input = toolUse.input as {
+    verdict?: unknown;
+    blockers?: unknown;
+    summary?: unknown;
+  };
+  const verdict = input.verdict;
+  if (verdict !== "approve" && verdict !== "rework" && verdict !== "reject") {
+    return errorResult(
+      agentId,
+      `design agent: invalid verdict "${String(verdict)}" in tool_use response.`,
+    );
+  }
+  const blockers: Blocker[] = [];
+  if (Array.isArray(input.blockers)) {
+    for (const raw of input.blockers) {
+      if (!raw || typeof raw !== "object") continue;
+      const b = raw as Record<string, unknown>;
+      const severity = b["severity"];
+      const category = b["category"];
+      const message = b["message"];
+      if (
+        (severity === "blocker" || severity === "major" || severity === "minor" || severity === "nit") &&
+        typeof category === "string" &&
+        typeof message === "string"
+      ) {
+        const blocker: Blocker = { severity, category, message };
+        if (typeof b["file"] === "string") blocker.file = b["file"] as string;
+        if (typeof b["line"] === "number") blocker.line = b["line"] as number;
+        blockers.push(blocker);
+      }
+    }
+  }
+  return {
+    agent: agentId,
+    verdict,
+    blockers,
+    summary: typeof input.summary === "string" ? input.summary : "",
+  };
+}
+
+/**
+ * Graceful error shape — returned in place of throwing when the vision
+ * response can't be parsed. Rendered as a `rework` so the council
+ * doesn't mistake a tool-call failure for a clean approve.
+ */
+function errorResult(agentId: string, reason: string): ReviewResult {
+  return {
+    agent: agentId,
+    verdict: "rework",
+    blockers: [
+      {
+        severity: "major",
+        category: "agent-error",
+        message: reason,
+      },
+    ],
+    summary: reason,
+  };
+}
+
+/**
+ * Approximate USD cost for a vision call on Claude Opus 4.7. We don't
+ * import `@conclave-ai/agent-claude`'s pricing table to keep the
+ * dependency graph tight; the efficiency gate uses this only for the
+ * per-PR budget accounting. Accuracy within ~20% is good enough.
+ */
+function estimateActualCost(
+  model: string,
+  usage: { input_tokens: number; output_tokens: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number },
+): number {
+  // Defaults: claude-opus-4-7 — $15/1M input, $75/1M output.
+  let inputPerMTok = 15;
+  let outputPerMTok = 75;
+  let cacheReadPerMTok = 1.5;
+  let cacheWritePerMTok = 18.75;
+  if (model === "claude-haiku-4-5") {
+    inputPerMTok = 0.25;
+    outputPerMTok = 1.25;
+    cacheReadPerMTok = 0.025;
+    cacheWritePerMTok = 0.3125;
+  } else if (model === "claude-sonnet-4-6") {
+    inputPerMTok = 3;
+    outputPerMTok = 15;
+    cacheReadPerMTok = 0.3;
+    cacheWritePerMTok = 3.75;
+  }
+  const cacheRead = usage.cache_read_input_tokens ?? 0;
+  const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+  const baseInput = Math.max(0, usage.input_tokens - cacheRead - cacheWrite);
+  return (
+    (baseInput * inputPerMTok +
+      cacheRead * cacheReadPerMTok +
+      cacheWrite * cacheWritePerMTok +
+      usage.output_tokens * outputPerMTok) /
+    1_000_000
+  );
+}

--- a/packages/agent-design/src/index.ts
+++ b/packages/agent-design/src/index.ts
@@ -1,0 +1,14 @@
+export { DesignAgent } from "./design-agent.js";
+export type {
+  DesignAgentOptions,
+  AnthropicLike,
+  AnthropicCreateParams,
+  AnthropicResponse,
+} from "./design-agent.js";
+export {
+  SYSTEM_PROMPT,
+  REVIEW_TOOL_NAME,
+  REVIEW_TOOL_DESCRIPTION,
+  REVIEW_TOOL_INPUT_SCHEMA,
+  buildUserPrompt,
+} from "./prompts.js";

--- a/packages/agent-design/src/prompts.ts
+++ b/packages/agent-design/src/prompts.ts
@@ -1,0 +1,120 @@
+import type { ReviewContext } from "@conclave-ai/core";
+
+export const SYSTEM_PROMPT = `You are a design-specialist reviewer on a multi-agent council for Conclave AI. Your lane: visual review of before/after screenshots of a pull request's UI.
+
+Your goal: catch real design regressions, accessibility issues, and unintentional style changes that the text-based reviewers would miss. The council weighs your verdict alongside the text-agents (Claude, OpenAI, Gemini) who are reading the diff. Cover what they can't: what the page actually looks like, rendered.
+
+Rules:
+- Focus on: layout regressions (cropped text, overlapping elements, broken alignment), contrast + WCAG AA accessibility, unintentional style changes (font weight/color drift, spacing regressions), visual bugs (missing states, broken responsive breakpoints).
+- Do NOT block on: imperceptible pixel noise, intentional redesigns that cleanly land, minor spacing nits when the overall composition still reads well.
+- When you find a real issue: name the element + describe the regression concretely. "Header CTA truncated on after screenshot — 'Sign up' becomes 'Sign u...'" beats "button looks wrong".
+- Severity: blocker = breaks core flow or inaccessible; major = obvious visual regression on primary surface; minor = secondary surface / easily fixed; nit = tiny polish.
+- When no visual artifacts were captured for this PR (empty \`visualArtifacts\`), respond verdict=approve and note the limitation in your summary. Do NOT fabricate findings from the text diff alone.
+- Never pad with encouragement ("great work but..."). Straight to concerns.
+- You MUST respond by calling the submit_review tool exactly once. No free-form text.`;
+
+export const REVIEW_TOOL_NAME = "submit_review";
+
+export const REVIEW_TOOL_DESCRIPTION =
+  "Submit your structured visual review of the before/after screenshots. Call this exactly once at the end of your analysis.";
+
+export const REVIEW_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    verdict: {
+      type: "string",
+      enum: ["approve", "rework", "reject"],
+      description:
+        "approve = visuals ship as-is; rework = fixable visual regressions (author should address); reject = fundamental design break (not mergeable).",
+    },
+    blockers: {
+      type: "array",
+      description:
+        "Ordered list of visual issues. Empty when verdict is approve. Each entry names the affected element + the regression.",
+      items: {
+        type: "object",
+        properties: {
+          severity: {
+            type: "string",
+            enum: ["blocker", "major", "minor", "nit"],
+            description:
+              "blocker = breaks core flow / inaccessible; major = obvious visual regression; minor = secondary surface; nit = polish.",
+          },
+          category: {
+            type: "string",
+            description:
+              "Short tag: 'layout-regression' / 'contrast' / 'cropped-text' / 'style-drift' / 'missing-state' / 'overflow' / 'accessibility'.",
+          },
+          message: {
+            type: "string",
+            description: "One-sentence description naming the element and the concrete regression.",
+          },
+          file: {
+            type: "string",
+            description: "Route or screenshot label, if attributable.",
+          },
+        },
+        required: ["severity", "category", "message"],
+      },
+    },
+    summary: {
+      type: "string",
+      description:
+        "One-paragraph summary of the visual review. Explain the overall verdict reasoning — what changed, whether it reads as intentional, and any caveats.",
+    },
+  },
+  required: ["verdict", "blockers", "summary"],
+} as const;
+
+export function buildUserPrompt(ctx: ReviewContext, routes: readonly string[]): string {
+  const sections: string[] = [];
+  sections.push(`# Design review target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`pull: #${ctx.pullNumber}`);
+  sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
+  if (routes.length > 0) {
+    sections.push(`routes: ${routes.join(", ")}`);
+  }
+  sections.push("");
+
+  if (ctx.deployStatus && ctx.deployStatus !== "unknown") {
+    sections.push(`# Deploy status`);
+    if (ctx.deployStatus === "failure") {
+      sections.push(
+        `deploy: FAILURE on this sha — treat as an automatic non-approve signal unless every visual concern is unambiguously unrelated to the deploy.`,
+      );
+    } else if (ctx.deployStatus === "success") {
+      sections.push(`deploy: success — green on this sha.`);
+    } else if (ctx.deployStatus === "pending") {
+      sections.push(`deploy: pending — not yet complete.`);
+    }
+    sections.push("");
+  }
+
+  sections.push(`# Instruction`);
+  sections.push(
+    `You will receive one or more BEFORE/AFTER screenshot pairs. Compare them region by region. Call submit_review exactly once with your verdict, blockers (if any), and a one-paragraph summary. If no pairs are attached, respond verdict=approve with summary noting the missing artifacts.`,
+  );
+
+  if (ctx.priors && ctx.priors.length > 0) {
+    sections.push("");
+    sections.push(`# Round ${ctx.round ?? 2} — other agents' verdicts from the previous round`);
+    sections.push(
+      `Read each agent's verdict + blockers. Update your verdict ONLY if you see a real visual issue you missed, or a false-positive you can now retract. Do not mirror the majority — the design lens is often the dissenting one.`,
+    );
+    sections.push("");
+    for (const p of ctx.priors) {
+      sections.push(`## ${p.agent}: ${p.verdict}`);
+      if (p.blockers.length > 0) {
+        for (const b of p.blockers.slice(0, 5)) {
+          sections.push(`- [${b.severity}/${b.category}] ${b.message}`);
+        }
+      } else {
+        sections.push(`- (no blockers)`);
+      }
+      sections.push("");
+    }
+  }
+
+  return sections.join("\n");
+}

--- a/packages/agent-design/test/agent.test.mjs
+++ b/packages/agent-design/test/agent.test.mjs
@@ -1,0 +1,212 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EfficiencyGate } from "@conclave-ai/core";
+import { DesignAgent, REVIEW_TOOL_NAME } from "../dist/index.js";
+
+function makeMockClient(responses) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    messages: {
+      create: async (params) => {
+        calls.push(params);
+        const r = responses[Math.min(i, responses.length - 1)];
+        i += 1;
+        return r;
+      },
+    },
+  };
+}
+
+function toolUseResponse({
+  verdict = "approve",
+  blockers = [],
+  summary = "visuals look clean",
+  inputTokens = 2_500,
+  outputTokens = 200,
+} = {}) {
+  return {
+    id: "msg_test",
+    model: "claude-opus-4-7",
+    content: [
+      {
+        type: "tool_use",
+        id: "tool_1",
+        name: REVIEW_TOOL_NAME,
+        input: { verdict, blockers, summary },
+      },
+    ],
+    stop_reason: "tool_use",
+    usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+  };
+}
+
+const baseCtx = {
+  diff: "diff --git a/x b/x\n+added",
+  repo: "acme/x",
+  pullNumber: 42,
+  newSha: "abc123",
+};
+
+const tinyPng = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+]);
+
+test("DesignAgent: no visual artifacts → graceful approve skip", async () => {
+  const agent = new DesignAgent({
+    apiKey: "test-key",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    // No client needed — this path never touches it.
+    client: {
+      calls: [],
+      messages: {
+        create: async () => {
+          throw new Error("DesignAgent should not hit the client when there are no visual artifacts");
+        },
+      },
+    },
+  });
+  const result = await agent.review({ ...baseCtx, domain: "design" });
+  assert.equal(result.agent, "design");
+  assert.equal(result.verdict, "approve");
+  assert.equal(result.blockers.length, 0);
+  assert.match(result.summary, /no visual artifacts/i);
+});
+
+test("DesignAgent: artifacts present → sends vision content, parses tool_use into ReviewResult", async () => {
+  const client = makeMockClient([
+    toolUseResponse({
+      verdict: "rework",
+      blockers: [
+        {
+          severity: "major",
+          category: "contrast",
+          message: "Body text contrast dropped below WCAG AA on hero section",
+          file: "/landing",
+        },
+        {
+          severity: "minor",
+          category: "layout-regression",
+          message: "CTA button right-edge crops on 1280 width",
+        },
+        { invalid: "shape", ignored: true },
+      ],
+      summary: "2 visual issues — hero contrast + CTA crop on medium viewport.",
+    }),
+  ]);
+  const agent = new DesignAgent({
+    apiKey: "test-key",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    client,
+  });
+  const result = await agent.review({
+    ...baseCtx,
+    domain: "design",
+    visualArtifacts: [{ route: "/landing", before: tinyPng, after: tinyPng }],
+  });
+  assert.equal(result.verdict, "rework");
+  assert.equal(result.blockers.length, 2);
+  assert.equal(result.blockers[0].category, "contrast");
+  assert.equal(result.blockers[0].severity, "major");
+  assert.equal(result.blockers[1].category, "layout-regression");
+  assert.match(result.summary, /hero contrast/);
+
+  // Verify the request shape: vision content blocks + tool_choice pin.
+  assert.equal(client.calls.length, 1);
+  const params = client.calls[0];
+  assert.equal(params.tool_choice.type, "tool");
+  assert.equal(params.tool_choice.name, REVIEW_TOOL_NAME);
+  const userContent = params.messages[0].content;
+  assert.ok(Array.isArray(userContent), "user content must be a vision blocks array");
+  const imageBlocks = userContent.filter((b) => b.type === "image");
+  assert.equal(imageBlocks.length, 2, "one before + one after image block");
+  for (const ib of imageBlocks) {
+    assert.equal(ib.source.type, "base64");
+    assert.equal(ib.source.media_type, "image/png");
+    assert.equal(typeof ib.source.data, "string");
+    assert.ok(ib.source.data.length > 0);
+  }
+  // System prompt must be cache-controlled for prompt-cache hits on
+  // repeat calls within the same PR deliberation.
+  assert.ok(Array.isArray(params.system));
+  assert.equal(params.system[0].cache_control?.type, "ephemeral");
+});
+
+test("DesignAgent: response missing tool_use → error-shaped ReviewResult (no throw)", async () => {
+  const client = {
+    calls: [],
+    messages: {
+      create: async () => ({
+        id: "msg_bad",
+        model: "claude-opus-4-7",
+        content: [{ type: "text", text: "I decided to reply as plain text, oops." }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 100, output_tokens: 10 },
+      }),
+    },
+  };
+  const agent = new DesignAgent({
+    apiKey: "test-key",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    client,
+  });
+  const result = await agent.review({
+    ...baseCtx,
+    domain: "design",
+    visualArtifacts: [{ route: "/x", before: tinyPng, after: tinyPng }],
+  });
+  assert.equal(result.agent, "design");
+  assert.equal(result.verdict, "rework");
+  assert.equal(result.blockers.length, 1);
+  assert.equal(result.blockers[0].category, "agent-error");
+  assert.match(result.summary, /did not include/i);
+});
+
+test("DesignAgent: invalid verdict value → error-shaped ReviewResult (no throw)", async () => {
+  const client = makeMockClient([toolUseResponse({ verdict: "ship-it-lol" })]);
+  const agent = new DesignAgent({
+    apiKey: "test-key",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    client,
+  });
+  const result = await agent.review({
+    ...baseCtx,
+    domain: "design",
+    visualArtifacts: [{ route: "/x", before: tinyPng, after: tinyPng }],
+  });
+  assert.equal(result.verdict, "rework");
+  assert.equal(result.blockers[0].category, "agent-error");
+  assert.match(result.summary, /invalid verdict/i);
+});
+
+test("DesignAgent: constructor throws when no api key AND no client", () => {
+  const orig = process.env.ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  try {
+    assert.throws(() => new DesignAgent());
+  } finally {
+    if (orig !== undefined) process.env.ANTHROPIC_API_KEY = orig;
+  }
+});
+
+test("DesignAgent: accepts base64 string artifacts (not just Buffer)", async () => {
+  const client = makeMockClient([toolUseResponse({ verdict: "approve", summary: "LGTM" })]);
+  const agent = new DesignAgent({
+    apiKey: "test-key",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    client,
+  });
+  const b64 = tinyPng.toString("base64");
+  const result = await agent.review({
+    ...baseCtx,
+    domain: "design",
+    visualArtifacts: [{ route: "/x", before: b64, after: b64 }],
+  });
+  assert.equal(result.verdict, "approve");
+  const params = client.calls[0];
+  const images = params.messages[0].content.filter((b) => b.type === "image");
+  assert.equal(images.length, 2);
+  assert.equal(images[0].source.data, b64);
+});

--- a/packages/agent-design/tsconfig.json
+++ b/packages/agent-design/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../visual-review" }
+  ]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@conclave-ai/agent-claude": "workspace:*",
+    "@conclave-ai/agent-design": "workspace:*",
     "@conclave-ai/agent-worker": "workspace:*",
     "@conclave-ai/agent-gemini": "workspace:*",
     "@conclave-ai/agent-grok": "workspace:*",

--- a/packages/cli/src/commands/init/config-writer.ts
+++ b/packages/cli/src/commands/init/config-writer.ts
@@ -43,12 +43,18 @@ export const DEFAULT_CONFIG = {
         models: { tier1: {}, tier2: { claude: "claude-opus-4-7", openai: "gpt-5.4" } },
       },
       design: {
-        tier1: ["claude", "openai", "gemini"],
-        tier2: ["claude", "openai"],
+        // v0.5 C: design-specialist agent leads on design reviews;
+        // Claude stays on as the text-backup so code changes paired
+        // with visuals still get a code-reading reviewer.
+        tier1: ["design", "claude"],
+        tier2: ["design", "claude"],
         tier1MaxRounds: 1,
         tier2MaxRounds: 2,
         alwaysEscalate: true,
-        models: { tier1: {}, tier2: { claude: "claude-opus-4-7", openai: "gpt-5.4" } },
+        models: {
+          tier1: { design: "claude-haiku-4-5" },
+          tier2: { design: "claude-opus-4-7", claude: "claude-opus-4-7" },
+        },
       },
     },
   },
@@ -96,8 +102,14 @@ export function buildConfigFor(repoSlug: string, selectedAgents?: readonly strin
   // Filter the tiered council to only agents the user actually has keys for.
   // If OpenAI/Gemini got deselected, drop them from tier1 + tier2 while
   // preserving order.
+  //
+  // `design` is not a distinct credential — it reuses ANTHROPIC_API_KEY,
+  // so it travels with `claude`. If Claude survived the filter, Design
+  // stays; if Claude got dropped, Design goes too.
   const allow = new Set(selectedAgents);
-  const filter = (arr: readonly string[]) => arr.filter((a) => allow.has(a));
+  const claudeSurvived = allow.has("claude");
+  const filter = (arr: readonly string[]) =>
+    arr.filter((a) => (a === "design" ? claudeSurvived : allow.has(a)));
   return {
     ...base,
     agents: filter(base.agents),

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -18,6 +18,7 @@ import {
   type TieredCouncilOutcome,
 } from "@conclave-ai/core";
 import { ClaudeAgent } from "@conclave-ai/agent-claude";
+import { DesignAgent } from "@conclave-ai/agent-design";
 import { OpenAIAgent } from "@conclave-ai/agent-openai";
 import { GeminiAgent } from "@conclave-ai/agent-gemini";
 import { OllamaAgent } from "@conclave-ai/agent-ollama";
@@ -179,6 +180,13 @@ export async function review(argv: string[]): Promise<void> {
     if (id === "claude") {
       if (!process.env["ANTHROPIC_API_KEY"]) return null;
       return new ClaudeAgent({ gate, ...modelOpt });
+    }
+    if (id === "design") {
+      if (!process.env["ANTHROPIC_API_KEY"]) {
+        process.stderr.write("conclave review: ANTHROPIC_API_KEY not set — skipping Design agent\n");
+        return null;
+      }
+      return new DesignAgent({ gate, ...modelOpt });
     }
     if (id === "openai") {
       if (!process.env["OPENAI_API_KEY"]) {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -7,7 +7,9 @@ export const CONFIG_FILENAME = ".conclaverc.json";
 
 export const ConclaveConfigSchema = z.object({
   version: z.literal(1),
-  agents: z.array(z.enum(["claude", "openai", "gemini", "ollama", "grok"])).default(["claude"]),
+  agents: z
+    .array(z.enum(["claude", "openai", "gemini", "ollama", "grok", "design"]))
+    .default(["claude"]),
   budget: z
     .object({
       perPrUsd: z.number().positive(),
@@ -100,10 +102,10 @@ export const ConclaveConfigSchema = z.object({
           z.enum(["code", "design"]),
           z.object({
             tier1: z
-              .array(z.enum(["claude", "openai", "gemini", "ollama", "grok"]))
+              .array(z.enum(["claude", "openai", "gemini", "ollama", "grok", "design"]))
               .default([]),
             tier2: z
-              .array(z.enum(["claude", "openai", "gemini", "ollama", "grok"]))
+              .array(z.enum(["claude", "openai", "gemini", "ollama", "grok", "design"]))
               .default([]),
             tier1MaxRounds: z.number().int().min(1).max(3).default(1),
             tier2MaxRounds: z.number().int().min(1).max(3).default(2),

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,6 +9,7 @@
   "references": [
     { "path": "../core" },
     { "path": "../agent-claude" },
+    { "path": "../agent-design" },
     { "path": "../agent-worker" },
     { "path": "../agent-gemini" },
     { "path": "../agent-grok" },

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -62,6 +62,25 @@ export interface ReviewContext {
    *  unknown   — no deploy platform attached to this PR, status not meaningful
    */
   deployStatus?: "success" | "failure" | "pending" | "unknown";
+  /**
+   * Optional before/after screenshot pairs captured for design-domain
+   * reviews. Consumed by vision-based design agents (e.g. `DesignAgent`
+   * from `@conclave-ai/agent-design`) to reason about layout regressions,
+   * contrast, and unintentional style changes.
+   *
+   * `before` / `after` are raw PNG bytes (Buffer) or base64-encoded PNG
+   * strings — the agent handles either form. `route` is the path or URL
+   * label the screenshot represents (e.g. "/dashboard", "signup-modal").
+   *
+   * Absent on code-domain reviews and on design reviews where the CLI
+   * could not produce screenshots (no preview URL, platform tokens
+   * missing, etc.); agents MUST degrade gracefully rather than throw.
+   */
+  visualArtifacts?: Array<{
+    before: Buffer | string;
+    after: Buffer | string;
+    route: string;
+  }>;
 }
 
 export interface ReviewResult {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,22 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/agent-design:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.65.0
+        version: 0.65.0(zod@3.25.76)
+      '@conclave-ai/core':
+        specifier: workspace:*
+        version: link:../core
+      '@conclave-ai/visual-review':
+        specifier: workspace:*
+        version: link:../visual-review
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/agent-gemini:
     dependencies:
       '@conclave-ai/core':
@@ -117,6 +133,9 @@ importers:
       '@conclave-ai/agent-claude':
         specifier: workspace:*
         version: link:../agent-claude
+      '@conclave-ai/agent-design':
+        specifier: workspace:*
+        version: link:../agent-design
       '@conclave-ai/agent-gemini':
         specifier: workspace:*
         version: link:../agent-gemini


### PR DESCRIPTION
## Summary

- New primary agent `@conclave-ai/agent-design` (v0.5.0) — reviews design PRs by reasoning over before/after screenshot pairs, returns the same `ReviewResult` shape as the text-based reviewers so Council debate works unchanged.
- Additive `ReviewContext.visualArtifacts` field in `@conclave-ai/core` (optional; existing code compiles). CLI wires `DesignAgent` behind the `design` agent id; default `.conclaverc.json` now leads the design domain with design-specialist + Claude text-backup.
- Graceful fallback: when no visual artifacts are attached (today's production state — screenshot capture not yet wired into `conclave review`), the agent returns a clean `approve` with a summary flagging the limitation. Never throws.

## Relationship to `ClaudeVisionJudge`

`ClaudeVisionJudge` in `@conclave-ai/visual-review` classifies pixel-diff regions — a helper layer in the visual-diff pipeline. `DesignAgent` is a first-class Council participant: takes before/after images as input, produces a verdict + blockers + summary, and votes alongside the text-reviewers. Complementary, not overlapping. Both stay.

## Test plan

- [x] `corepack pnpm install && corepack pnpm build` — 25/25 packages green.
- [x] `corepack pnpm --filter @conclave-ai/agent-design test` — 6/6 tests pass (skip path, happy-path vision content shape, missing tool_use error, invalid verdict error, constructor error, base64 string input).
- [x] `corepack pnpm --filter @conclave-ai/cli test` — 116/116 green (config enum + config-writer + review wiring didn't break anything).
- [x] `corepack pnpm --filter @conclave-ai/core test` — 214/214 green (additive `visualArtifacts` field).
- [ ] Follow-up PR: wire `@conclave-ai/visual-review` capture into `conclave review` so the artifacts flow end-to-end. Until then the agent runs safely and flags the limitation.

## Release notes

See `docs/releases/v0.5.0-alpha.md` (C section). F and H sections are left as placeholders for the parallel PRs.

## Parallel PRs

Low overlap with the sibling v0.5 PRs (Telegram central routing, D1 encryption, benchmark harness). The only shared file is `packages/cli/src/commands/review.ts` — I added a single `if (id === "design")` case in `buildAgent`; conflicts would be trivial to resolve if the Telegram PR also touches this file. Not resolving unilaterally per the task spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)