### PR TITLE
feat(central-plane,integration-telegram): route notifications via central plane (v0.4.4)

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,15 +17,28 @@
 #   ANTHROPIC_API_KEY       required
 #   OPENAI_API_KEY          optional (enables 3-agent tier-1; otherwise 1-agent)
 #   GEMINI_API_KEY          optional (same)
-#   TELEGRAM_BOT_TOKEN      optional (disables Telegram notifier if missing)
-#   TELEGRAM_CHAT_ID        optional (same)
+#   CONCLAVE_TOKEN          required for Telegram notifications — installed
+#                           by `conclave init`. Routes notifications through
+#                           the central @Conclave_ai_bot, so you never need
+#                           your own bot token. If absent, review still runs
+#                           but posts no Telegram notification.
 #   ORCHESTRATOR_PAT        optional — REQUIRED for the rework button loop
 #                           (persist-episodic-to-main step + rework push-back).
 #                           Without it, review runs but rework cannot resolve
 #                           the episodic id later.
 #
-# v0.4.0-beta will migrate this to call the central plane for memory sync
-# and CONCLAVE_TOKEN-based auth; the consumer wrapper file will not change.
+# Optional repo variables (GitHub Actions `vars`, not secrets):
+#   CONCLAVE_CENTRAL_URL    override the central plane base URL. Leave unset
+#                           for the production default. Useful for staging
+#                           or self-hosted deployments.
+#
+# v0.4.4 — Telegram now routes through the central plane by default.
+# The legacy TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID secrets are no longer
+# consulted by this workflow. Drop them with:
+#     gh secret delete TELEGRAM_BOT_TOKEN --repo <slug>
+#     gh secret delete TELEGRAM_CHAT_ID   --repo <slug>
+# Self-hosted users who still want the direct-bot path can invoke the CLI
+# outside this reusable workflow.
 
 name: Conclave AI Review (reusable)
 
