### PR TITLE
fix: telegram webhook illegal invocation + autofix exit code handling (v0.7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### Fixed
+- **Telegram webhook Illegal-invocation + autofix exit-code handling (v0.7.2).**
+  Two P0 bugs caught via live dogfood on `seunghunbae-3svs/eventbadge#21`.
+  (1) `apps/central-plane` `/telegram/webhook` crashed on every inbound
+  update with `TypeError: Illegal invocation: function called with
+  incorrect 'this' reference`. Root cause: `TelegramClient` stored
+  global `fetch` on `this.fetchImpl` and called it via `this.fetchImpl(...)`
+  — Cloudflare Workers rejects native-method invocations where
+  `this !== globalThis`. Fix: bind the default to `globalThis` at store
+  time and pull the impl into a local before call. (2) `conclave autofix`
+  treated `conclave review`'s non-zero exit as a crash. `conclave review`
+  uses 0=approve/1=rework/2=reject — all three carry a valid verdict JSON
+  on stdout. `defaultSpawnReview` now returns `{code:0|1|2, stdout}`
+  instead of throwing; only exit ≥ 3 (or no exit at all) re-throws.
+  Autofix also now refuses to fix a reject verdict (prints a clear
+  message + exits 1). 11 new regression tests (3 central-plane, 8 cli);
+  total 76 + 255 = 331 tests, 0 failing. Bumps
+  `@conclave-ai/central-plane` 0.6.1 → 0.7.1 (first bump since v0.6.1
+  — Bae needs to `corepack pnpm ship` post-merge to deploy) and
+  `@conclave-ai/cli` 0.7.1 → 0.7.2. See `docs/releases/v0.7.2.md`.
+
 ### Added
 - **`conclave review --json` + `conclave autofix` auto-spawn (v0.7.1).**
   `conclave autofix --pr N` now works with ONLY `ANTHROPIC_API_KEY` set

--- a/apps/central-plane/package.json
+++ b/apps/central-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/central-plane",
-  "version": "0.6.1",
+  "version": "0.7.1",
   "private": true,
   "description": "Conclave AI central control plane — Cloudflare Worker + D1 backing the v0.4 install model.",
   "license": "MIT",

--- a/apps/central-plane/src/telegram.ts
+++ b/apps/central-plane/src/telegram.ts
@@ -11,7 +11,15 @@ export class TelegramClient {
   constructor(opts: { token: string; fetch?: FetchLike }) {
     if (!opts.token) throw new Error("TelegramClient: token required");
     this.token = opts.token;
-    this.fetchImpl = opts.fetch ?? fetch;
+    // v0.7.2 fix: native `fetch` on Cloudflare Workers throws
+    // "Illegal invocation: function called with incorrect `this` reference"
+    // when called as `this.fetchImpl(...)` — the Workers runtime requires
+    // `this` === globalThis for platform-native methods. Storing the
+    // global directly (without binding) on an instance field and then
+    // invoking `this.fetchImpl(url, init)` sets `this` to the instance.
+    // Bind the default fall-through to globalThis; leave injected
+    // fetchImpls (tests) as-is since those are plain functions.
+    this.fetchImpl = opts.fetch ?? fetch.bind(globalThis);
   }
 
   private url(method: string): string {
@@ -35,7 +43,11 @@ export class TelegramClient {
     if (opts.parseMode) body.parse_mode = opts.parseMode;
     if (opts.replyToMessageId) body.reply_to_message_id = opts.replyToMessageId;
     if (opts.replyMarkup) body.reply_markup = opts.replyMarkup;
-    const resp = await this.fetchImpl(this.url("sendMessage"), {
+    // Use a local binding (not `this.fetchImpl(...)`) so `this` is
+    // undefined at call time — avoids the Workers "Illegal invocation"
+    // error even if the caller passes an unbound native fetch.
+    const fetchImpl = this.fetchImpl;
+    const resp = await fetchImpl(this.url("sendMessage"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
@@ -49,7 +61,8 @@ export class TelegramClient {
     const body: Record<string, unknown> = { callback_query_id: opts.id };
     if (opts.text !== undefined) body.text = opts.text;
     if (opts.showAlert !== undefined) body.show_alert = opts.showAlert;
-    const resp = await this.fetchImpl(this.url("answerCallbackQuery"), {
+    const fetchImpl = this.fetchImpl;
+    const resp = await fetchImpl(this.url("answerCallbackQuery"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),

--- a/apps/central-plane/test/telegram.test.mjs
+++ b/apps/central-plane/test/telegram.test.mjs
@@ -433,3 +433,148 @@ test("POST /telegram/webhook: TELEGRAM_WEBHOOK_SECRET matches → processes upda
   assert.equal(res.status, 200);
   assert.ok(fetchMock.calls.find((c) => c.url.includes("/sendMessage")));
 });
+
+// ---- v0.7.2 regression: "Illegal invocation" on Cloudflare Workers -------
+//
+// Background:
+//   Cloudflare Workers enforces that native platform methods (fetch, D1
+//   prepare, KV put/get, crypto.subtle.*) receive `this === the original
+//   platform object`. The v0.5..0.7.1 code stored the global fetch on
+//   `TelegramClient.fetchImpl` and later invoked `this.fetchImpl(...)` —
+//   at call-time, `this` was the TelegramClient instance, which tripped
+//   Workers' Illegal-invocation guard and bubbled a 500 from the `/telegram/webhook`
+//   route (observed via `wrangler tail` on 2026-04-21).
+//
+// These tests reproduce the bug in plain Node by wrapping globalThis.fetch
+// with a guard that throws when invoked with `this !== globalThis`. If the
+// regression reappears (someone refactors back to `this.fetchImpl(...)`),
+// these tests go red at CI time, not prod time.
+
+/**
+ * Replace `globalThis.fetch` with a wrapper that:
+ *   1. Throws the same "Illegal invocation" error that Workers throws when
+ *      invoked with `this !== globalThis` and `this !== undefined`.
+ *   2. Otherwise delegates to `inner(url, init)` for the mock response.
+ * Returns a `restore()` fn.
+ */
+function installIllegalInvocationGuard(inner) {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  const wrapped = function (url, init) {
+    // `this` in a bare call is undefined (strict mode) or globalThis.
+    // Both are ACCEPTABLE. ANY OTHER receiver means the call site did
+    // `someObj.fetch(...)` — the bug.
+    if (this !== undefined && this !== globalThis) {
+      throw new TypeError(
+        "Illegal invocation: function called with incorrect `this` reference.",
+      );
+    }
+    calls.push({ url: typeof url === "string" ? url : url.url, init });
+    return inner(url, init);
+  };
+  wrapped.calls = calls;
+  globalThis.fetch = wrapped;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+test("v0.7.2 regression: webhook /link uses global fetch without Illegal invocation", async () => {
+  // Install the guard FIRST so createApp's default-parameter `fetch` is
+  // captured from the guarded globalThis.fetch (not the real one).
+  const guard = installIllegalInvocationGuard(async () =>
+    new Response(JSON.stringify({ ok: true, result: {} }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  try {
+    // DO NOT inject fetch into createApp — exercise the default-fetch path.
+    const app = createApp();
+    const { env, token, installId } = makeEnvWithInstall();
+    const { res, body } = await fetchApp(app, "/telegram/webhook", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        update_id: 2001,
+        message: { chat: { id: 7001 }, text: `/link ${token}`, from: { username: "bae" } },
+      }),
+    }, env);
+    // If the bug is back, Hono's onError catches the TypeError and returns
+    // 500 with { error: "Illegal invocation: ..." }. Assert we got 200.
+    assert.equal(res.status, 200, `expected 200, got ${res.status}: ${JSON.stringify(body)}`);
+    assert.equal(body.ok, true);
+    // Confirm the global fetch wrapper was actually reached.
+    assert.ok(guard.calls.find((c) => c.url.includes("/sendMessage")), "sendMessage not called");
+    // Confirm link was actually persisted — we got past the fetch.
+    assert.equal(env.DB.state.links.get(7001)?.installId, installId);
+  } finally {
+    guard.restore();
+  }
+});
+
+test("v0.7.2 regression: webhook callback_query dispatch uses global fetch without Illegal invocation", async () => {
+  const guard = installIllegalInvocationGuard(async (url) => {
+    const u = typeof url === "string" ? url : url.url;
+    if (u.endsWith("/dispatches")) return new Response("{}", { status: 200 });
+    if (u.includes("/answerCallbackQuery"))
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    return new Response("{}", { status: 200 });
+  });
+  try {
+    // Encrypted-token dispatch path with default (un-injected) global fetch.
+    const app = createApp();
+    const { env, installId } = makeEnvWithInstall();
+    env.DB.state.links.set(7002, {
+      chatId: 7002,
+      installId,
+      linkedAt: "2026-04-20T00:00:00Z",
+      userLabel: "bae",
+    });
+    const { res } = await fetchApp(app, "/telegram/webhook", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        update_id: 2002,
+        callback_query: {
+          id: "cq-regression",
+          data: "ep:ep-regression:reworked",
+          from: { username: "bae" },
+          message: { chat: { id: 7002 } },
+        },
+      }),
+    }, env);
+    assert.equal(res.status, 200);
+    // Both the dispatch and the ack must have gone through the guarded fetch.
+    assert.ok(guard.calls.find((c) => c.url.endsWith("/dispatches")), "dispatch not called");
+    assert.ok(
+      guard.calls.find((c) => c.url.includes("/answerCallbackQuery")),
+      "answerCallbackQuery not called",
+    );
+  } finally {
+    guard.restore();
+  }
+});
+
+test("v0.7.2 regression: guard itself detects the pre-fix pattern (meta-test)", async () => {
+  // Sanity-check the guard: if someone does `obj.fetch(url)` with a non-global
+  // receiver, it throws. This test would FAIL if the guard were too lax and
+  // quietly masked the regression it is meant to catch.
+  const guard = installIllegalInvocationGuard(async () => new Response("{}", { status: 200 }));
+  try {
+    const obj = { fetch: globalThis.fetch };
+    let caught = null;
+    try {
+      await obj.fetch("https://example.com");
+    } catch (e) {
+      caught = e;
+    }
+    assert.ok(caught, "guard failed to detect bad-this invocation");
+    assert.match(caught.message, /Illegal invocation/);
+  } finally {
+    guard.restore();
+  }
+});

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -1,0 +1,214 @@
+# v0.7.2 — hotfix: Telegram webhook Illegal-invocation + autofix exit-code handling
+
+## TL;DR
+
+Two P0 bugs that blocked the E2E pipeline Bae was validating on
+`seunghunbae-3svs/eventbadge#21`:
+
+1. **Central plane** — `/telegram/webhook` crashed with `TypeError: Illegal
+   invocation: function called with incorrect 'this' reference` on every
+   inbound Telegram update. `🔧 / ✅ / ❌` buttons did nothing.
+2. **CLI** — `conclave autofix` refused to parse the perfectly valid
+   verdict JSON that `conclave review` emitted when the review verdict
+   was `rework` (exit code 1).
+
+Both fixes are minimal, targeted, and covered by regression tests that
+would have caught each bug at CI time instead of prod.
+
+## Bug 1 — central plane `/telegram/webhook` Illegal invocation
+
+### Evidence (from `wrangler tail`, 2026-04-21 22:54:40 KST)
+
+```
+POST https://conclave-ai.seunghunbae.workers.dev/telegram/webhook - Ok
+  (error) central-plane error: TypeError: Illegal invocation: function called with incorrect `this` reference.
+```
+
+Telegram retried the update repeatedly; every delivery hit the same
+500. Webhook never successfully linked a chat, never dispatched a
+`repository_dispatch` event.
+
+### Root cause
+
+`packages/../apps/central-plane/src/telegram.ts` — `TelegramClient`
+constructor (pre-v0.7.2):
+
+```ts
+constructor(opts: { token: string; fetch?: FetchLike }) {
+  this.fetchImpl = opts.fetch ?? fetch;          // stores global fetch on `this`
+}
+
+async sendMessage(...) {
+  const resp = await this.fetchImpl(url, init);  // invokes with `this === TelegramClient`
+}
+```
+
+Cloudflare Workers enforces that native platform methods (fetch, D1
+prepare, KV put/get, crypto.subtle.*) receive `this === the original
+platform object`. `this.fetchImpl(...)` sets `this` to the
+TelegramClient instance → Workers throws the Illegal-invocation
+TypeError.
+
+The Cloudflare docs call this out explicitly:
+<https://developers.cloudflare.com/workers/observability/errors/#illegal-invocation-errors>
+
+### Fix (two lines)
+
+`apps/central-plane/src/telegram.ts`:
+
+```ts
+// 1. Bind the default to globalThis at store time.
+this.fetchImpl = opts.fetch ?? fetch.bind(globalThis);
+
+// 2. Pull the impl into a local before call — `this` stays undefined
+//    at the call site, never the TelegramClient instance.
+const fetchImpl = this.fetchImpl;
+const resp = await fetchImpl(url, init);
+```
+
+Both guards are defensive — either alone fixes the bug. Together they
+ensure the pattern is safe even if a future refactor reintroduces
+one or the other.
+
+### Tests (3 new, 14 total in `telegram.test.mjs`)
+
+`apps/central-plane/test/telegram.test.mjs`:
+
+- `v0.7.2 regression: webhook /link uses global fetch without Illegal invocation`
+- `v0.7.2 regression: webhook callback_query dispatch uses global fetch without Illegal invocation`
+- `v0.7.2 regression: guard itself detects the pre-fix pattern (meta-test)`
+
+The key insight: existing tests all injected a fetch mock into
+`createApp({ fetch: ... })`, which completely bypassed the bug. The new
+tests DELIBERATELY skip that injection so the default-parameter
+`fetch` path runs — plus install a global-fetch guard that throws an
+identical "Illegal invocation" TypeError when `this !== globalThis`, so
+the Workers runtime behavior is reproduced locally in Node.
+
+Verified: reverting the fix in `dist/telegram.js` makes both regression
+tests go red with `500 !== 200` (Hono catches the TypeError, returns
+500). Restoring the fix → green.
+
+## Bug 2 — autofix treats review's non-zero exit as failure
+
+### Evidence (from Bae's actual autofix run)
+
+```
+autofix: no --verdict provided, spawning 'conclave review --pr 21 --json' to fetch live verdict
+autofix: failed to auto-fetch verdict via 'conclave review --pr 21 --json' — conclave review: auto-detected domain: mixed...
+conclave review: tier-1 agents: [design, claude, openai, gemini]
+...
+conclave review: plain summary ready (en, telegram+pr-comment)
+. Pass --verdict <file> manually or fix the review subprocess.
+```
+
+Review ran end-to-end, emitted valid verdict JSON on stdout, and
+exited with code 1 (the documented convention for `rework`).
+
+### Root cause
+
+`packages/cli/src/commands/autofix.ts` — `defaultSpawnReview` wrapped
+`child_process.execFile` in a try/catch. execFile's Promise rejects on
+ANY non-zero exit, so the catch block at the bottom re-threw for every
+exit code (1 = rework, 2 = reject, 3+ = crash).
+
+The call site at `runAutofix` already had exit-code-aware logic that
+would parse stdout for codes 0/1/2 — but it never ran, because the
+throw at `defaultSpawnReview` short-circuited it.
+
+### Fix (inside `defaultSpawnReview`)
+
+```ts
+// v0.7.2 fix: 0 (approve) / 1 (rework) / 2 (reject) all carry a valid
+// verdict JSON on stdout. Let the caller parse it.
+if (typeof e.code === "number" && e.code >= 0 && e.code < 3) {
+  return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", code: e.code };
+}
+// Only exit >= 3 (or no exit code, meaning abort/timeout) re-throws.
+throw Object.assign(new Error(...), { ... });
+```
+
+Plus a secondary guard at the top of the loop: when the verdict is
+`reject`, autofix prints a clear "refusing to autofix — too destructive"
+message and exits 1 (non-zero signal so CI doesn't silently treat it
+as a pass) **without** error-crashing. Autofix-ing a reject is never
+the right answer — the council wants the PR closed, not reworked.
+
+### Tests (8 new, 19 total in `autofix-spawn.test.mjs`)
+
+Four end-to-end tests at `runAutofix` level:
+
+- `v0.7.2: spawnReview exits 0 (approve) with no blockers → 'nothing to autofix', exit 0`
+- `v0.7.2: spawnReview exits 2 (reject) → refuses to autofix, exit 1, clear message`
+- `v0.7.2: spawnReview exits 1 (rework) with real blockers → proceeds to fix loop`
+- `v0.7.2: spawnReview exits 4 (genuine subprocess crash) → clear error, exit 2`
+
+Four direct unit tests against the real `defaultSpawnReview` using a
+temp fake `conclave.js` script that exits with controllable codes:
+
+- `defaultSpawnReview: exit 0 returns {code:0, stdout}`
+- `defaultSpawnReview: exit 1 (rework) DOES NOT THROW — returns {code:1, stdout}`
+- `defaultSpawnReview: exit 2 (reject) DOES NOT THROW — returns {code:2, stdout}`
+- `defaultSpawnReview: exit 5 (crash) throws with clear message`
+
+Verified: reverting the fix in `dist/commands/autofix.js` makes the
+rework/reject tests go red — exits throw instead of return.
+
+## What did NOT change
+
+- `conclave review` exit-code convention (0/1/2/3+) is unchanged.
+  Only autofix's SIDE of the interpretation.
+- Auth logic of the Telegram webhook — untouched. Just the `this`
+  binding of the fetch call inside TelegramClient.
+- Public API of `@conclave-ai/cli` — `defaultSpawnReview` is now
+  exported but marked as not-stable.
+
+## Test summary
+
+| suite           | before | after | delta |
+| --------------- | -----: | ----: | ----: |
+| central-plane   |     73 |    76 |    +3 |
+| cli             |    247 |   255 |    +8 |
+| **total new**   |        |       |   +11 |
+
+`corepack pnpm build && corepack pnpm test` — all 47 turbo tasks green.
+
+## Deploy instructions for Bae
+
+### 1. Central plane — `@conclave-ai/central-plane` 0.6.1 → 0.7.1
+
+**This is the first central-plane bump since v0.6.1.** The production
+Worker at `conclave-ai.seunghunbae.workers.dev` needs this deployed
+before the Telegram buttons will work on `eventbadge#21` (or any
+install).
+
+```bash
+cd apps/central-plane
+corepack pnpm ship        # runs preflight + wrangler deploy
+```
+
+### 2. CLI — `@conclave-ai/cli` 0.7.1 → 0.7.2
+
+```bash
+# Option A: publish to npm (Bae's call — v0.7.2 fixes a user-visible bug)
+corepack pnpm -F @conclave-ai/cli publish --access public
+
+# Option B: local install for dogfood
+corepack pnpm install
+corepack pnpm -F @conclave-ai/cli build
+pnpm link --global  # or similar
+```
+
+## Upgrade
+
+No config changes needed. No migration. No env-var changes. Existing
+`.conclaverc.json` files keep working. The D1 schema is unchanged.
+
+## Credit
+
+Both bugs caught via live debugging on the `eventbadge#21` dogfood run
+— the pipeline Bae was validating to close the v0.7 autofix loop.
+Neither slipped past `build && test` because both code paths had test
+coverage that mocked out the very surface where the bug lived
+(injected fetch for the Worker; injected spawnReview for autofix).
+The v0.7.2 regression tests exercise the real defaults.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/commands/autofix.ts
+++ b/packages/cli/src/commands/autofix.ts
@@ -249,7 +249,10 @@ const defaultGh: GhRunner = async (bin, args, opts) => {
  * plain `conclave` binary on PATH if argv[1] isn't a conclave entry. */
 const SPAWN_REVIEW_DEFAULT_TIMEOUT_MS = 60 * 60_000; // 60 min — review can be slow
 
-async function defaultSpawnReview(input: {
+/** v0.7.2 — exported for regression-test coverage of the exit-code
+ * interpretation layer. Not part of the public API; subject to change
+ * across patch versions. */
+export async function defaultSpawnReview(input: {
   prNumber: number;
   cwd: string;
   timeoutMs?: number;
@@ -292,6 +295,21 @@ async function defaultSpawnReview(input: {
         code: typeof e.code === "number" ? e.code : 124,
         timedOut: true,
       });
+    }
+    // v0.7.2 fix: `conclave review` deliberately uses non-zero exit codes
+    // to signal verdict outcome (0=approve, 1=rework, 2=reject). These
+    // are NOT crashes — the subprocess emitted a valid verdict JSON on
+    // stdout, and the caller MUST be allowed to parse it. Previously we
+    // re-threw for every non-zero code, so autofix's catch block bailed
+    // before the exit-code-aware check at the call site could run. Now
+    // we only re-throw when the exit code is absent (process aborted /
+    // couldn't start) or ≥3 (genuine subprocess crash).
+    if (typeof e.code === "number" && e.code >= 0 && e.code < 3) {
+      return {
+        stdout: e.stdout ?? "",
+        stderr: e.stderr ?? "",
+        code: e.code,
+      };
     }
     throw Object.assign(new Error(e.stderr ?? e.message), {
       stdout: e.stdout ?? "",
@@ -538,6 +556,31 @@ export async function runAutofix(args: AutofixArgs, deps: AutofixDeps = {}): Pro
         finalVerdict: "approve",
         remainingBlockers: [],
         mergeStatus: "not-merged",
+      },
+    };
+  }
+
+  // v0.7.2 — reject is too destructive to autofix. A reject means the
+  // council wants the PR closed (not reworked) — blindly feeding that
+  // into the fix loop would try to "fix" things like "this whole
+  // approach is wrong". Print a clear message and exit non-zero so CI
+  // doesn't silently treat reject like a pass, but DON'T error-crash.
+  if (initialVerdict === "reject") {
+    stdout(
+      `autofix: council verdict is REJECT — refusing to autofix (too destructive). ` +
+        `Remaining blockers: ${remainingBlockersFrom(initialReviews).length}. ` +
+        `Close the PR or re-open a scoped-down one.\n`,
+    );
+    return {
+      code: 1,
+      result: {
+        status: "bailed-no-patches",
+        iterations: [],
+        totalCostUsd: 0,
+        finalVerdict: "reject",
+        remainingBlockers: remainingBlockersFrom(initialReviews),
+        mergeStatus: "not-merged",
+        reason: "council verdict: reject — autofix refused",
       },
     };
   }

--- a/packages/cli/test/autofix-spawn.test.mjs
+++ b/packages/cli/test/autofix-spawn.test.mjs
@@ -1,6 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { runAutofix, parseVerdictFile } from "../dist/commands/autofix.js";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { runAutofix, parseVerdictFile, defaultSpawnReview } from "../dist/commands/autofix.js";
 
 // v0.7.1 — verify the three UX paths:
 //   1. --verdict -     (stdin pipe)
@@ -354,4 +357,265 @@ test("parseVerdictFile: accepts legacy standalone shape", () => {
 test("parseVerdictFile: rejects json with no reviews AND no agents", () => {
   const bad = JSON.stringify({ verdict: "rework" });
   assert.throws(() => parseVerdictFile(bad), /reviews.*agents/);
+});
+
+// ---- v0.7.2 regression: spawnReview exit-code interpretation -------------
+//
+// Background (live-debug on seunghunbae-3svs/eventbadge#21):
+//   `conclave review --json` exits 0/1/2 depending on verdict outcome
+//   (approve/rework/reject). The v0.7.1 defaultSpawnReview wrapper re-threw
+//   on any non-zero exit — so execFile's "child exited non-zero" rejection
+//   bubbled past the call-site's exit-code-aware branch, leaving autofix
+//   with "failed to auto-fetch verdict" even though the subprocess had
+//   successfully emitted valid verdict JSON on stdout.
+//
+//   The fix: defaultSpawnReview now returns {code:N, stdout, stderr} for
+//   codes 0/1/2 instead of throwing. The runAutofix exit-code guard at
+//   the call site (accepts 0/1/2, rejects ≥3) works as intended.
+
+const approveVerdictJson = JSON.stringify({
+  verdict: "approve",
+  domain: "code",
+  tiers: { tier1Count: 1, tier1Verdict: "approve", tier2Count: 0, tier2Verdict: "" },
+  agents: [{ id: "claude", verdict: "approve", blockers: [], summary: "lgtm" }],
+  metrics: { calls: 1, tokensIn: 50, tokensOut: 10, costUsd: 0.005, latencyMs: 100, cacheHitRate: 0 },
+  episodicId: "ep-43",
+  sha: "head-sha",
+  repo: "o/r",
+  prNumber: 21,
+});
+
+const rejectVerdictJson = JSON.stringify({
+  verdict: "reject",
+  domain: "code",
+  tiers: { tier1Count: 2, tier1Verdict: "reject", tier2Count: 0, tier2Verdict: "" },
+  agents: [
+    {
+      id: "claude",
+      verdict: "reject",
+      blockers: [{ severity: "blocker", category: "architecture", message: "wrong approach entirely" }],
+      summary: "please close",
+    },
+    {
+      id: "openai",
+      verdict: "reject",
+      blockers: [{ severity: "blocker", category: "security", message: "exposes secret" }],
+      summary: "sec issue",
+    },
+  ],
+  metrics: { calls: 2, tokensIn: 200, tokensOut: 80, costUsd: 0.02, latencyMs: 400, cacheHitRate: 0 },
+  episodicId: "ep-44",
+  sha: "head-sha",
+  repo: "o/r",
+  prNumber: 21,
+});
+
+test("v0.7.2: spawnReview exits 0 (approve) with no blockers → 'nothing to autofix', exit 0", async () => {
+  const stdoutBuf = [];
+  const { code, result } = await runAutofix(
+    { ...baseArgs, pr: 21, dryRun: false },
+    {
+      loadConfig: async () => fakeConfig,
+      worker: makeWorker(),
+      git: makeGit().exec,
+      verifier: makeVerifier(),
+      readFile: async () => "x",
+      spawnReview: async () => ({ stdout: approveVerdictJson, stderr: "", code: 0 }),
+      gh: okGh,
+      stdout: (s) => stdoutBuf.push(s),
+      stderr: () => {},
+    },
+  );
+
+  assert.equal(code, 0, "approve exits 0");
+  assert.equal(result.status, "approved");
+  assert.equal(result.finalVerdict, "approve");
+  const out = stdoutBuf.join("");
+  assert.ok(/already approves|nothing to fix/i.test(out), `should say verdict already approves: ${out}`);
+});
+
+test("v0.7.2: spawnReview exits 2 (reject) → refuses to autofix, exit 1, clear message", async () => {
+  const stdoutBuf = [];
+  const stderrBuf = [];
+  const { code, result } = await runAutofix(
+    { ...baseArgs, pr: 21, dryRun: false },
+    {
+      loadConfig: async () => fakeConfig,
+      worker: makeWorker(),
+      git: makeGit().exec,
+      verifier: makeVerifier(),
+      readFile: async () => "x",
+      spawnReview: async () => ({ stdout: rejectVerdictJson, stderr: "", code: 2 }),
+      gh: okGh,
+      stdout: (s) => stdoutBuf.push(s),
+      stderr: (s) => stderrBuf.push(s),
+    },
+  );
+
+  // Not a crash — exit 1 with explanatory message.
+  assert.equal(code, 1, "reject exits 1 (non-zero signal, but not error-crash)");
+  assert.equal(result.status, "bailed-no-patches");
+  assert.equal(result.finalVerdict, "reject");
+  // Should carry the actual blockers from the reject reviews.
+  assert.ok(result.remainingBlockers.length >= 1, "should surface the blockers so Bae sees them");
+  const out = stdoutBuf.join("");
+  assert.ok(/reject/i.test(out), `should mention reject: ${out}`);
+  assert.ok(/destructive|refus/i.test(out), `should explain why it refused: ${out}`);
+  // Must NOT have reached the "failed to auto-fetch" bailout.
+  const err = stderrBuf.join("");
+  assert.ok(!/failed to auto-fetch/.test(err), `should not claim auto-fetch failure: ${err}`);
+});
+
+test("v0.7.2: spawnReview exits 1 (rework) with real blockers → proceeds to fix loop", async () => {
+  // Same as existing test #7 but NOT dry-run — confirms the verdict is
+  // actually carried through into the worker loop and not bailed-out on.
+  let workerCalls = 0;
+  const worker = {
+    work: async () => {
+      workerCalls += 1;
+      return {
+        patch: "diff --git a/src/x.ts b/src/x.ts\n--- a/src/x.ts\n+++ b/src/x.ts\n@@\n-a\n+b\n",
+        message: "fix",
+        appliedFiles: ["src/x.ts"],
+        costUsd: 0.01,
+        tokensUsed: 10,
+      };
+    },
+  };
+
+  const { code, result } = await runAutofix(
+    { ...baseArgs, pr: 42, dryRun: true },
+    {
+      loadConfig: async () => fakeConfig,
+      worker,
+      git: makeGit().exec,
+      verifier: makeVerifier(),
+      readFile: async () => "x",
+      writeTempPatch: async () => {},
+      removeTempPatch: async () => {},
+      spawnReview: async () => ({ stdout: reworkVerdictJson, stderr: "", code: 1 }),
+      gh: okGh,
+      stdout: () => {},
+      stderr: () => {},
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.equal(result.status, "dry-run");
+  assert.ok(workerCalls >= 1, "worker must be invoked for rework blockers — the verdict was parsed");
+});
+
+test("v0.7.2: spawnReview exits 4 (genuine subprocess crash) → clear error, exit 2", async () => {
+  const stderrBuf = [];
+  const { code, result } = await runAutofix(
+    { ...baseArgs, pr: 42, dryRun: false },
+    {
+      loadConfig: async () => fakeConfig,
+      worker: makeWorker(),
+      git: makeGit().exec,
+      verifier: makeVerifier(),
+      readFile: async () => "x",
+      spawnReview: async () => ({ stdout: "", stderr: "internal panic: segfault", code: 4 }),
+      gh: okGh,
+      stdout: () => {},
+      stderr: (s) => stderrBuf.push(s),
+    },
+  );
+
+  assert.equal(code, 2);
+  assert.equal(result.status, "bailed-no-patches");
+  const err = stderrBuf.join("");
+  assert.ok(err.includes("exited 4"), `should mention exit 4: ${err}`);
+  assert.ok(err.includes("internal panic"), `should surface the subprocess stderr: ${err}`);
+});
+
+// ---- v0.7.2: defaultSpawnReview unit test (the bug's ground zero) --------
+//
+// This test runs the REAL defaultSpawnReview (not the injected one) against
+// a temporary fake `conclave.js` script that exits with controllable code
+// and stdout. Without the v0.7.2 fix, execFile's "child exited non-zero"
+// rejection bubbles up as a throw — defaultSpawnReview must instead return
+// {code:1, stdout, stderr} so the caller can parse the verdict.
+
+async function makeFakeConclave(exitCode, stdoutPayload, stderrPayload = "") {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "conclave-autofix-test-"));
+  const script = path.join(dir, "conclave.js");
+  // The script ignores its argv and just emits the configured stdout/stderr,
+  // then exits with the configured code.
+  const src = `
+process.stdout.write(${JSON.stringify(stdoutPayload)});
+process.stderr.write(${JSON.stringify(stderrPayload)});
+process.exit(${exitCode});
+`;
+  await fs.writeFile(script, src, "utf8");
+  return { dir, script };
+}
+
+async function callDefaultSpawnReviewWithFakeBinary(fakeScriptPath, cwd) {
+  // defaultSpawnReview picks the spawn target based on `process.argv[1]`:
+  //   - if argv[1] matches /conclave(\.js)?$/, it spawns `node argv[1] ...`
+  //   - otherwise it spawns `conclave` from PATH
+  // We temporarily override argv[1] to our fake script, call, then restore.
+  const originalArgv1 = process.argv[1];
+  process.argv[1] = fakeScriptPath;
+  try {
+    return await defaultSpawnReview({ prNumber: 999, cwd, timeoutMs: 10_000 });
+  } finally {
+    process.argv[1] = originalArgv1;
+  }
+}
+
+test("v0.7.2 defaultSpawnReview: exit 0 returns {code:0, stdout}", async () => {
+  const { dir, script } = await makeFakeConclave(0, approveVerdictJson);
+  try {
+    const result = await callDefaultSpawnReviewWithFakeBinary(script, dir);
+    assert.equal(result.code, 0);
+    assert.equal(result.stdout, approveVerdictJson);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("v0.7.2 defaultSpawnReview: exit 1 (rework) DOES NOT THROW — returns {code:1, stdout}", async () => {
+  // This is the exact bug Bae hit on eventbadge#21.
+  const { dir, script } = await makeFakeConclave(1, reworkVerdictJson);
+  try {
+    const result = await callDefaultSpawnReviewWithFakeBinary(script, dir);
+    assert.equal(result.code, 1, "exit 1 (rework) must be returned, not thrown");
+    assert.equal(result.stdout, reworkVerdictJson);
+    // Verify the stdout is actually parseable — proves the caller can use it.
+    const parsed = parseVerdictFile(result.stdout);
+    assert.equal(parsed.verdict, "rework");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("v0.7.2 defaultSpawnReview: exit 2 (reject) DOES NOT THROW — returns {code:2, stdout}", async () => {
+  const { dir, script } = await makeFakeConclave(2, rejectVerdictJson);
+  try {
+    const result = await callDefaultSpawnReviewWithFakeBinary(script, dir);
+    assert.equal(result.code, 2, "exit 2 (reject) must be returned, not thrown");
+    const parsed = parseVerdictFile(result.stdout);
+    assert.equal(parsed.verdict, "reject");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("v0.7.2 defaultSpawnReview: exit 5 (crash) throws with clear message", async () => {
+  const { dir, script } = await makeFakeConclave(5, "", "boom: subprocess crashed");
+  try {
+    let caught = null;
+    try {
+      await callDefaultSpawnReviewWithFakeBinary(script, dir);
+    } catch (err) {
+      caught = err;
+    }
+    assert.ok(caught, "exit 5 must throw");
+    assert.equal(caught.code, 5);
+    assert.match(caught.stderr, /boom/);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## TL;DR

Two P0 bugs caught on `seunghunbae-3svs/eventbadge#21` dogfood. Both block the E2E pipeline. Minimal targeted fixes + regression tests that would have caught each bug at CI time instead of prod.

## Bug 1 — central plane `/telegram/webhook` Illegal invocation

### Root cause
`apps/central-plane/src/telegram.ts` line 14 (pre-v0.7.2):

```ts
this.fetchImpl = opts.fetch ?? fetch;          // stores global fetch on `this`
// ...
const resp = await this.fetchImpl(url, init);  // calls with this === TelegramClient
```

Cloudflare Workers requires `this === globalThis` for native platform methods (fetch, D1 prepare, crypto.subtle.*). `this.fetchImpl(...)` sets receiver to the instance → Workers throws `TypeError: Illegal invocation`. Hono's onError turns it into a 500, Telegram retries indefinitely, webhook never links a chat or dispatches a button click.

Evidence from `wrangler tail`:
```
POST /telegram/webhook - Ok
  (error) central-plane error: TypeError: Illegal invocation: function called with incorrect `this` reference.
```
Reference: https://developers.cloudflare.com/workers/observability/errors/#illegal-invocation-errors

### Fix — `apps/central-plane/src/telegram.ts`
Two defensive changes (either alone fixes the bug; both together make the pattern safe against future refactors):

```ts
// 1. Bind default to globalThis at store time (line 22).
this.fetchImpl = opts.fetch ?? fetch.bind(globalThis);

// 2. Pull impl into a local before call — `this` stays undefined at the
//    call site. Both `sendMessage` and `answerCallbackQuery`.
const fetchImpl = this.fetchImpl;
const resp = await fetchImpl(this.url("sendMessage"), { ... });
```

### Regression tests — `apps/central-plane/test/telegram.test.mjs`
3 new tests, 14 total in suite:
- `v0.7.2 regression: webhook /link uses global fetch without Illegal invocation`
- `v0.7.2 regression: webhook callback_query dispatch uses global fetch without Illegal invocation`
- `v0.7.2 regression: guard itself detects the pre-fix pattern (meta-test)`

Key technique: existing tests ALL injected `createApp({ fetch: mockFetch })`, completely bypassing the bug. The new tests skip that injection and install a `globalThis.fetch` wrapper that throws an identical "Illegal invocation" TypeError when `this !== globalThis`, reproducing Workers runtime behavior in Node.

Verified: reverting the fix in `dist/telegram.js` makes both regression tests red with `500 !== 200`. Restoring → green.

## Bug 2 — autofix treats review's non-zero exit as failure

### Root cause
`packages/cli/src/commands/autofix.ts` `defaultSpawnReview` wrapped `execFile` in try/catch. `execFile`'s Promise rejects on ANY non-zero exit, so the catch re-threw for every code. The call-site at `runAutofix` already had exit-code-aware logic for 0/1/2 — but the throw short-circuited it.

Bae's actual log:
```
autofix: no --verdict provided, spawning 'conclave review --pr 21 --json' to fetch live verdict
autofix: failed to auto-fetch verdict via 'conclave review --pr 21 --json' — ...
. Pass --verdict <file> manually or fix the review subprocess.
```
Review ran end-to-end, emitted valid verdict JSON, exited 1 (rework).

### Fix — `packages/cli/src/commands/autofix.ts`
```ts
// v0.7.2: 0 (approve) / 1 (rework) / 2 (reject) all carry valid verdict
// JSON on stdout. Return so the caller can parse it; only >= 3 re-throws.
if (typeof e.code === "number" && e.code >= 0 && e.code < 3) {
  return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", code: e.code };
}
throw Object.assign(new Error(...), { ... });
```

Plus a secondary guard: when the verdict is `reject`, autofix prints `"council verdict is REJECT — refusing to autofix (too destructive). ..."` and exits 1 (non-zero signal for CI) without error-crashing. Autofix-ing a reject is never right.

### Regression tests — `packages/cli/test/autofix-spawn.test.mjs`
8 new tests, 19 total in suite:

**4 end-to-end at `runAutofix` level:**
- `v0.7.2: spawnReview exits 0 (approve) with no blockers → 'nothing to autofix', exit 0`
- `v0.7.2: spawnReview exits 2 (reject) → refuses to autofix, exit 1, clear message`
- `v0.7.2: spawnReview exits 1 (rework) with real blockers → proceeds to fix loop`
- `v0.7.2: spawnReview exits 4 (genuine subprocess crash) → clear error, exit 2`

**4 direct unit against the real `defaultSpawnReview`** (tests shell out to a temp `conclave.js` script that exits with a controllable code):
- `defaultSpawnReview: exit 0 returns {code:0, stdout}`
- `defaultSpawnReview: exit 1 (rework) DOES NOT THROW — returns {code:1, stdout}`
- `defaultSpawnReview: exit 2 (reject) DOES NOT THROW — returns {code:2, stdout}`
- `defaultSpawnReview: exit 5 (crash) throws with clear message`

Verified: reverting the fix in `dist/commands/autofix.js` makes the rework/reject tests go red.

## Test summary

| suite          | before | after | delta |
| -------------- | -----: | ----: | ----: |
| central-plane  |     73 |    76 |    +3 |
| cli            |    247 |   255 |    +8 |
| **total new**  |        |       |   +11 |

`corepack pnpm build && corepack pnpm test` — all 47 turbo tasks green.

## Bumps

- `@conclave-ai/central-plane` **0.6.1 → 0.7.1** (first bump since v0.6.1)
- `@conclave-ai/cli` **0.7.1 → 0.7.2**

## Deploy instructions for Bae

### 1. Central plane (REQUIRED — the production Worker is currently broken)
```bash
cd apps/central-plane
corepack pnpm ship        # runs preflight + wrangler deploy
```
Until this ships, Telegram buttons remain broken on every install.

### 2. CLI
```bash
# Publish to npm OR reinstall locally
corepack pnpm -F @conclave-ai/cli publish --access public
```

## What did NOT change

- `conclave review` exit-code convention (0/1/2/3+) — only autofix's interpretation of it.
- Telegram webhook auth / `/link` / dispatch logic — only the `this`-binding of the fetch call.
- D1 schema, env vars, `.conclaverc.json` — untouched. No migration needed.

## Test plan

- [x] `corepack pnpm build` green
- [x] `corepack pnpm test` green (all 47 tasks)
- [x] Verified each regression test catches its bug when fix is reverted
- [ ] Post-merge: `cd apps/central-plane && corepack pnpm ship`
- [ ] Post-deploy: re-dogfood on eventbadge#21 — `/link`, `🔧` button, `conclave autofix --pr 21`