### PR TITLE
feat(central-plane): field-level encryption for GitHub access tokens (v0.5 H)

### DIFF
--- a/apps/central-plane/migrations/0004_encrypt_github_tokens.sql
+++ b/apps/central-plane/migrations/0004_encrypt_github_tokens.sql
@@ -1,0 +1,39 @@
+-- v0.5 milestone H — field-level encryption for github_access_token.
+--
+-- Background:
+-- Migration 0003 added `installs.github_access_token` as PLAINTEXT with
+-- an explicit TODO to upgrade to encryption in v0.5. Any actor with D1
+-- read access (breached CF account, accidental dump, compromised wrangler
+-- token) gets plaintext GitHub access tokens for every install. This
+-- migration begins the upgrade.
+--
+-- Design — two-phase cutover:
+--   Phase 1 (THIS migration, v0.5 H):
+--     * Add `github_access_token_enc` TEXT column alongside the existing
+--       plaintext `github_access_token`.
+--     * No data backfill in SQL. Application code handles the lazy
+--       migration: on first read of a plaintext row, the Worker encrypts
+--       and writes `_enc`, then NULLs the plaintext column.
+--     * Both columns coexist during cutover so the Worker can tolerate
+--       either state (older rows plaintext, newer rows encrypted).
+--
+--   Phase 2 (future migration 0005, v0.6):
+--     * After Bae verifies round-trip works live (encrypt on write,
+--       decrypt on read, lazy-upgrade drains the plaintext column), drop
+--       `github_access_token` entirely.
+--
+-- Encryption scheme:
+--   AES-256-GCM. 32-byte KEK stored in Worker secret `CONCLAVE_TOKEN_KEK`
+--   (base64-encoded). Ciphertext format stored in `_enc`:
+--     base64( iv(12 bytes) || ciphertext || auth_tag(16 bytes) )
+--   SubtleCrypto appends the auth tag to the ciphertext automatically in
+--   AES-GCM, so callers only allocate for iv + (ct+tag).
+--
+-- Key rotation is OUT OF SCOPE for v0.5 (single key). v0.6 will introduce
+-- a key-ID prefix on the ciphertext so multiple KEKs can be tried during
+-- rotation windows.
+--
+-- Operator step: `wrangler secret put CONCLAVE_TOKEN_KEK --env production`.
+-- See docs/migrate-to-v0.4.md §"KEK setup (v0.5)" at the end of that file.
+
+ALTER TABLE installs ADD COLUMN github_access_token_enc TEXT;

--- a/apps/central-plane/package.json
+++ b/apps/central-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/central-plane",
-  "version": "0.4.4",
+  "version": "0.4.5-encrypt-tokens.0",
   "private": true,
   "description": "Conclave AI central control plane — Cloudflare Worker + D1 backing the v0.4 install model.",
   "license": "MIT",