@@ -87,8 +100,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          CONCLAVE_TOKEN: ${{ secrets.CONCLAVE_TOKEN }}
+          CONCLAVE_CENTRAL_URL: ${{ vars.CONCLAVE_CENTRAL_URL || '' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           conclave review \

--- a/apps/central-plane/package.json
+++ b/apps/central-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/central-plane",
-  "version": "0.4.0",
+  "version": "0.4.4",
   "private": true,
   "description": "Conclave AI central control plane — Cloudflare Worker + D1 backing the v0.4 install model.",
   "license": "MIT",

--- a/apps/central-plane/src/router.ts
+++ b/apps/central-plane/src/router.ts
@@ -6,6 +6,7 @@ import { episodicRoutes } from "./routes/episodic.js";
 import { memoryRoutes } from "./routes/memory.js";
 import { createOAuthRoutes } from "./routes/oauth.js";
 import { createTelegramRoutes } from "./routes/telegram.js";
+import { createReviewRoutes } from "./routes/review.js";
 import type { FetchLike } from "./github.js";
 
 export function createApp(opts: { fetch?: FetchLike } = {}): Hono<{ Bindings: Env }> {
@@ -16,6 +17,7 @@ export function createApp(opts: { fetch?: FetchLike } = {}): Hono<{ Bindings: En
   app.route("/", memoryRoutes);
   app.route("/", createOAuthRoutes(opts.fetch));
   app.route("/", createTelegramRoutes(opts.fetch));
+  app.route("/", createReviewRoutes(opts.fetch));
   app.onError((err, c) => {
     console.error("central-plane error:", err);
     return c.json({ error: err.message || "internal error" }, 500);

--- a/apps/central-plane/src/routes/review.ts
+++ b/apps/central-plane/src/routes/review.ts
@@ -1,0 +1,155 @@
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import type { FetchLike } from "../github.js";
+import { findInstallByTokenHash, touchInstall } from "../db/installs.js";
+import { sha256Hex } from "../util.js";
+import { TelegramClient } from "../telegram.js";
+
+/**
+ * POST /review/notify
+ *
+ * Bearer-auth'd endpoint that the CLI notifier hits when
+ * `CONCLAVE_TOKEN` is set. The central plane resolves the caller's
+ * install by SHA-256 of the bearer token, looks up every telegram_link
+ * row pointing at that install, and fans the `sendMessage` out to the
+ * central @Conclave_ai_bot. Consumer repos no longer need their own
+ * bot token — they already have CONCLAVE_TOKEN installed by
+ * `conclave init`.
+ *
+ * Shape of the request body:
+ *   {
+ *     repo_slug: string,
+ *     message:   string,
+ *     pr_number?: number,
+ *     verdict?:  "approve" | "rework" | "reject",
+ *     episodic_id?: string,
+ *   }
+ *
+ * Inline action keyboard (🔧 rework / ✅ merge / ❌ reject) is attached
+ * ONLY when `episodic_id` is provided — button callbacks are keyed by
+ * episodic, so without one the webhook handler can't do anything with a
+ * click. Keep parity with `apps/central-plane/src/routes/telegram.ts`
+ * which parses `ep:<episodicId>:<outcome>` callbacks.
+ */
+export function createReviewRoutes(fetchImpl: FetchLike = fetch): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+
+  app.post("/review/notify", async (c) => {
+    const auth = c.req.header("authorization") ?? c.req.header("Authorization");
+    if (!auth || !/^Bearer\s+(.+)$/i.test(auth)) {
+      return c.json({ error: "missing or malformed Authorization: Bearer <token>" }, 401);
+    }
+    const token = auth.replace(/^Bearer\s+/i, "").trim();
+    if (!token) return c.json({ error: "empty bearer token" }, 401);
+
+    const body = (await c.req.json().catch(() => null)) as
+      | {
+          repo_slug?: unknown;
+          message?: unknown;
+          pr_number?: unknown;
+          verdict?: unknown;
+          episodic_id?: unknown;
+        }
+      | null;
+    if (!body || typeof body !== "object") {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
+
+    // ---- manual shape validation (no zod dep in the Worker bundle) ----
+    if (typeof body.repo_slug !== "string" || body.repo_slug.length === 0) {
+      return c.json({ error: "repo_slug: expected non-empty string" }, 400);
+    }
+    if (typeof body.message !== "string" || body.message.length === 0) {
+      return c.json({ error: "message: expected non-empty string" }, 400);
+    }
+    if (
+      body.pr_number !== undefined &&
+      (typeof body.pr_number !== "number" || !Number.isFinite(body.pr_number))
+    ) {
+      return c.json({ error: "pr_number: expected finite number" }, 400);
+    }
+    if (
+      body.verdict !== undefined &&
+      body.verdict !== "approve" &&
+      body.verdict !== "rework" &&
+      body.verdict !== "reject"
+    ) {
+      return c.json({ error: "verdict: expected 'approve' | 'rework' | 'reject'" }, 400);
+    }
+    if (body.episodic_id !== undefined && typeof body.episodic_id !== "string") {
+      return c.json({ error: "episodic_id: expected string" }, 400);
+    }
+
+    // ---- auth: SHA-256(token) → installs.token_hash ----
+    const tokenHash = await sha256Hex(token);
+    const install = await findInstallByTokenHash(c.env, tokenHash);
+    if (!install) {
+      return c.json({ error: "unknown or revoked token" }, 401);
+    }
+
+    const now = new Date().toISOString();
+    // last_seen_at bump — best-effort; don't block dispatch on it.
+    await touchInstall(c.env, install.id, now).catch((err) => {
+      console.warn("touchInstall failed:", err);
+    });
+
+    // ---- telegram_links fanout ----
+    const chatRows = await c.env.DB.prepare(
+      "SELECT chat_id FROM telegram_links WHERE install_id = ?",
+    )
+      .bind(install.id)
+      .all<{ chat_id: number }>();
+    const chatIds = (chatRows.results ?? []).map((r) => r.chat_id);
+    if (chatIds.length === 0) {
+      return c.json({ ok: true, delivered: 0, reason: "no linked chat" });
+    }
+
+    const botToken = c.env.TELEGRAM_BOT_TOKEN;
+    if (!botToken || botToken.startsWith("REPLACE_WITH_")) {
+      // Operator misconfiguration — surface plainly, don't silently
+      // swallow. Consumer CLI will log the 503 and continue.
+      return c.json(
+        { ok: false, delivered: 0, error: "TELEGRAM_BOT_TOKEN not configured on central plane" },
+        503,
+      );
+    }
+
+    const telegram = new TelegramClient({ token: botToken, fetch: fetchImpl });
+
+    // Optional inline keyboard — only useful when we have an episodic_id
+    // to put in callback_data. See parseCallbackData in telegram.ts.
+    const episodicId = typeof body.episodic_id === "string" ? body.episodic_id : undefined;
+    const replyMarkup = episodicId
+      ? {
+          inline_keyboard: [
+            [
+              { text: "🔧 Rework", callback_data: `ep:${episodicId}:reworked` },
+              { text: "✅ Merge", callback_data: `ep:${episodicId}:merged` },
+              { text: "❌ Reject", callback_data: `ep:${episodicId}:rejected` },
+            ],
+          ],
+        }
+      : undefined;
+
+    let delivered = 0;
+    for (const chatId of chatIds) {
+      try {
+        await telegram.sendMessage({
+          chatId,
+          text: body.message,
+          parseMode: "HTML",
+          ...(replyMarkup ? { replyMarkup } : {}),
+        });
+        delivered += 1;
+      } catch (err) {
+        // Per-chat failure shouldn't abort the rest of the fanout —
+        // one dead chat shouldn't starve the others.
+        console.warn(`sendMessage to chat ${chatId} failed:`, err);
+      }
+    }
+
+    return c.json({ ok: true, delivered });
+  });
+
+  return app;
+}

--- a/apps/central-plane/src/telegram.ts
+++ b/apps/central-plane/src/telegram.ts
@@ -23,6 +23,9 @@ export class TelegramClient {
     text: string;
     parseMode?: "HTML" | "MarkdownV2";
     replyToMessageId?: number;
+    replyMarkup?: {
+      inline_keyboard: Array<Array<{ text: string; callback_data?: string; url?: string }>>;
+    };
   }): Promise<void> {
     const body: Record<string, unknown> = {
       chat_id: opts.chatId,
@@ -31,6 +34,7 @@ export class TelegramClient {
     };
     if (opts.parseMode) body.parse_mode = opts.parseMode;
     if (opts.replyToMessageId) body.reply_to_message_id = opts.replyToMessageId;
+    if (opts.replyMarkup) body.reply_markup = opts.replyMarkup;
     const resp = await this.fetchImpl(this.url("sendMessage"), {
       method: "POST",
       headers: { "content-type": "application/json" },

--- a/apps/central-plane/test/review.test.mjs
+++ b/apps/central-plane/test/review.test.mjs
@@ -1,0 +1,333 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { createApp } from "../dist/router.js";
+
+// ---- mock D1 covering installs + telegram_links (all + first) -----------
+
+function makeMockDb({ installs = new Map(), links = [] } = {}) {
+  const state = {
+    installs: new Map(installs),
+    // links is a flat array of { chatId, installId, linkedAt, userLabel }
+    links: [...links],
+  };
+  return {
+    state,
+    prepare(sql) {
+      let bound = [];
+      const wrap = {
+        bind: (...args) => {
+          bound = args;
+          return wrap;
+        },
+        async first() {
+          if (/SELECT \* FROM installs WHERE token_hash = \?/.test(sql)) {
+            for (const v of state.installs.values()) {
+              if (v.tokenHash === bound[0] && v.status === "active") {
+                return {
+                  id: v.id,
+                  repo_slug: v.repoSlug,
+                  token_hash: v.tokenHash,
+                  created_at: v.createdAt,
+                  last_seen_at: v.lastSeenAt,
+                  status: v.status,
+                };
+              }
+            }
+            return null;
+          }
+          return null;
+        },
+        async all() {
+          if (/SELECT chat_id FROM telegram_links WHERE install_id = \?/.test(sql)) {
+            const installId = bound[0];
+            const results = state.links
+              .filter((l) => l.installId === installId)
+              .map((l) => ({ chat_id: l.chatId }));
+            return { results, success: true };
+          }
+          return { results: [], success: true };
+        },
+        async run() {
+          if (/UPDATE installs SET last_seen_at/.test(sql)) {
+            const [lastSeenAt, id] = bound;
+            for (const v of state.installs.values()) {
+              if (v.id === id) v.lastSeenAt = lastSeenAt;
+            }
+          }
+          return { success: true };
+        },
+      };
+      return wrap;
+    },
+  };
+}
+
+function sha256(s) {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function makeFetch(handlers) {
+  const calls = [];
+  const fn = async (url, init = {}) => {
+    const urlStr = typeof url === "string" ? url : url.url;
+    calls.push({ url: urlStr, method: init.method, body: init.body, headers: init.headers });
+    for (const h of handlers) {
+      if (h.match(urlStr, init)) return h.respond(urlStr, init);
+    }
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function json(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function fetchApp(app, path, init = {}, env = {}) {
+  const ctx = { waitUntil: () => {}, passThroughOnException: () => {} };
+  const req = new Request(`http://localhost${path}`, init);
+  const res = await app.fetch(req, env, ctx);
+  return { res, body: await res.json().catch(() => null) };
+}
+
+// ---- fixtures ------------------------------------------------------------
+
+function makeEnv({ token = "c_rev_token_ok", repo = "acme/app", chatIds = [] } = {}) {
+  const tokenHash = sha256(token);
+  const installId = "c_install_rev1";
+  const installs = new Map([[
+    repo,
+    {
+      id: installId,
+      repoSlug: repo,
+      tokenHash,
+      createdAt: "2026-04-20T00:00:00Z",
+      lastSeenAt: "2026-04-20T00:00:00Z",
+      status: "active",
+    },
+  ]]);
+  const links = chatIds.map((cid) => ({
+    chatId: cid,
+    installId,
+    linkedAt: "2026-04-20T00:00:00Z",
+    userLabel: null,
+  }));
+  return {
+    env: {
+      DB: makeMockDb({ installs, links }),
+      ENVIRONMENT: "test",
+      TELEGRAM_BOT_TOKEN: "bot-rev-token",
+    },
+    token,
+    installId,
+    repo,
+  };
+}
+
+// ---- tests ---------------------------------------------------------------
+
+test("POST /review/notify: wrong bearer token → 401 and no dispatch", async () => {
+  const fetchMock = makeFetch([
+    { match: (u) => u.includes("/sendMessage"), respond: () => json(200, { ok: true }) },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const { env } = makeEnv({ chatIds: [42] });
+  const { res, body } = await fetchApp(
+    app,
+    "/review/notify",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer c_not_the_right_token",
+      },
+      body: JSON.stringify({ repo_slug: "acme/app", message: "hi" }),
+    },
+    env,
+  );
+  assert.equal(res.status, 401);
+  assert.ok(body.error);
+  const sent = fetchMock.calls.find((c) => c.url.includes("/sendMessage"));
+  assert.equal(sent, undefined, "no sendMessage should fire on auth failure");
+});
+
+test("POST /review/notify: missing Authorization header → 401", async () => {
+  const fetchMock = makeFetch([]);
+  const app = createApp({ fetch: fetchMock });
+  const { env } = makeEnv();
+  const { res } = await fetchApp(
+    app,
+    "/review/notify",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repo_slug: "acme/app", message: "hi" }),
+    },
+    env,
+  );
+  assert.equal(res.status, 401);
+});
+
+test("POST /review/notify: valid token + 1 linked chat → 1 dispatch + ok body", async () => {
+  const fetchMock = makeFetch([
+    { match: (u) => u.includes("/sendMessage"), respond: () => json(200, { ok: true, result: {} }) },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const { env, token } = makeEnv({ chatIds: [777] });
+  const { res, body } = await fetchApp(
+    app,
+    "/review/notify",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        repo_slug: "acme/app",
+        message: "🏛️ review complete",
+        pr_number: 42,
+        verdict: "approve",
+        episodic_id: "ep-happy-1",
+      }),
+    },
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.delivered, 1);
+  const sends = fetchMock.calls.filter((c) => c.url.includes("/sendMessage"));
+  assert.equal(sends.length, 1);
+  const payload = JSON.parse(sends[0].body);
+  assert.equal(payload.chat_id, 777);
+  assert.equal(payload.text, "🏛️ review complete");
+  assert.equal(payload.parse_mode, "HTML");
+  // episodic_id present → inline keyboard attached
+  assert.ok(payload.reply_markup);
+  const kb = payload.reply_markup.inline_keyboard;
+  assert.ok(Array.isArray(kb) && Array.isArray(kb[0]) && kb[0].length === 3);
+  const callbacks = kb[0].map((b) => b.callback_data);
+  assert.ok(callbacks.some((d) => d === "ep:ep-happy-1:reworked"));
+  assert.ok(callbacks.some((d) => d === "ep:ep-happy-1:merged"));
+  assert.ok(callbacks.some((d) => d === "ep:ep-happy-1:rejected"));
+});
+
+test("POST /review/notify: no linked chats → ok with delivered: 0 + reason", async () => {
+  const fetchMock = makeFetch([
+    { match: (u) => u.includes("/sendMessage"), respond: () => json(200, { ok: true }) },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const { env, token } = makeEnv({ chatIds: [] });
+  const { res, body } = await fetchApp(
+    app,
+    "/review/notify",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ repo_slug: "acme/app", message: "x" }),
+    },
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.delivered, 0);
+  assert.equal(body.reason, "no linked chat");
+  const sent = fetchMock.calls.find((c) => c.url.includes("/sendMessage"));
+  assert.equal(sent, undefined);
+});
+
+test("POST /review/notify: no episodic_id → no inline keyboard on message", async () => {
+  const fetchMock = makeFetch([
+    { match: (u) => u.includes("/sendMessage"), respond: () => json(200, { ok: true }) },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const { env, token } = makeEnv({ chatIds: [123] });
+  await fetchApp(
+    app,
+    "/review/notify",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ repo_slug: "acme/app", message: "bare" }),
+    },
+    env,
+  );
+  const sent = fetchMock.calls.find((c) => c.url.includes("/sendMessage"));
+  const payload = JSON.parse(sent.body);
+  assert.equal(payload.reply_markup, undefined);
+});
+
+test("POST /review/notify: malformed body → 400", async () => {
+  const fetchMock = makeFetch([]);
+  const app = createApp({ fetch: fetchMock });
+  const { env, token } = makeEnv();
+  const { res } = await fetchApp(
+    app,
+    "/review/notify",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ repo_slug: "acme/app" }), // missing message
+    },
+    env,
+  );
+  assert.equal(res.status, 400);
+});
+
+test("POST /review/notify: invalid verdict value → 400", async () => {
+  const fetchMock = makeFetch([]);
+  const app = createApp({ fetch: fetchMock });
+  const { env, token } = makeEnv({ chatIds: [1] });
+  const { res } = await fetchApp(
+    app,
+    "/review/notify",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ repo_slug: "acme/app", message: "x", verdict: "approved-ish" }),
+    },
+    env,
+  );
+  assert.equal(res.status, 400);
+});
+
+test("POST /review/notify: valid token → last_seen_at is bumped", async () => {
+  const fetchMock = makeFetch([
+    { match: (u) => u.includes("/sendMessage"), respond: () => json(200, { ok: true }) },
+  ]);
+  const app = createApp({ fetch: fetchMock });
+  const { env, token, installId } = makeEnv({ chatIds: [5] });
+  const before = [...env.DB.state.installs.values()][0].lastSeenAt;
+  await fetchApp(
+    app,
+    "/review/notify",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ repo_slug: "acme/app", message: "tick" }),
+    },
+    env,
+  );
+  const after = [...env.DB.state.installs.values()].find((v) => v.id === installId).lastSeenAt;
+  assert.notEqual(after, before, "last_seen_at should advance");
+});

