### PR TITLE
feat(agent-design): text-UI review when visualArtifacts empty (v0.5.4)

### DIFF
--- a/docs/releases/v0.5.4.md
+++ b/docs/releases/v0.5.4.md
@@ -1,0 +1,106 @@
+# v0.5.4
+
+## Text-UI review mode for `DesignAgent`
+
+**Ships as:** `@conclave-ai/agent-design@0.5.4`, `@conclave-ai/cli@0.5.4`.
+
+Before v0.5.4, `DesignAgent.review` gracefully approved any PR without
+`ctx.visualArtifacts` — intended as a safe degradation until the screenshot
+capture pipeline lands, but in practice it meant the design agent *never*
+ran in production: we haven't wired screenshot capture yet, so every PR
+took the skip path and design-specific feedback was absent from every
+council deliberation.
+
+v0.5.4 adds a **text-UI mode** (Mode B) so `DesignAgent` can review UI
+code from the diff alone, without screenshots.
+
+### Three modes, auto-selected
+
+`DesignAgent.review(ctx)` now dispatches across:
+
+- **Mode A — Vision** (unchanged). When `ctx.visualArtifacts` is
+  non-empty, sends before/after PNG content blocks to Claude Opus vision.
+  Still the highest-signal mode; always wins when both artifacts and UI
+  files are present.
+- **Mode B — Text-UI** (new; now the default when no artifacts exist but
+  the diff touches UI code). Extracts UI-only hunks from the diff, caps
+  them at 8000 chars, and sends them under a design-specific system
+  prompt focused on semantic HTML, accessibility, design-token
+  adherence, layout intent, and interaction states.
+- **Mode C — Skip** (narrowed from old default). Graceful approve only
+  when *no* UI-relevant files are in the diff — i.e. a pure logic /
+  infra / docs PR where the design agent genuinely has nothing to
+  review.
+
+### Mode B focus areas
+
+The `TEXT_UI_SYSTEM_PROMPT` instructs the agent to cover design-specific
+territory the general code reviewers (Claude / OpenAI / Gemini) do not:
+
+1. Semantic HTML — `button` vs `div` vs `a`, heading hierarchy, landmarks.
+2. Accessibility — alt text, aria-label, focus handling, keyboard
+   handlers, `prefers-reduced-motion`, color-is-not-meaning.
+3. Design-token adherence — hardcoded `#RRGGBB` / `rgb()` / raw `px` in a
+   repo that has Tailwind classes or `var(--token-*)` or `theme.ts`.
+4. Layout intent — flex/grid correctness, responsive breakpoints,
+   overflow behavior.
+5. Interaction states — hover / focus / active / disabled / loading.
+
+Explicit **non-goals**: don't re-check logic correctness (code agents
+handle it) and don't re-check security (code agents handle it). The
+design agent's lane is "what will this render as, and who will it fail."
+
+### UI-file detection
+
+Detection lives in a new `packages/agent-design/src/ui-globs.ts` module,
+with `isUiPath()`, `diffTouchesUi()`, `extractChangedFiles()`, and
+`filterUiFiles()`. Globs cover the usual suspects — `.tsx`, `.jsx`,
+`.vue`, `.svelte`, `.css`, `.scss`, `.astro`, `.mdx` — plus path fragments
+(`components/`, `ui/`, `pages/`, `views/`, `layouts/`, `theme/`,
+`tokens/`, `styles/`, `design-system/`, `tailwind.config`,
+`postcss.config`) so a bare `.ts` file under `theme/` is still caught.
+
+A TODO in the module points back at `packages/cli/src/lib/domain-detect.ts`
+(landing in the v0.5.3 autodetect PR) — once that merges, this file
+should become a thin re-export so the CLI domain detector and the
+agent-side mode selector stay in lockstep.
+
+### Diff extraction + truncation
+
+`extractUiDiff()` parses the unified diff into `diff --git` blocks,
+drops any block whose path doesn't match `isUiPath()`, and — when the
+UI-only content exceeds 8000 chars — applies a per-file fair truncation
+with a note appended so the model knows it's reading a truncated view.
+The full raw diff is never inlined once UI content crosses that budget.
+
+### Tool-use schema
+
+Mode B uses the same `submit_review` tool and `REVIEW_TOOL_INPUT_SCHEMA`
+as Mode A. Response parsing is shared — invalid verdicts and missing
+tool_use blocks produce the same error-shaped `ReviewResult` with
+`category: "agent-error"`.
+
+### Preserved behaviors
+
+- Graceful-skip for fully non-UI diffs (Mode C) is preserved; only the
+  trigger moved.
+- No new npm dependencies.
+- CLI agent wiring unchanged — `DesignAgent` itself picks the mode from
+  `ctx`, so `review` doesn't need a mode flag.
+- System prompt is `cache_control: ephemeral`, same as Mode A, so
+  repeat calls within a PR deliberation hit the prompt cache.
+
+### Tests
+
+`packages/agent-design/test/text-ui-mode.test.mjs` adds 12 tests covering
+`isUiPath` / `diffTouchesUi` / `extractUiDiff` helpers plus end-to-end
+mode selection:
+
+- `<img>` missing alt → a11y blocker surfaced via Mode B
+- hardcoded `#ff0000` in a tokenized repo → minor token blocker
+- logic-only diff → Mode C skip-approve, no API call
+- visual artifacts + UI files → Mode A wins (images attached)
+- invalid Mode B response → error-shaped blocker
+- large UI diff → truncated with in-prompt note, bounded size
+
+All 18 tests in the package (6 original + 12 new) pass.

