### PR TITLE
feat(cli): conclave audit — full-project health check (v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ reviewer. Concretely:
 This is **not** a tool for seasoned engineers polishing code they wrote
 themselves. It is a council for code that came out of an AI.
 
+## Start here (after install)
+
+```bash
+conclave init       # one-time setup
+conclave audit      # run right away — full-project health check
+```
+
+`conclave audit` (v0.6.0) walks your repo, samples high-signal files,
+and opens a GitHub issue with a prioritized list of real blockers /
+majors / minors — no PR required. Budget-capped at $2 by default
+(hard ceiling $10). See [docs/guides/audit.md](docs/guides/audit.md).
+
 ## How it works
 
 ```
@@ -83,6 +95,7 @@ negative); here `answer-keys ∥ failure-catalog` is the primitive — decision 
 
 ```
 conclave init                              # scaffold config + .conclave/ in repo
+conclave audit [options]                   # v0.6+ — full-project health check
 conclave review [--pr N] [--visual]        # run the 3-round council review
 conclave record-outcome --id <ep-id> --result merged|rejected|reworked
 conclave poll-outcomes [--quiet]           # auto outcome capture via gh

--- a/docs/guides/audit.md
+++ b/docs/guides/audit.md
@@ -1,0 +1,169 @@
+# `conclave audit` — full-project health check
+
+`conclave audit` is the first command you should run after `conclave init`.
+Unlike `conclave review`, which grades a PR diff, `audit` walks the
+current state of the repo and returns a prioritized list of real issues
+a human should fix this week — no PR required.
+
+## When to use it
+
+- Right after `conclave init`, to get an immediate value signal from
+  the existing codebase.
+- Weekly or monthly on your main branch to catch drift.
+- Before a major version bump, as a pre-release pass.
+- After migrating a codebase from another reviewer tool, to baseline
+  what the council thinks of the current state.
+
+Do NOT use it as a substitute for `conclave review` on PRs. The two
+commands complement each other: `review` is per-change; `audit` is
+point-in-time health.
+
+## Quickstart
+
+```bash
+conclave audit
+```
+
+Defaults: scope=all, budget=$2, max-files=40, domain=auto, output=issue.
+The command opens a GitHub issue titled `Conclave Project Audit —
+YYYY-MM-DD` with the structured findings.
+
+## Common flags
+
+```bash
+# preview which files would be audited — no LLM calls, no spend
+conclave audit --dry-run
+
+# only audit UI code, print to terminal
+conclave audit --scope ui --output stdout
+
+# larger budget for a deep-scan on a bigger repo
+conclave audit --budget 5 --max-files 80
+
+# design-only pass (DesignAgent alone)
+conclave audit --domain design --scope ui
+
+# cheap, fast — single round, no tier-2 debate
+conclave audit --tier-1-only --budget 1
+```
+
+## Output shape (GitHub issue)
+
+```
+## Conclave Project Audit — 2026-04-20
+
+**Repo:** acme/my-app
+**SHA:** aabbccddeeff
+**Scope:** all (domain: mixed)
+**Coverage:** 40 audited / 120 in scope  _(sampled)_
+**Batches:** 5/5
+
+### Summary
+| Severity | Count |
+|---|---|
+| Blocker | 3 |
+| Major | 7 |
+| Minor | 12 |
+| Nit | 4 |
+
+### Top blockers (by severity)
+- **BLOCKER** `a11y` — `src/Hero.tsx:12`
+  img missing alt attribute on a content image
+- **BLOCKER** `security` — `src/api/users.ts:47`
+  SQL interpolation of unsanitized user input
+...
+
+### Grouped by category
+<details><summary><code>a11y</code> — 5 findings</summary>
+...
+
+### Grouped by subsystem
+<details><summary><code>ui</code> — 12 findings</summary>
+...
+
+### Per-agent verdicts
+| Agent | Approve | Rework | Reject |
+|---|---|---|---|
+| claude | 2 | 3 | 0 |
+| openai | 1 | 4 | 0 |
+
+### Cost + latency
+- **Spend:** $1.8200 of $2.00 budget
+- **Calls:** 15
+- **Latency:** 42000ms
+```
+
+## Cost examples
+
+| Repo size | Scope | Budget | Est. spend |
+|---|---|---|---|
+| ~40 files | all | $2 | $0.30 – $0.80 |
+| ~100 files | all (sampled to 40) | $2 | $0.60 – $1.50 |
+| ~500 files | code, --tier-1-only | $1 | $0.40 – $0.90 |
+| ~500 files | all | $5 | $2 – $4 |
+
+Prompt caching + Anthropic's sliding context usually keep cost well
+below the budget ceiling. **Hard ceiling is $10** regardless of
+`--budget` value — even if you pass `--budget 50`, the CLI clamps to
+$10 and warns. Real users will forget.
+
+## What gets excluded automatically
+
+- `node_modules`, `dist`, `build`, `.next`, `out`, `.turbo`, `.cache`
+- lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lockb`)
+- source maps and minified bundles (`*.map`, `*.min.js`)
+- binaries (images, fonts, audio, video, executables)
+- test files (unless you pass `--scope test` — not supported in v0.6)
+- everything in `.gitignore`
+- everything in `.conclaveignore` (optional, same format as gitignore)
+
+Add a `.conclaveignore` at the repo root to override on a per-project
+basis.
+
+## Scope categories
+
+- **ui** — `.tsx / .jsx / .vue / .svelte / .astro / .css / .scss /
+  .html`, `tailwind.config.*`, `theme.*`, anything under
+  `tokens/` / `design-system/`.
+- **code** — `.ts / .js / .py / .go / .rs / .rb / .java / .kt /
+  .swift / .php / .c / .cpp / .cs` and friends.
+- **infra** — `Dockerfile`, `docker-compose.*`, `*.yml`, `wrangler.toml`,
+  `vercel.json`, `netlify.toml`, anything under `.github/workflows/`,
+  `terraform/`, `*.tf`, `Makefile`.
+- **docs** — `*.md`, `*.mdx`, `*.rst`, `*.txt`.
+
+Test files are always excluded from audit (tests that fail aren't a
+"codebase health" signal; failing CI is).
+
+## Budget enforcement
+
+Budget is enforced MANDATORILY. Before each batch, the command checks
+remaining budget; if the next call can't be afforded under the cap, the
+audit stops and returns a PARTIAL result labeled `budget exhausted
+after N/M batches`. The GitHub issue body and stdout both call this
+out clearly — no silent truncation.
+
+## Config
+
+Add an `audit` section to `.conclaverc.json` to set project defaults:
+
+```json
+{
+  "version": 1,
+  "audit": {
+    "defaultBudgetUsd": 2,
+    "defaultMaxFiles": 40,
+    "defaultScope": "all"
+  }
+}
+```
+
+CLI flags always win over config.
+
+## Exit codes
+
+- `0` — no findings, or only minor / nit findings.
+- `1` — at least one `major` finding (codebase has notable issues).
+- `2` — at least one `blocker` finding (fix immediately).
+
+Useful for wiring audit into CI as a periodic health check.

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,153 @@
+# v0.6.0 — `conclave audit` (the headline feature)
+
+## TL;DR
+
+`conclave audit` — a new CLI command that runs a full-project health
+check across the current codebase. Users can run it immediately after
+`conclave init` and get a prioritized list of real issues without
+having to craft a pull request first.
+
+This closes the gap identified in user feedback: PR-diff review alone
+doesn't help a new user who wants "what's wrong with my project right
+now". `conclave audit` becomes the natural "first command after init".
+
+## What's new
+
+### `conclave audit` command
+
+```bash
+conclave audit [options]
+
+Options:
+  --scope <set>       "all" (default), "ui", "code", "infra", "docs"
+  --budget <usd>      hard cap on LLM spend. default $2, MAX $10
+  --output <target>   "issue" (default) | "stdout" | "json" | "both"
+  --max-files <N>     cap files reviewed. default 40 (sampling if repo bigger)
+  --include <glob>    extra files to include (comma-separated)
+  --exclude <glob>    extra files to skip (comma-separated)
+  --domain <mode>     "auto" (default) | "code" | "design" | "mixed"
+  --dry-run           list files that would be audited without calling LLMs
+  --sha <sha>         audit state at a specific commit (default HEAD)
+  --tier-1-only       skip tier-2 debate; cheaper, faster, less precise
+```
+
+Default flow: discover repo files (respecting `.gitignore` +
+`.conclaveignore`), sample a category-balanced subset biased toward
+recently-modified files, batch into 6kB chunks, run each batch through
+the configured agents in audit mode, dedup findings across agents, and
+open a GitHub issue titled `Conclave Project Audit — YYYY-MM-DD`.
+
+### New files in the repo
+
+- `packages/cli/src/commands/audit.ts` — CLI command entrypoint
+- `packages/cli/src/lib/audit-discovery.ts` — file walk, categorize,
+  sample, batch
+- `packages/cli/src/lib/audit-output.ts` — aggregate findings, render
+  stdout / JSON / GitHub-issue markdown
+- `packages/cli/test/audit.test.mjs` — 14 tests covering discovery,
+  sampling, batching, dedup, budget ceiling, output formats
+- `docs/guides/audit.md` — user-facing guide
+- `docs/releases/v0.6.0.md` — this file
+
+### Core / agent changes
+
+- `@conclave-ai/core`: `ReviewContext` gains two optional fields:
+  - `mode?: "review" | "audit"` — lets agents switch prompts.
+  - `auditFiles?: readonly string[]` — paths packed into
+    `ctx.diff` so agents can attribute findings.
+  New exported type `ReviewMode`.
+- `@conclave-ai/agent-claude`, `@conclave-ai/agent-openai`,
+  `@conclave-ai/agent-gemini`: each adds an `AUDIT_SYSTEM_PROMPT`
+  + `buildAuditPrompt()`. `buildCacheablePrefix` now selects the
+  audit prompt when `ctx.mode === "audit"`.
+- `@conclave-ai/agent-design`: adds `AUDIT_SYSTEM_PROMPT` +
+  `buildAuditPrompt()`. DesignAgent's `review()` now routes to a new
+  `reviewAudit()` path when `ctx.mode === "audit"`; filters the batch
+  to UI files only.
+
+### Config schema
+
+`.conclaverc.json` gains an optional `audit` section:
+
+```json
+{
+  "version": 1,
+  "audit": {
+    "defaultBudgetUsd": 2,
+    "defaultMaxFiles": 40,
+    "defaultScope": "all"
+  }
+}
+```
+
+CLI flags always override config. The hard budget ceiling ($10) is
+enforced at the CLI layer and cannot be raised via config.
+
+## Budget guardrails
+
+- Default budget: $2 per audit.
+- Hard ceiling: $10 regardless of CLI flag or config. Even if a user
+  passes `--budget 50`, we clamp and warn.
+- Before each batch the command checks remaining budget; if it can't
+  afford the next call, it stops and returns a PARTIAL result marked
+  `budget exhausted after N/M batches` in both the GitHub issue and
+  stdout output. No silent truncation.
+
+## Version bumps
+
+| Package | From | To |
+|---|---|---|
+| `@conclave-ai/cli` | 0.5.4 | 0.6.0 |
+| `@conclave-ai/core` | 0.4.0 | 0.6.0 |
+| `@conclave-ai/agent-claude` | 0.4.0 | 0.6.0 |
+| `@conclave-ai/agent-openai` | 0.4.0 | 0.6.0 |
+| `@conclave-ai/agent-gemini` | 0.4.0 | 0.6.0 |
+| `@conclave-ai/agent-design` | 0.5.4 | 0.6.0 |
+
+No bumps to `central-plane` or `integration-*` packages — audit is a
+CLI + agent feature only.
+
+## Backward compatibility
+
+- `ReviewContext.mode` is optional; all existing callers (Council,
+  TieredCouncil, every agent) treat `undefined` as `"review"`.
+- Agents' `buildReviewPrompt()` dispatches to the audit path only when
+  `ctx.mode === "audit"`; review-mode behavior is unchanged.
+- No config migration required — `.conclaverc.json` without an
+  `audit` section still validates.
+
+## Tests
+
+14 new tests in `packages/cli/test/audit.test.mjs` covering:
+
+- `.gitignore` + `.conclaveignore` respect
+- scope + include/exclude filters
+- category-balanced sampling over `--max-files`
+- batching stays under per-agent char budget
+- cross-agent dedup by `(file, line, category, severity)`
+- binary-extension exclusion
+- recency sort (newest files first)
+- categorize heuristics (tsx → ui, Dockerfile → infra, etc.)
+- hard $10 budget ceiling
+- JSON / stdout / issue-body output renderers
+
+Full suite: `corepack pnpm build && corepack pnpm test` — 47 tasks
+green, 154 CLI tests pass (was 140 before audit was added).
+
+## Acceptance smoke test
+
+```bash
+export PATH="/c/Program Files/nodejs:$PATH"
+conclave audit --dry-run --scope ui --cwd /path/to/small-repo
+# prints file list with no LLM calls
+```
+
+## What's NOT in this release
+
+- No Playwright / vision-based UI audit — text-UI mode is enough for
+  v0.6.0. Vision-based audit is deferred to v0.6.1+.
+- No `central-plane` changes; audit runs entirely client-side.
+- No memory persistence of audit findings — each audit is
+  point-in-time; the memory substrate (answer-keys / failure-catalog)
+  is still PR-scoped.
+- No `--scope test` — audit skips tests by design.

--- a/packages/agent-claude/package.json
+++ b/packages/agent-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-claude",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "description": "Conclave AI Claude agent — wraps @anthropic-ai/claude-agent-sdk.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-claude/src/prompts.ts
+++ b/packages/agent-claude/src/prompts.ts
@@ -1,5 +1,24 @@
 import type { ReviewContext } from "@conclave-ai/core";
 
+/**
+ * Audit-mode system prompt (v0.6.0). Used by `conclave audit` to run a
+ * full-project health check instead of a PR-diff review. Agents receive
+ * full file contents (not a diff) and must flag real issues in the
+ * code as-shipped.
+ */
+export const AUDIT_SYSTEM_PROMPT = `You are a senior code auditor on a multi-agent council for Conclave AI. The council is auditing an already-shipped codebase — NOT a pull-request diff. Treat everything in the context as code that is live right now.
+
+Your goal: surface real issues a human should fix this week. You work alongside other agents (OpenAI, Gemini, possibly a design specialist); spurious findings dilute the signal and waste the user's budget.
+
+Rules:
+- Flag real problems: correctness, security, injection risk, regression risk, accessibility violations, missing input validation, dead code, design-token drift, performance cliffs on hot paths.
+- Do NOT pad with stylistic nits, import order, or taste-based naming suggestions.
+- Every blocker MUST name the file and (when you can tell) a line or line-range. Concrete > abstract.
+- Severity — blocker = ships broken / unsafe; major = observable regression risk or clear a11y violation; minor = real issue but low blast radius; nit = polish.
+- Category — one of: security, a11y, correctness, regression, token-drift, dead-code, performance, test-coverage, docs.
+- When the file contents are short and clean, approve cleanly — over-flagging is a bigger sin than missing a nit.
+- You MUST respond by calling the submit_review tool exactly once. Do not emit free-form text.`;
+
 export const SYSTEM_PROMPT = `You are a senior code reviewer on a multi-agent council for Conclave AI. The council reviews AI-generated code and design changes before merge.
 
 Your goal: catch real blockers, not style nits. You work alongside other agents (OpenAI, Gemini, possibly domain-specific specialists). Your reviews are weighed against theirs; spurious blockers hurt your agent score and waste the rework budget.
@@ -14,6 +33,7 @@ Rules:
 - You MUST respond by calling the submit_review tool exactly once. Do not emit free-form text.`;
 
 export function buildReviewPrompt(ctx: ReviewContext): string {
+  if (ctx.mode === "audit") return buildAuditPrompt(ctx);
   const sections: string[] = [];
   sections.push(`# Review target`);
   sections.push(`repo: ${ctx.repo}`);
@@ -96,7 +116,7 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
  * `cache_control: ephemeral` and sits at the head of the messages array.
  */
 export function buildCacheablePrefix(ctx: ReviewContext): string {
-  const parts: string[] = [SYSTEM_PROMPT];
+  const parts: string[] = [ctx.mode === "audit" ? AUDIT_SYSTEM_PROMPT : SYSTEM_PROMPT];
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
     parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
   }
@@ -104,4 +124,61 @@ export function buildCacheablePrefix(ctx: ReviewContext): string {
     parts.push("failure-catalog:\n" + ctx.failureCatalog.slice(0, 8).join("\n"));
   }
   return parts.join("\n---\n");
+}
+
+/**
+ * Audit-mode user prompt (v0.6.0). `ctx.diff` carries the full current
+ * contents of the batched files (not a unified diff); `ctx.auditFiles`
+ * lists the paths. Priors are still honored so tier-2 escalation works.
+ */
+export function buildAuditPrompt(ctx: ReviewContext): string {
+  const sections: string[] = [];
+  sections.push(`# Audit target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`sha:  ${ctx.newSha}`);
+  if (ctx.auditFiles && ctx.auditFiles.length > 0) {
+    sections.push(`files in this batch (${ctx.auditFiles.length}): ${ctx.auditFiles.join(", ")}`);
+  }
+  sections.push("");
+
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    sections.push(`# Known failure patterns (failure-catalog)`);
+    sections.push(
+      `These patterns caused real incidents in the past. Flag them aggressively if you see them in the files below.`,
+    );
+    sections.push("");
+    for (const entry of ctx.failureCatalog.slice(0, 8)) sections.push(`- ${entry}`);
+    sections.push("");
+  }
+
+  sections.push(`# Files (current state — already shipped)`);
+  sections.push("```");
+  sections.push(ctx.diff || "(empty — respond with verdict=approve and a note that the batch is empty)");
+  sections.push("```");
+  sections.push("");
+
+  if (ctx.priors && ctx.priors.length > 0) {
+    sections.push(`# Round ${ctx.round ?? 2} — other agents' audit findings from the previous round`);
+    sections.push(
+      `Read each agent's blockers. Update your verdict ONLY if you see a real issue you missed, or a false-positive you can now retract. Do not mirror the majority.`,
+    );
+    sections.push("");
+    for (const p of ctx.priors) {
+      sections.push(`## ${p.agent}: ${p.verdict}`);
+      if (p.blockers.length > 0) {
+        for (const b of p.blockers.slice(0, 5)) {
+          const loc = b.file ? ` (${b.file}${b.line ? ":" + b.line : ""})` : "";
+          sections.push(`- [${b.severity}/${b.category}] ${b.message}${loc}`);
+        }
+      } else {
+        sections.push(`- (no blockers)`);
+      }
+      sections.push("");
+    }
+  }
+
+  sections.push(
+    `Call submit_review exactly once. Treat every file as already-shipped; do NOT assume there is a diff. Focus on blockers users should fix now — not "the diff looks clean". Empty blockers list + approve is fine when the batch is genuinely clean.`,
+  );
+  return sections.join("\n");
 }