--- a/docs/migrate-to-v0.4.md
+++ b/docs/migrate-to-v0.4.md
@@ -40,14 +40,16 @@ v0.4 needs exactly one conclave-owned secret on your repo: `CONCLAVE_TOKEN`. The
 
 **Drop if present:**
 - `ORCHESTRATOR_PAT` — v0.4's central bot fires dispatches server-side using the GitHub token captured during OAuth
-- `TELEGRAM_BOT_TOKEN` — v0.4 uses a single central bot (`@Conclave_ai_bot`); you no longer run your own
-- `TELEGRAM_CHAT_ID` — same reason
+- `TELEGRAM_BOT_TOKEN` — **fully unused from v0.4.4 onward.** v0.4.4 routes all Telegram notifications through the central `@Conclave_ai_bot` using your `CONCLAVE_TOKEN`. Earlier v0.4.0–v0.4.3 still consulted this secret for the notifier; from v0.4.4 the reusable workflow no longer sets it, and the CLI notifier prefers the central path when `CONCLAVE_TOKEN` is present. Safe to delete.
+- `TELEGRAM_CHAT_ID` — same reason.
 
 ```powershell
 gh secret delete ORCHESTRATOR_PAT   --repo owner/repo
 gh secret delete TELEGRAM_BOT_TOKEN --repo owner/repo
 gh secret delete TELEGRAM_CHAT_ID   --repo owner/repo
 ```
+
+> **Self-hosted Conclave?** If you run a private central plane, the CLI notifier still honours `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` when `CONCLAVE_TOKEN` is absent. See `packages/integration-telegram` for the dual-path implementation; the reusable workflow above assumes the public central plane.
 
 **Keep:**
 - `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY` — still user-owned in v0.4 (D6). `conclave init` will remind you to set these if they're missing.