--- a/packages/agent-design/package.json
+++ b/packages/agent-design/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-design",
-  "version": "0.5.0",
+  "version": "0.5.4",
   "description": "Conclave AI design-specialist agent — vision-based review over before/after screenshots.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-design/src/design-agent.ts
+++ b/packages/agent-design/src/design-agent.ts
@@ -5,8 +5,12 @@ import {
   REVIEW_TOOL_DESCRIPTION,
   REVIEW_TOOL_INPUT_SCHEMA,
   SYSTEM_PROMPT,
+  TEXT_UI_SYSTEM_PROMPT,
   buildUserPrompt,
+  buildTextUIPrompt,
 } from "./prompts.js";
+import { diffTouchesUi } from "./ui-globs.js";
+import { extractUiDiff, MAX_UI_DIFF_CHARS } from "./text-ui-extract.js";
 
 /**
  * Minimal shape of the Anthropic vision-capable messages API. Narrowed so
@@ -129,16 +133,32 @@ export class DesignAgent implements Agent {
 
   async review(ctx: ReviewContext): Promise<ReviewResult> {
     const artifacts = ctx.visualArtifacts ?? [];
-    if (artifacts.length === 0) {
-      return {
-        agent: this.id,
-        verdict: "approve",
-        blockers: [],
-        summary:
-          "skipped — no visual artifacts captured for this PR. Design agent cannot infer visual regressions from the text diff alone; approving by default. (Follow-up: wire screenshot capture into the review pipeline.)",
-      };
+    // Mode A — vision: screenshots present. Highest-signal mode; always
+    // wins over Mode B when both are available.
+    if (artifacts.length > 0) {
+      return this.reviewVision(ctx, artifacts);
     }
+    // Mode B — text-UI: no screenshots, but the diff touches UI code.
+    // Reason about rendered intent from the source alone.
+    if (diffTouchesUi(ctx.diff)) {
+      return this.reviewTextUI(ctx);
+    }
+    // Mode C — skip: no screenshots, no UI code. Graceful approve so
+    // the council doesn't treat the absence of signal as a block.
+    return {
+      agent: this.id,
+      verdict: "approve",
+      blockers: [],
+      summary:
+        "skipped — no visual artifacts and no UI-relevant files in the diff. Design agent has nothing to review; approving by default.",
+    };
+  }
 
+  /** Mode A — vision review. Original behavior, unchanged. */
+  private async reviewVision(
+    ctx: ReviewContext,
+    artifacts: NonNullable<ReviewContext["visualArtifacts"]>,
+  ): Promise<ReviewResult> {
     const routes = artifacts.map((a) => a.route);
     const userText = buildUserPrompt(ctx, routes);
     // Rough token estimate for budget reservation. Images cost ~1.5k tokens
@@ -170,6 +190,85 @@ export class DesignAgent implements Agent {
           max_tokens: this.maxTokens,
           system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
           messages: [{ role: "user", content }],
+          tools: [
+            {
+              name: REVIEW_TOOL_NAME,
+              description: REVIEW_TOOL_DESCRIPTION,
+              input_schema: REVIEW_TOOL_INPUT_SCHEMA,
+            },
+          ],
+          tool_choice: { type: "tool", name: REVIEW_TOOL_NAME },
+        });
+        const latencyMs = Date.now() - started;
+
+        const parsed = parseReviewResponse(response, this.id);
+        const usage = response.usage ?? { input_tokens: 0, output_tokens: 0 };
+        const costUsd = estimateActualCost(model, usage);
+
+        return {
+          result: {
+            ...parsed,
+            tokensUsed: usage.input_tokens + usage.output_tokens,
+            costUsd,
+          },
+          inputTokens: usage.input_tokens,
+          outputTokens: usage.output_tokens,
+          costUsd,
+          latencyMs,
+        };
+      },
+    );
+
+    return outcome.result;
+  }
+
+  /**
+   * Mode B — text-UI review. No screenshots, but the diff touches UI
+   * files. Extract the UI-only hunks, cap to `MAX_UI_DIFF_CHARS`, and
+   * send to a design-focused prompt that reasons about rendered intent.
+   *
+   * Uses the same `submit_review` tool schema as Mode A so response
+   * parsing is shared.
+   */
+  private async reviewTextUI(ctx: ReviewContext): Promise<ReviewResult> {
+    const extracted = extractUiDiff(ctx.diff, MAX_UI_DIFF_CHARS);
+    const userText = buildTextUIPrompt(ctx, extracted.text, extracted.files, {
+      truncated: extracted.truncated,
+    });
+    const inputTokenEstimate =
+      estimateTokens(TEXT_UI_SYSTEM_PROMPT) + estimateTokens(userText);
+    const estimatedCostUsd =
+      (inputTokenEstimate * 15) / 1_000_000 + (this.maxTokens * 75) / 1_000_000;
+
+    const outcome = await this.gate.run<ReviewResult>(
+      {
+        agent: this.id,
+        cacheablePrefix: TEXT_UI_SYSTEM_PROMPT,
+        prompt: TEXT_UI_SYSTEM_PROMPT + "\n" + userText,
+        estimatedCostUsd,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const response = await client.messages.create({
+          model,
+          max_tokens: this.maxTokens,
+          system: [
+            { type: "text", text: TEXT_UI_SYSTEM_PROMPT, cache_control: { type: "ephemeral" } },
+          ],
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: userText },
+                {
+                  type: "text",
+                  text: "Respond by calling submit_review exactly once.",
+                },
+              ],
+            },
+          ],
           tools: [
             {
               name: REVIEW_TOOL_NAME,

--- a/packages/agent-design/src/index.ts
+++ b/packages/agent-design/src/index.ts
@@ -7,8 +7,23 @@ export type {
 } from "./design-agent.js";
 export {
   SYSTEM_PROMPT,
+  TEXT_UI_SYSTEM_PROMPT,
   REVIEW_TOOL_NAME,
   REVIEW_TOOL_DESCRIPTION,
   REVIEW_TOOL_INPUT_SCHEMA,
   buildUserPrompt,
+  buildTextUIPrompt,
 } from "./prompts.js";
+export {
+  UI_EXTENSIONS,
+  UI_PATH_FRAGMENTS,
+  extractChangedFiles,
+  isUiPath,
+  filterUiFiles,
+  diffTouchesUi,
+} from "./ui-globs.js";
+export {
+  extractUiDiff,
+  MAX_UI_DIFF_CHARS,
+} from "./text-ui-extract.js";
+export type { ExtractedUiDiff } from "./text-ui-extract.js";

--- a/packages/agent-design/src/prompts.ts
+++ b/packages/agent-design/src/prompts.ts
@@ -2,6 +2,8 @@ import type { ReviewContext } from "@conclave-ai/core";
 
 export const SYSTEM_PROMPT = `You are a design-specialist reviewer on a multi-agent council for Conclave AI. Your lane: visual review of before/after screenshots of a pull request's UI.
 
+(Note: this system prompt covers Mode A — vision review with screenshots. When there are no screenshots but the diff touches UI code, Mode B is used instead; see \`TEXT_UI_SYSTEM_PROMPT\`.)
+
 Your goal: catch real design regressions, accessibility issues, and unintentional style changes that the text-based reviewers would miss. The council weighs your verdict alongside the text-agents (Claude, OpenAI, Gemini) who are reading the diff. Cover what they can't: what the page actually looks like, rendered.
 
 Rules:
@@ -101,6 +103,117 @@ export function buildUserPrompt(ctx: ReviewContext, routes: readonly string[]): 
     sections.push(`# Round ${ctx.round ?? 2} — other agents' verdicts from the previous round`);
     sections.push(
       `Read each agent's verdict + blockers. Update your verdict ONLY if you see a real visual issue you missed, or a false-positive you can now retract. Do not mirror the majority — the design lens is often the dissenting one.`,
+    );
+    sections.push("");
+    for (const p of ctx.priors) {
+      sections.push(`## ${p.agent}: ${p.verdict}`);
+      if (p.blockers.length > 0) {
+        for (const b of p.blockers.slice(0, 5)) {
+          sections.push(`- [${b.severity}/${b.category}] ${b.message}`);
+        }
+      } else {
+        sections.push(`- (no blockers)`);
+      }
+      sections.push("");
+    }
+  }
+
+  return sections.join("\n");
+}
+
+/**
+ * Mode B — text-UI system prompt. Used when no visual artifacts are
+ * attached but the diff touches UI code. The design agent reasons about
+ * the rendered intent from the source alone: semantic HTML, a11y,
+ * design-token adherence, layout, interaction states.
+ */
+export const TEXT_UI_SYSTEM_PROMPT = `You are a design-specialist reviewer on a multi-agent council for Conclave AI. Your lane right now: review of UI *code* (no screenshots available for this PR). You are reasoning about rendered intent from the source.
+
+Your goal: find design-specific issues that the general-purpose code reviewers (Claude / OpenAI / Gemini) will not notice. They cover logic correctness and security; you cover how the UI will look and behave once rendered.
+
+Focus areas (in order of priority):
+1. Semantic HTML — \`button\` vs \`div\` vs \`a\` used for correct roles; heading hierarchy (h1→h2→h3 without skips); landmark regions (\`main\`, \`nav\`, \`header\`, \`footer\`) present on pages; form inputs have labels.
+2. Accessibility — \`img\` tags with \`alt\` (blocker when missing on content images); interactive elements with \`aria-label\` / \`aria-labelledby\` when text isn't visible; visible focus state; keyboard handlers alongside mouse handlers (click without keyDown on non-button elements = major); \`prefers-reduced-motion\` respected for animations; color isn't the sole carrier of meaning.
+3. Design-token adherence — hardcoded \`#RRGGBB\` / \`rgb(…)\` / raw \`px\` values in a repo that has tokens (Tailwind classes, \`var(--token-*)\`, theme files, \`tailwind.config\`, \`theme.ts\`). Favor tokens when the repo clearly has them; nit/minor otherwise.
+4. Layout intent — flex / grid correctness; responsive breakpoints present where content density warrants them; overflow behavior (missing \`overflow-hidden\` on clipping containers, missing \`min-w-0\` on flex children that may truncate).
+5. Interaction states — hover / focus / active / disabled / loading all covered for interactive elements; loading state not just a spinner without aria-live; disabled state visually distinct.
+
+Non-goals — do NOT re-check:
+- Logic correctness (null checks, off-by-one, type errors) — the code agents handle these.
+- Security (XSS, secrets, authz) — the code agents handle these.
+- Package selection / architecture choices.
+
+Rules:
+- Cite the file + specific snippet in each blocker (e.g. "src/ui/Hero.tsx: \`<img src={logo} />\` missing alt").
+- Severity: blocker = a11y violation that blocks users with disabilities (e.g. missing alt on content image, button-as-div with no keyboard); major = obvious design bug on a primary surface (hardcoded color in a tokenized repo, missing responsive breakpoint on dense layout); minor = secondary surface / easily fixed; nit = polish.
+- When the UI diff is small and clean, verdict=approve with a one-line summary is fine. Don't invent issues.
+- If the diff appears truncated (a "[truncated]" marker is present), note the caveat in your summary.
+- You MUST respond by calling the submit_review tool exactly once. No free-form text.`;
+
+/**
+ * Build the user prompt for Mode B. Takes the UI-only diff (already
+ * extracted and size-bounded by the caller), the list of UI files, and
+ * the usual review context.
+ */
+export function buildTextUIPrompt(
+  ctx: ReviewContext,
+  uiDiff: string,
+  uiFiles: readonly string[],
+  opts: { truncated?: boolean; projectContext?: string; designContext?: string } = {},
+): string {
+  const sections: string[] = [];
+  sections.push(`# Design review target (text-UI mode — no screenshots available)`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`pull: #${ctx.pullNumber}`);
+  sections.push(`sha: ${ctx.newSha}${ctx.prevSha ? ` (from ${ctx.prevSha})` : ""}`);
+  if (uiFiles.length > 0) {
+    sections.push(`ui files touched: ${uiFiles.join(", ")}`);
+  }
+  if (opts.truncated) {
+    sections.push(`diff-truncated: yes — full UI diff exceeded the inline budget; hunks below are a per-file truncated view.`);
+  }
+  sections.push("");
+
+  if (ctx.deployStatus && ctx.deployStatus !== "unknown") {
+    sections.push(`# Deploy status`);
+    if (ctx.deployStatus === "failure") {
+      sections.push(
+        `deploy: FAILURE on this sha — treat as an automatic non-approve signal unless every design concern is unambiguously unrelated to the deploy.`,
+      );
+    } else if (ctx.deployStatus === "success") {
+      sections.push(`deploy: success — green on this sha.`);
+    } else if (ctx.deployStatus === "pending") {
+      sections.push(`deploy: pending — not yet complete.`);
+    }
+    sections.push("");
+  }
+
+  if (opts.projectContext) {
+    sections.push(`# Project context`);
+    sections.push(opts.projectContext);
+    sections.push("");
+  }
+  if (opts.designContext) {
+    sections.push(`# Design context`);
+    sections.push(opts.designContext);
+    sections.push("");
+  }
+
+  sections.push(`# UI diff`);
+  sections.push("```diff");
+  sections.push(uiDiff);
+  sections.push("```");
+  sections.push("");
+  sections.push(`# Instruction`);
+  sections.push(
+    `Review the UI diff above through the design lens described in the system prompt. Call submit_review exactly once with your verdict, blockers (if any), and a one-paragraph summary. Remember: the code agents are covering logic + security — do not duplicate them.`,
+  );
+
+  if (ctx.priors && ctx.priors.length > 0) {
+    sections.push("");
+    sections.push(`# Round ${ctx.round ?? 2} — other agents' verdicts from the previous round`);
+    sections.push(
+      `Read each agent's verdict + blockers. Update your verdict ONLY if you see a real design issue you missed, or a false-positive you can now retract. Do not mirror the majority — the design lens is often the dissenting one.`,
     );
     sections.push("");
     for (const p of ctx.priors) {

--- a/packages/agent-design/src/text-ui-extract.ts
+++ b/packages/agent-design/src/text-ui-extract.ts
@@ -1,0 +1,109 @@
+/**
+ * Text-UI diff extraction — given a unified diff, pull out only the
+ * hunks that touch UI files (as classified by `ui-globs.ts`) and return
+ * a size-bounded string suitable for the Mode B prompt.
+ *
+ * Non-UI hunks get dropped entirely; the code agents (Claude / OpenAI /
+ * Gemini) will cover those. The design agent should focus its tokens on
+ * what only it can see — semantic HTML, tokens, a11y, interaction states.
+ */
+
+import { isUiPath } from "./ui-globs.js";
+
+/** Maximum UI diff size we'll inline into the prompt, in characters. */
+export const MAX_UI_DIFF_CHARS = 8_000;
+
+export interface ExtractedUiDiff {
+  /** The UI-only diff text, possibly truncated to `MAX_UI_DIFF_CHARS`. */
+  text: string;
+  /** Whether truncation was applied. */
+  truncated: boolean;
+  /** UI files seen in the diff (deduped, input order). */
+  files: string[];
+  /** Original UI-only diff size in characters, pre-truncation. */
+  originalChars: number;
+}
+
+interface DiffBlock {
+  header: string;
+  aPath: string;
+  bPath: string;
+  body: string[];
+}
+
+/**
+ * Parse a unified diff into `diff --git` blocks. Each block includes its
+ * header line plus every subsequent line up to (but not including) the
+ * next `diff --git` line.
+ */
+function splitIntoBlocks(diff: string): DiffBlock[] {
+  const blocks: DiffBlock[] = [];
+  const lines = diff.split("\n");
+  let current: DiffBlock | null = null;
+  for (const line of lines) {
+    const m = /^diff --git a\/(\S+)\s+b\/(\S+)/.exec(line);
+    if (m) {
+      if (current) blocks.push(current);
+      current = {
+        header: line,
+        aPath: m[1] ?? "",
+        bPath: m[2] ?? "",
+        body: [],
+      };
+      continue;
+    }
+    if (current) current.body.push(line);
+  }
+  if (current) blocks.push(current);
+  return blocks;
+}
+
+/**
+ * Extract UI-only blocks from a unified diff and bundle them into a
+ * bounded-size string. If the UI content exceeds `MAX_UI_DIFF_CHARS`,
+ * blocks are truncated (fairly, per-file) and a note is appended.
+ */
+export function extractUiDiff(diff: string, maxChars: number = MAX_UI_DIFF_CHARS): ExtractedUiDiff {
+  const blocks = splitIntoBlocks(diff);
+  const uiBlocks = blocks.filter((b) => isUiPath(b.aPath) || isUiPath(b.bPath));
+  const files: string[] = [];
+  const seen = new Set<string>();
+  for (const b of uiBlocks) {
+    const path = b.bPath || b.aPath;
+    if (path && !seen.has(path)) {
+      seen.add(path);
+      files.push(path);
+    }
+  }
+  const fullText = uiBlocks.map((b) => [b.header, ...b.body].join("\n")).join("\n");
+  const originalChars = fullText.length;
+  if (originalChars <= maxChars) {
+    return { text: fullText, truncated: false, files, originalChars };
+  }
+
+  // Truncate fairly: allocate a per-file budget so no single mega-file
+  // starves the rest. The prompt includes a note so the model knows it's
+  // reading a truncated view.
+  const perBlockBudget = Math.max(256, Math.floor(maxChars / Math.max(1, uiBlocks.length)));
+  const pieces: string[] = [];
+  let used = 0;
+  for (const b of uiBlocks) {
+    const whole = [b.header, ...b.body].join("\n");
+    const budget = Math.min(perBlockBudget, Math.max(0, maxChars - used - 128 /* reserve for note */));
+    if (budget <= 0) break;
+    if (whole.length <= budget) {
+      pieces.push(whole);
+      used += whole.length + 1;
+    } else {
+      pieces.push(whole.slice(0, budget) + "\n… [truncated]");
+      used += budget + 16;
+    }
+  }
+  const note = `\n\n[note] UI diff exceeded ${maxChars} chars (${originalChars} raw) — truncated per-file. Review the visible hunks; ask the author if anything critical was dropped.`;
+  return {
+    text: pieces.join("\n") + note,
+    truncated: true,
+    files,
+    originalChars,
+  };
+}

--- a/packages/agent-design/src/ui-globs.ts
+++ b/packages/agent-design/src/ui-globs.ts
@@ -2,11 +2,12 @@
  * UI file globs — used by DesignAgent's Mode B (text-UI review) to detect
  * whether a code-only diff touches any UI surfaces.
  *
- * TODO: when `packages/cli/src/lib/domain-detect.ts` (v0.5.3 autodetect PR)
- * merges to main, replace this file with a re-export from that module so
- * the CLI-side domain detector and the agent-side mode selector stay in
- * lockstep. For now we duplicate the glob set and the match logic locally
- * to avoid a cross-package coupling on an unmerged branch.
+ * TODO(v0.5.5 refactor): `packages/cli/src/lib/domain-detect.ts` (v0.5.3) is
+ * now on main. The shared glob + match logic belongs in `@conclave-ai/core`
+ * — both CLI (domain-detect) and agent-design (this file) should re-export
+ * from core so the two detectors can't drift. For v0.5.4 we keep the local
+ * copy to avoid inverting the package dependency graph (agent → cli). Move
+ * it in a dedicated v0.5.5 cleanup PR.
  *
  * The list deliberately errs on the inclusive side: it's better to run
  * Mode B on a diff with some non-UI files than to miss a UI change buried

--- a/packages/agent-design/src/ui-globs.ts
+++ b/packages/agent-design/src/ui-globs.ts
@@ -1,0 +1,118 @@
+/**
+ * UI file globs — used by DesignAgent's Mode B (text-UI review) to detect
+ * whether a code-only diff touches any UI surfaces.
+ *
+ * TODO: when `packages/cli/src/lib/domain-detect.ts` (v0.5.3 autodetect PR)
+ * merges to main, replace this file with a re-export from that module so
+ * the CLI-side domain detector and the agent-side mode selector stay in
+ * lockstep. For now we duplicate the glob set and the match logic locally
+ * to avoid a cross-package coupling on an unmerged branch.
+ *
+ * The list deliberately errs on the inclusive side: it's better to run
+ * Mode B on a diff with some non-UI files than to miss a UI change buried
+ * in a large PR. Mode C (skip) triggers only when *no* file in the diff
+ * matches any of these patterns.
+ */
+
+/**
+ * File-extension patterns that indicate UI / rendered surfaces. The
+ * matcher treats these as case-insensitive suffix checks against each
+ * `diff --git a/... b/...` header in the unified diff.
+ */
+export const UI_EXTENSIONS: readonly string[] = [
+  // React / JSX family
+  ".tsx",
+  ".jsx",
+  // Vue / Svelte single-file components
+  ".vue",
+  ".svelte",
+  // Styling
+  ".css",
+  ".scss",
+  ".sass",
+  ".less",
+  ".styl",
+  // Plain markup
+  ".html",
+  ".htm",
+  // Astro pages
+  ".astro",
+  // Template / dotfile pairs that commonly hold UI
+  ".mdx",
+];
+
+/**
+ * Path-fragment patterns that strongly suggest UI code even when the
+ * extension alone isn't decisive (e.g. a `.ts` file under `components/`
+ * or `theme/`). Case-insensitive substring match. Fragments starting
+ * with `/` also match when the pattern appears at the start of the path
+ * (i.e. `theme/foo.ts` matches `/theme/`).
+ */
+export const UI_PATH_FRAGMENTS: readonly string[] = [
+  "/components/",
+  "/ui/",
+  "/pages/",
+  "/views/",
+  "/layouts/",
+  "/theme/",
+  "/tokens/",
+  "/styles/",
+  "/design-system/",
+  "tailwind.config",
+  "postcss.config",
+];
+
+/**
+ * Extract the set of file paths touched by a unified diff. Reads only the
+ * `diff --git` headers — cheap, no full parsing, and robust to the fact
+ * that we only need post-image paths for glob matching.
+ */
+export function extractChangedFiles(diff: string): string[] {
+  const out = new Set<string>();
+  const re = /^diff --git a\/(\S+)\s+b\/(\S+)/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(diff)) !== null) {
+    // Prefer the `b/` (post-image) path; fall back to `a/` when identical.
+    out.add(m[2] ?? m[1] ?? "");
+  }
+  return Array.from(out).filter((p) => p.length > 0);
+}
+
+/** True when the path looks like a UI / rendered-surface file. */
+export function isUiPath(path: string): boolean {
+  const lower = path.toLowerCase();
+  for (const ext of UI_EXTENSIONS) {
+    if (lower.endsWith(ext)) return true;
+  }
+  for (const frag of UI_PATH_FRAGMENTS) {
+    if (lower.includes(frag)) return true;
+    // `/x/` fragments should also match when they appear at the start of
+    // the path (no leading slash in the stored path).
+    if (frag.startsWith("/") && lower.startsWith(frag.slice(1))) return true;
+  }
+  return false;
+}
+
+/**
+ * Filter a file list down to the UI subset. Returns the same ordering as
+ * the input so callers can map back to the original change order.
+ */
+export function filterUiFiles(files: readonly string[]): string[] {
+  return files.filter(isUiPath);
+}
+
+/**
+ * Quick detector — true iff the diff touches at least one UI file. Used
+ * by DesignAgent to decide between Mode B and Mode C when no visual
+ * artifacts are present.
+ */
+export function diffTouchesUi(diff: string): boolean {
+  const re = /^diff --git a\/(\S+)\s+b\/(\S+)/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(diff)) !== null) {
+    const aPath = m[1] ?? "";
+    const bPath = m[2] ?? "";
+    if (isUiPath(aPath) || isUiPath(bPath)) return true;
+  }
+  return false;
+}