--- a/packages/agent-design/package.json
+++ b/packages/agent-design/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-design",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Conclave AI design-specialist agent — vision-based review over before/after screenshots.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-design/src/design-agent.ts
+++ b/packages/agent-design/src/design-agent.ts
@@ -6,10 +6,12 @@ import {
   REVIEW_TOOL_INPUT_SCHEMA,
   SYSTEM_PROMPT,
   TEXT_UI_SYSTEM_PROMPT,
+  AUDIT_SYSTEM_PROMPT,
   buildUserPrompt,
   buildTextUIPrompt,
+  buildAuditPrompt,
 } from "./prompts.js";
-import { diffTouchesUi } from "./ui-globs.js";
+import { diffTouchesUi, isUiPath } from "./ui-globs.js";
 import { extractUiDiff, MAX_UI_DIFF_CHARS } from "./text-ui-extract.js";
 
 /**
@@ -132,6 +134,11 @@ export class DesignAgent implements Agent {
   }
 
   async review(ctx: ReviewContext): Promise<ReviewResult> {
+    // v0.6.0 — audit mode. Full file contents in `ctx.diff`, UI paths in
+    // `ctx.auditFiles`. If no UI files are in the batch, graceful approve.
+    if (ctx.mode === "audit") {
+      return this.reviewAudit(ctx);
+    }
     const artifacts = ctx.visualArtifacts ?? [];
     // Mode A — vision: screenshots present. Highest-signal mode; always
     // wins over Mode B when both are available.
@@ -152,6 +159,90 @@ export class DesignAgent implements Agent {
       summary:
         "skipped — no visual artifacts and no UI-relevant files in the diff. Design agent has nothing to review; approving by default.",
     };
+  }
+
+  /**
+   * v0.6.0 — audit mode. The batch's full file contents arrive in
+   * `ctx.diff` and the list of files in `ctx.auditFiles`. We filter down
+   * to UI-relevant files and, when there are any, run a design-focused
+   * audit prompt. When there are none, graceful approve.
+   */
+  private async reviewAudit(ctx: ReviewContext): Promise<ReviewResult> {
+    const files = (ctx.auditFiles ?? []).filter((p) => isUiPath(p));
+    if (files.length === 0) {
+      return {
+        agent: this.id,
+        verdict: "approve",
+        blockers: [],
+        summary:
+          "skipped — no UI-relevant files in this audit batch. Nothing to review from the design lens.",
+      };
+    }
+    const userText = buildAuditPrompt(ctx, ctx.diff, files);
+    const inputTokenEstimate =
+      estimateTokens(AUDIT_SYSTEM_PROMPT) + estimateTokens(userText);
+    const estimatedCostUsd =
+      (inputTokenEstimate * 15) / 1_000_000 + (this.maxTokens * 75) / 1_000_000;
+
+    const outcome = await this.gate.run<ReviewResult>(
+      {
+        agent: this.id,
+        cacheablePrefix: AUDIT_SYSTEM_PROMPT,
+        prompt: AUDIT_SYSTEM_PROMPT + "\n" + userText,
+        estimatedCostUsd,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const response = await client.messages.create({
+          model,
+          max_tokens: this.maxTokens,
+          system: [
+            { type: "text", text: AUDIT_SYSTEM_PROMPT, cache_control: { type: "ephemeral" } },
+          ],
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: userText },
+                {
+                  type: "text",
+                  text: "Respond by calling submit_review exactly once.",
+                },
+              ],
+            },
+          ],
+          tools: [
+            {
+              name: REVIEW_TOOL_NAME,
+              description: REVIEW_TOOL_DESCRIPTION,
+              input_schema: REVIEW_TOOL_INPUT_SCHEMA,
+            },
+          ],
+          tool_choice: { type: "tool", name: REVIEW_TOOL_NAME },
+        });
+        const latencyMs = Date.now() - started;
+
+        const parsed = parseReviewResponse(response, this.id);
+        const usage = response.usage ?? { input_tokens: 0, output_tokens: 0 };
+        const costUsd = estimateActualCost(model, usage);
+
+        return {
+          result: {
+            ...parsed,
+            tokensUsed: usage.input_tokens + usage.output_tokens,
+            costUsd,
+          },
+          inputTokens: usage.input_tokens,
+          outputTokens: usage.output_tokens,
+          costUsd,
+          latencyMs,
+        };
+      },
+    );
+
+    return outcome.result;
   }
 
   /** Mode A — vision review. Original behavior, unchanged. */

