### PR TITLE
fix(cli): render DesignAgent verdict in mixed-domain output (v0.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+- **P1: DesignAgent verdict silently dropped from mixed-domain output (v0.6.2).** On any `conclave review` that auto-detected to `mixed` (code + UI signals in the diff), users only saw `claude` / `openai` / `gemini` sections even though the diff included `.jsx` / `.css` / other UI files. Dogfooded on `seunghunbae-3svs/eventbadge#20`. Root cause: the tier-1 merge in `review.ts` unioned `domains.code.tier1 ∪ domains.design.tier1`, but for any `.conclaverc.json` written by `conclave init` pre-v0.5.0-alpha.1 (PR #84) the design list was `["claude","openai","gemini"]` — no `"design"` entry — so `buildAgent("design", …)` was never called, the Council never got a DesignAgent, and the renderer (which was correctly iterating `results`) had no design section to emit.
+  - **Fix 1 — stale-config safety net.** When `resolvedDomain === "mixed"` and the merged tier-1 list doesn't include `"design"`, inject it at the head. Same for tier-2 when non-empty (design's `alwaysEscalate: true` makes tier-2 the binding verdict on mixed runs). Legitimate tier-1-only configs (empty tier-2 on both domains) are left alone. Handles legacy configs without requiring a migration.
+  - **Fix 2 — tier-resolver extraction.** Moved the tier-1/tier-2 merge + safety-net logic out of `review.ts` into `packages/cli/src/lib/tier-resolver.ts` as a pure `resolveTierIds(...)` function so the merge is unit-testable. 10 new tests cover pure-code, pure-design, mixed-current-config, mixed-stale-config (the exact eventbadge#20 shape), model-override precedence (design over code), empty-tier-2 edge, and missing-config edges.
+  - **Diagnostic logging.** `conclave review` now prints `tier-1 agents: [...]` (and `tier-2 agents: [...]` when relevant) before the council runs so users can immediately tell whether DesignAgent made the cut. Prints actually-built agent ids, so credential-skipped agents drop out of the list.
+  - **Regression coverage.** 2 new renderer tests assert the `design → ...` section renders alongside `claude → ...` / `openai → ...` in mixed-domain output, and that it still renders when another agent errored mid-round (verifies the synthetic `agent-failure` rework result doesn't crowd out the design section).
+  - `@conclave-ai/cli` bumped to 0.6.2. No other packages touched. No schema changes. See `docs/releases/v0.6.2.md`.
+
 ### Security
 - **Reusable review workflow hardening (v0.5.2).** Three fixes to `.github/workflows/review.yml`, all flagged by Conclave's own council on `seunghunbae-3svs/eventbadge#19`:
   - **Workflow-security:** secret-bearing steps (LLM keys, `CONCLAVE_TOKEN`, `GH_TOKEN`, `ORCHESTRATOR_PAT`) now gated to non-fork, owner-authored PRs. Fork PRs + external-contributor PRs get a friendly "install locally" fallback comment that uses only the ambient `GITHUB_TOKEN`. Closes the same-repo-branch-PR vector where attacker-controlled PR code would execute inside the secret-bearing step.

--- a/docs/releases/v0.6.2.md
+++ b/docs/releases/v0.6.2.md
@@ -1,0 +1,108 @@
+# v0.6.2 — Render DesignAgent verdict in mixed-domain output
+
+## TL;DR
+
+Fixes a silent-drop bug where, on a PR that auto-detects to `mixed`
+(code + UI signals), the DesignAgent either wasn't called or had its
+verdict section omitted from the rendered output — so the user only
+saw `claude` and `openai` sections even though the diff included
+`.jsx` / `.css` / other UI files.
+
+**Root cause:** the tier-1 merge in `conclave review` unioned
+`config.council.domains.code.tier1` with `config.council.domains.design.tier1`.
+For any `.conclaverc.json` written by `conclave init` **before**
+v0.5.0-alpha.1 (PR #84), `domains.design.tier1` was
+`["claude", "openai", "gemini"]` — no literal `"design"` entry. The
+merged list therefore never included the `design` id, `buildAgent("design", …)`
+was never called, and the renderer (which loops over whatever results
+the Council returned) never had a design section to emit.
+
+Example: `seunghunbae-3svs/eventbadge#20` — auto-detected `mixed` from
+`.jsx` changes, ran tier-1 with claude + openai + gemini, escalated to
+tier-2 with claude + openai. No DesignAgent anywhere.
+
+## Fix
+
+Two-part:
+
+1. **Stale-config safety net (the real fix).** When
+   `resolvedDomain === "mixed"` and the merged tier-1 list doesn't
+   include `"design"`, inject it at the head of the list. Same for
+   tier-2 when tier-2 is non-empty (design's `alwaysEscalate: true`
+   makes tier-2 the binding verdict for mixed runs; a stale config
+   that left `"design"` out of tier-2 would re-trigger the regression
+   on escalation). Tier-1-only configs (empty tier-2 on both domains)
+   are left alone.
+2. **Tier-resolver extraction.** The tier-1/tier-2 merge + safety-net
+   logic was inlined in `packages/cli/src/commands/review.ts`, which
+   made it untestable in isolation. Extracted to
+   `packages/cli/src/lib/tier-resolver.ts` as a pure function
+   `resolveTierIds({ resolvedDomain, codeDomainCfg, designDomainCfg })`
+   returning `{ tier1Ids, tier2Ids, tier1Models, tier2Models }`.
+   10 unit tests cover the full matrix (pure code, pure design,
+   mixed + stale config, mixed + current config, model-override
+   precedence, empty-tier edges, the exact eventbadge#20 shape).
+
+## Diagnostic logging
+
+`conclave review` now prints the resolved tier-1 (and, when
+applicable, tier-2) agent-id list BEFORE the council runs:
+
+```
+conclave review: auto-detected domain: mixed (reason: changed files include *.jsx)
+conclave review: tier-1 agents: [claude, openai, gemini, design]
+conclave review: tier-2 agents: [claude, openai, design]
+```
+
+The list reflects **actually-built** agents (credential-skipped agents
+don't show up), so a user staring at their output can immediately tell
+whether DesignAgent made the cut.
+
+## What this does NOT change
+
+- DesignAgent's text-UI mode (v0.5.4) — still used as-is.
+- Auto-detect rules (v0.5.3) — unchanged.
+- The renderer (`lib/output.ts`) — it was already correct; it iterates
+  `results` without filtering. The regression was upstream in which
+  agents actually ran.
+- Config defaults — `DEFAULT_CONFIG.council.domains.design.tier1`
+  already had `["design", "claude"]` post-PR#84; nothing to update
+  there. Users can still re-run `conclave init --force` to migrate,
+  but they don't have to — the safety net handles stale configs.
+
+## Version bumps
+
+| Package | From | To |
+|---|---|---|
+| `@conclave-ai/cli` | 0.6.0 | 0.6.2 |
+
+No other packages touched. No schema changes. No migration required.
+
+## Tests
+
+12 new tests added:
+
+- `packages/cli/test/tier-resolver.test.mjs` (10 tests): all code /
+  design / mixed resolution paths; dedup; safety-net injection at
+  tier-1 head (with exact eventbadge#20 shape as the regression
+  fixture); no duplication when current-default configs are used;
+  empty-tier-2 edge case; model-override precedence (design over code);
+  missing-config edges.
+- `packages/cli/test/output.test.mjs` (+2 tests): renderer emits a
+  `design → ...` section alongside `claude → ...` / `openai → ...`
+  in mixed-domain output; design section still renders when another
+  agent errored mid-run (verifies the `agent-failure` synthetic
+  result doesn't crowd design out).
+
+Full suite: `corepack pnpm build && corepack pnpm test` — 47 tasks
+green, 166 CLI tests pass (was 154 before v0.6.2).
+
+## How to reproduce the original bug (for the record)
+
+Run `conclave review --pr 20` on a repo whose `.conclaverc.json`
+matches the pre-PR#84 shape (any repo that ran `conclave init` prior
+to 2026-04-18) against a PR with `.jsx` / `.css` changes. Before the
+fix: output includes `Domain:  mixed` but only `claude` + `openai`
+sections. After the fix: `design → ...` section present too, and
+`conclave review: tier-1 agents: [..., design]` appears before the
+verdict.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -45,6 +45,7 @@ import {
   type DomainDetectionResult,
 } from "../lib/domain-detect.js";
 import { ClaudeHaikuPlainSummaryLlm } from "../lib/plain-summary-llm.js";
+import { resolveTierIds } from "../lib/tier-resolver.js";
 
 type ReviewDomainInput = "code" | "design";
 interface ReviewArgs {
@@ -292,45 +293,18 @@ export async function review(argv: string[]): Promise<void> {
   if (useTiered && domainConfig) {
     // For "mixed" runs, union tier-1 / tier-2 across code + design
     // domain configs (deduped, preserving order: code first, then any
-    // design-only additions). Tier depth settings inherit from the
-    // design config when present (design always-escalate wins so the
-    // Design agent always gets a chance at tier-2), else code's.
-    function mergedTierIds(pick: (c: typeof codeDomainCfg) => readonly string[]): string[] {
-      const seen = new Set<string>();
-      const out: string[] = [];
-      const push = (ids: readonly string[] | undefined) => {
-        if (!ids) return;
-        for (const id of ids) {
-          if (!seen.has(id)) {
-            seen.add(id);
-            out.push(id);
-          }
-        }
-      };
-      if (resolvedDomain === "mixed") {
-        push(codeDomainCfg ? pick(codeDomainCfg) : undefined);
-        push(designDomainCfg ? pick(designDomainCfg) : undefined);
-      } else {
-        push(pick(domainConfig));
-      }
-      return out;
-    }
-    function mergedModels(tier: "tier1" | "tier2"): Record<string, string> {
-      if (resolvedDomain !== "mixed") {
-        return domainConfig!.models?.[tier] ?? {};
-      }
-      // design overrides code — design's model picks are tuned for
-      // design work; code agents keep whichever override code supplied
-      // unless design explicitly pinned the same agent.
-      return {
-        ...(codeDomainCfg?.models?.[tier] ?? {}),
-        ...(designDomainCfg?.models?.[tier] ?? {}),
-      };
-    }
-    const tier1Ids = mergedTierIds((c) => c?.tier1 ?? []);
-    const tier2Ids = mergedTierIds((c) => c?.tier2 ?? []);
-    const tier1Models = mergedModels("tier1");
-    const tier2Models = mergedModels("tier2");
+    // design-only additions) and auto-inject "design" if a stale config
+    // left it out. See `lib/tier-resolver.ts` for the full rule — it's
+    // kept pure + exported so the merge logic is unit-testable.
+    const resolved = resolveTierIds({
+      resolvedDomain,
+      codeDomainCfg,
+      designDomainCfg,
+    });
+    const tier1Ids = [...resolved.tier1Ids];
+    const tier2Ids = [...resolved.tier2Ids];
+    const tier1Models = resolved.tier1Models;
+    const tier2Models = resolved.tier2Models;
     const tier1: Agent[] = [];
     for (const id of tier1Ids) {
       const a = buildAgent(id, tier1Models[id]);
@@ -340,6 +314,18 @@ export async function review(argv: string[]): Promise<void> {
     for (const id of tier2Ids) {
       const a = buildAgent(id, tier2Models[id]);
       if (a) tier2.push(a);
+    }
+    // v0.6.2 diagnostic — surface the resolved tier-1 (and, when
+    // relevant, tier-2) agent list BEFORE council runs so users can
+    // immediately see whether e.g. the Design agent made it in after
+    // a mixed-domain auto-detect. Prints the actually-built agent ids
+    // (credential-skipped agents don't show up), matching what the
+    // council will deliberate with.
+    const tier1IdLog = tier1.map((a) => a.id).join(", ");
+    process.stdout.write(`conclave review: tier-1 agents: [${tier1IdLog}]\n`);
+    if (tier2.length > 0) {
+      const tier2IdLog = tier2.map((a) => a.id).join(", ");
+      process.stdout.write(`conclave review: tier-2 agents: [${tier2IdLog}]\n`);
     }
     if (tier1.length === 0) {
       process.stderr.write(

--- a/packages/cli/src/lib/tier-resolver.ts
+++ b/packages/cli/src/lib/tier-resolver.ts
@@ -1,0 +1,143 @@
+/**
+ * Tier-resolver — pure, testable computation of the tier-1 / tier-2
+ * agent-id lists (and per-tier model overrides) for a given resolved
+ * review domain, given the per-domain config blocks.
+ *
+ * Lives in `lib/` rather than inside `commands/review.ts` so the
+ * merge + safety-net logic can be unit-tested without spinning up
+ * the full review pipeline.
+ *
+ * The key rule this module encodes — and the v0.6.2 regression fix —
+ * is the **mixed-domain design safety net**:
+ *
+ *   When `resolvedDomain === "mixed"` (UI signal hit in the diff),
+ *   the Design agent MUST appear in tier-1. Pre-v0.5.0-alpha.1 configs
+ *   written by the old `conclave init` wizard set
+ *   `domains.design.tier1: ["claude", "openai", "gemini"]` without a
+ *   literal `"design"` entry. In that case the naive merge of
+ *   `code.tier1 ∪ design.tier1` produces no DesignAgent, the Council
+ *   never calls DesignAgent.review(), and the rendered verdict silently
+ *   omits the `design → ...` section.
+ *
+ *   We inject `"design"` at the head of tier-1 for mixed runs whenever
+ *   it's absent, so legacy configs don't need a migration to get the
+ *   Design review back. Same safety net applies to tier-2 when it's
+ *   non-empty, since design's `alwaysEscalate: true` makes tier-2 the
+ *   binding verdict for mixed runs.
+ *
+ * Users who explicitly want a design-free mixed run can either pass
+ * `--domain code` or disable auto-detect (`autoDetect.enabled: false`).
+ */
+
+/**
+ * Per-domain config shape we care about here. Matches the Zod-inferred
+ * `ConclaveConfig.council.domains[<name>]` without the extra bits
+ * `tier-resolver` doesn't need (tier*MaxRounds, alwaysEscalate — those
+ * stay in review.ts where the Council is actually constructed).
+ */
+export interface DomainTierCfg {
+  readonly tier1: readonly string[];
+  readonly tier2: readonly string[];
+  readonly models?: {
+    readonly tier1?: Readonly<Record<string, string>>;
+    readonly tier2?: Readonly<Record<string, string>>;
+  };
+}
+
+export type ResolvedDomain = "code" | "design" | "mixed";
+
+export interface ResolveTierInput {
+  readonly resolvedDomain: ResolvedDomain;
+  readonly codeDomainCfg?: DomainTierCfg | undefined;
+  readonly designDomainCfg?: DomainTierCfg | undefined;
+}
+
+export interface ResolveTierOutput {
+  readonly tier1Ids: readonly string[];
+  readonly tier2Ids: readonly string[];
+  readonly tier1Models: Readonly<Record<string, string>>;
+  readonly tier2Models: Readonly<Record<string, string>>;
+}
+
+function pushUnique(seen: Set<string>, out: string[], ids: readonly string[] | undefined): void {
+  if (!ids) return;
+  for (const id of ids) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+}
+
+/**
+ * Compute the merged, dedup'd, design-safety-net'd tier-1 and tier-2
+ * agent id lists for a resolved review domain.
+ *
+ * `resolvedDomain === "code"` → pulls tier1/tier2 from `codeDomainCfg` only.
+ * `resolvedDomain === "design"` → pulls from `designDomainCfg` only.
+ * `resolvedDomain === "mixed"` → unions code.tier* ∪ design.tier* with
+ *   code first, design-only additions appended, then auto-injects
+ *   `"design"` at the head of tier-1 (and tier-2 when non-empty) if it
+ *   isn't already present.
+ *
+ * Returns empty arrays rather than throwing when the relevant config
+ * block is absent — callers decide how to handle that (review.ts falls
+ * back to legacy flat-Council when `useTiered === false`).
+ */
+export function resolveTierIds(input: ResolveTierInput): ResolveTierOutput {
+  const { resolvedDomain, codeDomainCfg, designDomainCfg } = input;
+
+  const mergeTier = (pick: (c: DomainTierCfg) => readonly string[]): string[] => {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    if (resolvedDomain === "mixed") {
+      if (codeDomainCfg) pushUnique(seen, out, pick(codeDomainCfg));
+      if (designDomainCfg) pushUnique(seen, out, pick(designDomainCfg));
+    } else if (resolvedDomain === "code") {
+      if (codeDomainCfg) pushUnique(seen, out, pick(codeDomainCfg));
+    } else {
+      if (designDomainCfg) pushUnique(seen, out, pick(designDomainCfg));
+    }
+    return out;
+  };
+
+  const tier1Ids = mergeTier((c) => c.tier1 ?? []);
+  const tier2Ids = mergeTier((c) => c.tier2 ?? []);
+
+  // v0.6.2 safety net — see module comment above for full rationale.
+  if (resolvedDomain === "mixed" && !tier1Ids.includes("design")) {
+    tier1Ids.unshift("design");
+  }
+  if (
+    resolvedDomain === "mixed" &&
+    tier2Ids.length > 0 &&
+    !tier2Ids.includes("design")
+  ) {
+    tier2Ids.unshift("design");
+  }
+
+  const mergeModels = (
+    tier: "tier1" | "tier2",
+  ): Record<string, string> => {
+    if (resolvedDomain === "code") {
+      return { ...(codeDomainCfg?.models?.[tier] ?? {}) };
+    }
+    if (resolvedDomain === "design") {
+      return { ...(designDomainCfg?.models?.[tier] ?? {}) };
+    }
+    // mixed — design overrides code. Design's model picks are tuned
+    // for design work; code agents keep whichever override code
+    // supplied unless design explicitly pinned the same agent.
+    return {
+      ...(codeDomainCfg?.models?.[tier] ?? {}),
+      ...(designDomainCfg?.models?.[tier] ?? {}),
+    };
+  };
+
+  return {
+    tier1Ids,
+    tier2Ids,
+    tier1Models: mergeModels("tier1"),
+    tier2Models: mergeModels("tier2"),
+  };
+}

--- a/packages/cli/test/output.test.mjs
+++ b/packages/cli/test/output.test.mjs
@@ -82,6 +82,101 @@ test("renderReview: reject output tagged", () => {
   assert.match(out, /Verdict: REJECT/);
 });
 
+test("renderReview: v0.6.2 — DesignAgent verdict renders alongside claude + openai in mixed-domain output", () => {
+  // Regression for eventbadge#20: when domain auto-detects to "mixed",
+  // the DesignAgent result must appear in the rendered output as its
+  // own `design → ...` section, same shape as claude + openai. The
+  // renderer must not filter by agent id.
+  const out = renderReview({
+    repo: "acme/my-app",
+    pullNumber: 20,
+    sha: "abcdef1234567890",
+    source: "gh-pr",
+    councilVerdict: "rework",
+    consensus: false,
+    domain: "mixed",
+    tier: { escalated: true, reason: "alwaysEscalate=true", tier1Rounds: 1, tier2Rounds: 2 },
+    results: [
+      {
+        agent: "claude",
+        verdict: "rework",
+        blockers: [{ severity: "major", category: "ci-config", message: "missing env var", file: ".github/workflows/conclave.yml", line: 15 }],
+        summary: "workflow needs env",
+      },
+      {
+        agent: "openai",
+        verdict: "rework",
+        blockers: [{ severity: "blocker", category: "CI/workflow", message: "token not propagated", file: ".github/workflows/conclave.yml", line: 15 }],
+        summary: "token issue",
+      },
+      {
+        agent: "design",
+        verdict: "approve",
+        blockers: [],
+        summary: "jsx changes pass visual-accessibility heuristics",
+      },
+    ],
+    metrics: baseMetrics,
+  });
+  assert.match(out, /── claude → REWORK/);
+  assert.match(out, /── openai → REWORK/);
+  assert.match(out, /── design → APPROVE/, "design section must render");
+  assert.match(out, /Domain:  mixed/);
+  assert.match(out, /Tiers:   1 \(1r\) → 2 \(2r\) — alwaysEscalate=true/);
+});
+
+test("renderReview: v0.6.2 — design section renders even when Claude errored (regression: agent-failure shouldn't eat design)", () => {
+  // If one agent fails mid-run, Council synthesizes an "agent-failure"
+  // rework result. The renderer must still emit every agent's section
+  // — design included — not silently drop sections for error paths.
+  const out = renderReview({
+    repo: "acme/my-app",
+    pullNumber: 21,
+    sha: "deadbeef1234",
+    source: "gh-pr",
+    councilVerdict: "rework",
+    consensus: false,
+    domain: "mixed",
+    results: [
+      {
+        agent: "claude",
+        verdict: "rework",
+        blockers: [
+          {
+            severity: "major",
+            category: "agent-failure",
+            message: "Claude Sonnet 4.6 failed: 429 rate limit",
+          },
+        ],
+        summary: "Claude errored during round 1 and was excluded from the tally.",
+      },
+      {
+        agent: "openai",
+        verdict: "approve",
+        blockers: [],
+        summary: "code looks fine",
+      },
+      {
+        agent: "design",
+        verdict: "rework",
+        blockers: [
+          {
+            severity: "minor",
+            category: "typography",
+            message: "inconsistent heading scale across the new page",
+          },
+        ],
+        summary: "design needs minor polish",
+      },
+    ],
+    metrics: baseMetrics,
+  });
+  assert.match(out, /── claude → REWORK/);
+  assert.match(out, /── openai → APPROVE/);
+  assert.match(out, /── design → REWORK/, "design section must still render when another agent errors");
+  assert.match(out, /typography/);
+});
+
 test("renderReview: metrics section rendered", () => {
   const out = renderReview({
     repo: "acme/my-app",

--- a/packages/cli/test/tier-resolver.test.mjs
+++ b/packages/cli/test/tier-resolver.test.mjs
@@ -1,0 +1,212 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveTierIds } from "../dist/lib/tier-resolver.js";
+
+// ─── Pure domain: no merge, no safety net ───────────────────────────
+
+test("resolveTierIds: resolvedDomain=code pulls from codeDomainCfg only", () => {
+  const out = resolveTierIds({
+    resolvedDomain: "code",
+    codeDomainCfg: {
+      tier1: ["claude", "openai", "gemini"],
+      tier2: ["claude", "openai"],
+      models: { tier1: {}, tier2: { claude: "claude-opus-4-7" } },
+    },
+    designDomainCfg: {
+      tier1: ["design", "claude"],
+      tier2: ["design", "claude"],
+    },
+  });
+  assert.deepEqual(out.tier1Ids, ["claude", "openai", "gemini"]);
+  assert.deepEqual(out.tier2Ids, ["claude", "openai"]);
+  assert.deepEqual(out.tier2Models, { claude: "claude-opus-4-7" });
+});
+
+test("resolveTierIds: resolvedDomain=design pulls from designDomainCfg only", () => {
+  const out = resolveTierIds({
+    resolvedDomain: "design",
+    codeDomainCfg: {
+      tier1: ["claude", "openai", "gemini"],
+      tier2: ["claude", "openai"],
+    },
+    designDomainCfg: {
+      tier1: ["design", "claude"],
+      tier2: ["design", "claude"],
+      models: { tier1: { design: "claude-haiku-4-5" }, tier2: {} },
+    },
+  });
+  assert.deepEqual(out.tier1Ids, ["design", "claude"]);
+  assert.deepEqual(out.tier2Ids, ["design", "claude"]);
+  assert.deepEqual(out.tier1Models, { design: "claude-haiku-4-5" });
+});
+
+// ─── Mixed-domain: the v0.6.2 regression fix ────────────────────────
+
+test("resolveTierIds: resolvedDomain=mixed unions code + design, dedup preserved", () => {
+  const out = resolveTierIds({
+    resolvedDomain: "mixed",
+    codeDomainCfg: {
+      tier1: ["claude", "openai", "gemini"],
+      tier2: ["claude", "openai"],
+    },
+    designDomainCfg: {
+      tier1: ["design", "claude"],
+      tier2: ["design", "claude"],
+    },
+  });
+  // code first, design-only additions appended ("design" is design-only).
+  // With the safety net, "design" is already present so no duplication.
+  assert.deepEqual(out.tier1Ids, ["claude", "openai", "gemini", "design"]);
+  assert.deepEqual(out.tier2Ids, ["claude", "openai", "design"]);
+});
+
+test("resolveTierIds: mixed + stale config (no 'design' in either list) → safety net injects design at tier-1 head", () => {
+  // Reproduces the eventbadge#20 bug: pre-v0.5.0-alpha.1 configs had
+  // domains.design.tier1 = ["claude","openai","gemini"] without a
+  // literal "design" entry. Without the safety net, the merged tier-1
+  // would never include DesignAgent and the rendered verdict would
+  // silently drop the design section.
+  const out = resolveTierIds({
+    resolvedDomain: "mixed",
+    codeDomainCfg: {
+      tier1: ["claude", "openai", "gemini"],
+      tier2: ["claude", "openai"],
+    },
+    designDomainCfg: {
+      // Stale shape — no "design" here.
+      tier1: ["claude", "openai", "gemini"],
+      tier2: ["claude", "openai"],
+    },
+  });
+  // Safety net must inject "design" at the head of tier-1.
+  assert.equal(out.tier1Ids[0], "design");
+  assert.ok(out.tier1Ids.includes("claude"));
+  assert.ok(out.tier1Ids.includes("openai"));
+  assert.ok(out.tier1Ids.includes("gemini"));
+  // Same safety net for tier-2 (non-empty → design always-escalates
+  // is the binding verdict).
+  assert.equal(out.tier2Ids[0], "design");
+});
+
+test("resolveTierIds: mixed with empty tier-2 on both configs → safety net does NOT inject design into tier-2", () => {
+  // Tier-1-only mode is a legitimate config; we shouldn't force
+  // tier-2 to exist where the user intentionally left it empty.
+  const out = resolveTierIds({
+    resolvedDomain: "mixed",
+    codeDomainCfg: {
+      tier1: ["claude", "openai"],
+      tier2: [],
+    },
+    designDomainCfg: {
+      tier1: ["claude"],
+      tier2: [],
+    },
+  });
+  assert.equal(out.tier1Ids[0], "design");
+  assert.deepEqual(out.tier2Ids, []);
+});
+
+test("resolveTierIds: mixed with 'design' already in design config (post-PR#84) → no duplication", () => {
+  const out = resolveTierIds({
+    resolvedDomain: "mixed",
+    codeDomainCfg: {
+      tier1: ["claude", "openai", "gemini"],
+      tier2: ["claude", "openai"],
+    },
+    designDomainCfg: {
+      // Current default: "design" is first in tier-1.
+      tier1: ["design", "claude"],
+      tier2: ["design", "claude"],
+    },
+  });
+  // "design" appears exactly once in each tier.
+  assert.equal(out.tier1Ids.filter((id) => id === "design").length, 1);
+  assert.equal(out.tier2Ids.filter((id) => id === "design").length, 1);
+});
+
+test("resolveTierIds: mixed — design model overrides win over code model overrides", () => {
+  const out = resolveTierIds({
+    resolvedDomain: "mixed",
+    codeDomainCfg: {
+      tier1: ["claude", "openai"],
+      tier2: ["claude", "openai"],
+      models: {
+        tier1: {},
+        tier2: { claude: "claude-opus-4-7", openai: "gpt-5.4" },
+      },
+    },
+    designDomainCfg: {
+      tier1: ["design", "claude"],
+      tier2: ["design", "claude"],
+      models: {
+        tier1: { design: "claude-haiku-4-5" },
+        // design overrides code's `claude` pick here intentionally.
+        tier2: { design: "claude-opus-4-7", claude: "claude-opus-4-7-forced" },
+      },
+    },
+  });
+  assert.equal(out.tier1Models.design, "claude-haiku-4-5");
+  assert.equal(out.tier2Models.claude, "claude-opus-4-7-forced");
+  assert.equal(out.tier2Models.openai, "gpt-5.4");
+  assert.equal(out.tier2Models.design, "claude-opus-4-7");
+});
+
+// ─── Missing-config edges ───────────────────────────────────────────
+
+test("resolveTierIds: mixed with only codeDomainCfg present → still injects design", () => {
+  const out = resolveTierIds({
+    resolvedDomain: "mixed",
+    codeDomainCfg: {
+      tier1: ["claude", "openai"],
+      tier2: ["claude"],
+    },
+    designDomainCfg: undefined,
+  });
+  assert.equal(out.tier1Ids[0], "design");
+  assert.ok(out.tier1Ids.includes("claude"));
+  assert.ok(out.tier1Ids.includes("openai"));
+  assert.equal(out.tier2Ids[0], "design");
+});
+
+test("resolveTierIds: code with missing codeDomainCfg → empty arrays", () => {
+  const out = resolveTierIds({
+    resolvedDomain: "code",
+    codeDomainCfg: undefined,
+    designDomainCfg: undefined,
+  });
+  assert.deepEqual(out.tier1Ids, []);
+  assert.deepEqual(out.tier2Ids, []);
+});
+
+// ─── Regression: the eventbadge#20 scenario end-to-end ──────────────
+
+test("resolveTierIds: regression — eventbadge#20 stale config + mixed detect → DesignAgent in tier-1", () => {
+  // Reproduces the exact .conclaverc.json shape from
+  // seunghunbae-3svs/eventbadge as of 2026-04-20.
+  const eventbadgeConfig = {
+    codeDomainCfg: {
+      tier1: ["claude", "openai", "gemini"],
+      tier2: ["claude", "openai"],
+      models: { tier1: {}, tier2: { claude: "claude-opus-4-7", openai: "gpt-5.4" } },
+    },
+    designDomainCfg: {
+      // Stale — no "design" entry.
+      tier1: ["claude", "openai", "gemini"],
+      tier2: ["claude", "openai"],
+      models: { tier1: {}, tier2: { claude: "claude-opus-4-7", openai: "gpt-5.4" } },
+    },
+  };
+  const out = resolveTierIds({ resolvedDomain: "mixed", ...eventbadgeConfig });
+
+  // Before the fix: tier1Ids = ["claude", "openai", "gemini"] → no
+  // design → DesignAgent never instantiated → renderer drops section.
+  // After the fix: "design" is injected at the head.
+  assert.ok(
+    out.tier1Ids.includes("design"),
+    `tier-1 must include "design" for mixed-domain; got ${JSON.stringify(out.tier1Ids)}`,
+  );
+  assert.ok(
+    out.tier2Ids.includes("design"),
+    `tier-2 must include "design" for mixed-domain with non-empty tier-2`,
+  );
+});


### PR DESCRIPTION
## Root cause

On any `conclave review` that auto-detected to `mixed` (code + UI signals in the diff), users only saw `claude` / `openai` / `gemini` sections even though the diff included `.jsx` / `.css` / other UI files. Dogfooded on `seunghunbae-3svs/eventbadge#20` (the verdict output showed `Domain:  mixed` but no `design → ...` section).

The tier-1 merge in `packages/cli/src/commands/review.ts` unioned `config.council.domains.code.tier1 ∪ config.council.domains.design.tier1`. For any `.conclaverc.json` written by `conclave init` **before** v0.5.0-alpha.1 (PR #84 — the one that introduced DesignAgent), `domains.design.tier1` was `["claude", "openai", "gemini"]` — no literal `"design"` entry. The merged list therefore never included the `design` id, `buildAgent("design", …)` was never called, the Council never got a DesignAgent, and the renderer (which was correctly iterating `results` with no filter) simply had no design section to emit.

Verified against the eventbadge repo's actual `.conclaverc.json` — confirmed the shape matches the stale-pre-PR#84 form.

## Fix

Two-part:

1. **Stale-config safety net.** When `resolvedDomain === "mixed"` and the merged tier-1 list doesn't include `"design"`, inject it at the head. Same for tier-2 when tier-2 is non-empty (design's `alwaysEscalate: true` makes tier-2 the binding verdict for mixed runs; a stale config that left `"design"` out of tier-2 would re-trigger the regression on escalation). Tier-1-only configs (empty tier-2 on both domains) are left alone. Handles legacy configs without a forced migration.
2. **Tier-resolver extraction.** The tier-1/tier-2 merge + safety-net logic was inlined inside `review()` in `review.ts`, which made it untestable in isolation. Extracted to `packages/cli/src/lib/tier-resolver.ts` as a pure `resolveTierIds({ resolvedDomain, codeDomainCfg, designDomainCfg })` returning `{ tier1Ids, tier2Ids, tier1Models, tier2Models }`. 10 unit tests cover the full matrix.

## Diagnostic logging

`conclave review` now prints the resolved tier-1 (and, when applicable, tier-2) agent-id list BEFORE the council runs:

```
conclave review: auto-detected domain: mixed (reason: changed files include *.jsx)
conclave review: tier-1 agents: [claude, openai, gemini, design]
conclave review: tier-2 agents: [claude, openai, design]
```

The list reflects **actually-built** agents — credential-skipped agents drop out — so future diagnoses are trivial.

## How this was reproduced

The repo's real eventbadge `.conclaverc.json` has `domains.design.tier1: ["claude","openai","gemini"]` (pre-PR#84 shape). PR #20 on that repo changes `.github/workflows/conclave.yml` plus `.jsx` files, which flips auto-detect to `mixed`. The posted verdict shows `Domain:  mixed`, `Tiers:   1 (1r) → 2 (2r) — alwaysEscalate=true`, `claude` + `openai` sections — no `design` section. Matches our test fixture `resolveTierIds: regression — eventbadge#20 stale config + mixed detect → DesignAgent in tier-1`.

## What this does NOT change

- DesignAgent's text-UI mode (v0.5.4) — untouched.
- Auto-detect rules (v0.5.3) — unchanged.
- The renderer (`lib/output.ts`) — already correct; no changes needed. Regression was upstream in the agent set.
- Config defaults — `DEFAULT_CONFIG` in `config-writer.ts` already has `domains.design.tier1: ["design", "claude"]` post-PR#84. No migration required; the safety net handles stale configs transparently.

## Version bumps

| Package | From | To |
|---|---|---|
| `@conclave-ai/cli` | 0.6.0 | 0.6.2 |

No other packages touched. No schema changes.

## Test plan

- [x] `corepack pnpm build` — 47 tasks successful
- [x] `corepack pnpm test` — 47 tasks green, 166 CLI tests pass (was 154)
- [x] `corepack pnpm typecheck` (cli) — clean
- [x] 10 new tests in `packages/cli/test/tier-resolver.test.mjs`: pure code / pure design / mixed-current / mixed-stale (exact eventbadge#20 shape) / no-duplication / empty-tier-2 / model-override precedence / missing-config edges / regression fixture
- [x] 2 new tests in `packages/cli/test/output.test.mjs`: renderer emits `design → ...` alongside `claude → ...` / `openai → ...` for mixed-domain; design section still renders when another agent errored mid-round

🤖 Generated with [Claude Code](https://claude.com/claude-code)