--- a/docs/releases/v0.4.4.md
+++ b/docs/releases/v0.4.4.md
@@ -1,0 +1,68 @@
+# Conclave AI v0.4.4
+
+Release date: 2026-04-21
+
+**Telegram notifications now route through the Conclave AI central plane.**
+
+## Summary
+
+v0.4.4 closes the last v0.3-style leak in the default install: the reusable review workflow (and the CLI's Telegram notifier) no longer ask the consumer repo for `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID`. Instead, the CLI POSTs to a new `/review/notify` endpoint on the central plane, authenticated with the `CONCLAVE_TOKEN` that `conclave init` already installed. The central plane fans the message out to every Telegram chat linked to that install via `/link`, using the central `@Conclave_ai_bot` that landed in PR #74.
+
+This was the root cause of the v0.4 smoke-test warning `conclave review: TELEGRAM_BOT_TOKEN not set — skipping Telegram notifier` even after a successful `/link`.
+
+## What shipped
+
+### 1. Central plane: new `POST /review/notify`
+
+- File: `apps/central-plane/src/routes/review.ts`
+- Auth: bearer token in `Authorization: Bearer <CONCLAVE_TOKEN>`; matched against `installs.token_hash` (SHA-256). Updates `installs.last_seen_at` on success.
+- Body: `{ repo_slug, message, pr_number?, verdict?, episodic_id? }`.
+- Behaviour: fans out to every `telegram_links.chat_id` row for the matched install. Attaches an inline 🔧 rework / ✅ merge / ❌ reject keyboard when `episodic_id` is present — payload matches the `ep:<id>:<outcome>` format the existing `/telegram/webhook` handler already parses, so button clicks keep working end-to-end.
+- Returns `{ ok: true, delivered: <count> }`. Zero linked chats returns `{ ok: true, delivered: 0, reason: "no linked chat" }` (not an error).
+- `apps/central-plane` bumped to 0.4.4.
+
+### 2. CLI notifier: dual-path
+
+- File: `packages/integration-telegram/src/notifier.ts`.
+- **Path A (default when `CONCLAVE_TOKEN` is set):** POST to `${CONCLAVE_CENTRAL_URL || default}/review/notify` with the bearer token. Logs `conclave review: telegram via central plane`.
+- **Path B (fallback):** unchanged — direct Telegram Bot API using `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID`. Logs `conclave review: telegram via direct bot token`. Preserved for self-hosted Conclave deployments and v0.3-style installs.
+- `useCentralPlane: false` opt-out on `TelegramNotifierOptions` for tests / overrides.
+- `@conclave-ai/integration-telegram` bumped to 0.4.4. `@conclave-ai/cli` behaviour unchanged (it just reads the new env var), so no CLI version bump.
+
+### 3. Reusable workflow
+
+- File: `.github/workflows/review.yml`.
+- Removed `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` from the review step's `env:` block.
+- Added `CONCLAVE_TOKEN: ${{ secrets.CONCLAVE_TOKEN }}` — required for Telegram delivery from v0.4.4 onward.
+- Added `CONCLAVE_CENTRAL_URL: ${{ vars.CONCLAVE_CENTRAL_URL || '' }}` — optional GitHub Actions repo variable for staging / self-hosted central planes. Empty value falls back to the CLI's default.
+- Header comment updated to reflect the new secret list.
+
+## Migration
+
+If you migrated to v0.4 at any point between v0.4.0 and v0.4.3, drop the now-unused Telegram secrets:
+
+```powershell
+gh secret delete TELEGRAM_BOT_TOKEN --repo <owner>/<repo>
+gh secret delete TELEGRAM_CHAT_ID   --repo <owner>/<repo>
+```
+
+Nothing else changes. `CONCLAVE_TOKEN` is already installed by `conclave init`, and the /link step in Telegram wires the chat → install relationship the central plane uses to route.
+
+See `docs/migrate-to-v0.4.md` for the full migration walkthrough (updated with the v0.4.4 clarifications).
+
+## Self-hosted users
+
+If you run a private central plane, the direct-bot path still works — leave `CONCLAVE_TOKEN` unset in your environment and the notifier falls back to `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` exactly as it did in v0.4.0–v0.4.3. You can also force the direct path with `useCentralPlane: false` when constructing `TelegramNotifier` programmatically.
+
+## What did NOT change
+
+- `telegram_links` schema — unchanged.
+- Existing `/telegram/webhook` callback handling — unchanged. Button click parsing (`ep:<id>:<outcome>`) still routes through the same code path.
+- Any other integration (Discord / Slack / Email) — unchanged.
+- LLM API keys — still user-owned (D6).
+
+## Not in this release
+
+- **Design agent (v0.5 C)** — tracked separately.
+- **D1 token encryption at rest (v0.5 H)** — tracked separately.
+- **Benchmarks repo** — tracked separately.

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -333,10 +333,26 @@ export async function review(argv: string[]): Promise<void> {
   const notifiers: Notifier[] = [];
   const tg = config.integrations?.telegram;
   if (tg?.enabled !== false) {
+    // v0.4.4 — dual-path: CONCLAVE_TOKEN routes through the central plane
+    // (no per-repo bot token needed). Direct-bot path still works when
+    // CONCLAVE_TOKEN is absent (self-hosted / v0.3-style installs).
+    const hasConclaveToken = !!process.env["CONCLAVE_TOKEN"];
     const hasToken = !!process.env["TELEGRAM_BOT_TOKEN"];
     const hasChat = tg?.chatId !== undefined || !!process.env["TELEGRAM_CHAT_ID"];
-    if (tg?.enabled === true && !hasToken) {
-      process.stderr.write("conclave review: TELEGRAM_BOT_TOKEN not set — skipping Telegram notifier\n");
+    if (hasConclaveToken) {
+      const opts: ConstructorParameters<typeof TelegramNotifier>[0] = {};
+      if (tg?.includeActionButtons !== undefined) opts.includeActionButtons = tg.includeActionButtons;
+      try {
+        notifiers.push(new TelegramNotifier(opts));
+      } catch (err) {
+        process.stderr.write(
+          `conclave review: Telegram notifier (central) init failed — ${(err as Error).message}\n`,
+        );
+      }
+    } else if (tg?.enabled === true && !hasToken) {
+      process.stderr.write(
+        "conclave review: neither CONCLAVE_TOKEN nor TELEGRAM_BOT_TOKEN set — skipping Telegram notifier\n",
+      );
     } else if (hasToken && hasChat) {
       const opts: ConstructorParameters<typeof TelegramNotifier>[0] = {};
       if (tg?.chatId !== undefined) opts.chatId = tg.chatId;

--- a/packages/integration-telegram/package.json
+++ b/packages/integration-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/integration-telegram",
-  "version": "0.4.0",
+  "version": "0.4.4",
   "description": "Conclave AI Telegram notifier — posts review outcomes to a Telegram chat via Bot API.",
   "license": "MIT",
   "type": "module",

--- a/packages/integration-telegram/src/index.ts
+++ b/packages/integration-telegram/src/index.ts
@@ -6,6 +6,6 @@ export type {
   TelegramResponse,
   HttpFetch,
 } from "./client.js";
-export { TelegramNotifier } from "./notifier.js";
+export { TelegramNotifier, DEFAULT_CENTRAL_URL } from "./notifier.js";
 export type { TelegramNotifierOptions } from "./notifier.js";
 export { formatReviewForTelegram } from "./format.js";

--- a/packages/integration-telegram/src/notifier.ts
+++ b/packages/integration-telegram/src/notifier.ts
@@ -2,6 +2,16 @@ import type { Notifier, NotifyReviewInput } from "@conclave-ai/core";
 import { TelegramClient, type HttpFetch, type TelegramInlineKeyboard } from "./client.js";
 import { formatReviewForTelegram } from "./format.js";
 
+/**
+ * Default Conclave central plane URL. Duplicated from
+ * `packages/cli/src/commands/init/central-client.ts` — importing it
+ * directly would create a circular workspace dep (cli → integration-
+ * telegram → cli). Kept in sync by policy; the two constants MUST
+ * match. When the central plane URL changes, update both files in the
+ * same PR.
+ */
+export const DEFAULT_CENTRAL_URL = "https://conclave-ai.seunghunbae.workers.dev";
+
 export interface TelegramNotifierOptions {
   /** Bot token from BotFather. If omitted, read from TELEGRAM_BOT_TOKEN env. */
   token?: string;
@@ -15,6 +25,26 @@ export interface TelegramNotifierOptions {
   baseUrl?: string;
   /** If true, attaches inline buttons (approve/reject/rework) to the message. Default true. */
   includeActionButtons?: boolean;
+  /**
+   * If true, route notifications through the Conclave central plane
+   * rather than hitting the Telegram Bot API directly. Ignored if
+   * CONCLAVE_TOKEN env is not set. Defaults to automatic: central path
+   * on, if and only if CONCLAVE_TOKEN is present in env.
+   */
+  useCentralPlane?: boolean;
+  /**
+   * Override central plane base URL (tests). Falls back to
+   * CONCLAVE_CENTRAL_URL env then DEFAULT_CENTRAL_URL.
+   */
+  centralUrl?: string;
+  /**
+   * Repo slug override. Falls back to GITHUB_REPOSITORY env (set by
+   * GitHub Actions automatically). If neither source yields a slug, the
+   * notifier still works — the central plane only uses it for logging.
+   */
+  repoSlug?: string;
+  /** Logger for `which path taken` diagnostics. Defaults to stderr. */
+  log?: (msg: string) => void;
 }
 
 /**
@@ -25,23 +55,74 @@ export interface TelegramNotifierOptions {
  * intentionally minimal — sendMessage + optional action buttons.
  * Inbound bot command handling (approve via button, /status, etc.) lives
  * in a separate command-surface package if/when added.
+ *
+ * v0.4.4 — dual-path delivery:
+ *
+ *   path A (CONCLAVE_TOKEN set, default in v0.4.4+):
+ *     POST {CONCLAVE_CENTRAL_URL}/review/notify with bearer auth
+ *     → central plane fans out to every linked Telegram chat
+ *     → no per-repo TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID needed
+ *
+ *   path B (self-hosted / v0.3 compat):
+ *     direct POST to https://api.telegram.org/bot{token}/sendMessage
+ *     → requires TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID
+ *     → preserved so users on private Conclave deployments keep working
  */
 export class TelegramNotifier implements Notifier {
   readonly id = "telegram";
   readonly displayName = "Telegram";
 
-  private readonly chatId: number | string;
-  private readonly client: TelegramClient;
+  // path A (central plane) — populated when useCentralPlane is on
+  private readonly centralUrl: string | null;
+  private readonly centralToken: string | null;
+  private readonly centralFetch: HttpFetch | null;
+  private readonly repoSlug: string;
+
+  // path B (direct bot) — populated when useCentralPlane is off
+  private readonly chatId: number | string | null;
+  private readonly client: TelegramClient | null;
+
   private readonly includeActionButtons: boolean;
+  private readonly log: (msg: string) => void;
 
   constructor(opts: TelegramNotifierOptions = {}) {
+    this.includeActionButtons = opts.includeActionButtons ?? true;
+    this.log = opts.log ?? ((m) => process.stderr.write(m + "\n"));
+
+    // Decide path. Explicit opts.useCentralPlane overrides env detection.
+    const conclaveToken = process.env["CONCLAVE_TOKEN"] ?? "";
+    const useCentral =
+      opts.useCentralPlane !== undefined ? opts.useCentralPlane : conclaveToken.length > 0;
+
+    if (useCentral) {
+      if (!conclaveToken && opts.useCentralPlane === true) {
+        throw new Error(
+          "TelegramNotifier: useCentralPlane=true but CONCLAVE_TOKEN is not set in env",
+        );
+      }
+      this.centralToken = conclaveToken;
+      this.centralUrl = (
+        opts.centralUrl ?? process.env["CONCLAVE_CENTRAL_URL"] ?? DEFAULT_CENTRAL_URL
+      ).replace(/\/$/, "");
+      this.centralFetch = opts.fetch ?? null;
+      this.repoSlug = opts.repoSlug ?? process.env["GITHUB_REPOSITORY"] ?? "unknown/unknown";
+      this.chatId = null;
+      this.client = null;
+      return;
+    }
+
+    // Path B — direct-to-Telegram, original v0.3 behaviour.
     const token = opts.token ?? process.env["TELEGRAM_BOT_TOKEN"] ?? "";
     const chatRaw = opts.chatId ?? process.env["TELEGRAM_CHAT_ID"] ?? "";
     if (!token && !opts.client) {
-      throw new Error("TelegramNotifier: TELEGRAM_BOT_TOKEN not set (pass opts.token, opts.client, or env)");
+      throw new Error(
+        "TelegramNotifier: TELEGRAM_BOT_TOKEN not set (pass opts.token, opts.client, or env), and CONCLAVE_TOKEN also absent",
+      );
     }
     if (!chatRaw) {
-      throw new Error("TelegramNotifier: TELEGRAM_CHAT_ID not set (pass opts.chatId or env)");
+      throw new Error(
+        "TelegramNotifier: TELEGRAM_CHAT_ID not set (pass opts.chatId or env), and CONCLAVE_TOKEN also absent",
+      );
     }
     this.chatId = typeof chatRaw === "string" && /^-?\d+$/.test(chatRaw) ? Number(chatRaw) : chatRaw;
     if (opts.client) {
@@ -52,10 +133,72 @@ export class TelegramNotifier implements Notifier {
       if (opts.baseUrl) clientOpts.baseUrl = opts.baseUrl;
       this.client = new TelegramClient(clientOpts);
     }
-    this.includeActionButtons = opts.includeActionButtons ?? true;
+    this.centralToken = null;
+    this.centralUrl = null;
+    this.centralFetch = null;
+    this.repoSlug = "";
   }
 
   async notifyReview(input: NotifyReviewInput): Promise<void> {
+    if (this.centralToken && this.centralUrl) {
+      this.log("conclave review: telegram via central plane");
+      await this.notifyViaCentral(input);
+      return;
+    }
+    this.log("conclave review: telegram via direct bot token");
+    await this.notifyViaDirect(input);
+  }
+
+  private async notifyViaCentral(input: NotifyReviewInput): Promise<void> {
+    const text = formatReviewForTelegram(input);
+    const repoSlug = input.ctx?.repo || this.repoSlug;
+    const body: {
+      repo_slug: string;
+      message: string;
+      pr_number?: number;
+      verdict?: "approve" | "rework" | "reject";
+      episodic_id?: string;
+    } = {
+      repo_slug: repoSlug,
+      message: text,
+    };
+    if (typeof input.ctx?.pullNumber === "number") body.pr_number = input.ctx.pullNumber;
+    if (input.outcome?.verdict) body.verdict = input.outcome.verdict;
+    // Only include episodic_id when the consumer wanted action buttons —
+    // keeps parity with the direct path where includeActionButtons
+    // controls button rendering, and with central /review/notify which
+    // attaches buttons iff episodic_id is present.
+    if (this.includeActionButtons && input.episodicId) body.episodic_id = input.episodicId;
+
+    const fetchFn: HttpFetch | typeof fetch =
+      this.centralFetch ??
+      ((...args: Parameters<typeof fetch>) =>
+        fetch(...args) as unknown as ReturnType<HttpFetch>);
+
+    const resp = await (fetchFn as HttpFetch)(`${this.centralUrl}/review/notify`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${this.centralToken ?? ""}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      const msg = await resp.text().catch(() => "");
+      throw new Error(
+        `TelegramNotifier (central): /review/notify returned HTTP ${resp.status} — ${msg.slice(0, 300)}`,
+      );
+    }
+    // Drain body so sockets close promptly. Do not parse strictly — the
+    // central plane contract is `{ ok: true, delivered: number }` but we
+    // don't gate on it from the CLI side.
+    await resp.json().catch(() => null);
+  }
+
+  private async notifyViaDirect(input: NotifyReviewInput): Promise<void> {
+    if (!this.client || this.chatId === null) {
+      throw new Error("TelegramNotifier: direct path selected but client/chatId not configured");
+    }
     const text = formatReviewForTelegram(input);
     const sendParams: Parameters<TelegramClient["sendMessage"]>[0] = {
       chat_id: this.chatId,

--- a/packages/integration-telegram/test/notifier.test.mjs
+++ b/packages/integration-telegram/test/notifier.test.mjs
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { TelegramNotifier } from "../dist/index.js";
+import { TelegramNotifier, DEFAULT_CENTRAL_URL } from "../dist/index.js";
+
+// ---- mock fetches --------------------------------------------------------
 
 function mockFetch(response = { ok: true, result: { message_id: 1 } }) {
   const calls = [];
@@ -9,6 +11,21 @@ function mockFetch(response = { ok: true, result: { message_id: 1 } }) {
     return {
       ok: true,
       status: 200,
+      json: async () => response,
+      text: async () => JSON.stringify(response),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function mockCentralFetch(response = { ok: true, delivered: 1 }, status = 200) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init, body: init.body ? JSON.parse(init.body) : null });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
       json: async () => response,
       text: async () => JSON.stringify(response),
     };
@@ -29,85 +46,324 @@ const baseInput = {
   totalCostUsd: 0.01,
 };
 
-test("TelegramNotifier: constructor throws on missing token", () => {
-  const orig = process.env.TELEGRAM_BOT_TOKEN;
-  delete process.env.TELEGRAM_BOT_TOKEN;
-  try {
-    assert.throws(() => new TelegramNotifier({ chatId: 1 }));
-  } finally {
-    if (orig !== undefined) process.env.TELEGRAM_BOT_TOKEN = orig;
+const reworkInput = {
+  outcome: {
+    verdict: "rework",
+    rounds: 1,
+    consensusReached: false,
+    results: [
+      {
+        agent: "claude",
+        verdict: "rework",
+        blockers: [
+          { severity: "major", category: "security", message: "hardcoded secret", file: "a.ts", line: 5 },
+        ],
+        summary: "needs fixes",
+      },
+    ],
+  },
+  ctx: { diff: "", repo: "acme/app", pullNumber: 7, newSha: "def" },
+  episodicId: "ep-rework",
+  totalCostUsd: 0.02,
+};
+
+function withEnv(mutations, fn) {
+  const originals = {};
+  for (const [k, v] of Object.entries(mutations)) {
+    originals[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
   }
+  try {
+    return fn();
+  } finally {
+    for (const [k, v] of Object.entries(originals)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+async function withEnvAsync(mutations, fn) {
+  const originals = {};
+  for (const [k, v] of Object.entries(mutations)) {
+    originals[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [k, v] of Object.entries(originals)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+// ---- direct path (path B) — legacy v0.3 behaviour, preserved ------------
+
+test("TelegramNotifier direct: constructor throws on missing token when CONCLAVE_TOKEN absent", () => {
+  withEnv(
+    { TELEGRAM_BOT_TOKEN: undefined, CONCLAVE_TOKEN: undefined, TELEGRAM_CHAT_ID: undefined },
+    () => {
+      assert.throws(() => new TelegramNotifier({ chatId: 1 }));
+    },
+  );
 });
 
-test("TelegramNotifier: constructor throws on missing chatId", () => {
-  const orig = process.env.TELEGRAM_CHAT_ID;
-  delete process.env.TELEGRAM_CHAT_ID;
-  try {
+test("TelegramNotifier direct: constructor throws on missing chatId when CONCLAVE_TOKEN absent", () => {
+  withEnv({ CONCLAVE_TOKEN: undefined, TELEGRAM_CHAT_ID: undefined }, () => {
     assert.throws(() => new TelegramNotifier({ token: "t" }));
-  } finally {
-    if (orig !== undefined) process.env.TELEGRAM_CHAT_ID = orig;
-  }
+  });
 });
 
-test("TelegramNotifier: numeric-string chat id is coerced to number", async () => {
-  const f = mockFetch();
-  const n = new TelegramNotifier({ token: "t", chatId: "-100123", fetch: f });
-  await n.notifyReview(baseInput);
-  assert.equal(typeof f.calls[0].body.chat_id, "number");
-  assert.equal(f.calls[0].body.chat_id, -100123);
-});
-
-test("TelegramNotifier: notifyReview posts HTML + disable_web_page_preview", async () => {
-  const f = mockFetch();
-  const n = new TelegramNotifier({ token: "t", chatId: 999, fetch: f });
-  await n.notifyReview(baseInput);
-  assert.equal(f.calls[0].body.parse_mode, "HTML");
-  assert.equal(f.calls[0].body.disable_web_page_preview, true);
-  assert.match(f.calls[0].body.text, /Approved/);
-});
-
-test("TelegramNotifier: includes inline action keyboard by default", async () => {
-  const f = mockFetch();
-  const n = new TelegramNotifier({ token: "t", chatId: 999, fetch: f });
-  await n.notifyReview(baseInput);
-  const kb = f.calls[0].body.reply_markup?.inline_keyboard;
-  assert.ok(Array.isArray(kb));
-  assert.equal(kb[0].length, 3);
-  const callbacks = kb[0].map((b) => b.callback_data);
-  assert.ok(callbacks[0].startsWith("ep:ep-test:merged"));
-  assert.ok(callbacks[1].startsWith("ep:ep-test:reworked"));
-  assert.ok(callbacks[2].startsWith("ep:ep-test:rejected"));
-});
-
-test("TelegramNotifier: includeActionButtons:false omits reply_markup", async () => {
-  const f = mockFetch();
-  const n = new TelegramNotifier({ token: "t", chatId: 999, fetch: f, includeActionButtons: false });
-  await n.notifyReview(baseInput);
-  assert.equal(f.calls[0].body.reply_markup, undefined);
-});
-
-test("TelegramNotifier: uses TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID env fallback", async () => {
-  const origT = process.env.TELEGRAM_BOT_TOKEN;
-  const origC = process.env.TELEGRAM_CHAT_ID;
-  process.env.TELEGRAM_BOT_TOKEN = "env-token";
-  process.env.TELEGRAM_CHAT_ID = "555";
-  const f = mockFetch();
-  try {
-    const n = new TelegramNotifier({ fetch: f });
+test("TelegramNotifier direct: numeric-string chat id is coerced to number", async () => {
+  await withEnvAsync({ CONCLAVE_TOKEN: undefined }, async () => {
+    const f = mockFetch();
+    const n = new TelegramNotifier({ token: "t", chatId: "-100123", fetch: f });
     await n.notifyReview(baseInput);
-    assert.ok(f.calls[0].url.includes("env-token"));
-    assert.equal(f.calls[0].body.chat_id, 555);
-  } finally {
-    if (origT !== undefined) process.env.TELEGRAM_BOT_TOKEN = origT;
-    else delete process.env.TELEGRAM_BOT_TOKEN;
-    if (origC !== undefined) process.env.TELEGRAM_CHAT_ID = origC;
-    else delete process.env.TELEGRAM_CHAT_ID;
-  }
+    assert.equal(typeof f.calls[0].body.chat_id, "number");
+    assert.equal(f.calls[0].body.chat_id, -100123);
+  });
 });
 
-test("TelegramNotifier: conforms to Notifier interface", () => {
-  const n = new TelegramNotifier({ token: "t", chatId: 1, fetch: async () => ({ ok: true, status: 200, json: async () => ({ ok: true, result: {} }), text: async () => "" }) });
-  assert.equal(n.id, "telegram");
-  assert.equal(n.displayName, "Telegram");
-  assert.equal(typeof n.notifyReview, "function");
+test("TelegramNotifier direct: notifyReview posts HTML + disable_web_page_preview", async () => {
+  await withEnvAsync({ CONCLAVE_TOKEN: undefined }, async () => {
+    const f = mockFetch();
+    const n = new TelegramNotifier({ token: "t", chatId: 999, fetch: f });
+    await n.notifyReview(baseInput);
+    assert.equal(f.calls[0].body.parse_mode, "HTML");
+    assert.equal(f.calls[0].body.disable_web_page_preview, true);
+    assert.match(f.calls[0].body.text, /Approved/);
+  });
+});
+
+test("TelegramNotifier direct: includes inline action keyboard by default", async () => {
+  await withEnvAsync({ CONCLAVE_TOKEN: undefined }, async () => {
+    const f = mockFetch();
+    const n = new TelegramNotifier({ token: "t", chatId: 999, fetch: f });
+    await n.notifyReview(baseInput);
+    const kb = f.calls[0].body.reply_markup?.inline_keyboard;
+    assert.ok(Array.isArray(kb));
+    assert.equal(kb[0].length, 3);
+    const callbacks = kb[0].map((b) => b.callback_data);
+    assert.ok(callbacks[0].startsWith("ep:ep-test:merged"));
+    assert.ok(callbacks[1].startsWith("ep:ep-test:reworked"));
+    assert.ok(callbacks[2].startsWith("ep:ep-test:rejected"));
+  });
+});
+
+test("TelegramNotifier direct: includeActionButtons:false omits reply_markup", async () => {
+  await withEnvAsync({ CONCLAVE_TOKEN: undefined }, async () => {
+    const f = mockFetch();
+    const n = new TelegramNotifier({
+      token: "t",
+      chatId: 999,
+      fetch: f,
+      includeActionButtons: false,
+    });
+    await n.notifyReview(baseInput);
+    assert.equal(f.calls[0].body.reply_markup, undefined);
+  });
+});
+
+test("TelegramNotifier direct: uses TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID env fallback", async () => {
+  await withEnvAsync(
+    { CONCLAVE_TOKEN: undefined, TELEGRAM_BOT_TOKEN: "env-token", TELEGRAM_CHAT_ID: "555" },
+    async () => {
+      const f = mockFetch();
+      const n = new TelegramNotifier({ fetch: f });
+      await n.notifyReview(baseInput);
+      assert.ok(f.calls[0].url.includes("env-token"));
+      assert.equal(f.calls[0].body.chat_id, 555);
+    },
+  );
+});
+
+test("TelegramNotifier direct: conforms to Notifier interface", () => {
+  withEnv({ CONCLAVE_TOKEN: undefined }, () => {
+    const n = new TelegramNotifier({
+      token: "t",
+      chatId: 1,
+      fetch: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, result: {} }),
+        text: async () => "",
+      }),
+    });
+    assert.equal(n.id, "telegram");
+    assert.equal(n.displayName, "Telegram");
+    assert.equal(typeof n.notifyReview, "function");
+  });
+});
+
+test("TelegramNotifier direct: logs 'via direct bot token'", async () => {
+  await withEnvAsync({ CONCLAVE_TOKEN: undefined }, async () => {
+    const f = mockFetch();
+    const logs = [];
+    const n = new TelegramNotifier({
+      token: "t",
+      chatId: 1,
+      fetch: f,
+      log: (m) => logs.push(m),
+    });
+    await n.notifyReview(baseInput);
+    assert.ok(
+      logs.some((l) => l.includes("via direct bot token")),
+      `expected direct-path log, got: ${logs.join(" | ")}`,
+    );
+  });
+});
+
+// ---- central plane path (path A) — v0.4.4+ default ---------------------
+
+test("TelegramNotifier central: CONCLAVE_TOKEN set → hits /review/notify instead of Bot API", async () => {
+  await withEnvAsync(
+    { CONCLAVE_TOKEN: "c_tok_central", CONCLAVE_CENTRAL_URL: undefined },
+    async () => {
+      const f = mockCentralFetch({ ok: true, delivered: 1 });
+      // No token/chatId opts — the central path doesn't require them.
+      const n = new TelegramNotifier({ fetch: f });
+      await n.notifyReview(baseInput);
+      assert.equal(f.calls.length, 1);
+      assert.equal(f.calls[0].url, `${DEFAULT_CENTRAL_URL}/review/notify`);
+      assert.equal(f.calls[0].init.method, "POST");
+      assert.equal(
+        f.calls[0].init.headers.authorization,
+        "Bearer c_tok_central",
+      );
+      const body = f.calls[0].body;
+      assert.equal(body.repo_slug, "acme/app");
+      assert.equal(body.pr_number, 42);
+      assert.equal(body.verdict, "approve");
+      assert.equal(body.episodic_id, "ep-test");
+      assert.match(body.message, /Approved/);
+    },
+  );
+});
+
+test("TelegramNotifier central: honours CONCLAVE_CENTRAL_URL override", async () => {
+  await withEnvAsync(
+    {
+      CONCLAVE_TOKEN: "c_tok_central",
+      CONCLAVE_CENTRAL_URL: "https://staging.example.com",
+    },
+    async () => {
+      const f = mockCentralFetch();
+      const n = new TelegramNotifier({ fetch: f });
+      await n.notifyReview(baseInput);
+      assert.equal(f.calls[0].url, "https://staging.example.com/review/notify");
+    },
+  );
+});
+
+test("TelegramNotifier central: strips trailing slash on central URL", async () => {
+  await withEnvAsync(
+    {
+      CONCLAVE_TOKEN: "c_tok_central",
+      CONCLAVE_CENTRAL_URL: "https://example.com/",
+    },
+    async () => {
+      const f = mockCentralFetch();
+      const n = new TelegramNotifier({ fetch: f });
+      await n.notifyReview(baseInput);
+      assert.equal(f.calls[0].url, "https://example.com/review/notify");
+    },
+  );
+});
+
+test("TelegramNotifier central: includeActionButtons:false omits episodic_id in body", async () => {
+  await withEnvAsync({ CONCLAVE_TOKEN: "c_tok_central" }, async () => {
+    const f = mockCentralFetch();
+    const n = new TelegramNotifier({ fetch: f, includeActionButtons: false });
+    await n.notifyReview(baseInput);
+    assert.equal(f.calls[0].body.episodic_id, undefined);
+  });
+});
+
+test("TelegramNotifier central: includeActionButtons:true includes episodic_id", async () => {
+  await withEnvAsync({ CONCLAVE_TOKEN: "c_tok_central" }, async () => {
+    const f = mockCentralFetch();
+    const n = new TelegramNotifier({ fetch: f, includeActionButtons: true });
+    await n.notifyReview(reworkInput);
+    assert.equal(f.calls[0].body.episodic_id, "ep-rework");
+    assert.equal(f.calls[0].body.verdict, "rework");
+  });
+});
+
+test("TelegramNotifier central: auto-selects central path when CONCLAVE_TOKEN is set and no bot token provided", async () => {
+  await withEnvAsync(
+    {
+      CONCLAVE_TOKEN: "c_tok_central",
+      TELEGRAM_BOT_TOKEN: undefined,
+      TELEGRAM_CHAT_ID: undefined,
+    },
+    async () => {
+      const f = mockCentralFetch();
+      // Nothing else passed — should still succeed via the central path.
+      const n = new TelegramNotifier({ fetch: f });
+      await n.notifyReview(baseInput);
+      assert.equal(f.calls[0].url, `${DEFAULT_CENTRAL_URL}/review/notify`);
+    },
+  );
+});
+
+test("TelegramNotifier central: 401 from central → notifyReview throws with informative message", async () => {
+  await withEnvAsync({ CONCLAVE_TOKEN: "c_tok_central" }, async () => {
+    const f = mockCentralFetch({ error: "unknown or revoked token" }, 401);
+    const n = new TelegramNotifier({ fetch: f });
+    await assert.rejects(n.notifyReview(baseInput), /HTTP 401/);
+  });
+});
+
+test("TelegramNotifier central: logs 'via central plane'", async () => {
+  await withEnvAsync({ CONCLAVE_TOKEN: "c_tok_central" }, async () => {
+    const f = mockCentralFetch();
+    const logs = [];
+    const n = new TelegramNotifier({ fetch: f, log: (m) => logs.push(m) });
+    await n.notifyReview(baseInput);
+    assert.ok(
+      logs.some((l) => l.includes("via central plane")),
+      `expected central-plane log, got: ${logs.join(" | ")}`,
+    );
+  });
+});
+
+test("TelegramNotifier central: explicit useCentralPlane:false forces direct path even with CONCLAVE_TOKEN", async () => {
+  await withEnvAsync({ CONCLAVE_TOKEN: "c_tok_central" }, async () => {
+    const f = mockFetch();
+    const n = new TelegramNotifier({
+      token: "t",
+      chatId: 1,
+      fetch: f,
+      useCentralPlane: false,
+    });
+    await n.notifyReview(baseInput);
+    // Went to api.telegram.org, not /review/notify
+    assert.ok(f.calls[0].url.includes("api.telegram.org"));
+  });
+});
+
+test("TelegramNotifier central: useCentralPlane:true without CONCLAVE_TOKEN throws", () => {
+  withEnv({ CONCLAVE_TOKEN: undefined }, () => {
+    assert.throws(() => new TelegramNotifier({ useCentralPlane: true }));
+  });
+});
+
+test("TelegramNotifier central: repo_slug falls back from GITHUB_REPOSITORY when ctx.repo absent", async () => {
+  await withEnvAsync(
+    { CONCLAVE_TOKEN: "c_tok_central", GITHUB_REPOSITORY: "owner/fallback" },
+    async () => {
+      const f = mockCentralFetch();
+      const n = new TelegramNotifier({ fetch: f });
+      const input = {
+        ...baseInput,
+        ctx: { ...baseInput.ctx, repo: "" },
+      };
+      await n.notifyReview(input);
+      assert.equal(f.calls[0].body.repo_slug, "owner/fallback");
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Closes the last v0.3-style leak in the v0.4 install model — consumer repos no longer need their own `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID`. The CLI notifier POSTs to a new `/review/notify` endpoint on the central plane, authenticated with the `CONCLAVE_TOKEN` that `conclave init` already installs; the central plane fans the message out to every linked chat via `@Conclave_ai_bot`.

Fixes today's smoke-test warning `conclave review: TELEGRAM_BOT_TOKEN not set — skipping Telegram notifier` even after a working `/link`.

## Change sets

### 1. Central plane: new `POST /review/notify`
- `apps/central-plane/src/routes/review.ts` (new)
- `apps/central-plane/src/router.ts` — wired into route table
- `apps/central-plane/src/telegram.ts` — extended `sendMessage` to accept `replyMarkup`
- `apps/central-plane/test/review.test.mjs` (new, 8 tests)

Auth via `Authorization: Bearer <CONCLAVE_TOKEN>` → SHA-256 match against `installs.token_hash`. Updates `installs.last_seen_at` on success. Fans out to every `telegram_links.chat_id` row for the matched install. Attaches inline 🔧 rework / ✅ merge / ❌ reject keyboard iff `episodic_id` is present — payload matches the `ep:<id>:<outcome>` format the existing `/telegram/webhook` handler already parses, so button clicks keep working end-to-end without touching that handler.

Returns `{ ok: true, delivered: <count> }`; zero linked chats returns `{ ok: true, delivered: 0, reason: "no linked chat" }` (not an error).

### 2. CLI notifier: dual-path
- `packages/integration-telegram/src/notifier.ts` — rewritten as dual-path
- `packages/integration-telegram/src/index.ts` — exports `DEFAULT_CENTRAL_URL`
- `packages/integration-telegram/test/notifier.test.mjs` — 20 tests total (8 existing + 12 new)
- `packages/cli/src/commands/review.ts` — stops short-circuiting on missing `TELEGRAM_BOT_TOKEN` when `CONCLAVE_TOKEN` is present

Path A (default when `CONCLAVE_TOKEN` is set): POSTs to `${CONCLAVE_CENTRAL_URL || default}/review/notify`, logs `conclave review: telegram via central plane`.
Path B (fallback): unchanged direct-to-Telegram-Bot-API, logs `conclave review: telegram via direct bot token`. Preserved for self-hosted Conclave deployments.
`useCentralPlane: false` opt-out available for programmatic overrides.

`DEFAULT_CENTRAL_URL` is duplicated from `packages/cli/src/commands/init/central-client.ts` with a cross-reference comment — direct import would be circular (`cli` → `integration-telegram` → `cli`).

### 3. Reusable workflow + docs
- `.github/workflows/review.yml` — removes `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` from review step env; adds `CONCLAVE_TOKEN` (required) and `CONCLAVE_CENTRAL_URL` (optional repo `vars`) passthrough. Header comment rewritten.
- `docs/migrate-to-v0.4.md` — clarifies the `TELEGRAM_*` secrets are now fully unused (previously marked for removal but still referenced by the workflow).
- `docs/releases/v0.4.4.md` — new release note.

## Versions

- `@conclave-ai/central-plane`        0.4.0 → 0.4.4
- `@conclave-ai/integration-telegram` 0.4.0 → 0.4.4
- `@conclave-ai/cli` — behaviour unchanged (reads a new env var only); no bump.

## Test plan
- [x] `corepack pnpm install && corepack pnpm build && corepack pnpm test` — all 45 workspace tasks green locally
- [x] `@conclave-ai/integration-telegram` — 35 tests pass (20 notifier + 15 client/format)
- [x] `@conclave-ai/central-plane` — 54 tests pass (8 new /review/notify tests + 46 existing)
- [x] `@conclave-ai/cli` — 116 tests pass
- [ ] Manual smoke on staging: `curl -X POST $CENTRAL/review/notify -H "Authorization: Bearer \$CONCLAVE_TOKEN" -d '{"repo_slug":"owner/repo","message":"manual smoke"}'` should hit a linked chat.
- [ ] End-to-end: re-run the same smoke PR that surfaced today's warning; confirm Telegram delivery without `TELEGRAM_BOT_TOKEN`.
- [ ] Deploy central plane (`pnpm --filter @conclave-ai/central-plane ship`) before merging to npm-publish `@conclave-ai/integration-telegram@0.4.4`.

## Parallel context
No merge conflicts expected with the three sibling PRs on this commit. The H (D1 token encryption) branch also touches `apps/central-plane/src/routes/telegram.ts` and `apps/central-plane/src/db/telegram.ts` — this PR only touches `.../routes/review.ts` (new), `router.ts` (one-line route registration), and `telegram.ts` lib (adds optional `replyMarkup` param). Conflict risk on `router.ts` route-table line if H adds its own route; easy to resolve either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)