--- a/packages/agent-design/src/index.ts
+++ b/packages/agent-design/src/index.ts
@@ -8,11 +8,13 @@ export type {
 export {
   SYSTEM_PROMPT,
   TEXT_UI_SYSTEM_PROMPT,
+  AUDIT_SYSTEM_PROMPT,
   REVIEW_TOOL_NAME,
   REVIEW_TOOL_DESCRIPTION,
   REVIEW_TOOL_INPUT_SCHEMA,
   buildUserPrompt,
   buildTextUIPrompt,
+  buildAuditPrompt,
 } from "./prompts.js";
 export {
   UI_EXTENSIONS,

--- a/packages/agent-design/src/prompts.ts
+++ b/packages/agent-design/src/prompts.ts
@@ -122,6 +122,31 @@ export function buildUserPrompt(ctx: ReviewContext, routes: readonly string[]): 
 }
 
 /**
+ * Audit-mode system prompt (v0.6.0). Used by `conclave audit` when the
+ * batch contains UI files. DesignAgent reasons about UI issues in
+ * already-shipped code — no diff, no screenshots. Accessibility and
+ * token-adherence are the highest-value findings here.
+ */
+export const AUDIT_SYSTEM_PROMPT = `You are a design-specialist auditor on a multi-agent council for Conclave AI. The council is auditing an already-shipped codebase — NOT a pull-request diff. You're the UI lane: code + markup + styles, as they exist on main right now.
+
+Your goal: find UI issues the general-purpose code agents will not notice. They cover logic + security; you cover how the UI will look and behave once rendered.
+
+Focus areas (in order of priority):
+1. Accessibility — images without alt text, buttons-as-divs with no keyboard handler, form inputs without labels, missing visible focus states, color-only meaning, missing aria labels on icon-only buttons, heading hierarchy skips, missing landmarks.
+2. Semantic HTML — role / element mismatches (div with onClick used as a button, a non-interactive element with no keyboard handler).
+3. Design-token drift — hardcoded \`#RRGGBB\` / \`rgb(...)\` / raw \`px\` values in a repo that clearly uses Tailwind / CSS variables / a theme file. Favor tokens; call out the drift.
+4. Layout / responsive — missing responsive breakpoints on dense surfaces, missing \`overflow-hidden\` on clipping containers, missing \`min-w-0\` on flex children that will truncate, obvious layout bugs (absolute positioning without a relative parent, z-index wars).
+5. Interaction states — missing hover / focus / active / disabled / loading coverage on interactive elements.
+
+Rules:
+- Cite the file + specific snippet in each blocker (e.g. "src/ui/Hero.tsx: <img src={logo} /> missing alt").
+- Severity — blocker = a11y violation that blocks users (missing alt on content image, button-as-div with no keyboard); major = obvious design bug on a primary surface; minor = secondary surface; nit = polish.
+- Category — one of: a11y, semantic-html, token-drift, layout, responsive, interaction-state, contrast, overflow.
+- Do NOT re-check logic correctness / security / package choices — the code agents handle those.
+- When the UI files are short and clean, verdict=approve with a one-line summary is fine.
+- You MUST respond by calling the submit_review tool exactly once. No free-form text.`;
+
+/**
  * Mode B — text-UI system prompt. Used when no visual artifacts are
  * attached but the diff touches UI code. The design agent reasons about
  * the rendered intent from the source alone: semantic HTML, a11y,
@@ -149,6 +174,57 @@ Rules:
 - When the UI diff is small and clean, verdict=approve with a one-line summary is fine. Don't invent issues.
 - If the diff appears truncated (a "[truncated]" marker is present), note the caveat in your summary.
 - You MUST respond by calling the submit_review tool exactly once. No free-form text.`;
+
+/**
+ * Build the audit-mode user prompt for DesignAgent (v0.6.0). Takes the
+ * current contents of the UI files in the batch (already size-bounded by
+ * the CLI) and the list of UI file paths.
+ */
+export function buildAuditPrompt(
+  ctx: ReviewContext,
+  uiFilesContent: string,
+  uiFiles: readonly string[],
+): string {
+  const sections: string[] = [];
+  sections.push(`# UI audit target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`sha:  ${ctx.newSha}`);
+  if (uiFiles.length > 0) {
+    sections.push(`ui files in this batch (${uiFiles.length}): ${uiFiles.join(", ")}`);
+  }
+  sections.push("");
+
+  sections.push(`# UI files (current state — already shipped)`);
+  sections.push("```");
+  sections.push(uiFilesContent || "(empty batch)");
+  sections.push("```");
+  sections.push("");
+
+  if (ctx.priors && ctx.priors.length > 0) {
+    sections.push(`# Round ${ctx.round ?? 2} — other agents' audit findings from the previous round`);
+    sections.push(
+      `Read each agent's blockers. Update your verdict ONLY if you see a real UI issue you missed, or a false-positive you can now retract.`,
+    );
+    sections.push("");
+    for (const p of ctx.priors) {
+      sections.push(`## ${p.agent}: ${p.verdict}`);
+      if (p.blockers.length > 0) {
+        for (const b of p.blockers.slice(0, 5)) {
+          sections.push(`- [${b.severity}/${b.category}] ${b.message}`);
+        }
+      } else {
+        sections.push(`- (no blockers)`);
+      }
+      sections.push("");
+    }
+  }
+
+  sections.push(`# Instruction`);
+  sections.push(
+    `Audit the UI files above through the design lens in the system prompt. Call submit_review exactly once. The code agents are covering logic + security — do not duplicate them. Empty blockers + approve is fine when the batch is clean.`,
+  );
+  return sections.join("\n");
+}
 
 /**
  * Build the user prompt for Mode B. Takes the UI-only diff (already

--- a/packages/agent-gemini/package.json
+++ b/packages/agent-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-gemini",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "description": "Conclave AI Gemini agent — wraps @google/genai with responseSchema structured output. Long-context slot per decision #10.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-gemini/src/prompts.ts
+++ b/packages/agent-gemini/src/prompts.ts
@@ -1,5 +1,24 @@
 import type { ReviewContext } from "@conclave-ai/core";
 
+/**
+ * Audit-mode system prompt (v0.6.0). Whole-project health check, not a
+ * PR-diff review. Gemini's long-context window shines here — we batch
+ * more files per call than Claude/OpenAI.
+ */
+export const AUDIT_SYSTEM_PROMPT = `You are a senior code auditor on a multi-agent council for Conclave AI. The council is auditing an already-shipped codebase — NOT a pull-request diff. Treat everything in the context as code that is live right now.
+
+You have a long-context window; use it to reason across files in the batch, not just one at a time. Cross-file issues (dead imports, broken references, duplicated logic) are uniquely yours to catch.
+
+Goal: surface real issues a human should fix this week. Spurious findings dilute the signal.
+
+Rules:
+- Flag real problems: correctness, security, injection risk, regression risk, accessibility violations, missing input validation, dead code, design-token drift, performance cliffs on hot paths, cross-file impact.
+- Do NOT pad with stylistic nits or taste-based naming suggestions.
+- Every blocker MUST name the file and (when you can tell) a line or line-range.
+- Severity — blocker = ships broken / unsafe; major = observable regression or clear a11y violation; minor = real issue but low blast radius; nit = polish.
+- Category — one of: security, a11y, correctness, regression, token-drift, dead-code, performance, test-coverage, docs.
+- You MUST respond as JSON matching the provided response schema. Do not wrap the JSON in prose.`;
+
 export const SYSTEM_PROMPT = `You are a senior code reviewer on a multi-agent council for Conclave AI. The council reviews AI-generated code and design changes before merge.
 
 You have a long-context window and are typically routed here when the diff + context exceeds what Claude or OpenAI handle efficiently. Use that capacity to consider the whole change surface, not just the diff in isolation.
@@ -16,6 +35,7 @@ Rules:
 - You MUST respond as JSON matching the provided response schema. Do not wrap the JSON in prose.`;
 
 export function buildReviewPrompt(ctx: ReviewContext): string {
+  if (ctx.mode === "audit") return buildAuditPrompt(ctx);
   const sections: string[] = [];
   sections.push(`# Review target`);
   sections.push(`repo: ${ctx.repo}`);
@@ -87,8 +107,60 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   return sections.join("\n");
 }
 
+export function buildAuditPrompt(ctx: ReviewContext): string {
+  const sections: string[] = [];
+  sections.push(`# Audit target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`sha:  ${ctx.newSha}`);
+  if (ctx.auditFiles && ctx.auditFiles.length > 0) {
+    sections.push(`files in this batch (${ctx.auditFiles.length}): ${ctx.auditFiles.join(", ")}`);
+  }
+  sections.push("");
+
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    sections.push(`# Known failure patterns (failure-catalog)`);
+    sections.push(
+      `These patterns caused real incidents. Flag them aggressively if present in the files below.`,
+    );
+    sections.push("");
+    for (const entry of ctx.failureCatalog.slice(0, 8)) sections.push(`- ${entry}`);
+    sections.push("");
+  }
+
+  sections.push(`# Files (current state — already shipped)`);
+  sections.push("```");
+  sections.push(ctx.diff || "(empty — respond with verdict=approve, blockers=[], summary noting empty batch)");
+  sections.push("```");
+  sections.push("");
+
+  if (ctx.priors && ctx.priors.length > 0) {
+    sections.push(`# Round ${ctx.round ?? 2} — other agents' audit findings from the previous round`);
+    sections.push(
+      `Read each agent's blockers. Update your verdict ONLY if you see a real issue you missed, or a false-positive you can now retract. Do not mirror the majority.`,
+    );
+    sections.push("");
+    for (const p of ctx.priors) {
+      sections.push(`## ${p.agent}: ${p.verdict}`);
+      if (p.blockers.length > 0) {
+        for (const b of p.blockers.slice(0, 5)) {
+          const loc = b.file ? ` (${b.file}${b.line ? ":" + b.line : ""})` : "";
+          sections.push(`- [${b.severity}/${b.category}] ${b.message}${loc}`);
+        }
+      } else {
+        sections.push(`- (no blockers)`);
+      }
+      sections.push("");
+    }
+  }
+
+  sections.push(
+    `Respond as JSON matching the response schema. Treat every file as already-shipped; do NOT assume there is a diff.`,
+  );
+  return sections.join("\n");
+}
+
 export function buildCacheablePrefix(ctx: ReviewContext): string {
-  const parts: string[] = [SYSTEM_PROMPT];
+  const parts: string[] = [ctx.mode === "audit" ? AUDIT_SYSTEM_PROMPT : SYSTEM_PROMPT];
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
     parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
   }

--- a/packages/agent-openai/package.json
+++ b/packages/agent-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/agent-openai",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "description": "Conclave AI OpenAI agent — wraps the OpenAI SDK with strict-JSON-schema structured output.",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-openai/src/prompts.ts
+++ b/packages/agent-openai/src/prompts.ts
@@ -1,5 +1,23 @@
 import type { ReviewContext } from "@conclave-ai/core";
 
+/**
+ * Audit-mode system prompt (v0.6.0). Full-project health check rather
+ * than a PR-diff review. See `agent-claude/src/prompts.ts` for the
+ * same rationale.
+ */
+export const AUDIT_SYSTEM_PROMPT = `You are a senior code auditor on a multi-agent council for Conclave AI. The council is auditing an already-shipped codebase — NOT a pull-request diff. Treat everything in the context as code that is live right now.
+
+Your goal: surface real issues a human should fix this week. You work alongside other agents (Claude, Gemini, possibly a design specialist); spurious findings dilute the signal and waste the user's budget.
+
+Rules:
+- Flag real problems: correctness, security, injection risk, regression risk, accessibility violations, missing input validation, dead code, design-token drift, performance cliffs on hot paths.
+- Do NOT pad with stylistic nits, import order, or taste-based naming suggestions.
+- Every blocker MUST name the file and (when you can tell) a line or line-range.
+- Severity — blocker = ships broken / unsafe; major = observable regression risk or clear a11y violation; minor = real issue but low blast radius; nit = polish.
+- Category — one of: security, a11y, correctness, regression, token-drift, dead-code, performance, test-coverage, docs.
+- When the file contents are short and clean, approve cleanly.
+- You MUST respond in the provided JSON schema. Any field marked nullable uses null when not applicable (do not omit it).`;
+
 export const SYSTEM_PROMPT = `You are a senior code reviewer on a multi-agent council for Conclave AI. The council reviews AI-generated code and design changes before merge.
 
 Your goal: catch real blockers, not style nits. You work alongside other agents (Claude, Gemini, possibly domain-specific specialists). Your reviews are weighed against theirs; spurious blockers hurt your agent score and waste the rework budget.
@@ -14,6 +32,7 @@ Rules:
 - You MUST respond in the provided JSON schema. Any field marked nullable uses null when not applicable (do not omit it).`;
 
 export function buildReviewPrompt(ctx: ReviewContext): string {
+  if (ctx.mode === "audit") return buildAuditPrompt(ctx);
   const sections: string[] = [];
   sections.push(`# Review target`);
   sections.push(`repo: ${ctx.repo}`);
@@ -85,8 +104,60 @@ export function buildReviewPrompt(ctx: ReviewContext): string {
   return sections.join("\n");
 }
 
+export function buildAuditPrompt(ctx: ReviewContext): string {
+  const sections: string[] = [];
+  sections.push(`# Audit target`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`sha:  ${ctx.newSha}`);
+  if (ctx.auditFiles && ctx.auditFiles.length > 0) {
+    sections.push(`files in this batch (${ctx.auditFiles.length}): ${ctx.auditFiles.join(", ")}`);
+  }
+  sections.push("");
+
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    sections.push(`# Known failure patterns (failure-catalog)`);
+    sections.push(
+      `These patterns caused real incidents in the past. Flag them aggressively if you see them in the files below.`,
+    );
+    sections.push("");
+    for (const entry of ctx.failureCatalog.slice(0, 8)) sections.push(`- ${entry}`);
+    sections.push("");
+  }
+
+  sections.push(`# Files (current state — already shipped)`);
+  sections.push("```");
+  sections.push(ctx.diff || "(empty — respond with verdict=approve and note the batch is empty)");
+  sections.push("```");
+  sections.push("");
+
+  if (ctx.priors && ctx.priors.length > 0) {
+    sections.push(`# Round ${ctx.round ?? 2} — other agents' audit findings from the previous round`);
+    sections.push(
+      `Read each agent's blockers. Update your verdict ONLY if you see a real issue you missed, or a false-positive you can now retract. Do not mirror the majority.`,
+    );
+    sections.push("");
+    for (const p of ctx.priors) {
+      sections.push(`## ${p.agent}: ${p.verdict}`);
+      if (p.blockers.length > 0) {
+        for (const b of p.blockers.slice(0, 5)) {
+          const loc = b.file ? ` (${b.file}${b.line ? ":" + b.line : ""})` : "";
+          sections.push(`- [${b.severity}/${b.category}] ${b.message}${loc}`);
+        }
+      } else {
+        sections.push(`- (no blockers)`);
+      }
+      sections.push("");
+    }
+  }
+
+  sections.push(
+    `Respond using the conclave_review JSON schema. Treat every file as already-shipped; do NOT assume there is a diff. Focus on blockers users should fix now.`,
+  );
+  return sections.join("\n");
+}
+
 export function buildCacheablePrefix(ctx: ReviewContext): string {
-  const parts: string[] = [SYSTEM_PROMPT];
+  const parts: string[] = [ctx.mode === "audit" ? AUDIT_SYSTEM_PROMPT : SYSTEM_PROMPT];
   if (ctx.answerKeys && ctx.answerKeys.length > 0) {
     parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,0 +1,476 @@
+/**
+ * `conclave audit` — full-project health check (v0.6.0).
+ *
+ * Unlike `review`, which operates on a PR diff, `audit` walks the
+ * current state of the repo, samples high-signal files, batches them
+ * into council-sized chunks, and runs each batch through the configured
+ * agents in audit mode. Findings are deduped, sorted, and emitted as a
+ * GitHub issue (default), stdout, JSON, or both.
+ *
+ * Core principles:
+ *   - Budget is MANDATORY and HARD-CAPPED at $10. Real users will forget.
+ *   - Smart about what to audit — categories, recency, --max-files.
+ *   - Degrades gracefully — budget exhaustion returns a PARTIAL result,
+ *     never a crash.
+ */
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  BudgetTracker,
+  Council,
+  EfficiencyGate,
+  MetricsRecorder,
+  type Agent,
+  type ReviewContext,
+  type ReviewResult,
+} from "@conclave-ai/core";
+import { ClaudeAgent } from "@conclave-ai/agent-claude";
+import { DesignAgent } from "@conclave-ai/agent-design";
+import { OpenAIAgent } from "@conclave-ai/agent-openai";
+import { GeminiAgent } from "@conclave-ai/agent-gemini";
+import { loadConfig } from "../lib/config.js";
+import {
+  discoverAuditFiles,
+  buildAuditBatches,
+  DEFAULT_UI_SIGNALS,
+  type AuditScope,
+  type AuditCategory,
+  type DiscoveredFile,
+} from "../lib/audit-discovery.js";
+import {
+  aggregateFindings,
+  renderAuditStdout,
+  renderAuditJson,
+  renderAuditIssueBody,
+  type AuditReport,
+  type PerBatchResult,
+} from "../lib/audit-output.js";
+
+const execFile = promisify(execFileCb);
+
+// Hard ceiling — even if a user passes --budget 50, we clamp to $10.
+// Rationale: new users are the audience; guardrail > flexibility.
+export const HARD_BUDGET_CEILING_USD = 10;
+
+// Conservative per-call cost estimate used for reservations. Real cost
+// usually lands lower (prompt caching). Better to reserve generously and
+// release nothing than to under-reserve and over-spend.
+const ESTIMATED_COST_PER_BATCH_USD = 0.15;
+
+export type AuditOutputTarget = "issue" | "stdout" | "json" | "both";
+export type AuditDomain = "auto" | "code" | "design" | "mixed";
+
+interface ParsedArgs {
+  help: boolean;
+  scope: AuditScope;
+  budgetUsd: number;
+  output: AuditOutputTarget;
+  maxFiles: number;
+  include: string[];
+  exclude: string[];
+  domain: AuditDomain;
+  dryRun: boolean;
+  sha?: string;
+  tier1Only: boolean;
+  cwd?: string;
+  jsonPath?: string;
+}
+
+const HELP = `conclave audit — full-project health check across the current codebase
+
+Usage:
+  conclave audit [options]
+
+Options:
+  --scope <set>       "all" (default), "ui", "code", "infra", "docs"
+  --budget <usd>      hard cap on LLM spend. default $2, MAX $10
+  --output <target>   "issue" (default) | "stdout" | "json" | "both"
+  --max-files <N>     cap files reviewed. default 40 (sampling if repo bigger)
+  --include <glob>    extra files to include (comma-separated)
+  --exclude <glob>    extra files to skip (comma-separated)
+  --domain <mode>     "auto" (default) | "code" | "design" | "mixed"
+  --dry-run           list files that would be audited without calling LLMs
+  --sha <sha>         audit state at a specific commit (default HEAD)
+  --tier-1-only       skip tier-2 debate; cheaper, faster, less precise
+  --cwd <path>        repo to audit (default: process.cwd())
+  --json-out <path>   write JSON to a file (implies --output json if not set)
+
+Environment:
+  ANTHROPIC_API_KEY   required — primary Claude agent.
+  OPENAI_API_KEY      optional — adds OpenAI agent.
+  GOOGLE_API_KEY      optional — adds Gemini agent (long-context batches).
+
+Examples:
+  conclave audit                                 # default: scope=all, $2 budget, GH issue
+  conclave audit --dry-run --scope ui            # preview which files would be audited
+  conclave audit --budget 5 --output stdout      # larger budget, print to terminal
+  conclave audit --scope code --max-files 20     # quick, cheap scan
+  conclave audit --domain design --scope ui      # DesignAgent only
+`;
+
+function parseArgv(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = {
+    help: false,
+    scope: "all",
+    budgetUsd: 2,
+    output: "issue",
+    maxFiles: 40,
+    include: [],
+    exclude: [],
+    domain: "auto",
+    dryRun: false,
+    tier1Only: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--tier-1-only") out.tier1Only = true;
+    else if (a === "--scope" && argv[i + 1]) {
+      const v = argv[++i]!;
+      if (v === "all" || v === "ui" || v === "code" || v === "infra" || v === "docs") out.scope = v;
+    } else if (a === "--budget" && argv[i + 1]) {
+      const n = Number.parseFloat(argv[++i]!);
+      if (!Number.isNaN(n) && n > 0) out.budgetUsd = n;
+    } else if (a === "--output" && argv[i + 1]) {
+      const v = argv[++i]!;
+      if (v === "issue" || v === "stdout" || v === "json" || v === "both") out.output = v;
+    } else if (a === "--max-files" && argv[i + 1]) {
+      const n = Number.parseInt(argv[++i]!, 10);
+      if (!Number.isNaN(n) && n > 0) out.maxFiles = n;
+    } else if (a === "--include" && argv[i + 1]) {
+      out.include = argv[++i]!.split(",").map((s) => s.trim()).filter(Boolean);
+    } else if (a === "--exclude" && argv[i + 1]) {
+      out.exclude = argv[++i]!.split(",").map((s) => s.trim()).filter(Boolean);
+    } else if (a === "--domain" && argv[i + 1]) {
+      const v = argv[++i]!;
+      if (v === "auto" || v === "code" || v === "design" || v === "mixed") out.domain = v;
+    } else if (a === "--sha" && argv[i + 1]) {
+      out.sha = argv[++i]!;
+    } else if (a === "--cwd" && argv[i + 1]) {
+      out.cwd = argv[++i]!;
+    } else if (a === "--json-out" && argv[i + 1]) {
+      out.jsonPath = argv[++i]!;
+    }
+  }
+  return out;
+}
+
+async function resolveRepoSlug(cwd: string): Promise<string> {
+  try {
+    const { stdout } = await execFile("git", ["-C", cwd, "config", "--get", "remote.origin.url"], {
+      maxBuffer: 1024 * 1024,
+    });
+    const url = stdout.trim();
+    // match git@github.com:owner/repo(.git)? or https://github.com/owner/repo(.git)?
+    const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+    if (m) return `${m[1]}/${m[2]}`;
+  } catch {
+    // not a git repo or no origin — fall through
+  }
+  return path.basename(cwd);
+}
+
+async function resolveHeadSha(cwd: string, override?: string): Promise<string> {
+  if (override) return override;
+  try {
+    const { stdout } = await execFile("git", ["-C", cwd, "rev-parse", "HEAD"], {
+      maxBuffer: 1024 * 1024,
+    });
+    return stdout.trim();
+  } catch {
+    return "HEAD";
+  }
+}
+
+function buildAgentsForDomain(
+  domain: AuditDomain,
+  gate: EfficiencyGate,
+): { agents: Agent[]; skipped: string[]; resolvedDomain: "code" | "design" | "mixed" } {
+  const skipped: string[] = [];
+  const agents: Agent[] = [];
+  // auto → mixed for audit (we don't have a diff to sniff from; broadest
+  // coverage wins).
+  const resolved: "code" | "design" | "mixed" = domain === "auto" ? "mixed" : domain;
+
+  const addClaude = () => {
+    if (process.env["ANTHROPIC_API_KEY"]) agents.push(new ClaudeAgent({ gate }));
+    else skipped.push("claude (ANTHROPIC_API_KEY not set)");
+  };
+  const addOpenAI = () => {
+    if (process.env["OPENAI_API_KEY"]) agents.push(new OpenAIAgent({ gate }));
+    else skipped.push("openai (OPENAI_API_KEY not set)");
+  };
+  const addGemini = () => {
+    if (process.env["GOOGLE_API_KEY"] || process.env["GEMINI_API_KEY"]) {
+      agents.push(new GeminiAgent({ gate }));
+    } else {
+      skipped.push("gemini (GOOGLE_API_KEY not set)");
+    }
+  };
+  const addDesign = () => {
+    if (process.env["ANTHROPIC_API_KEY"]) agents.push(new DesignAgent({ gate }));
+    else skipped.push("design (ANTHROPIC_API_KEY not set)");
+  };
+
+  if (resolved === "code") {
+    addClaude();
+    addOpenAI();
+    addGemini();
+  } else if (resolved === "design") {
+    addDesign();
+  } else {
+    // mixed — code agents + design
+    addClaude();
+    addOpenAI();
+    addGemini();
+    addDesign();
+  }
+  return { agents, skipped, resolvedDomain: resolved };
+}
+
+export async function audit(argv: string[]): Promise<void> {
+  const args = parseArgv(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  const cwd = path.resolve(args.cwd ?? process.cwd());
+  const { config } = await loadConfig(cwd);
+
+  // Apply config defaults when CLI flag omitted (CLI wins over config).
+  const auditCfg = config.audit;
+  let budgetUsd = args.budgetUsd;
+  if (!argv.includes("--budget") && auditCfg?.defaultBudgetUsd) {
+    budgetUsd = auditCfg.defaultBudgetUsd;
+  }
+  let maxFiles = args.maxFiles;
+  if (!argv.includes("--max-files") && auditCfg?.defaultMaxFiles) {
+    maxFiles = auditCfg.defaultMaxFiles;
+  }
+  let scope: AuditScope = args.scope;
+  if (!argv.includes("--scope") && auditCfg?.defaultScope) {
+    scope = auditCfg.defaultScope;
+  }
+
+  // Hard ceiling enforcement. Clamp + warn.
+  if (budgetUsd > HARD_BUDGET_CEILING_USD) {
+    process.stderr.write(
+      `conclave audit: --budget $${budgetUsd} exceeds hard ceiling — clamping to $${HARD_BUDGET_CEILING_USD}\n`,
+    );
+    budgetUsd = HARD_BUDGET_CEILING_USD;
+  }
+
+  // 1. Resolve repo / sha.
+  const repo = await resolveRepoSlug(cwd);
+  const sha = await resolveHeadSha(cwd, args.sha);
+
+  // 2. Discover files.
+  const uiSignals =
+    config.autoDetect?.uiSignals && config.autoDetect.uiSignals.length > 0
+      ? config.autoDetect.uiSignals
+      : DEFAULT_UI_SIGNALS;
+  const discovery = await discoverAuditFiles({
+    cwd,
+    scope,
+    maxFiles,
+    include: args.include,
+    exclude: args.exclude,
+    uiSignals,
+  });
+
+  process.stdout.write(
+    `conclave audit: repo=${repo} sha=${sha.slice(0, 12)} scope=${scope} domain=${args.domain}\n`,
+  );
+  process.stdout.write(`  ${discovery.reason}\n`);
+
+  // 3. --dry-run: list + exit.
+  if (args.dryRun) {
+    process.stdout.write(`\nfiles that would be audited (${discovery.files.length}):\n`);
+    for (const f of discovery.files) {
+      process.stdout.write(`  [${f.category}] ${f.path}  (${f.sizeBytes}b)\n`);
+    }
+    process.stdout.write(`\n--dry-run — no LLM calls made. Budget remains $${budgetUsd.toFixed(2)}.\n`);
+    return;
+  }
+
+  if (discovery.files.length === 0) {
+    process.stdout.write(`conclave audit: nothing to audit. Exiting clean.\n`);
+    return;
+  }
+
+  // 4. Build batches.
+  const batches = await buildAuditBatches(discovery.files, cwd);
+  process.stdout.write(
+    `  packed into ${batches.length} batch(es), ${batches.reduce((s, b) => s + b.charCount, 0)} chars total\n`,
+  );
+
+  // 5. Wire budget + agents.
+  const budget = new BudgetTracker({ perPrUsd: budgetUsd });
+  budget.onWarning((spent, cap) => {
+    process.stderr.write(
+      `conclave audit: budget warning — spent $${spent.toFixed(4)} of $${cap.toFixed(2)} cap\n`,
+    );
+  });
+  const metrics = new MetricsRecorder();
+  const gate = new EfficiencyGate({ budget, metrics });
+
+  const { agents, skipped, resolvedDomain } = buildAgentsForDomain(args.domain, gate);
+  for (const s of skipped) {
+    process.stderr.write(`conclave audit: ${s}\n`);
+  }
+  if (agents.length === 0) {
+    process.stderr.write(
+      `conclave audit: no agents available. Set at least ANTHROPIC_API_KEY and re-run.\n`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  // 6. Council per batch. We don't escalate to tier-2 for audit by
+  //    default; a single round across all agents is cheaper and usually
+  //    enough. `--tier-1-only` further enforces single-round.
+  const council = new Council({
+    agents,
+    maxRounds: args.tier1Only ? 1 : 2,
+    enableDebate: !args.tier1Only,
+  });
+
+  const perBatch: PerBatchResult[] = [];
+  let budgetExhausted = false;
+  let batchesRun = 0;
+  for (let i = 0; i < batches.length; i++) {
+    const b = batches[i]!;
+    // Budget pre-check: bail if we can't afford another batch.
+    if (budget.remainingUsd < ESTIMATED_COST_PER_BATCH_USD) {
+      process.stderr.write(
+        `conclave audit: budget exhausted after ${batchesRun}/${batches.length} batches — returning partial result\n`,
+      );
+      budgetExhausted = true;
+      break;
+    }
+    const startedBatch = Date.now();
+    const ctx: ReviewContext = {
+      diff: b.payload,
+      repo,
+      pullNumber: 0,
+      newSha: sha,
+      mode: "audit",
+      auditFiles: b.files.map((f) => f.path),
+      domain: resolvedDomain === "design" ? "design" : "code",
+    };
+    let outcome;
+    try {
+      outcome = await council.deliberate(ctx);
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (/budget/i.test(msg)) {
+        process.stderr.write(
+          `conclave audit: budget exceeded mid-batch (${msg}) — returning partial result\n`,
+        );
+        budgetExhausted = true;
+        break;
+      }
+      process.stderr.write(`conclave audit: batch ${i + 1} failed — ${msg}\n`);
+      continue;
+    }
+    const batchCost = outcome.results.reduce((s, r) => s + (r.costUsd ?? 0), 0);
+    perBatch.push({
+      batchIndex: i,
+      files: b.files,
+      results: outcome.results,
+      costUsd: batchCost,
+      latencyMs: Date.now() - startedBatch,
+    });
+    batchesRun += 1;
+  }
+
+  // 7. Aggregate + attribute.
+  const fileToCategory = new Map<string, AuditCategory>();
+  for (const f of discovery.files) fileToCategory.set(f.path, f.category);
+  const findings = aggregateFindings(perBatch, fileToCategory);
+
+  const perAgentAcc = new Map<
+    string,
+    { approvedBatches: number; reworkBatches: number; rejectBatches: number }
+  >();
+  for (const b of perBatch) {
+    for (const r of b.results) {
+      const acc =
+        perAgentAcc.get(r.agent) ?? { approvedBatches: 0, reworkBatches: 0, rejectBatches: 0 };
+      if (r.verdict === "approve") acc.approvedBatches += 1;
+      else if (r.verdict === "rework") acc.reworkBatches += 1;
+      else acc.rejectBatches += 1;
+      perAgentAcc.set(r.agent, acc);
+    }
+  }
+  const perAgentVerdict = Array.from(perAgentAcc.entries()).map(([agent, v]) => ({
+    agent,
+    ...v,
+  }));
+
+  const report: AuditReport = {
+    repo,
+    sha,
+    scope,
+    domain: resolvedDomain,
+    filesAudited: discovery.files.length,
+    filesInScope: discovery.totalMatched,
+    sampled: discovery.sampled,
+    discoveryReason: discovery.reason,
+    findings,
+    perAgentVerdict,
+    budgetUsd,
+    spentUsd: metrics.summary().totalCostUsd,
+    budgetExhausted,
+    batchesRun,
+    batchesTotal: batches.length,
+    metrics: metrics.summary(),
+  };
+
+  // 8. Emit per --output.
+  const output = args.output;
+  if (output === "stdout" || output === "both") {
+    process.stdout.write("\n");
+    process.stdout.write(renderAuditStdout(report));
+  }
+  if (output === "json" || args.jsonPath) {
+    const json = renderAuditJson(report);
+    if (args.jsonPath) {
+      await fs.promises.mkdir(path.dirname(path.resolve(args.jsonPath)), { recursive: true });
+      await fs.promises.writeFile(args.jsonPath, json, "utf8");
+      process.stdout.write(`\nconclave audit: wrote JSON to ${args.jsonPath}\n`);
+    } else if (output === "json") {
+      process.stdout.write(json);
+    }
+  }
+  if (output === "issue" || output === "both") {
+    const body = renderAuditIssueBody(report);
+    const date = new Date().toISOString().slice(0, 10);
+    const title = `Conclave Project Audit — ${date}`;
+    try {
+      const { stdout } = await execFile(
+        "gh",
+        ["issue", "create", "--title", title, "--body", body],
+        { maxBuffer: 4 * 1024 * 1024 },
+      );
+      process.stdout.write(`\nconclave audit: opened issue — ${stdout.trim()}\n`);
+    } catch (err) {
+      process.stderr.write(
+        `conclave audit: could not open GitHub issue (${(err as Error).message}). Falling back to stdout.\n`,
+      );
+      process.stdout.write("\n");
+      process.stdout.write(renderAuditStdout(report));
+    }
+  }
+
+  // Exit code: 0 if no blockers / majors, 1 if rework-worthy, 2 if any
+  // blocker. Matches review's contract.
+  const hasBlocker = findings.some((f) => f.severity === "blocker");
+  const hasMajor = findings.some((f) => f.severity === "major");
+  if (hasBlocker) process.exit(2);
+  if (hasMajor) process.exit(1);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { init } from "./commands/init.js";
 import { review } from "./commands/review.js";
+import { audit } from "./commands/audit.js";
 import { recordOutcome } from "./commands/record-outcome.js";
 import { rework } from "./commands/rework.js";
 import { pollOutcomesCommand } from "./commands/poll-outcomes.js";
@@ -17,6 +18,7 @@ Usage:
 
 Commands:
   init                  Set up conclave in the current repo (config + skeleton)
+  audit                 Full-project health check across the current codebase (v0.6+)
   review                Run a council review on the current branch
   rework                Apply a worker-generated patch for a pending council "rework" verdict
   record-outcome        Record a PR's merge/reject/rework outcome manually
@@ -31,6 +33,8 @@ Commands:
 
 Examples:
   conclave init
+  conclave audit                          # run right after init — full-project health check
+  conclave audit --dry-run --scope ui     # preview which files would be audited
   conclave review --pr 42 --visual
   conclave rework --pr 42                 # apply worker patch for the latest pending review on PR 42
   conclave record-outcome --id ep-... --result merged
@@ -56,6 +60,9 @@ export async function run(argv: string[]): Promise<void> {
   switch (cmd) {
     case "init":
       await init(rest);
+      return;
+    case "audit":
+      await audit(rest);
       return;
     case "review":
       await review(rest);

--- a/packages/cli/src/lib/audit-discovery.ts
+++ b/packages/cli/src/lib/audit-discovery.ts
@@ -1,0 +1,545 @@
+/**
+ * File discovery for `conclave audit` (v0.6.0).
+ *
+ * Walks the repo rooted at `cwd`, respects `.gitignore` + `.conclaveignore`,
+ * drops binaries and generated artifacts, categorizes each surviving file
+ * (ui / code / infra / docs / test), filters by --scope + --include /
+ * --exclude, and — when the total exceeds --max-files — samples a
+ * category-representative subset biased toward recently-modified files.
+ *
+ * No external deps beyond node:fs / node:path and the inline glob matcher
+ * re-used from `./domain-detect.js`. We deliberately avoid shelling out to
+ * `git ls-files` because the CLI targets installs where git metadata may
+ * be absent (e.g. a fresh scaffold before the first commit).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import { globToRegExp } from "./domain-detect.js";
+
+const execFile = promisify(execFileCb);
+
+export type AuditCategory = "ui" | "code" | "infra" | "docs" | "test";
+export type AuditScope = "all" | AuditCategory;
+
+export interface DiscoveredFile {
+  /** Path relative to `cwd`. Forward-slash normalized on all platforms. */
+  path: string;
+  category: AuditCategory;
+  sizeBytes: number;
+  /** Epoch ms of last modification. Used for recency-sorted sampling. */
+  mtimeMs: number;
+}
+
+export interface DiscoveryOptions {
+  cwd: string;
+  scope?: AuditScope;
+  maxFiles?: number;
+  include?: readonly string[];
+  exclude?: readonly string[];
+  /**
+   * Shared with v0.5.3 domain-detect. When a file matches one of these
+   * globs AND isn't excluded, we tag it `ui`.
+   */
+  uiSignals?: readonly string[];
+  /**
+   * When true, try to sort candidates by git-log recency (last 90 days
+   * bias). Falls back to mtime when git isn't available.
+   */
+  useGitRecency?: boolean;
+}
+
+export interface DiscoveryResult {
+  /** Files selected for audit. Respects maxFiles + sampling. */
+  files: DiscoveredFile[];
+  /** Total files that matched scope/include/exclude before sampling. */
+  totalMatched: number;
+  /** True when sampling was applied (totalMatched > maxFiles). */
+  sampled: boolean;
+  /** Reason the discovery returned what it did — surfaced to the user. */
+  reason: string;
+}
+
+// ─── Constants / default lists ────────────────────────────────────────
+
+/** UI-signal globs mirror v0.5.3's DEFAULT_UI_SIGNALS. Extended deliberately
+ *  for audit-mode — we count markdown and astro as "ui/docs" respectively. */
+export const DEFAULT_UI_SIGNALS: readonly string[] = [
+  "**/*.{tsx,jsx,vue,svelte,astro}",
+  "**/*.{css,scss,sass,less,styl,pcss}",
+  "**/tailwind.config.{js,ts,cjs,mjs}",
+  "**/postcss.config.{js,ts,cjs,mjs}",
+  "**/*.{html,htm}",
+  "**/tokens/**",
+  "**/design-system/**",
+  "**/theme.{js,ts,json}",
+];
+
+const DOC_GLOBS: readonly string[] = [
+  "**/*.md",
+  "**/*.mdx",
+  "**/*.rst",
+  "**/*.txt",
+];
+
+const TEST_GLOBS: readonly string[] = [
+  "**/*.test.{ts,tsx,js,jsx,mjs,cjs}",
+  "**/*.spec.{ts,tsx,js,jsx,mjs,cjs}",
+  "**/test/**",
+  "**/tests/**",
+  "**/__tests__/**",
+];
+
+const INFRA_GLOBS: readonly string[] = [
+  "**/Dockerfile",
+  "**/docker-compose.{yml,yaml}",
+  "**/*.{yml,yaml}",
+  "**/wrangler.toml",
+  "**/vercel.json",
+  "**/netlify.toml",
+  "**/.github/workflows/**",
+  "**/terraform/**",
+  "**/*.tf",
+  "**/Makefile",
+];
+
+const CODE_GLOBS: readonly string[] = [
+  "**/*.{ts,js,mjs,cjs,py,go,rs,rb,java,kt,swift,php,c,cpp,h,hpp,cs}",
+];
+
+/**
+ * Always-excluded path fragments. Dropped BEFORE any other matching —
+ * a file matching one of these never appears in the result set. Tuned
+ * for the JS/TS ecosystem but harmless on polyglot repos.
+ */
+const DEFAULT_HARD_EXCLUDES: readonly string[] = [
+  "node_modules/**",
+  "**/node_modules/**",
+  "dist/**",
+  "**/dist/**",
+  "build/**",
+  "**/build/**",
+  "coverage/**",
+  "**/coverage/**",
+  ".next/**",
+  "**/.next/**",
+  "out/**",
+  "**/out/**",
+  ".turbo/**",
+  "**/.turbo/**",
+  ".cache/**",
+  "**/.cache/**",
+  ".vercel/**",
+  "**/.vercel/**",
+  ".git/**",
+  "**/.git/**",
+  "**/.tsbuildinfo",
+  "**/*.min.{js,css}",
+  "**/*.map",
+  "**/*.lock",
+  "**/package-lock.json",
+  "**/pnpm-lock.yaml",
+  "**/yarn.lock",
+  "**/bun.lockb",
+  "**/Cargo.lock",
+  "**/poetry.lock",
+];
+
+/**
+ * Binary file extensions — we never send these to an LLM. Extensions here
+ * override any include/scope match.
+ */
+const BINARY_EXTS = new Set([
+  ".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".bmp", ".ico",
+  ".pdf", ".zip", ".tar", ".gz", ".tgz", ".bz2", ".7z", ".rar",
+  ".woff", ".woff2", ".ttf", ".otf", ".eot",
+  ".mp3", ".mp4", ".webm", ".mov", ".avi", ".mkv",
+  ".exe", ".dll", ".so", ".dylib", ".bin", ".o", ".a",
+  ".class", ".pyc", ".wasm", ".bundle",
+  // svg is text but rarely high-signal for audit, and we still let domain-detect
+  // treat it as a UI signal in review-mode. Skip in audit.
+  ".svg",
+]);
+
+/**
+ * Text-file extensions we always allow regardless of category — prevents
+ * surprise skips of CI / lint / editor config files when scope=infra.
+ */
+const ALWAYS_TEXT_EXTS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
+  ".py", ".go", ".rs", ".rb", ".java", ".kt", ".swift", ".php",
+  ".c", ".cpp", ".h", ".hpp", ".cs", ".m",
+  ".css", ".scss", ".sass", ".less", ".styl", ".pcss",
+  ".html", ".htm", ".vue", ".svelte", ".astro",
+  ".md", ".mdx", ".rst", ".txt",
+  ".json", ".yaml", ".yml", ".toml", ".xml", ".ini", ".env",
+  ".sh", ".bash", ".zsh", ".ps1", ".bat", ".cmd",
+  ".tf", ".hcl", ".sql", ".graphql", ".gql",
+  ".dockerfile",
+]);
+
+// ─── ignore-file parsing ──────────────────────────────────────────────
+
+/**
+ * Parse `.gitignore` / `.conclaveignore` format into a glob list the
+ * inline matcher understands. Blank + comment lines dropped. `!`-prefix
+ * (negation) is rare; when present we prefix the stored entry with `!`
+ * and the caller filters in two passes.
+ *
+ * Leading `/` means repo-root anchored; stored without the leading slash
+ * so the globToRegExp matcher anchors the full path anyway.
+ */
+export function parseIgnoreFile(contents: string): string[] {
+  const out: string[] = [];
+  for (const raw of contents.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    let glob = line;
+    if (glob.startsWith("/")) glob = glob.slice(1);
+    // Trailing slash means "directory" in gitignore; we emit both a
+    // directory-equivalent glob AND the bare form so the matcher catches
+    // entries inside it.
+    if (glob.endsWith("/")) {
+      const dir = glob.slice(0, -1);
+      out.push(dir + "/**");
+      out.push("**/" + dir + "/**");
+    } else {
+      out.push(glob);
+      // Also match deep — `src/foo.ts` in gitignore should match any
+      // `foo.ts` under `src/`. Inline globs starting with `**/` are fine.
+      if (!glob.startsWith("**/") && !glob.includes("/")) {
+        out.push("**/" + glob);
+      }
+    }
+  }
+  return out;
+}
+
+async function readIgnoreFile(p: string): Promise<string[]> {
+  try {
+    const s = await fs.promises.readFile(p, "utf8");
+    return parseIgnoreFile(s);
+  } catch {
+    return [];
+  }
+}
+
+// ─── categorization ───────────────────────────────────────────────────
+
+function matchesAny(normPath: string, patterns: readonly string[]): string | null {
+  for (const g of patterns) {
+    const re = globToRegExp(g);
+    if (re.test(normPath)) return g;
+  }
+  return null;
+}
+
+/**
+ * Assign a category. Priority: test → ui → infra → docs → code. "Test"
+ * takes precedence so a `Button.test.tsx` is test, not ui.
+ */
+export function categorize(
+  filePath: string,
+  opts: { uiSignals?: readonly string[] } = {},
+): AuditCategory {
+  const p = filePath.replace(/\\/g, "/");
+  if (matchesAny(p, TEST_GLOBS)) return "test";
+  const ui = opts.uiSignals ?? DEFAULT_UI_SIGNALS;
+  if (matchesAny(p, ui)) return "ui";
+  if (matchesAny(p, INFRA_GLOBS)) return "infra";
+  if (matchesAny(p, DOC_GLOBS)) return "docs";
+  if (matchesAny(p, CODE_GLOBS)) return "code";
+  // Fallback: if the extension is a known text extension, call it code.
+  const ext = path.extname(p).toLowerCase();
+  if (ALWAYS_TEXT_EXTS.has(ext)) return "code";
+  return "code";
+}
+
+// ─── filesystem walk ──────────────────────────────────────────────────
+
+/**
+ * Recursive walk that respects the compiled ignore-set at each step.
+ * Returns paths relative to `cwd`, normalized with forward slashes.
+ *
+ * Symlinks: not followed. Hidden dirs starting with `.` are walked
+ * (ignore patterns handle `.git` etc.) — users sometimes have source
+ * under `.config/` and skipping all dotdirs would mystify them.
+ */
+async function walk(
+  cwd: string,
+  ignores: readonly string[],
+): Promise<Array<{ rel: string; sizeBytes: number; mtimeMs: number }>> {
+  const out: Array<{ rel: string; sizeBytes: number; mtimeMs: number }> = [];
+  async function recurse(dir: string, relDir: string): Promise<void> {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const ent of entries) {
+      const abs = path.join(dir, ent.name);
+      const rel = relDir ? `${relDir}/${ent.name}` : ent.name;
+      // Cheap early exit on hard-coded + user-supplied ignores.
+      const relDirMarker = rel + "/";
+      if (matchesAny(rel, ignores) || matchesAny(relDirMarker, ignores)) continue;
+      if (ent.isSymbolicLink()) continue;
+      if (ent.isDirectory()) {
+        await recurse(abs, rel);
+        continue;
+      }
+      if (!ent.isFile()) continue;
+      let stat: fs.Stats;
+      try {
+        stat = await fs.promises.stat(abs);
+      } catch {
+        continue;
+      }
+      out.push({ rel, sizeBytes: stat.size, mtimeMs: stat.mtimeMs });
+    }
+  }
+  await recurse(cwd, "");
+  return out;
+}
+
+// ─── binary detection ─────────────────────────────────────────────────
+
+export function isBinaryExtension(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return BINARY_EXTS.has(ext);
+}
+
+// ─── scope + filter logic ─────────────────────────────────────────────
+
+function scopeMatches(category: AuditCategory, scope: AuditScope): boolean {
+  if (scope === "all") return category !== "test"; // tests never audited by default
+  return category === scope;
+}
+
+// ─── git recency ──────────────────────────────────────────────────────
+
+/**
+ * Return a mapping of path → last-commit-epoch-ms for files touched in
+ * the last 90 days. Returns an empty map when git isn't available or
+ * the cwd isn't a git repo — callers fall back to mtime.
+ */
+async function gitRecencyMap(cwd: string): Promise<Map<string, number>> {
+  try {
+    const { stdout } = await execFile(
+      "git",
+      [
+        "-C",
+        cwd,
+        "log",
+        "--name-only",
+        "--pretty=format:%ct",
+        "--since=90.days.ago",
+      ],
+      { maxBuffer: 20 * 1024 * 1024 },
+    );
+    const map = new Map<string, number>();
+    let currentTs = 0;
+    for (const line of stdout.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      if (/^\d+$/.test(line.trim())) {
+        currentTs = Number.parseInt(line.trim(), 10) * 1000;
+        continue;
+      }
+      if (currentTs === 0) continue;
+      const existing = map.get(line);
+      if (existing === undefined || existing < currentTs) {
+        map.set(line, currentTs);
+      }
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+// ─── sampling ─────────────────────────────────────────────────────────
+
+/**
+ * Round-robin category sampling — take one from each category until
+ * `maxFiles` is hit. Within a category files are pre-sorted by recency
+ * so the "first N" from each bucket are the most-recent. Guarantees that
+ * a 40-file cap on a repo of 1,000 files still hits every non-empty
+ * category at least once (assuming ≥5 categories present).
+ */
+function sampleCategoryBalanced(
+  files: DiscoveredFile[],
+  maxFiles: number,
+): DiscoveredFile[] {
+  if (files.length <= maxFiles) return files;
+  const byCat = new Map<AuditCategory, DiscoveredFile[]>();
+  for (const f of files) {
+    const list = byCat.get(f.category) ?? [];
+    list.push(f);
+    byCat.set(f.category, list);
+  }
+  // Pre-sort each bucket by recency (newest first).
+  for (const [, list] of byCat) {
+    list.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  }
+  const out: DiscoveredFile[] = [];
+  const cursors = new Map<AuditCategory, number>();
+  const cats = Array.from(byCat.keys());
+  while (out.length < maxFiles) {
+    let appendedThisRound = false;
+    for (const cat of cats) {
+      if (out.length >= maxFiles) break;
+      const list = byCat.get(cat)!;
+      const idx = cursors.get(cat) ?? 0;
+      if (idx >= list.length) continue;
+      out.push(list[idx]!);
+      cursors.set(cat, idx + 1);
+      appendedThisRound = true;
+    }
+    if (!appendedThisRound) break;
+  }
+  return out;
+}
+
+// ─── public API ───────────────────────────────────────────────────────
+
+export async function discoverAuditFiles(opts: DiscoveryOptions): Promise<DiscoveryResult> {
+  const cwd = path.resolve(opts.cwd);
+  const scope: AuditScope = opts.scope ?? "all";
+  const maxFiles = opts.maxFiles ?? 40;
+  if (maxFiles <= 0) {
+    return { files: [], totalMatched: 0, sampled: false, reason: "max-files ≤ 0 — nothing to audit" };
+  }
+
+  // Load ignore sources.
+  const gitIgnore = await readIgnoreFile(path.join(cwd, ".gitignore"));
+  const conclaveIgnore = await readIgnoreFile(path.join(cwd, ".conclaveignore"));
+  const ignores: string[] = [
+    ...DEFAULT_HARD_EXCLUDES,
+    ...gitIgnore,
+    ...conclaveIgnore,
+    ...(opts.exclude ?? []),
+  ];
+
+  // Walk the tree.
+  const walked = await walk(cwd, ignores);
+
+  // Filter: no binaries, apply --include (if supplied).
+  const include = opts.include && opts.include.length > 0 ? opts.include : null;
+  const staged: DiscoveredFile[] = [];
+  for (const w of walked) {
+    if (isBinaryExtension(w.rel)) continue;
+    // If --include is set, the file must match at least one include glob.
+    if (include) {
+      if (!matchesAny(w.rel, include)) continue;
+    }
+    const category = categorize(w.rel, { uiSignals: opts.uiSignals ?? DEFAULT_UI_SIGNALS });
+    if (!scopeMatches(category, scope)) continue;
+    staged.push({
+      path: w.rel,
+      category,
+      sizeBytes: w.sizeBytes,
+      mtimeMs: w.mtimeMs,
+    });
+  }
+
+  const totalMatched = staged.length;
+  if (totalMatched === 0) {
+    return {
+      files: [],
+      totalMatched: 0,
+      sampled: false,
+      reason: `no files matched scope=${scope} after exclusions`,
+    };
+  }
+
+  // Sort globally by recency first — surfaces the "fresh" files even when
+  // maxFiles isn't a binding constraint.
+  const gitMap = opts.useGitRecency === false ? new Map<string, number>() : await gitRecencyMap(cwd);
+  for (const f of staged) {
+    const git = gitMap.get(f.path);
+    if (git !== undefined) f.mtimeMs = Math.max(f.mtimeMs, git);
+  }
+  staged.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  if (totalMatched <= maxFiles) {
+    return {
+      files: staged,
+      totalMatched,
+      sampled: false,
+      reason: `${totalMatched} files matched — under max-files=${maxFiles}, auditing all`,
+    };
+  }
+
+  const sampled = sampleCategoryBalanced(staged, maxFiles);
+  return {
+    files: sampled,
+    totalMatched,
+    sampled: true,
+    reason: `${totalMatched} matched > max-files=${maxFiles} — sampled ${sampled.length} (recency + category-balanced)`,
+  };
+}
+
+// ─── batching ─────────────────────────────────────────────────────────
+
+export interface AuditBatch {
+  files: DiscoveredFile[];
+  /** Rendered payload ready to stuff into ReviewContext.diff. */
+  payload: string;
+  charCount: number;
+}
+
+/**
+ * Pack files into batches no larger than `maxCharsPerBatch` (default
+ * 6000). A single oversize file is still emitted in its own batch — we
+ * truncate its contents to budget with a clear marker so the agent
+ * knows. Never throws.
+ */
+export async function buildAuditBatches(
+  files: readonly DiscoveredFile[],
+  cwd: string,
+  maxCharsPerBatch = 6_000,
+): Promise<AuditBatch[]> {
+  const batches: AuditBatch[] = [];
+  let current: { files: DiscoveredFile[]; chunks: string[]; chars: number } = {
+    files: [],
+    chunks: [],
+    chars: 0,
+  };
+
+  const flush = () => {
+    if (current.files.length === 0) return;
+    batches.push({
+      files: current.files,
+      payload: current.chunks.join("\n\n"),
+      charCount: current.chars,
+    });
+    current = { files: [], chunks: [], chars: 0 };
+  };
+
+  for (const f of files) {
+    let contents: string;
+    try {
+      contents = await fs.promises.readFile(path.join(cwd, f.path), "utf8");
+    } catch {
+      contents = "(unreadable — skipped)";
+    }
+    // Single-file-too-large: truncate with a marker so the agent sees
+    // *something*. We still count it as one batch for consistency.
+    const header = `--- file: ${f.path} (${f.category}, ${f.sizeBytes} bytes) ---`;
+    let chunk = `${header}\n${contents}`;
+    if (chunk.length > maxCharsPerBatch) {
+      const head = contents.slice(0, Math.max(0, maxCharsPerBatch - header.length - 128));
+      chunk = `${header}\n${head}\n\n... [truncated — file was ${contents.length} chars, budget ${maxCharsPerBatch}]`;
+    }
+    if (current.chars + chunk.length > maxCharsPerBatch && current.files.length > 0) {
+      flush();
+    }
+    current.files.push(f);
+    current.chunks.push(chunk);
+    current.chars += chunk.length;
+  }
+  flush();
+  return batches;
+}

--- a/packages/cli/src/lib/audit-output.ts
+++ b/packages/cli/src/lib/audit-output.ts
@@ -1,0 +1,344 @@
+/**
+ * Audit-mode output formatters (v0.6.0).
+ *
+ * Three targets:
+ *   - "stdout": ANSI-colored human summary. Reuses tone of renderReview.
+ *   - "json":   machine-readable bundle (no colors).
+ *   - "issue":  GitHub-issue markdown body, grouped by severity + category
+ *               + subsystem. Matches the "headline feature" spec.
+ *
+ * Aggregation is identical across targets — they diverge only in the
+ * serializer. Dedup key = (file, lineRange, category, severity). When
+ * two agents flag the same (file, line, category) we collapse them into
+ * one entry and attribute the message with `agents: [claude, openai]`.
+ */
+
+import type { Blocker, MetricsSummary, ReviewResult } from "@conclave-ai/core";
+import type { AuditCategory, DiscoveredFile } from "./audit-discovery.js";
+
+export interface PerBatchResult {
+  batchIndex: number;
+  files: readonly DiscoveredFile[];
+  results: readonly ReviewResult[];
+  costUsd: number;
+  latencyMs: number;
+}
+
+export interface AggregatedFinding {
+  severity: Blocker["severity"];
+  category: string;
+  file: string;
+  line?: number;
+  message: string;
+  agents: string[];
+  /** Subsystem derived from the file path (ui / code / infra / docs). */
+  subsystem: AuditCategory;
+}
+
+export interface AuditReport {
+  repo: string;
+  sha: string;
+  scope: string;
+  domain: string;
+  filesAudited: number;
+  filesInScope: number;
+  sampled: boolean;
+  discoveryReason: string;
+  findings: AggregatedFinding[];
+  perAgentVerdict: Array<{
+    agent: string;
+    approvedBatches: number;
+    reworkBatches: number;
+    rejectBatches: number;
+  }>;
+  budgetUsd: number;
+  spentUsd: number;
+  budgetExhausted: boolean;
+  batchesRun: number;
+  batchesTotal: number;
+  metrics: MetricsSummary;
+}
+
+const SEVERITY_ORDER: Record<Blocker["severity"], number> = {
+  blocker: 0,
+  major: 1,
+  minor: 2,
+  nit: 3,
+};
+
+const CATEGORY_ORDER: readonly string[] = [
+  "security",
+  "a11y",
+  "correctness",
+  "regression",
+  "token-drift",
+  "dead-code",
+  "performance",
+  "semantic-html",
+  "layout",
+  "responsive",
+  "interaction-state",
+  "contrast",
+  "overflow",
+  "test-coverage",
+  "docs",
+];
+
+/**
+ * Aggregate per-batch review results into a single deduped finding list.
+ * Dedup key: normalize file path, round line to nearest 5-line range,
+ * category + severity literal. Agents are merged into an attribution
+ * array rather than producing duplicate entries.
+ */
+export function aggregateFindings(
+  batches: readonly PerBatchResult[],
+  fileToCategory: Map<string, AuditCategory>,
+): AggregatedFinding[] {
+  const acc = new Map<string, AggregatedFinding>();
+  for (const batch of batches) {
+    for (const res of batch.results) {
+      for (const b of res.blockers) {
+        const file = b.file ?? "(unknown)";
+        const lineBucket = b.line !== undefined ? Math.floor(b.line / 5) * 5 : -1;
+        const key = `${file}::${lineBucket}::${b.category}::${b.severity}`;
+        const existing = acc.get(key);
+        const subsystem = fileToCategory.get(file) ?? inferSubsystemFromPath(file);
+        if (existing) {
+          if (!existing.agents.includes(res.agent)) existing.agents.push(res.agent);
+          // Keep the longest / most-specific message.
+          if (b.message.length > existing.message.length) existing.message = b.message;
+          continue;
+        }
+        const finding: AggregatedFinding = {
+          severity: b.severity,
+          category: b.category,
+          file,
+          message: b.message,
+          agents: [res.agent],
+          subsystem,
+        };
+        if (b.line !== undefined) finding.line = b.line;
+        acc.set(key, finding);
+      }
+    }
+  }
+  const all = Array.from(acc.values());
+  all.sort((a, b) => {
+    const s = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+    if (s !== 0) return s;
+    const ca = CATEGORY_ORDER.indexOf(a.category);
+    const cb = CATEGORY_ORDER.indexOf(b.category);
+    const cDelta = (ca < 0 ? 999 : ca) - (cb < 0 ? 999 : cb);
+    if (cDelta !== 0) return cDelta;
+    return a.file.localeCompare(b.file);
+  });
+  return all;
+}
+
+function inferSubsystemFromPath(p: string): AuditCategory {
+  const lower = p.toLowerCase();
+  if (/\.(tsx|jsx|vue|svelte|astro|css|scss|html)$/.test(lower)) return "ui";
+  if (/\.(ya?ml|toml|tf|dockerfile)$/.test(lower) || lower.includes(".github/workflows/")) return "infra";
+  if (/\.(md|mdx|rst|txt)$/.test(lower)) return "docs";
+  return "code";
+}
+
+// ─── stdout renderer ──────────────────────────────────────────────────
+
+function severityTag(s: Blocker["severity"]): string {
+  switch (s) {
+    case "blocker":
+      return "[BLOCKER]";
+    case "major":
+      return "[MAJOR]  ";
+    case "minor":
+      return "[MINOR]  ";
+    case "nit":
+      return "[NIT]    ";
+  }
+}
+
+export function renderAuditStdout(report: AuditReport): string {
+  const lines: string[] = [];
+  lines.push(`conclave audit — ${report.repo}`);
+  lines.push(`  sha:    ${report.sha.slice(0, 12)}`);
+  lines.push(`  scope:  ${report.scope}   domain: ${report.domain}`);
+  lines.push(
+    `  files:  ${report.filesAudited} audited / ${report.filesInScope} in scope${report.sampled ? " (sampled)" : ""}`,
+  );
+  lines.push(`          ${report.discoveryReason}`);
+  lines.push(
+    `  batches: ${report.batchesRun}/${report.batchesTotal}${report.budgetExhausted ? "  (BUDGET EXHAUSTED)" : ""}`,
+  );
+  lines.push("");
+
+  const bySeverity = groupBy(report.findings, (f) => f.severity);
+  const blockers = bySeverity.get("blocker") ?? [];
+  const majors = bySeverity.get("major") ?? [];
+  const minors = bySeverity.get("minor") ?? [];
+  const nits = bySeverity.get("nit") ?? [];
+
+  lines.push(
+    `Findings: ${blockers.length} blockers / ${majors.length} major / ${minors.length} minor / ${nits.length} nit`,
+  );
+  lines.push("");
+
+  if (report.findings.length === 0) {
+    lines.push("  (no findings — audit came back clean)");
+    lines.push("");
+  }
+
+  for (const f of report.findings) {
+    const loc = f.line ? `  ${f.file}:${f.line}` : `  ${f.file}`;
+    const attr = f.agents.length > 1 ? `  [${f.agents.join(", ")}]` : "";
+    lines.push(`  ${severityTag(f.severity)} (${f.category} / ${f.subsystem})${loc}${attr}`);
+    lines.push(`    ${f.message}`);
+  }
+  lines.push("");
+
+  lines.push("── per-agent verdicts ──");
+  for (const v of report.perAgentVerdict) {
+    lines.push(
+      `  ${v.agent.padEnd(8)}  approve=${v.approvedBatches}  rework=${v.reworkBatches}  reject=${v.rejectBatches}`,
+    );
+  }
+  lines.push("");
+
+  lines.push("── metrics ──");
+  lines.push(`  calls:      ${report.metrics.callCount}`);
+  lines.push(`  tokens:     in=${report.metrics.totalInputTokens} out=${report.metrics.totalOutputTokens}`);
+  lines.push(`  cost:       $${report.metrics.totalCostUsd.toFixed(4)} of $${report.budgetUsd.toFixed(2)} budget`);
+  lines.push(`  latency:    ${report.metrics.totalLatencyMs}ms`);
+  lines.push(`  cache hit:  ${(report.metrics.cacheHitRate * 100).toFixed(1)}%`);
+
+  return lines.join("\n") + "\n";
+}
+
+// ─── JSON renderer ────────────────────────────────────────────────────
+
+export function renderAuditJson(report: AuditReport): string {
+  return JSON.stringify(report, null, 2) + "\n";
+}
+
+// ─── GitHub-issue renderer ────────────────────────────────────────────
+
+export function renderAuditIssueBody(report: AuditReport): string {
+  const date = new Date().toISOString().slice(0, 10);
+  const sections: string[] = [];
+  sections.push(`## Conclave Project Audit — ${date}`);
+  sections.push("");
+  sections.push(`**Repo:** \`${report.repo}\`  `);
+  sections.push(`**SHA:** \`${report.sha.slice(0, 12)}\`  `);
+  sections.push(`**Scope:** \`${report.scope}\` (domain: \`${report.domain}\`)  `);
+  sections.push(
+    `**Coverage:** ${report.filesAudited} audited / ${report.filesInScope} in scope${report.sampled ? "  _(sampled)_" : ""}`,
+  );
+  sections.push(
+    `**Batches:** ${report.batchesRun}/${report.batchesTotal}${report.budgetExhausted ? " _(budget exhausted — partial result)_" : ""}`,
+  );
+  sections.push("");
+
+  // Top-line summary
+  const bySeverity = groupBy(report.findings, (f) => f.severity);
+  const counts = {
+    blocker: (bySeverity.get("blocker") ?? []).length,
+    major: (bySeverity.get("major") ?? []).length,
+    minor: (bySeverity.get("minor") ?? []).length,
+    nit: (bySeverity.get("nit") ?? []).length,
+  };
+  sections.push(`### Summary`);
+  sections.push(
+    `| Severity | Count |\n|---|---|\n| Blocker | ${counts.blocker} |\n| Major | ${counts.major} |\n| Minor | ${counts.minor} |\n| Nit | ${counts.nit} |`,
+  );
+  sections.push("");
+
+  // Top blockers (first): severity desc
+  if (report.findings.length === 0) {
+    sections.push(`_No findings — audit came back clean._`);
+    sections.push("");
+  } else {
+    sections.push(`### Top blockers (by severity)`);
+    const topN = report.findings.slice(0, 10);
+    for (const f of topN) {
+      const loc = f.line ? `\`${f.file}:${f.line}\`` : `\`${f.file}\``;
+      const attr = f.agents.length > 1 ? ` _(${f.agents.join(", ")})_` : "";
+      sections.push(`- **${f.severity.toUpperCase()}** \`${f.category}\` — ${loc}${attr}`);
+      sections.push(`  ${f.message}`);
+    }
+    sections.push("");
+
+    // Grouped by category
+    sections.push(`### Grouped by category`);
+    const byCategory = groupBy(report.findings, (f) => f.category);
+    for (const [cat, items] of sortedMap(byCategory, (a, b) => {
+      const ai = CATEGORY_ORDER.indexOf(a);
+      const bi = CATEGORY_ORDER.indexOf(b);
+      return (ai < 0 ? 999 : ai) - (bi < 0 ? 999 : bi);
+    })) {
+      sections.push(`<details><summary><code>${cat}</code> — ${items.length} findings</summary>`);
+      sections.push("");
+      for (const f of items) {
+        const loc = f.line ? `${f.file}:${f.line}` : f.file;
+        sections.push(`- \`${f.severity}\` \`${loc}\` — ${f.message}`);
+      }
+      sections.push("</details>");
+      sections.push("");
+    }
+
+    // Grouped by subsystem
+    sections.push(`### Grouped by subsystem`);
+    const bySub = groupBy(report.findings, (f) => f.subsystem);
+    for (const [sub, items] of bySub) {
+      sections.push(`<details><summary><code>${sub}</code> — ${items.length} findings</summary>`);
+      sections.push("");
+      for (const f of items) {
+        const loc = f.line ? `${f.file}:${f.line}` : f.file;
+        sections.push(`- \`${f.severity}\` \`${f.category}\` \`${loc}\` — ${f.message}`);
+      }
+      sections.push("</details>");
+      sections.push("");
+    }
+  }
+
+  // Per-agent verdicts
+  sections.push(`### Per-agent verdicts`);
+  sections.push(`| Agent | Approve | Rework | Reject |`);
+  sections.push(`|---|---|---|---|`);
+  for (const v of report.perAgentVerdict) {
+    sections.push(`| ${v.agent} | ${v.approvedBatches} | ${v.reworkBatches} | ${v.rejectBatches} |`);
+  }
+  sections.push("");
+
+  // Stats
+  sections.push(`### Cost + latency`);
+  sections.push(
+    `- **Spend:** $${report.metrics.totalCostUsd.toFixed(4)} of $${report.budgetUsd.toFixed(2)} budget`,
+  );
+  sections.push(`- **Calls:** ${report.metrics.callCount}`);
+  sections.push(
+    `- **Tokens:** in=${report.metrics.totalInputTokens}, out=${report.metrics.totalOutputTokens}`,
+  );
+  sections.push(`- **Latency:** ${report.metrics.totalLatencyMs}ms`);
+  sections.push(`- **Cache hit:** ${(report.metrics.cacheHitRate * 100).toFixed(1)}%`);
+  sections.push("");
+  sections.push(`_Generated by [conclave audit](https://www.npmjs.com/package/@conclave-ai/cli)._`);
+
+  return sections.join("\n");
+}
+
+// ─── small utils ──────────────────────────────────────────────────────
+
+function groupBy<T, K>(items: readonly T[], key: (t: T) => K): Map<K, T[]> {
+  const out = new Map<K, T[]>();
+  for (const it of items) {
+    const k = key(it);
+    const arr = out.get(k) ?? [];
+    arr.push(it);
+    out.set(k, arr);
+  }
+  return out;
+}
+
+function sortedMap<K, V>(m: Map<K, V>, cmp: (a: K, b: K) => number): Array<[K, V]> {
+  return Array.from(m.entries()).sort((a, b) => cmp(a[0], b[0]));
+}

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -157,6 +157,18 @@ export const ConclaveConfigSchema = z.object({
       excludes: z.array(z.string()).optional(),
     })
     .optional(),
+  /**
+   * v0.6.0 — `conclave audit` defaults. Hard ceiling on `defaultBudgetUsd`
+   * is enforced at the CLI layer (HARD_BUDGET_CEILING_USD, $10) — this
+   * field is only the starting value when `--budget` is omitted.
+   */
+  audit: z
+    .object({
+      defaultBudgetUsd: z.number().positive().default(2),
+      defaultMaxFiles: z.number().int().positive().default(40),
+      defaultScope: z.enum(["all", "ui", "code", "infra", "docs"]).default("all"),
+    })
+    .optional(),
 });
 
 export type ConclaveConfig = z.infer<typeof ConclaveConfigSchema>;

--- a/packages/cli/test/audit.test.mjs
+++ b/packages/cli/test/audit.test.mjs
@@ -1,0 +1,356 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  discoverAuditFiles,
+  buildAuditBatches,
+  categorize,
+  isBinaryExtension,
+  parseIgnoreFile,
+  DEFAULT_UI_SIGNALS,
+} from "../dist/lib/audit-discovery.js";
+import {
+  aggregateFindings,
+  renderAuditJson,
+  renderAuditStdout,
+  renderAuditIssueBody,
+} from "../dist/lib/audit-output.js";
+import { HARD_BUDGET_CEILING_USD } from "../dist/commands/audit.js";
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+function tmpRepo() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "aic-audit-"));
+}
+
+function touch(root, rel, body = "x", mtimeMs) {
+  const p = path.join(root, rel);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, body);
+  if (mtimeMs !== undefined) {
+    fs.utimesSync(p, new Date(mtimeMs), new Date(mtimeMs));
+  }
+}
+
+// ─── 1. discovery respects .gitignore + scope ────────────────────────
+
+test("audit-discovery: respects .gitignore and applies scope filter", async () => {
+  const root = tmpRepo();
+  try {
+    touch(root, ".gitignore", "secrets.ts\ntmp/\n");
+    touch(root, "src/app.ts", "x");
+    touch(root, "src/Button.tsx", "x");
+    touch(root, "secrets.ts", "x");
+    touch(root, "tmp/generated.ts", "x");
+    touch(root, "README.md", "x");
+
+    const result = await discoverAuditFiles({
+      cwd: root,
+      scope: "all",
+      useGitRecency: false,
+    });
+    const paths = result.files.map((f) => f.path).sort();
+    assert.ok(paths.includes("src/app.ts"), "src/app.ts should be discovered");
+    assert.ok(paths.includes("src/Button.tsx"), "src/Button.tsx should be discovered");
+    assert.ok(paths.includes("README.md"), "README.md should be discovered");
+    assert.ok(!paths.includes("secrets.ts"), ".gitignore entry should be excluded");
+    assert.ok(!paths.includes("tmp/generated.ts"), ".gitignore dir should be excluded");
+
+    const uiOnly = await discoverAuditFiles({ cwd: root, scope: "ui", useGitRecency: false });
+    const uiPaths = uiOnly.files.map((f) => f.path);
+    assert.deepEqual(uiPaths, ["src/Button.tsx"]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ─── 2. sampling picks recent files when over max ────────────────────
+
+test("audit-discovery: samples category-balanced when over max-files", async () => {
+  const root = tmpRepo();
+  try {
+    // 30 code files, 10 ui files. Make the LAST 5 code files the most recent.
+    for (let i = 0; i < 30; i++) {
+      const age = i < 25 ? Date.now() - 1000 * 60 * 60 * 24 * 30 : Date.now();
+      touch(root, `src/code${i}.ts`, "x", age);
+    }
+    for (let i = 0; i < 10; i++) {
+      touch(root, `src/ui${i}.tsx`, "x", Date.now() - 1000 * 60 * 60 * 24 * 10);
+    }
+
+    const result = await discoverAuditFiles({
+      cwd: root,
+      scope: "all",
+      maxFiles: 10,
+      useGitRecency: false,
+    });
+    assert.equal(result.sampled, true);
+    assert.equal(result.files.length, 10);
+    const cats = new Set(result.files.map((f) => f.category));
+    assert.ok(cats.has("code"), "should include code files");
+    assert.ok(cats.has("ui"), "should include ui files (category-balanced)");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ─── 3. batching doesn't exceed per-agent char budget ────────────────
+
+test("audit-batching: packs files under the char budget per batch", async () => {
+  const root = tmpRepo();
+  try {
+    touch(root, "a.ts", "a".repeat(2_000));
+    touch(root, "b.ts", "b".repeat(2_000));
+    touch(root, "c.ts", "c".repeat(2_000));
+    touch(root, "d.ts", "d".repeat(2_000));
+
+    const discovery = await discoverAuditFiles({ cwd: root, useGitRecency: false });
+    const batches = await buildAuditBatches(discovery.files, root, 3_000);
+    for (const b of batches) {
+      // Header adds a few bytes per file; allow 10% headroom beyond cap
+      // when a single oversize file is in a batch alone.
+      assert.ok(b.charCount <= 3_500, `batch chars ${b.charCount} over cap`);
+    }
+    assert.ok(batches.length >= 2, "should create multiple batches");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ─── 4. aggregation dedupes across agents ────────────────────────────
+
+test("audit-aggregate: dedupes same (file,line,category,severity) across agents", () => {
+  const perBatch = [
+    {
+      batchIndex: 0,
+      files: [],
+      costUsd: 0,
+      latencyMs: 0,
+      results: [
+        {
+          agent: "claude",
+          verdict: "rework",
+          summary: "",
+          blockers: [
+            { severity: "blocker", category: "a11y", message: "missing alt", file: "Hero.tsx", line: 12 },
+          ],
+        },
+        {
+          agent: "openai",
+          verdict: "rework",
+          summary: "",
+          blockers: [
+            { severity: "blocker", category: "a11y", message: "img missing alt attr", file: "Hero.tsx", line: 13 },
+          ],
+        },
+      ],
+    },
+  ];
+  const cat = new Map();
+  cat.set("Hero.tsx", "ui");
+  const findings = aggregateFindings(perBatch, cat);
+  assert.equal(findings.length, 1, "overlapping blockers should collapse");
+  assert.deepEqual(findings[0].agents.sort(), ["claude", "openai"]);
+  // Longest message wins
+  assert.match(findings[0].message, /img missing alt attr/);
+});
+
+// ─── 5. budget exhaustion → partial (no crash) ───────────────────────
+// We exercise this via the aggregation path rather than spinning up
+// agents. A report with budgetExhausted=true must still render.
+
+test("audit-output: renders a partial (budget-exhausted) report without throwing", () => {
+  const report = {
+    repo: "acme/x",
+    sha: "deadbeefcafe",
+    scope: "all",
+    domain: "mixed",
+    filesAudited: 40,
+    filesInScope: 120,
+    sampled: true,
+    discoveryReason: "120 matched > max-files=40 — sampled 40",
+    findings: [],
+    perAgentVerdict: [{ agent: "claude", approvedBatches: 2, reworkBatches: 0, rejectBatches: 0 }],
+    budgetUsd: 2,
+    spentUsd: 1.9,
+    budgetExhausted: true,
+    batchesRun: 2,
+    batchesTotal: 5,
+    metrics: {
+      callCount: 2,
+      totalInputTokens: 1000,
+      totalOutputTokens: 200,
+      totalCostUsd: 1.9,
+      totalLatencyMs: 8000,
+      cacheHitRate: 0,
+      byAgent: {},
+      byModel: {},
+    },
+  };
+  const s = renderAuditStdout(report);
+  assert.match(s, /BUDGET EXHAUSTED/);
+  assert.match(s, /batches: 2\/5/);
+  const issue = renderAuditIssueBody(report);
+  assert.match(issue, /budget exhausted/i);
+  assert.match(issue, /2\/5/);
+});
+
+// ─── 6. --dry-run no LLM calls ───────────────────────────────────────
+// Asserted indirectly: discovery returns files but we never call agents.
+// The test below is a structural smoke — discovery shouldn't throw on a
+// minimal repo and its result shape should be ready to pass to --dry-run.
+
+test("audit-discovery: minimal repo yields a dry-run-able result", async () => {
+  const root = tmpRepo();
+  try {
+    touch(root, "src/a.ts", "x");
+    const d = await discoverAuditFiles({ cwd: root, useGitRecency: false });
+    assert.equal(d.files.length, 1);
+    assert.equal(d.files[0].path, "src/a.ts");
+    assert.equal(d.files[0].category, "code");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ─── 7. --output json valid ──────────────────────────────────────────
+
+test("audit-output: --output json produces parseable JSON", () => {
+  const report = {
+    repo: "acme/x",
+    sha: "abcdef",
+    scope: "code",
+    domain: "code",
+    filesAudited: 1,
+    filesInScope: 1,
+    sampled: false,
+    discoveryReason: "1 matched",
+    findings: [
+      {
+        severity: "major",
+        category: "correctness",
+        file: "a.ts",
+        line: 5,
+        message: "possible null deref",
+        agents: ["claude"],
+        subsystem: "code",
+      },
+    ],
+    perAgentVerdict: [{ agent: "claude", approvedBatches: 0, reworkBatches: 1, rejectBatches: 0 }],
+    budgetUsd: 2,
+    spentUsd: 0.1,
+    budgetExhausted: false,
+    batchesRun: 1,
+    batchesTotal: 1,
+    metrics: {
+      callCount: 1,
+      totalInputTokens: 100,
+      totalOutputTokens: 20,
+      totalCostUsd: 0.1,
+      totalLatencyMs: 500,
+      cacheHitRate: 0,
+      byAgent: {},
+      byModel: {},
+    },
+  };
+  const json = renderAuditJson(report);
+  const parsed = JSON.parse(json);
+  assert.equal(parsed.findings[0].file, "a.ts");
+  assert.equal(parsed.findings[0].severity, "major");
+});
+
+// ─── 8. --domain design → DesignAgent only (routing) ─────────────────
+// The domain routing happens inside the command. We spot-check the flag
+// parser separately via categorize + UI-signal defaults.
+
+test("audit-discovery: ui scope picks up tsx / css / tailwind.config", () => {
+  // Categorization is the routing primitive.
+  assert.equal(categorize("src/Hero.tsx"), "ui");
+  assert.equal(categorize("app/styles.css"), "ui");
+  assert.equal(categorize("tailwind.config.ts"), "ui");
+  assert.equal(categorize("lib/util.ts"), "code");
+  assert.equal(categorize("src/lib/__tests__/foo.test.ts"), "test");
+  assert.equal(categorize("README.md"), "docs");
+  assert.equal(categorize("Dockerfile"), "infra");
+});
+
+// ─── 9. hard-ceiling $10 enforcement ────────────────────────────────
+
+test("audit: hard budget ceiling is exported as $10", () => {
+  assert.equal(HARD_BUDGET_CEILING_USD, 10);
+});
+
+// ─── 10. .conclaveignore respected ──────────────────────────────────
+
+test("audit-discovery: respects .conclaveignore in addition to .gitignore", async () => {
+  const root = tmpRepo();
+  try {
+    touch(root, ".conclaveignore", "secret.ts\n");
+    touch(root, "secret.ts", "x");
+    touch(root, "public.ts", "x");
+    const d = await discoverAuditFiles({ cwd: root, useGitRecency: false });
+    const paths = d.files.map((f) => f.path);
+    assert.ok(paths.includes("public.ts"));
+    assert.ok(!paths.includes("secret.ts"), ".conclaveignore should drop secret.ts");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ─── 11. binary files excluded ──────────────────────────────────────
+
+test("audit-discovery: binary extensions are never returned", async () => {
+  const root = tmpRepo();
+  try {
+    touch(root, "logo.png", "binary");
+    touch(root, "font.woff2", "binary");
+    touch(root, "a.ts", "x");
+    const d = await discoverAuditFiles({ cwd: root, useGitRecency: false });
+    const paths = d.files.map((f) => f.path);
+    assert.ok(paths.includes("a.ts"));
+    assert.ok(!paths.includes("logo.png"));
+    assert.ok(!paths.includes("font.woff2"));
+    assert.equal(isBinaryExtension("logo.png"), true);
+    assert.equal(isBinaryExtension("a.ts"), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ─── 12. recent modification priority works ─────────────────────────
+
+test("audit-discovery: files are sorted by mtime (newest first)", async () => {
+  const root = tmpRepo();
+  try {
+    const now = Date.now();
+    touch(root, "old.ts", "x", now - 1000 * 60 * 60 * 24 * 90);
+    touch(root, "mid.ts", "x", now - 1000 * 60 * 60 * 24 * 10);
+    touch(root, "new.ts", "x", now);
+    const d = await discoverAuditFiles({ cwd: root, useGitRecency: false });
+    assert.equal(d.files[0].path, "new.ts");
+    assert.equal(d.files[1].path, "mid.ts");
+    assert.equal(d.files[2].path, "old.ts");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ─── bonus: parseIgnoreFile sanity ───────────────────────────────────
+
+test("parseIgnoreFile: ignores blanks + comments, expands dir patterns", () => {
+  const out = parseIgnoreFile("# comment\n\nfoo.ts\ntmp/\n");
+  assert.ok(out.includes("foo.ts"));
+  assert.ok(out.includes("tmp/**") || out.some((g) => g.endsWith("tmp/**")));
+});
+
+// ─── bonus: DEFAULT_UI_SIGNALS includes tsx/jsx ──────────────────────
+
+test("audit-discovery: DEFAULT_UI_SIGNALS includes the core frameworks", () => {
+  const joined = DEFAULT_UI_SIGNALS.join(" ");
+  assert.match(joined, /tsx/);
+  assert.match(joined, /vue/);
+  assert.match(joined, /svelte/);
+  assert.match(joined, /css/);
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/core",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "description": "Conclave AI core — Agent interface, council orchestration, self-evolve substrate, efficiency gate.",
   "license": "MIT",
   "type": "module",

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -28,6 +28,18 @@ export interface PriorReview {
  */
 export type ReviewDomain = "code" | "design";
 
+/**
+ * Mode of the review. v0.6.0 adds "audit" — a whole-file, whole-project
+ * health check rather than a PR-diff review. Agents should switch their
+ * prompts to treat the file contents as already-shipped code and call
+ * out real issues (a11y, security, regression risk, token drift, etc.)
+ * rather than reasoning about "what changed".
+ *
+ * Absent ≡ "review" for backward compatibility with every pre-v0.6
+ * caller of Council / TieredCouncil / the individual agents.
+ */
+export type ReviewMode = "review" | "audit";
+
 export interface ReviewContext {
   diff: string;
   repo: string;
@@ -42,6 +54,20 @@ export interface ReviewContext {
   priors?: PriorReview[];
   /** "code" (default) or "design" — see `ReviewDomain`. */
   domain?: ReviewDomain;
+  /**
+   * "review" (default) or "audit". When "audit", the `diff` field carries
+   * the full current contents of the batched files (not a unified diff),
+   * and agents are expected to identify issues in the code as-shipped.
+   * See `ReviewMode` for the rationale.
+   */
+  mode?: ReviewMode;
+  /**
+   * v0.6 audit-mode hint — the list of file paths whose contents are
+   * packed into `diff`. Lets agents attribute blockers precisely without
+   * having to parse the (non-standard, non-unified) payload themselves.
+   * Omitted on review-mode calls.
+   */
+  auditFiles?: readonly string[];
   /**
    * Tier number, 1-indexed. Set by `TieredCouncil` when it calls agents
    * so prompts + agent scoring can attribute results to the correct tier.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export type { Agent, ReviewContext, ReviewResult, Blocker, Severity, PriorReview, ReviewDomain } from "./agent.js";
+export type { Agent, ReviewContext, ReviewResult, Blocker, Severity, PriorReview, ReviewDomain, ReviewMode } from "./agent.js";
 export { Council } from "./council.js";
 export type { CouncilOutcome, CouncilOptions, RoundOutcome } from "./council.js";
 export { TieredCouncil } from "./tiered-council.js";


### PR DESCRIPTION
## Summary

- `conclave audit` — a new CLI command that runs a full-project health check across the current codebase instead of a PR diff. Users run it right after `conclave init` to get a prioritized list of real issues — no PR required.
- Opens a GitHub issue (default) with severity / category / subsystem groupings, top blockers, per-agent verdicts, and cost + latency metrics.
- Budget-capped at \$2 by default with a HARD \$10 ceiling — even if a user passes `--budget 50`, the CLI clamps and warns. Pre-batch budget check returns a partial result on exhaustion; never crashes.

## Example output (GitHub issue body)

```
## Conclave Project Audit — 2026-04-20

**Repo:** acme/my-app  |  **SHA:** aabbccddeeff  |  **Scope:** all (domain: mixed)
**Coverage:** 40 audited / 120 in scope (sampled)
**Batches:** 5/5

### Summary
| Severity | Count |
|---|---|
| Blocker | 3 |
| Major | 7 |
| Minor | 12 |

### Top blockers (by severity)
- **BLOCKER** \`a11y\` — \`src/Hero.tsx:12\`
  img missing alt attribute on a content image
- **BLOCKER** \`security\` — \`src/api/users.ts:47\`
  SQL interpolation of unsanitized user input
...

### Per-agent verdicts
| Agent | Approve | Rework | Reject |
|---|---|---|---|
| claude | 2 | 3 | 0 |

### Cost + latency
- **Spend:** \$1.82 of \$2.00 budget
- **Calls:** 15  |  **Latency:** 42000ms
```

## What changed

- New CLI command: \`packages/cli/src/commands/audit.ts\` (~340 lines).
- New file discovery: \`packages/cli/src/lib/audit-discovery.ts\` — walks repo respecting \`.gitignore\` + \`.conclaveignore\`, categorizes files (ui/code/infra/docs/test), filters by \`--scope\`, samples category-balanced when over \`--max-files\`, biases to recency via git-log + mtime.
- New output: \`packages/cli/src/lib/audit-output.ts\` — dedup across agents by (file, line, category, severity); stdout / JSON / GitHub-issue markdown renderers.
- Core: \`ReviewContext.mode?: "review" | "audit"\` + \`auditFiles?: readonly string[]\`.
- All 4 agents (claude / openai / gemini / design): AUDIT_SYSTEM_PROMPT + buildAuditPrompt(). DesignAgent adds a reviewAudit() path that filters batch to UI files only.
- Config schema: optional \`audit.defaultBudgetUsd / defaultMaxFiles / defaultScope\`.

## Version bumps

| Package | From | To |
|---|---|---|
| @conclave-ai/cli | 0.5.4 | 0.6.0 |
| @conclave-ai/core | 0.4.0 | 0.6.0 |
| @conclave-ai/agent-claude | 0.4.0 | 0.6.0 |
| @conclave-ai/agent-openai | 0.4.0 | 0.6.0 |
| @conclave-ai/agent-gemini | 0.4.0 | 0.6.0 |
| @conclave-ai/agent-design | 0.5.4 | 0.6.0 |

No \`central-plane\` or \`integration-*\` bumps.

## Cost guardrails

- Default \$2 budget per audit; hard ceiling \$10 (cannot be raised via CLI or config).
- Budget pre-check before every batch — if next call can't be afforded, stops and returns a \`budget exhausted after N/M batches\` partial result.
- \`--tier-1-only\` flag skips second round for users who want the cheapest possible scan.
- Table in \`docs/guides/audit.md\` shows typical spend by repo size + scope.

## Test plan

- [x] \`corepack pnpm build\` — 25 workspace packages green
- [x] \`corepack pnpm test\` — 47 tasks green, 154 CLI tests (was 140; +14 new audit tests)
- [x] Manual smoke: \`conclave audit --dry-run --scope ui --cwd /tmp/small-repo\` → prints file list, zero LLM calls, zero spend
- [x] Manual smoke: \`conclave audit --help\` renders the full flag reference
- [x] Manual smoke: \`conclave --help\` includes \`audit\` in the top-level command list

### Tests added (packages/cli/test/audit.test.mjs)

1. File discovery respects .gitignore + scope
2. Sampling picks recent files when over max
3. Batching doesn't exceed per-agent char budget
4. Aggregation dedupes across agents
5. Budget exhaustion → partial result renders without crash
6. --dry-run no LLM calls (structural smoke)
7. --output json valid
8. Category routing (tsx → ui, Dockerfile → infra, etc.)
9. Hard-ceiling \$10 enforcement
10. .conclaveignore respected
11. Binary files excluded
12. Recent modification priority works
13. parseIgnoreFile sanity
14. DEFAULT_UI_SIGNALS includes core frameworks

## Docs

- \`docs/guides/audit.md\` — user-facing guide (when to use, cost examples, exclusion rules, config, exit codes)
- \`docs/releases/v0.6.0.md\` — release notes
- \`README.md\` top-level: "Start here (after install)" section puts \`conclave audit\` first

## Not included

- No Playwright / vision UI audit (deferred to v0.6.1+)
- No central-plane / integration-* changes
- No npm publish; no merge — PR is review-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)