--- a/apps/central-plane/src/crypto.ts
+++ b/apps/central-plane/src/crypto.ts
@@ -1,0 +1,170 @@
+/**
+ * Field-level encryption for GitHub access tokens (v0.5 H).
+ *
+ * AES-256-GCM via SubtleCrypto. The KEK (32 bytes) is stored in the
+ * Worker secret `CONCLAVE_TOKEN_KEK`, base64-encoded. Ciphertext wire
+ * format — base64 of:
+ *
+ *   [  IV (12 bytes)  |  ciphertext  |  auth tag (16 bytes)  ]
+ *
+ * SubtleCrypto's AES-GCM encrypt appends the 16-byte auth tag to the
+ * ciphertext buffer; decrypt verifies + strips it. We concatenate the
+ * 12-byte IV in front so the decrypt side can recover the IV without a
+ * separate column.
+ *
+ * Intentionally narrow API:
+ *   encryptToken(plaintext, kekB64)  → base64 ciphertext
+ *   decryptToken(ciphertext, kekB64) → plaintext  (throws on tamper)
+ *
+ * Both helpers accept an optional `subtle` DI for tests — default is
+ * `globalThis.crypto.subtle` which is available in Cloudflare Workers
+ * and in Node 24+. The helpers do NOT swallow tag-auth failures into a
+ * boolean; callers need to distinguish "tampered" from "not yet
+ * encrypted" so the lazy-migration path on read can tell which branch
+ * to take.
+ */
+
+export const IV_BYTES = 12;
+export const TAG_BYTES = 16;
+export const KEK_BYTES = 32;
+
+export interface CryptoDeps {
+  subtle?: SubtleCrypto;
+  getRandomValues?: (buf: Uint8Array) => Uint8Array;
+}
+
+function getSubtle(deps?: CryptoDeps): SubtleCrypto {
+  const s = deps?.subtle ?? (typeof crypto !== "undefined" ? crypto.subtle : undefined);
+  if (!s) {
+    throw new Error(
+      "crypto.subtle is not available in this runtime — Conclave central plane requires Workers or Node 24+",
+    );
+  }
+  return s;
+}
+
+function getRandomFn(deps?: CryptoDeps): (buf: Uint8Array) => Uint8Array {
+  if (deps?.getRandomValues) return deps.getRandomValues;
+  if (typeof crypto === "undefined" || typeof crypto.getRandomValues !== "function") {
+    throw new Error("crypto.getRandomValues is not available in this runtime");
+  }
+  return (buf: Uint8Array) => {
+    crypto.getRandomValues(buf);
+    return buf;
+  };
+}
+
+/**
+ * Base64 ↔ bytes helpers. Uses atob/btoa which are available in both
+ * Workers and Node ≥16. We only handle ASCII-safe bytes here (we're
+ * round-tripping binary through base64), which is fine.
+ */
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
+  return btoa(bin);
+}
+
+/**
+ * Decode the KEK from base64 and import it as an AES-GCM key. Throws on
+ * invalid base64 or wrong byte length (must decode to exactly KEK_BYTES).
+ */
+export async function importKek(kekBase64: string, deps?: CryptoDeps): Promise<CryptoKey> {
+  if (typeof kekBase64 !== "string" || kekBase64.length === 0) {
+    throw new Error("CONCLAVE_TOKEN_KEK is required (non-empty base64 string)");
+  }
+  let raw: Uint8Array;
+  try {
+    raw = base64ToBytes(kekBase64);
+  } catch {
+    throw new Error("CONCLAVE_TOKEN_KEK is not valid base64");
+  }
+  if (raw.length !== KEK_BYTES) {
+    throw new Error(
+      `CONCLAVE_TOKEN_KEK must decode to exactly ${KEK_BYTES} bytes (got ${raw.length}) — generate with: node -e "console.log(crypto.randomBytes(32).toString('base64'))"`,
+    );
+  }
+  const subtle = getSubtle(deps);
+  return subtle.importKey("raw", raw, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+}
+
+/**
+ * Encrypt plaintext with the given base64 KEK. Returns base64(iv || ct+tag).
+ * Generates a fresh random 12-byte IV per call — never reuse IVs with the
+ * same key under AES-GCM.
+ */
+export async function encryptToken(
+  plaintext: string,
+  kekBase64: string,
+  deps?: CryptoDeps,
+): Promise<string> {
+  if (typeof plaintext !== "string") {
+    throw new Error("encryptToken: plaintext must be a string");
+  }
+  const key = await importKek(kekBase64, deps);
+  const subtle = getSubtle(deps);
+  const rand = getRandomFn(deps);
+  const iv = new Uint8Array(IV_BYTES);
+  rand(iv);
+  const ptBytes = new TextEncoder().encode(plaintext);
+  const ctBuf = await subtle.encrypt({ name: "AES-GCM", iv }, key, ptBytes);
+  const ct = new Uint8Array(ctBuf);
+  const out = new Uint8Array(iv.length + ct.length);
+  out.set(iv, 0);
+  out.set(ct, iv.length);
+  return bytesToBase64(out);
+}
+
+/**
+ * Decrypt base64 ciphertext with the given base64 KEK. Throws on:
+ *   - invalid KEK (bad base64 / wrong length)
+ *   - malformed ciphertext (too short to contain iv + tag)
+ *   - auth-tag failure (tampered ciphertext, wrong KEK, etc.)
+ *
+ * The caller is expected to catch these and NOT silently fall back to a
+ * plaintext column — a tag failure on an `_enc` value means the row was
+ * tampered with or the KEK was changed without rotation, which is an
+ * operator-level problem that should surface as an error.
+ */
+export async function decryptToken(
+  ciphertextBase64: string,
+  kekBase64: string,
+  deps?: CryptoDeps,
+): Promise<string> {
+  if (typeof ciphertextBase64 !== "string" || ciphertextBase64.length === 0) {
+    throw new Error("decryptToken: ciphertext must be a non-empty string");
+  }
+  let blob: Uint8Array;
+  try {
+    blob = base64ToBytes(ciphertextBase64);
+  } catch {
+    throw new Error("decryptToken: ciphertext is not valid base64");
+  }
+  if (blob.length < IV_BYTES + TAG_BYTES) {
+    throw new Error(
+      `decryptToken: ciphertext too short (${blob.length} bytes, need >= ${IV_BYTES + TAG_BYTES})`,
+    );
+  }
+  const iv = blob.slice(0, IV_BYTES);
+  const ct = blob.slice(IV_BYTES);
+  const key = await importKek(kekBase64, deps);
+  const subtle = getSubtle(deps);
+  let ptBuf: ArrayBuffer;
+  try {
+    ptBuf = await subtle.decrypt({ name: "AES-GCM", iv }, key, ct);
+  } catch (err) {
+    // SubtleCrypto throws OperationError (DOMException) on tag failure in
+    // Workers and a generic Error in Node. Normalise to a clear message.
+    throw new Error(
+      `decryptToken: authentication failure — ciphertext was tampered with, KEK is wrong, or the value was not encrypted with this scheme (${(err as Error)?.message ?? "unknown"})`,
+    );
+  }
+  return new TextDecoder().decode(ptBuf);
+}

--- a/apps/central-plane/src/db/telegram.ts
+++ b/apps/central-plane/src/db/telegram.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env.js";
+import { encryptToken, decryptToken } from "../crypto.js";
 
 export interface TelegramLink {
   chatId: number;
@@ -51,34 +52,82 @@ export async function upsertLink(
  * Fetch the install row WITH the github_access_token column (needed for
  * dispatch on behalf of the user). Separate from findInstallBySlug because
  * leaking the token through the generic lookup is a bad-default pattern.
+ *
+ * v0.5 H: reads the encrypted column (`github_access_token_enc`) first,
+ * and falls back to the plaintext column for rows that existed before
+ * the encryption upgrade. On a plaintext-fallback read, the caller
+ * triggers a one-time lazy upgrade via `upgradeInstallTokenEncryption`.
  */
 export interface InstallWithToken {
   id: string;
   repoSlug: string;
   githubAccessToken: string | null;
   githubTokenScope: string | null;
+  /**
+   * Internal flag — true when the token was decoded from the plaintext
+   * column and the row should be lazily upgraded to `_enc`. The caller
+   * that actually USES the token (not just inspects it) is responsible
+   * for calling `upgradeInstallTokenEncryption` after a successful
+   * dispatch. We upgrade after-dispatch (not before) so a KEK mis-set
+   * doesn't brick reads on rollback.
+   */
+  needsLazyEncrypt: boolean;
+}
+
+interface DispatchRow {
+  id: string;
+  repo_slug: string;
+  github_access_token: string | null;
+  github_access_token_enc: string | null;
+  github_token_scope: string | null;
 }
 
 export async function getInstallForDispatch(env: Env, installId: string): Promise<InstallWithToken | null> {
   const row = await env.DB.prepare(
-    "SELECT id, repo_slug, github_access_token, github_token_scope FROM installs WHERE id = ? AND status = 'active'",
+    "SELECT id, repo_slug, github_access_token, github_access_token_enc, github_token_scope FROM installs WHERE id = ? AND status = 'active'",
   )
     .bind(installId)
-    .first<{
-      id: string;
-      repo_slug: string;
-      github_access_token: string | null;
-      github_token_scope: string | null;
-    }>();
+    .first<DispatchRow>();
   if (!row) return null;
+
+  // Prefer the encrypted column when present. A non-NULL `_enc` MUST
+  // decrypt successfully with the configured KEK — we do not silently
+  // fall back to plaintext in that case, because it would mask tamper /
+  // KEK-mismatch bugs. Bubble the error.
+  if (row.github_access_token_enc) {
+    const kek = env.CONCLAVE_TOKEN_KEK;
+    if (!kek) {
+      throw new Error(
+        "getInstallForDispatch: row has encrypted github_access_token_enc but CONCLAVE_TOKEN_KEK is not set",
+      );
+    }
+    const plaintext = await decryptToken(row.github_access_token_enc, kek);
+    return {
+      id: row.id,
+      repoSlug: row.repo_slug,
+      githubAccessToken: plaintext,
+      githubTokenScope: row.github_token_scope,
+      needsLazyEncrypt: false,
+    };
+  }
+
+  // Fallback — plaintext column (legacy row from before v0.5 H). Flag
+  // it so the caller can schedule a lazy encrypt.
   return {
     id: row.id,
     repoSlug: row.repo_slug,
     githubAccessToken: row.github_access_token,
     githubTokenScope: row.github_token_scope,
+    needsLazyEncrypt: row.github_access_token !== null,
   };
 }
 
+/**
+ * Persist the GitHub access token, always in encrypted form. Called from
+ * the OAuth callback on initial install and on token rotation. Sets the
+ * plaintext column to NULL in the same UPDATE so no row ever has BOTH
+ * columns populated after v0.5 H rolls out.
+ */
 export async function setGithubAccessToken(
   env: Env,
   installId: string,
@@ -86,9 +135,45 @@ export async function setGithubAccessToken(
   scope: string,
   now: string,
 ): Promise<void> {
+  const kek = env.CONCLAVE_TOKEN_KEK;
+  if (!kek) {
+    throw new Error(
+      "setGithubAccessToken: CONCLAVE_TOKEN_KEK is not set — refusing to persist a GitHub access token without encryption. Run `wrangler secret put CONCLAVE_TOKEN_KEK`.",
+    );
+  }
+  const ciphertext = await encryptToken(accessToken, kek);
   await env.DB.prepare(
-    "UPDATE installs SET github_access_token = ?, github_token_scope = ?, github_token_set_at = ? WHERE id = ?",
+    "UPDATE installs SET github_access_token_enc = ?, github_access_token = NULL, github_token_scope = ?, github_token_set_at = ? WHERE id = ?",
   )
-    .bind(accessToken, scope, now, installId)
+    .bind(ciphertext, scope, now, installId)
+    .run();
+}
+
+/**
+ * One-time lazy upgrade: take a plaintext token that was just read from
+ * the legacy `github_access_token` column, encrypt it, write the
+ * ciphertext into `_enc`, and NULL out the plaintext. Called by the
+ * Telegram webhook after a successful dispatch so rollback on KEK
+ * misconfiguration is still possible up to that moment.
+ *
+ * Idempotent: the WHERE clause guards against clobbering a parallel
+ * writer by requiring `github_access_token_enc IS NULL`.
+ */
+export async function upgradeInstallTokenEncryption(
+  env: Env,
+  installId: string,
+  plaintextToken: string,
+): Promise<void> {
+  const kek = env.CONCLAVE_TOKEN_KEK;
+  if (!kek) {
+    throw new Error(
+      "upgradeInstallTokenEncryption: CONCLAVE_TOKEN_KEK is not set — cannot lazy-encrypt legacy plaintext token",
+    );
+  }
+  const ciphertext = await encryptToken(plaintextToken, kek);
+  await env.DB.prepare(
+    "UPDATE installs SET github_access_token_enc = ?, github_access_token = NULL WHERE id = ? AND github_access_token_enc IS NULL",
+  )
+    .bind(ciphertext, installId)
     .run();
 }

--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -23,4 +23,19 @@ export interface Env {
    * updates without a matching `X-Telegram-Bot-Api-Secret-Token` header.
    */
   TELEGRAM_WEBHOOK_SECRET?: string;
+  /**
+   * v0.5 H — base64-encoded 32-byte KEK used to AES-GCM encrypt the
+   * GitHub access token stored in D1 (`installs.github_access_token_enc`).
+   * Set via `wrangler secret put CONCLAVE_TOKEN_KEK --env production`.
+   *
+   * Runtime behaviour:
+   *   - If unset: OAuth callback refuses to persist tokens (the
+   *     `setGithubAccessToken` write throws) and Telegram button clicks
+   *     that hit an encrypted row error out with a clear operator
+   *     message. The /oauth/device/start path keeps working — only the
+   *     token-persistence step gates on this secret.
+   *   - If set but wrong length / not valid base64: startup preflight
+   *     fails fast with a clear message (see src/preflight.ts).
+   */
+  CONCLAVE_TOKEN_KEK?: string;
 }

--- a/apps/central-plane/src/index.ts
+++ b/apps/central-plane/src/index.ts
@@ -1,10 +1,23 @@
 import { createApp } from "./router.js";
 import type { Env } from "./env.js";
+import { assertPreflight } from "./preflight.js";
 
 const app = createApp();
 
+// Module-scoped cache: run the preflight once per isolate. The key is
+// the KEK value so that a secret rotation restarts the check on the
+// next request — cheap and safe. Sentinel distinguishes "never checked"
+// from "checked with undefined".
+const UNCHECKED = Symbol("unchecked");
+let preflightCheckedFor: string | null | typeof UNCHECKED = UNCHECKED;
+
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const kek = env.CONCLAVE_TOKEN_KEK ?? null;
+    if (preflightCheckedFor === UNCHECKED || preflightCheckedFor !== kek) {
+      assertPreflight(env);
+      preflightCheckedFor = kek;
+    }
     return app.fetch(request, env, ctx);
   },
 };

--- a/apps/central-plane/src/preflight.ts
+++ b/apps/central-plane/src/preflight.ts
@@ -1,0 +1,93 @@
+/**
+ * Runtime preflight checks for the central-plane Worker.
+ *
+ * Workers don't have a classical "startup" phase — `fetch` is invoked
+ * per-request. We approximate a fail-fast startup by running these
+ * checks inside the Worker `fetch` entrypoint before the router
+ * dispatches, on first request. Cloudflare caches the isolate so the
+ * checks only run once per cold start.
+ *
+ * Separate from `scripts/preflight.mjs` which is a BUILD-time TOML
+ * validator that can't see runtime secrets. This file validates the
+ * secret *values* the Worker sees at request time — specifically the
+ * shape of `CONCLAVE_TOKEN_KEK`.
+ *
+ * What we check:
+ *   - If `CONCLAVE_TOKEN_KEK` is set, it must base64-decode to exactly
+ *     32 bytes. A wrong length would cause every encrypt/decrypt call
+ *     to throw deep inside the request path with a cryptic SubtleCrypto
+ *     error — failing fast with a clear message here is much better.
+ *
+ * What we DON'T check (deliberately):
+ *   - Whether `CONCLAVE_TOKEN_KEK` is set at all. The plane is meant to
+ *     run in partial-configuration modes (operator deploys first, sets
+ *     secrets second). Reads/writes that need the KEK throw their own
+ *     clear errors; routes that don't need it keep working.
+ *   - Whether `GITHUB_CLIENT_ID` is set. Same reason (see the BUILD
+ *     preflight comment — deploy first, register OAuth second).
+ */
+
+import { KEK_BYTES } from "./crypto.js";
+
+export interface PreflightResult {
+  ok: boolean;
+  /** Human-readable error lines, empty when ok === true. */
+  errors: string[];
+}
+
+function tryBase64Decode(b64: string): Uint8Array | null {
+  try {
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate the shape of runtime secrets. Pure — returns errors as data
+ * so the caller can decide between failing the request, logging, or
+ * throwing.
+ */
+export function runPreflight(env: {
+  CONCLAVE_TOKEN_KEK?: string;
+}): PreflightResult {
+  const errors: string[] = [];
+
+  if (env.CONCLAVE_TOKEN_KEK !== undefined && env.CONCLAVE_TOKEN_KEK !== "") {
+    const raw = tryBase64Decode(env.CONCLAVE_TOKEN_KEK);
+    if (raw === null) {
+      errors.push(
+        "CONCLAVE_TOKEN_KEK is set but is not valid base64. " +
+          'Generate a valid key with: node -e "console.log(crypto.randomBytes(32).toString(\'base64\'))" ' +
+          "then `wrangler secret put CONCLAVE_TOKEN_KEK`.",
+      );
+    } else if (raw.length !== KEK_BYTES) {
+      errors.push(
+        `CONCLAVE_TOKEN_KEK base64-decodes to ${raw.length} bytes; must be exactly ${KEK_BYTES}. ` +
+          'Regenerate: node -e "console.log(crypto.randomBytes(32).toString(\'base64\'))" ' +
+          "then `wrangler secret put CONCLAVE_TOKEN_KEK`.",
+      );
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Throw a clear error if preflight fails. Called once per isolate from
+ * the Worker entrypoint.
+ */
+export function assertPreflight(env: { CONCLAVE_TOKEN_KEK?: string }): void {
+  const result = runPreflight(env);
+  if (!result.ok) {
+    throw new Error(
+      [
+        "conclave central-plane preflight failed:",
+        ...result.errors.map((e) => `  - ${e}`),
+      ].join("\n"),
+    );
+  }
+}

--- a/apps/central-plane/src/routes/telegram.ts
+++ b/apps/central-plane/src/routes/telegram.ts
@@ -2,7 +2,12 @@ import { Hono } from "hono";
 import type { Env } from "../env.js";
 import type { FetchLike } from "../github.js";
 import { findInstallByTokenHash } from "../db/installs.js";
-import { findLinkByChatId, upsertLink, getInstallForDispatch } from "../db/telegram.js";
+import {
+  findLinkByChatId,
+  upsertLink,
+  getInstallForDispatch,
+  upgradeInstallTokenEncryption,
+} from "../db/telegram.js";
 import { sha256Hex } from "../util.js";
 import {
   TelegramClient,
@@ -165,6 +170,19 @@ export function createTelegramRoutes(fetchImpl: FetchLike = fetch): Hono<{ Bindi
           eventType,
           clientPayload,
         );
+        // v0.5 H — lazy-upgrade the token field to encrypted storage if
+        // we just used a plaintext legacy row. Runs after the dispatch
+        // succeeds so a KEK mis-set (which would throw here) doesn't
+        // block the action the user wanted. We log the error instead of
+        // failing the request — the dispatch already succeeded and the
+        // user got their ack.
+        if (install.needsLazyEncrypt) {
+          try {
+            await upgradeInstallTokenEncryption(c.env, install.id, install.githubAccessToken);
+          } catch (upgradeErr) {
+            console.error("token lazy-encrypt upgrade failed:", upgradeErr);
+          }
+        }
         await telegram.answerCallbackQuery({
           id: cq.id!,
           text: `✓ ${eventType} dispatched on ${install.repoSlug}`,

--- a/apps/central-plane/test/crypto.test.mjs
+++ b/apps/central-plane/test/crypto.test.mjs
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { encryptToken, decryptToken, importKek, KEK_BYTES } from "../dist/crypto.js";
+
+function genKekB64() {
+  return randomBytes(KEK_BYTES).toString("base64");
+}
+
+// ---- round-trip ---------------------------------------------------------
+
+test("encryptToken + decryptToken: round-trip recovers plaintext", async () => {
+  const kek = genKekB64();
+  const plaintext = "gho_abc123DEF456_live_github_access_token";
+  const ct = await encryptToken(plaintext, kek);
+  assert.notEqual(ct, plaintext, "ciphertext must not equal plaintext");
+  assert.ok(ct.length > plaintext.length, "ciphertext should include iv+tag overhead");
+  const recovered = await decryptToken(ct, kek);
+  assert.equal(recovered, plaintext);
+});
+
+test("encryptToken: two encrypts of the same plaintext produce distinct ciphertexts (random IV)", async () => {
+  const kek = genKekB64();
+  const plaintext = "gho_same_value";
+  const ct1 = await encryptToken(plaintext, kek);
+  const ct2 = await encryptToken(plaintext, kek);
+  assert.notEqual(ct1, ct2, "fresh IV per call — ciphertexts must differ");
+  // But both should decrypt back to the same plaintext.
+  assert.equal(await decryptToken(ct1, kek), plaintext);
+  assert.equal(await decryptToken(ct2, kek), plaintext);
+});
+
+// ---- tampered ciphertext ------------------------------------------------
+
+test("decryptToken: tampered ciphertext throws (auth tag failure)", async () => {
+  const kek = genKekB64();
+  const ct = await encryptToken("gho_original", kek);
+  // Flip one bit by corrupting a byte in the middle of the base64 payload.
+  // The tampered base64 must stay structurally valid base64 so we only
+  // exercise the AES-GCM auth-tag rejection path.
+  const raw = Buffer.from(ct, "base64");
+  raw[raw.length - 3] ^= 0xff; // flip a byte in the auth tag region
+  const tampered = raw.toString("base64");
+  await assert.rejects(
+    () => decryptToken(tampered, kek),
+    /authentication failure|tampered|wrong|OperationError/i,
+  );
+});
+
+test("decryptToken: wrong KEK throws", async () => {
+  const kek1 = genKekB64();
+  const kek2 = genKekB64();
+  const ct = await encryptToken("gho_secret_token", kek1);
+  await assert.rejects(
+    () => decryptToken(ct, kek2),
+    /authentication failure|tampered|wrong|OperationError/i,
+  );
+});
+
+// ---- invalid KEK length / shape ----------------------------------------
+
+test("importKek: rejects KEK that does not decode to 32 bytes", async () => {
+  const short = Buffer.alloc(16).toString("base64"); // 16 bytes, should be 32
+  await assert.rejects(() => importKek(short), /exactly 32 bytes|must decode/i);
+  const long = Buffer.alloc(48).toString("base64"); // 48 bytes
+  await assert.rejects(() => importKek(long), /exactly 32 bytes|must decode/i);
+});
+
+test("importKek: rejects empty / non-string KEK", async () => {
+  await assert.rejects(() => importKek(""), /required|non-empty/i);
+  await assert.rejects(
+    () => importKek(/** @type {any} */ (undefined)),
+    /required|non-empty/i,
+  );
+});
+
+test("encryptToken: rejects missing KEK via importKek", async () => {
+  await assert.rejects(() => encryptToken("tok", ""), /required|non-empty/i);
+});
+
+test("decryptToken: malformed short ciphertext throws", async () => {
+  const kek = genKekB64();
+  // 12 bytes or fewer (iv+tag = 28, threshold) — must fail the length check.
+  const tooShort = Buffer.alloc(20).toString("base64");
+  await assert.rejects(() => decryptToken(tooShort, kek), /too short|authentication failure/i);
+});
+
+test("decryptToken: empty ciphertext throws", async () => {
+  const kek = genKekB64();
+  await assert.rejects(() => decryptToken("", kek), /non-empty/i);
+});

--- a/apps/central-plane/test/installs.test.mjs
+++ b/apps/central-plane/test/installs.test.mjs
@@ -1,0 +1,226 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import {
+  getInstallForDispatch,
+  setGithubAccessToken,
+  upgradeInstallTokenEncryption,
+} from "../dist/db/telegram.js";
+
+function genKekB64() {
+  return randomBytes(32).toString("base64");
+}
+
+/**
+ * Mock D1 that models the installs table with both token columns.
+ * Captures bound values and returns rows shaped like real D1 output.
+ */
+function makeMockDb({ installs = new Map() } = {}) {
+  const state = { installs: new Map(installs) };
+  return {
+    state,
+    prepare(sql) {
+      let bound = [];
+      const api = {
+        bind: (...args) => {
+          bound = args;
+          return api;
+        },
+        async first() {
+          if (
+            /SELECT id, repo_slug, github_access_token, github_access_token_enc, github_token_scope FROM installs WHERE id = \? AND status = 'active'/.test(
+              sql,
+            )
+          ) {
+            for (const v of state.installs.values()) {
+              if (v.id === bound[0] && v.status === "active") {
+                return {
+                  id: v.id,
+                  repo_slug: v.repoSlug,
+                  github_access_token: v.githubAccessToken ?? null,
+                  github_access_token_enc: v.githubAccessTokenEnc ?? null,
+                  github_token_scope: v.githubTokenScope ?? null,
+                };
+              }
+            }
+            return null;
+          }
+          return null;
+        },
+        async run() {
+          if (
+            /UPDATE installs SET github_access_token_enc = \?, github_access_token = NULL, github_token_scope = \?, github_token_set_at = \? WHERE id = \?/.test(
+              sql,
+            )
+          ) {
+            const [enc, scope, setAt, id] = bound;
+            for (const v of state.installs.values()) {
+              if (v.id === id) {
+                v.githubAccessTokenEnc = enc;
+                v.githubAccessToken = null;
+                v.githubTokenScope = scope;
+                v.githubTokenSetAt = setAt;
+              }
+            }
+          } else if (
+            /UPDATE installs SET github_access_token_enc = \?, github_access_token = NULL WHERE id = \? AND github_access_token_enc IS NULL/.test(
+              sql,
+            )
+          ) {
+            const [enc, id] = bound;
+            for (const v of state.installs.values()) {
+              if (v.id === id && (v.githubAccessTokenEnc ?? null) === null) {
+                v.githubAccessTokenEnc = enc;
+                v.githubAccessToken = null;
+              }
+            }
+          }
+          return { success: true };
+        },
+      };
+      return api;
+    },
+  };
+}
+
+function mkInstall(overrides = {}) {
+  return {
+    id: "c_install_A",
+    repoSlug: "acme/service",
+    tokenHash: "hashhashhash",
+    status: "active",
+    createdAt: "2026-04-20T00:00:00Z",
+    lastSeenAt: "2026-04-20T00:00:00Z",
+    githubAccessToken: null,
+    githubAccessTokenEnc: null,
+    githubTokenScope: null,
+    ...overrides,
+  };
+}
+
+// ---- write path: setGithubAccessToken encrypts + NULLs plaintext --------
+
+test("setGithubAccessToken: stores ciphertext in _enc and NULLs plaintext column", async () => {
+  const kek = genKekB64();
+  const install = mkInstall({ githubAccessToken: "STALE_PLAINTEXT" });
+  const DB = makeMockDb({ installs: new Map([[install.id, install]]) });
+  const env = { DB, CONCLAVE_TOKEN_KEK: kek };
+
+  await setGithubAccessToken(env, install.id, "gho_freshly_minted", "repo", "2026-04-20T12:00:00Z");
+
+  const row = DB.state.installs.get(install.id);
+  assert.equal(row.githubAccessToken, null, "plaintext column must be nulled");
+  assert.ok(row.githubAccessTokenEnc, "enc column must be populated");
+  assert.notEqual(row.githubAccessTokenEnc, "gho_freshly_minted", "enc must not equal plaintext");
+  assert.equal(row.githubTokenScope, "repo");
+  assert.equal(row.githubTokenSetAt, "2026-04-20T12:00:00Z");
+});
+
+test("setGithubAccessToken: refuses to write when CONCLAVE_TOKEN_KEK is unset", async () => {
+  const install = mkInstall();
+  const DB = makeMockDb({ installs: new Map([[install.id, install]]) });
+  const env = { DB }; // no KEK
+  await assert.rejects(
+    () => setGithubAccessToken(env, install.id, "gho_x", "repo", "t"),
+    /CONCLAVE_TOKEN_KEK is not set|refusing to persist/i,
+  );
+});
+
+// ---- read path: prefers _enc, falls back to plaintext --------------------
+
+test("getInstallForDispatch: reads encrypted _enc column and decrypts it", async () => {
+  const kek = genKekB64();
+  const install = mkInstall();
+  const DB = makeMockDb({ installs: new Map([[install.id, install]]) });
+  const env = { DB, CONCLAVE_TOKEN_KEK: kek };
+
+  // First populate via the write path so _enc holds a real ciphertext.
+  await setGithubAccessToken(env, install.id, "gho_live_token", "repo", "t");
+
+  const result = await getInstallForDispatch(env, install.id);
+  assert.ok(result, "install row should be found");
+  assert.equal(result.githubAccessToken, "gho_live_token");
+  assert.equal(result.needsLazyEncrypt, false, "encrypted row must NOT flag lazy-encrypt");
+});
+
+test("getInstallForDispatch: falls back to plaintext column when _enc is NULL (legacy row)", async () => {
+  const install = mkInstall({
+    githubAccessToken: "gho_legacy_plaintext",
+    githubAccessTokenEnc: null,
+    githubTokenScope: "repo",
+  });
+  const DB = makeMockDb({ installs: new Map([[install.id, install]]) });
+  const env = { DB, CONCLAVE_TOKEN_KEK: genKekB64() };
+  const result = await getInstallForDispatch(env, install.id);
+  assert.ok(result);
+  assert.equal(result.githubAccessToken, "gho_legacy_plaintext");
+  assert.equal(result.needsLazyEncrypt, true, "legacy row MUST flag lazy-encrypt");
+});
+
+test("getInstallForDispatch: cleanly returns null token when both columns are NULL", async () => {
+  const install = mkInstall(); // both nulls by default
+  const DB = makeMockDb({ installs: new Map([[install.id, install]]) });
+  const env = { DB, CONCLAVE_TOKEN_KEK: genKekB64() };
+  const result = await getInstallForDispatch(env, install.id);
+  assert.ok(result);
+  assert.equal(result.githubAccessToken, null);
+  assert.equal(result.needsLazyEncrypt, false);
+});
+
+test("getInstallForDispatch: throws if _enc is set but CONCLAVE_TOKEN_KEK is missing", async () => {
+  const kek = genKekB64();
+  const install = mkInstall();
+  const DB = makeMockDb({ installs: new Map([[install.id, install]]) });
+  const env = { DB, CONCLAVE_TOKEN_KEK: kek };
+  await setGithubAccessToken(env, install.id, "gho_x", "repo", "t");
+
+  // Now drop the KEK and attempt a read — must surface a clear error.
+  const envNoKek = { DB };
+  await assert.rejects(
+    () => getInstallForDispatch(envNoKek, install.id),
+    /CONCLAVE_TOKEN_KEK is not set/i,
+  );
+});
+
+// ---- lazy upgrade path --------------------------------------------------
+
+test("upgradeInstallTokenEncryption: writes ciphertext to _enc and NULLs plaintext", async () => {
+  const kek = genKekB64();
+  const install = mkInstall({
+    githubAccessToken: "gho_legacy_plaintext",
+    githubAccessTokenEnc: null,
+    githubTokenScope: "repo",
+  });
+  const DB = makeMockDb({ installs: new Map([[install.id, install]]) });
+  const env = { DB, CONCLAVE_TOKEN_KEK: kek };
+
+  await upgradeInstallTokenEncryption(env, install.id, "gho_legacy_plaintext");
+
+  const row = DB.state.installs.get(install.id);
+  assert.equal(row.githubAccessToken, null, "plaintext column must be nulled after upgrade");
+  assert.ok(row.githubAccessTokenEnc, "enc column must be populated after upgrade");
+
+  // A subsequent read must decrypt cleanly.
+  const result = await getInstallForDispatch(env, install.id);
+  assert.equal(result.githubAccessToken, "gho_legacy_plaintext");
+  assert.equal(result.needsLazyEncrypt, false);
+});
+
+test("upgradeInstallTokenEncryption: idempotent — does not clobber existing _enc", async () => {
+  const kek = genKekB64();
+  const install = mkInstall({
+    githubAccessTokenEnc: "SOMETHING_ALREADY_THERE",
+    githubAccessToken: null,
+  });
+  const DB = makeMockDb({ installs: new Map([[install.id, install]]) });
+  const env = { DB, CONCLAVE_TOKEN_KEK: kek };
+
+  await upgradeInstallTokenEncryption(env, install.id, "gho_any");
+  const row = DB.state.installs.get(install.id);
+  // The WHERE clause `AND github_access_token_enc IS NULL` blocks the write.
+  assert.equal(
+    row.githubAccessTokenEnc,
+    "SOMETHING_ALREADY_THERE",
+    "idempotent upgrade must not overwrite existing ciphertext",
+  );
+});

--- a/apps/central-plane/test/oauth.test.mjs
+++ b/apps/central-plane/test/oauth.test.mjs
@@ -1,6 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
 import { createApp } from "../dist/router.js";
+
+// v0.5 H — valid KEK required for setGithubAccessToken in the oauth
+// success path. Test env gets a fresh KEK per process.
+const TEST_KEK = randomBytes(32).toString("base64");
 
 // ---- mock D1 + oauth_devices table ---------------------------------------
 
@@ -51,6 +56,23 @@ function makeMockDb(installsSeed = new Map(), devicesSeed = new Map()) {
                 const [flag, id] = bound;
                 const d = state.devices.get(id);
                 if (d) d.consumed = flag;
+              } else if (
+                /UPDATE installs SET github_access_token_enc = \?, github_access_token = NULL, github_token_scope = \?, github_token_set_at = \? WHERE id = \?/.test(
+                  sql,
+                )
+              ) {
+                // v0.5 H — OAuth success path now writes the encrypted
+                // token column. Capture ciphertext + scope so the tests
+                // can inspect the install row just as before.
+                const [enc, scope, setAt, id] = bound;
+                for (const v of state.installs.values()) {
+                  if (v.id === id) {
+                    v.githubAccessTokenEnc = enc;
+                    v.githubAccessToken = null;
+                    v.githubTokenScope = scope;
+                    v.githubTokenSetAt = setAt;
+                  }
+                }
               }
               return { success: true };
             },
@@ -81,6 +103,7 @@ function makeEnv(overrides = {}) {
     DB: makeMockDb(),
     ENVIRONMENT: "test",
     GITHUB_CLIENT_ID: "Iv1.testclient",
+    CONCLAVE_TOKEN_KEK: TEST_KEK,
     ...overrides,
   };
 }

--- a/apps/central-plane/test/telegram.test.mjs
+++ b/apps/central-plane/test/telegram.test.mjs
@@ -1,8 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { createApp } from "../dist/router.js";
 import { parseCallbackData, eventTypeFor } from "../dist/telegram.js";
+
+// v0.5 H — a valid KEK for the tests that exercise the dispatch path.
+// Lazy-upgrade writes on stale plaintext rows require this to be set.
+const TEST_KEK = randomBytes(32).toString("base64");
 
 // ---- mock D1 covering installs + telegram_links -------------------------
 
@@ -47,13 +51,14 @@ function makeMockDb({ installs = new Map(), links = new Map() } = {}) {
                 }
               : null;
           }
-          if (/SELECT id, repo_slug, github_access_token, github_token_scope FROM installs WHERE id = \?/.test(sql)) {
+          if (/SELECT id, repo_slug, github_access_token, github_access_token_enc, github_token_scope FROM installs WHERE id = \?/.test(sql)) {
             for (const v of state.installs.values()) {
               if (v.id === bound[0] && v.status === "active") {
                 return {
                   id: v.id,
                   repo_slug: v.repoSlug,
                   github_access_token: v.githubAccessToken ?? null,
+                  github_access_token_enc: v.githubAccessTokenEnc ?? null,
                   github_token_scope: v.githubTokenScope ?? null,
                 };
               }
@@ -70,6 +75,20 @@ function makeMockDb({ installs = new Map(), links = new Map() } = {}) {
             const [lastSeenAt, id] = bound;
             for (const v of state.installs.values()) {
               if (v.id === id) v.lastSeenAt = lastSeenAt;
+            }
+          } else if (
+            /UPDATE installs SET github_access_token_enc = \?, github_access_token = NULL WHERE id = \? AND github_access_token_enc IS NULL/.test(
+              sql,
+            )
+          ) {
+            // v0.5 H — lazy upgrade path. The telegram webhook tests
+            // exercise it implicitly when `needsLazyEncrypt` is true.
+            const [enc, id] = bound;
+            for (const v of state.installs.values()) {
+              if (v.id === id && (v.githubAccessTokenEnc ?? null) === null) {
+                v.githubAccessTokenEnc = enc;
+                v.githubAccessToken = null;
+              }
             }
           }
           return { success: true };
@@ -132,6 +151,7 @@ function makeEnvWithInstall({ token = "c_linktest_token_xyz", repo = "acme/servi
       DB: makeMockDb({ installs }),
       ENVIRONMENT: "test",
       TELEGRAM_BOT_TOKEN: "bot-test-token",
+      CONCLAVE_TOKEN_KEK: TEST_KEK,
     },
     token,
     installId: "c_install_tg1",

--- a/docs/migrate-to-v0.4.md
+++ b/docs/migrate-to-v0.4.md
@@ -148,3 +148,40 @@ The v0.3 workflow templates are frozen at tag `v0.3.3` and will remain installab
 **Telegram bot doesn't reply to `/link`** — the bot is at `@Conclave_ai_bot`. Double-check the handle; if your DM gets no reply within 10 seconds, the central plane's webhook might be down — ping the conclave-ai repo issues.
 
 **Review doesn't fire on PR** — confirm `.github/workflows/conclave.yml` exists on the PR's base branch (not just the PR itself). Reusable workflows only dispatch when the call-side workflow is on the default branch.
+
+---
+
+## KEK setup (v0.5)
+
+v0.5 introduces field-level encryption for the GitHub access tokens the
+central plane stores in D1 (v0.5 item H). The Worker reads the KEK from
+the secret `CONCLAVE_TOKEN_KEK` — 32 random bytes, base64 encoded.
+
+One-time setup on the central plane:
+
+```powershell
+# 1. Generate a fresh 32-byte key and copy the base64 string
+node -e "console.log(crypto.randomBytes(32).toString('base64'))"
+
+# 2. Store it as a Worker secret (paste the value when prompted)
+cd apps/central-plane
+wrangler secret put CONCLAVE_TOKEN_KEK --env production
+
+# 3. Run the migration that adds the encrypted column
+wrangler d1 execute conclave-ai --remote --file=./migrations/0004_encrypt_github_tokens.sql
+
+# 4. Deploy the Worker so it starts writing the encrypted column
+pnpm --filter @conclave-ai/central-plane ship
+```
+
+After deploy:
+- New OAuth-driven token writes go straight to the encrypted column.
+- Legacy rows with plaintext tokens stay readable and get
+  lazy-upgraded on first Telegram-webhook dispatch.
+- A future migration 0005 will drop the plaintext column once all rows
+  are upgraded. Do not run it until we ship that migration in v0.6.
+
+Do NOT commit the generated key anywhere — it lives only inside the CF
+Worker secret store. If you lose it, every encrypted token becomes
+unreadable and users must re-run `conclave init` to re-authenticate
+their repos.

--- a/docs/releases/v0.5.0-alpha.md
+++ b/docs/releases/v0.5.0-alpha.md
@@ -59,8 +59,79 @@ constructor-error path, and base64-string artifact input.
 
 ## F — i18n (forthcoming)
 
-*(This section will be populated by the F PR.)*
+*(This section will be populated by the F PR. Telegram notifier central
+routing shipped in v0.4.4; i18n of button labels and messages builds on
+that path.)*
 
-## H — D1 token encryption (forthcoming)
+## H — D1 token field encryption
 
-*(This section will be populated by the H PR.)*
+**Status:** implemented, pending operator KEK setup for live cutover.
+
+v0.4 stored `installs.github_access_token` as plaintext in D1 with a
+documented "v0.5 upgrades to field-level encryption with a KMS-backed
+key" note on migration 0003. v0.5 H delivers that upgrade.
+
+### What changed
+
+- **Migration 0004** adds the `github_access_token_enc TEXT` column to
+  `installs`. No SQL-level backfill — the Worker handles lazy migration
+  of legacy rows on first use. Migration 0003's plaintext column stays
+  in place for this release so a rollback is still possible; a future
+  migration 0005 (v0.6) will drop it after Bae verifies round-trip works
+  live.
+- **`apps/central-plane/src/crypto.ts`** (new) provides AES-256-GCM
+  encrypt/decrypt helpers via SubtleCrypto. Ciphertext wire format:
+  `base64(iv(12) || ciphertext || tag(16))`. Fresh random IV per call.
+  Tag-auth failures throw a clear error instead of silently returning
+  an empty string — callers need to distinguish tamper from legacy.
+- **Read path** (`getInstallForDispatch` in `src/db/telegram.ts`) prefers
+  the `_enc` column and decrypts it. Falls back to plaintext only when
+  `_enc` is NULL (legacy rows from before this release).
+- **Write path** (`setGithubAccessToken`) always encrypts and sets the
+  plaintext column to NULL in the same UPDATE. Refuses to run when
+  `CONCLAVE_TOKEN_KEK` is unset.
+- **Lazy upgrade** (`upgradeInstallTokenEncryption`) — after a
+  successful Telegram-webhook dispatch that used a legacy plaintext
+  token, the Worker encrypts it in-place and NULLs out the plaintext
+  column. Runs *after* dispatch so a KEK misconfiguration cannot brick
+  the user's action. Idempotent — the WHERE clause guards against
+  clobbering a concurrent writer.
+- **Runtime preflight** (`src/preflight.ts`, wired into `src/index.ts`)
+  fails fast with a clear error if `CONCLAVE_TOKEN_KEK` is set but
+  doesn't base64-decode to exactly 32 bytes. Unset is allowed at startup
+  (consistent with existing GITHUB_CLIENT_ID semantics); writes that
+  require the KEK throw their own clear errors.
+
+### Key management (v0.5 scope)
+
+Single KEK, no rotation envelope. A future v0.6 PR will introduce a
+key-ID prefix on the ciphertext so multiple KEKs can be tried during
+rotation windows. For now:
+
+1. Generate a 32-byte key:
+   ```
+   node -e "console.log(crypto.randomBytes(32).toString('base64'))"
+   ```
+2. Install it into the Worker:
+   ```
+   wrangler secret put CONCLAVE_TOKEN_KEK --env production
+   ```
+3. Deploy. Existing plaintext rows continue to work via the fallback
+   path and upgrade themselves on next use.
+
+Also documented in `docs/migrate-to-v0.4.md` under "KEK setup (v0.5)".
+
+### What didn't change (deliberately)
+
+- The `CONCLAVE_TOKEN` hash column — already SHA-256, never plaintext,
+  out of scope.
+- The `installs.github_access_token` plaintext column itself — will be
+  dropped in a follow-up 0005 migration once Bae verifies live.
+- Key rotation — v0.6.
+
+### Tests
+
+17 new tests in `apps/central-plane/test/crypto.test.mjs` and
+`test/installs.test.mjs` covering round-trip, tamper rejection, wrong
+KEK, invalid KEK length, insert-encrypts, read-fallback, and lazy-upgrade
+paths. Existing oauth + telegram tests updated to seed a test KEK.


### PR DESCRIPTION
## Summary

v0.5 item **H** — replaces plaintext storage of `installs.github_access_token` in D1 with AES-256-GCM encryption, closing the plaintext-token exposure documented as a TODO on migration 0003. KEK lives in the Worker secret `CONCLAVE_TOKEN_KEK`.

## Change areas

1. **Migration** — `apps/central-plane/migrations/0004_encrypt_github_tokens.sql` adds `github_access_token_enc TEXT`. No SQL backfill; Worker handles lazy upgrade. Two-phase cutover: this PR adds the column; a follow-up 0005 (v0.6) drops the plaintext column after live verification.
2. **Crypto helpers** — `apps/central-plane/src/crypto.ts` (new) exports `encryptToken` / `decryptToken` / `importKek` using SubtleCrypto AES-256-GCM. Wire format: `base64(iv(12) || ct || tag(16))`. Fresh random IV per call. Tag-auth failures throw a clear error (no silent-fallback).
3. **Read/write wiring** — `src/db/telegram.ts`
   - `setGithubAccessToken` now always encrypts and NULLs the plaintext column in the same UPDATE. Refuses to write when the KEK is unset.
   - `getInstallForDispatch` reads `_enc` first, falls back to plaintext for legacy rows, flags them with `needsLazyEncrypt`.
   - `upgradeInstallTokenEncryption` is the one-time lazy-upgrade call wired into the Telegram webhook *after* a successful dispatch (so KEK mis-config can't brick user actions).
4. **Preflight + env** — `src/preflight.ts` (new) validates KEK shape (must base64-decode to exactly 32 bytes) and is invoked once per isolate from `src/index.ts`. `Env.CONCLAVE_TOKEN_KEK?` added to `src/env.ts`.

## Operator step Bae must run

```powershell
node -e "console.log(crypto.randomBytes(32).toString('base64'))"
wrangler secret put CONCLAVE_TOKEN_KEK --env production
# paste the value when prompted
wrangler d1 execute conclave-ai --remote --file=./migrations/0004_encrypt_github_tokens.sql
pnpm --filter @conclave-ai/central-plane ship
```

Full walkthrough: `docs/migrate-to-v0.4.md` → "KEK setup (v0.5)".

**If the KEK is lost, all encrypted tokens become unreadable** — users have to re-run `conclave init`. Back it up somewhere out-of-band before rotation.

## Tests

63/63 passing (17 new):
- `test/crypto.test.mjs` — round-trip, random-IV uniqueness, tamper rejection, wrong-KEK rejection, invalid-KEK-length rejection, empty/short ciphertext rejection (9 tests).
- `test/installs.test.mjs` — encrypt-on-write, refuse-without-KEK, decrypt-on-read, plaintext-fallback, both-null handling, KEK-missing error, lazy-upgrade round-trip, idempotent lazy-upgrade (8 tests).
- Existing `test/oauth.test.mjs` + `test/telegram.test.mjs` updated to seed a valid KEK and match the new SELECT/UPDATE shapes.

## Out of scope (deliberately)

- Key rotation envelope — v0.6.
- Dropping the `github_access_token` plaintext column — v0.6, migration 0005, after Bae verifies live.
- `CONCLAVE_TOKEN` hash column (already SHA-256, never plaintext).
- `@conclave-ai/cli` version bump (this is a central-plane-only change).

## Potential conflict with sibling PR

The "Telegram central routing" parallel PR also modifies `apps/central-plane/src/routes/telegram.ts`. This PR adds a 10-line lazy-upgrade block inside the dispatch try/catch. If the routing PR reshapes the same function, merge order matters — flagging here, not resolving unilaterally.

## Test plan

- [ ] `corepack pnpm --filter @conclave-ai/central-plane build` locally (verified green)
- [ ] `corepack pnpm --filter @conclave-ai/central-plane test` locally (63/63 green)
- [ ] After merge + operator KEK setup: run `conclave init` on a test repo, verify OAuth path writes an `_enc` row with plaintext column NULL (D1 query).
- [ ] Click a 🔧 button in Telegram, verify dispatch fires and (on a pre-existing legacy row) the plaintext column is NULLed afterward.
- [ ] Temporarily unset KEK and confirm preflight error message is clear on cold-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)