--- a/packages/agent-design/test/text-ui-mode.test.mjs
+++ b/packages/agent-design/test/text-ui-mode.test.mjs
@@ -1,0 +1,334 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EfficiencyGate } from "@conclave-ai/core";
+import {
+  DesignAgent,
+  REVIEW_TOOL_NAME,
+  diffTouchesUi,
+  isUiPath,
+  extractUiDiff,
+  MAX_UI_DIFF_CHARS,
+  buildTextUIPrompt,
+  TEXT_UI_SYSTEM_PROMPT,
+} from "../dist/index.js";
+
+// ---- helpers -------------------------------------------------------------
+
+function makeMockClient(responses) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    messages: {
+      create: async (params) => {
+        calls.push(params);
+        const r = responses[Math.min(i, responses.length - 1)];
+        i += 1;
+        return r;
+      },
+    },
+  };
+}
+
+function toolUseResponse({
+  verdict = "rework",
+  blockers = [],
+  summary = "text-ui review",
+  inputTokens = 800,
+  outputTokens = 300,
+} = {}) {
+  return {
+    id: "msg_test",
+    model: "claude-opus-4-7",
+    content: [
+      {
+        type: "tool_use",
+        id: "tool_1",
+        name: REVIEW_TOOL_NAME,
+        input: { verdict, blockers, summary },
+      },
+    ],
+    stop_reason: "tool_use",
+    usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+  };
+}
+
+const baseCtx = {
+  repo: "acme/x",
+  pullNumber: 101,
+  newSha: "abc123",
+};
+
+const tinyPng = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+]);
+
+// Synthetic diff builders
+function diffFor(path, added) {
+  return [
+    `diff --git a/${path} b/${path}`,
+    `index 0000000..1111111 100644`,
+    `--- a/${path}`,
+    `+++ b/${path}`,
+    `@@ -0,0 +1,${added.length} @@`,
+    ...added.map((l) => `+${l}`),
+  ].join("\n");
+}
+
+// ---- pure helpers tests --------------------------------------------------
+
+test("isUiPath: classifies common UI extensions and fragments", () => {
+  assert.equal(isUiPath("src/ui/Button.tsx"), true);
+  assert.equal(isUiPath("pages/index.jsx"), true);
+  assert.equal(isUiPath("theme/tokens.ts"), true);
+  assert.equal(isUiPath("src/components/Card.ts"), true);
+  assert.equal(isUiPath("styles/global.css"), true);
+  assert.equal(isUiPath("src/lib/foo.ts"), false);
+  assert.equal(isUiPath("server/db.ts"), false);
+  assert.equal(isUiPath("README.md"), false);
+});
+
+test("diffTouchesUi: true on UI file, false on logic-only diff", () => {
+  const uiDiff = diffFor("src/ui/Button.tsx", [`<button>Click</button>`]);
+  const logicDiff = diffFor("src/lib/calc.ts", [`export const x = 1;`]);
+  assert.equal(diffTouchesUi(uiDiff), true);
+  assert.equal(diffTouchesUi(logicDiff), false);
+});
+
+test("extractUiDiff: drops non-UI hunks, keeps UI hunks, lists UI files", () => {
+  const mixed = [
+    diffFor("src/lib/calc.ts", [`export const x = 1;`]),
+    diffFor("src/ui/Hero.tsx", [`<img src="x.png" />`]),
+    diffFor("server/db.ts", [`const q = sql\`...\`;`]),
+    diffFor("src/ui/Card.tsx", [`<div className="text-red">hi</div>`]),
+  ].join("\n");
+  const ex = extractUiDiff(mixed);
+  assert.equal(ex.truncated, false);
+  assert.deepEqual(ex.files, ["src/ui/Hero.tsx", "src/ui/Card.tsx"]);
+  assert.match(ex.text, /src\/ui\/Hero\.tsx/);
+  assert.match(ex.text, /src\/ui\/Card\.tsx/);
+  assert.doesNotMatch(ex.text, /src\/lib\/calc\.ts/);
+  assert.doesNotMatch(ex.text, /server\/db\.ts/);
+});
+
+test("extractUiDiff: truncates when UI content exceeds 8000 chars", () => {
+  const bigBody = Array.from({ length: 2000 }, (_, i) => `<div>line ${i} — lots of text</div>`);
+  const big = diffFor("src/ui/Huge.tsx", bigBody);
+  // Force truncation by feeding oversize diff.
+  const ex = extractUiDiff(big);
+  assert.equal(ex.truncated, true);
+  assert.ok(ex.originalChars > MAX_UI_DIFF_CHARS);
+  assert.match(ex.text, /truncated/i);
+  assert.ok(ex.text.length <= MAX_UI_DIFF_CHARS + 512, "truncated output stays near the budget");
+});
+
+test("buildTextUIPrompt: includes UI files, truncation note, and diff fence", () => {
+  const diff = diffFor("src/ui/X.tsx", [`<div />`]);
+  const ex = extractUiDiff(diff);
+  const prompt = buildTextUIPrompt(
+    { ...baseCtx, diff },
+    ex.text,
+    ex.files,
+    { truncated: false },
+  );
+  assert.match(prompt, /text-UI mode/);
+  assert.match(prompt, /src\/ui\/X\.tsx/);
+  assert.match(prompt, /```diff/);
+  assert.match(prompt, /submit_review/);
+});
+
+test("TEXT_UI_SYSTEM_PROMPT: covers all five focus areas + non-goals", () => {
+  assert.match(TEXT_UI_SYSTEM_PROMPT, /[Ss]emantic HTML/);
+  assert.match(TEXT_UI_SYSTEM_PROMPT, /[Aa]ccessibility/);
+  assert.match(TEXT_UI_SYSTEM_PROMPT, /token/i);
+  assert.match(TEXT_UI_SYSTEM_PROMPT, /[Ll]ayout/);
+  assert.match(TEXT_UI_SYSTEM_PROMPT, /[Ii]nteraction state/);
+  assert.match(TEXT_UI_SYSTEM_PROMPT, /do NOT re-check/i);
+  assert.match(TEXT_UI_SYSTEM_PROMPT, /[Ss]ecurity/);
+});
+
+// ---- DesignAgent.review integration tests -------------------------------
+
+test("Mode B: <img> missing alt → a11y blocker surfaced via Mode B", async () => {
+  const client = makeMockClient([
+    toolUseResponse({
+      verdict: "rework",
+      blockers: [
+        {
+          severity: "blocker",
+          category: "accessibility",
+          message: "src/ui/Hero.tsx: `<img src=\"x.png\" />` missing alt — screen-reader users skip content.",
+          file: "src/ui/Hero.tsx",
+        },
+      ],
+      summary: "1 a11y blocker: hero image lacks alt text.",
+    }),
+  ]);
+  const agent = new DesignAgent({
+    apiKey: "test-key",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    client,
+  });
+  const diff = diffFor("src/ui/Hero.tsx", [`<img src="x.png" />`]);
+  const result = await agent.review({
+    ...baseCtx,
+    domain: "design",
+    diff,
+  });
+  assert.equal(result.agent, "design");
+  assert.equal(result.verdict, "rework");
+  assert.equal(result.blockers.length, 1);
+  assert.equal(result.blockers[0].severity, "blocker");
+  assert.equal(result.blockers[0].category, "accessibility");
+  assert.match(result.blockers[0].message, /alt/i);
+
+  // Verify Mode B shape: no image content blocks, text-only user content,
+  // TEXT_UI_SYSTEM_PROMPT in system.
+  assert.equal(client.calls.length, 1);
+  const params = client.calls[0];
+  assert.ok(Array.isArray(params.system));
+  assert.equal(params.system[0].text, TEXT_UI_SYSTEM_PROMPT);
+  const userContent = params.messages[0].content;
+  const imageBlocks = userContent.filter((b) => b.type === "image");
+  assert.equal(imageBlocks.length, 0, "Mode B must not attach images");
+  const textBlocks = userContent.filter((b) => b.type === "text");
+  assert.ok(textBlocks.some((b) => /Hero\.tsx/.test(b.text)));
+});
+
+test("Mode B: hardcoded #ff0000 in tokenized repo → minor token blocker", async () => {
+  const client = makeMockClient([
+    toolUseResponse({
+      verdict: "rework",
+      blockers: [
+        {
+          severity: "minor",
+          category: "token-adherence",
+          message:
+            "src/ui/Card.tsx: hardcoded color `#ff0000` — repo defines `theme.ts` with token `var(--color-danger)`; use that.",
+          file: "src/ui/Card.tsx",
+        },
+      ],
+      summary: "One minor: hardcoded color bypasses theme token.",
+    }),
+  ]);
+  const agent = new DesignAgent({
+    apiKey: "test-key",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    client,
+  });
+  const diff = [
+    diffFor("src/theme.ts", [`export const tokens = { danger: "var(--color-danger)" };`]),
+    diffFor("src/ui/Card.tsx", [`<div style={{ color: "#ff0000" }}>hi</div>`]),
+  ].join("\n");
+  const result = await agent.review({
+    ...baseCtx,
+    domain: "design",
+    diff,
+  });
+  assert.equal(result.verdict, "rework");
+  assert.equal(result.blockers.length, 1);
+  assert.equal(result.blockers[0].severity, "minor");
+  assert.match(result.blockers[0].category, /token/);
+});
+
+test("Mode C: pure logic-only diff → graceful skip-approve, no API call", async () => {
+  const client = {
+    calls: [],
+    messages: {
+      create: async () => {
+        throw new Error("Mode C must not hit the API");
+      },
+    },
+  };
+  const agent = new DesignAgent({
+    apiKey: "test-key",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    client,
+  });
+  const diff = [
+    diffFor("src/lib/calc.ts", [`export const x = 1;`]),
+    diffFor("server/db.ts", [`const q = 1;`]),
+    diffFor("package.json", [`"version": "1.0.0"`]),
+  ].join("\n");
+  const result = await agent.review({
+    ...baseCtx,
+    domain: "code",
+    diff,
+  });
+  assert.equal(result.verdict, "approve");
+  assert.equal(result.blockers.length, 0);
+  assert.match(result.summary, /no UI-relevant/i);
+  assert.equal(client.calls.length, 0);
+});
+
+test("Mode A wins over Mode B when both visualArtifacts and UI files are present", async () => {
+  const client = makeMockClient([
+    toolUseResponse({ verdict: "approve", summary: "vision LGTM" }),
+  ]);
+  const agent = new DesignAgent({
+    apiKey: "test-key",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    client,
+  });
+  const diff = diffFor("src/ui/Hero.tsx", [`<img src="x.png" alt="hero" />`]);
+  const result = await agent.review({
+    ...baseCtx,
+    domain: "design",
+    diff,
+    visualArtifacts: [{ route: "/", before: tinyPng, after: tinyPng }],
+  });
+  assert.equal(result.verdict, "approve");
+  // Vision mode sends image blocks; Mode B does not.
+  const params = client.calls[0];
+  const imageBlocks = params.messages[0].content.filter((b) => b.type === "image");
+  assert.equal(imageBlocks.length, 2, "Mode A must attach before + after images");
+});
+
+test("Mode B: invalid tool_use response → error-shaped blocker (no throw)", async () => {
+  const client = {
+    calls: [],
+    messages: {
+      create: async () => ({
+        id: "msg_bad",
+        model: "claude-opus-4-7",
+        content: [{ type: "text", text: "oops plain text" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 50, output_tokens: 5 },
+      }),
+    },
+  };
+  const agent = new DesignAgent({
+    apiKey: "test-key",
+    gate: new EfficiencyGate({ perPrUsd: 1 }),
+    client,
+  });
+  const diff = diffFor("src/ui/Hero.tsx", [`<img src="x" />`]);
+  const result = await agent.review({ ...baseCtx, diff });
+  assert.equal(result.verdict, "rework");
+  assert.equal(result.blockers[0].category, "agent-error");
+});
+
+test("Mode B: large UI diff → truncated, prompt contains truncation note", async () => {
+  const client = makeMockClient([
+    toolUseResponse({ verdict: "approve", summary: "ok" }),
+  ]);
+  const agent = new DesignAgent({
+    apiKey: "test-key",
+    gate: new EfficiencyGate({ perPrUsd: 10 }),
+    client,
+  });
+  const bigBody = Array.from({ length: 3000 }, (_, i) => `<div data-row="${i}">row ${i} filler text</div>`);
+  const diff = diffFor("src/ui/Huge.tsx", bigBody);
+  const result = await agent.review({ ...baseCtx, diff });
+  assert.equal(result.verdict, "approve");
+  const params = client.calls[0];
+  const userText = params.messages[0].content.find((b) => b.type === "text").text;
+  assert.match(userText, /diff-truncated: yes/);
+  assert.match(userText, /truncated/i);
+  // Full raw diff is NOT inlined.
+  assert.ok(
+    userText.length < 12_000,
+    `prompt must stay bounded; got ${userText.length} chars`,
+  );
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- **Three-mode dispatch in `DesignAgent.review`.** Before v0.5.4 the agent skip-approved any PR without `ctx.visualArtifacts`, which meant it never ran in production. Now: Mode A (vision, unchanged) when artifacts exist; **Mode B (text-UI, new)** when the diff touches UI code but no artifacts are attached — reasons about rendered intent from the source alone with a design-specific system prompt (semantic HTML, a11y, design tokens, layout, interaction states; explicit non-goals: logic + security); Mode C (graceful skip-approve) narrowed to diffs with no UI files at all.
- **UI-file detection** lives in new `packages/agent-design/src/ui-globs.ts` with a TODO pointing back at `packages/cli/src/lib/domain-detect.ts` from the v0.5.3 autodetect PR. That PR hasn't merged yet so globs are duplicated locally for now; once it merges this file should collapse to a thin re-export. Extraction + 8000-char fair per-file truncation in `text-ui-extract.ts`.
- **Tests:** 12 new in `text-ui-mode.test.mjs` (pure helpers + end-to-end). 18/18 pass. `corepack pnpm build` green across the monorepo. Same `submit_review` tool schema as Mode A so response parsing is shared.

Bumps `@conclave-ai/agent-design` to `0.5.4` and `@conclave-ai/cli` to `0.5.4`.

## Test plan

- [x] `corepack pnpm --filter @conclave-ai/agent-design build` green
- [x] `corepack pnpm --filter @conclave-ai/agent-design test` → 18/18 pass (6 original + 12 new)
- [x] `corepack pnpm build` (monorepo) green — 25/25 tasks successful
- [x] Manual check: synthetic `<img src="x.png" />` JSX diff through a mocked DesignAgent → verdict=`rework`, a11y blocker surfaced, zero image content blocks attached (confirms Mode B dispatched, not Mode A)
- [ ] Release re-tag `v0.4` floating pointer post-merge (Bae does it)
- [ ] Publish to npm (explicitly not done in this PR)

## Notes

- No new npm dependencies.
- Graceful skip for fully non-UI diffs preserved (Mode C).
- System prompt uses `cache_control: ephemeral` so repeat calls in a deliberation hit the prompt cache.
- Release notes appended at `docs/releases/v0.5.4.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)