### PR TITLE
feat(cli): conclave config — persistent per-user credentials (v0.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Added
+- **`conclave config` — persistent per-user credential storage (v0.7.4).**
+  Eliminates the daily API-key-paste friction in fresh shells. One-time
+  `conclave config` writes keys to `%USERPROFILE%\.conclave\
+  credentials.json` (Windows, ACL-restricted to the current user via
+  `icacls`) or `~/.config/conclave/credentials.json` (Unix, chmod 0600).
+  Subcommands: `set` (programmatic, accepts stdin via `-`), `get`
+  (masked by default, `--show-raw` for the full value), `list`
+  (length + last-4 chars, never full secret), `unset`, `path`,
+  `migrate` (imports current env-var values into storage). Resolution
+  order: **env var first** (CI unchanged), stored fallback, then nothing
+  (agent skipped). CLI entry-point hydrates `process.env` from storage
+  for any env var that isn't already set, so subprocess spawns
+  (`autofix` → `review --json`) and packages that read
+  `process.env` directly (`integration-telegram` CONCLAVE_TOKEN) pick
+  up stored values without per-package changes. All CLI call sites
+  (`review.ts` / `audit.ts` / `autofix.ts` / `rework.ts` /
+  `plain-summary-llm.ts`) migrated to `resolveKey()`. Supported keys:
+  `anthropic`, `openai`, `gemini` (accepts `GOOGLE_API_KEY` alias),
+  `conclave-token`, `xai`. No encryption at rest in v0.7.4 (file-mode
+  0600 / Windows ACL); master-password + OS Keychain integration
+  tracked for v0.8+. 33 new CLI tests; total 309 cli tests,
+  all 47 turbo tasks green. Bumps `@conclave-ai/cli` 0.7.3 → 0.7.4.
+  See `docs/releases/v0.7.4.md`.
+
 ### Fixed
 - **Telegram webhook Illegal-invocation + autofix exit-code handling (v0.7.2).**
   Two P0 bugs caught via live dogfood on `seunghunbae-3svs/eventbadge#21`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,17 +26,49 @@ conclave --version
 
 ## 2. Set agent API keys
 
+**Recommended (v0.7.4+)** — run `conclave config` ONCE and never paste
+again. Keys are stored per-user in `%USERPROFILE%\.conclave\
+credentials.json` (Windows, ACL-restricted) or
+`~/.config/conclave/credentials.json` (Unix, chmod 600).
+
+```bash
+conclave config
+#   anthropic (ANTHROPIC_API_KEY) → <paste>
+#   openai (OPENAI_API_KEY)       → <paste>
+#   gemini (GEMINI_API_KEY)       → Enter to skip
+#   conclave-token (CONCLAVE_TOKEN) → <paste> (only if using central-plane Telegram)
+#   xai (XAI_API_KEY)             → Enter to skip
+```
+
+Subsequent `conclave` subcommands resolve keys from storage — no
+shell env-var dance, no retyping in new PowerShell / terminal
+sessions.
+
+If you prefer env vars (CI / CD, or you already have them set):
+
 | Agent | Env var |
 |---|---|
 | Claude | `ANTHROPIC_API_KEY` |
 | OpenAI | `OPENAI_API_KEY` |
-| Gemini | `GOOGLE_API_KEY` (or `GEMINI_API_KEY` as fallback) |
+| Gemini | `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) |
+| Grok | `XAI_API_KEY` |
+| Central-plane Telegram | `CONCLAVE_TOKEN` |
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
 # Optional:
 export OPENAI_API_KEY=sk-proj-...
-export GOOGLE_API_KEY=...
+export GEMINI_API_KEY=...
+```
+
+**Resolution order**: env var first, stored `credentials.json` as
+fallback, nothing (agent skipped) otherwise. CI workflows that export
+env vars from GitHub secrets keep working unchanged.
+
+Already have env vars set and want to move them into storage?
+
+```bash
+conclave config migrate
 ```
 
 ## 3. Initialize the target repo

--- a/docs/releases/v0.7.4.md
+++ b/docs/releases/v0.7.4.md
@@ -1,0 +1,261 @@
+# v0.7.4 — `conclave config`: persistent per-user credentials
+
+## TL;DR
+
+Bae has pasted API keys into fresh PowerShell sessions 4+ times today.
+Every paste is a leak risk. v0.7.4 ends the paste cycle: one `conclave
+config` run writes keys to `%USERPROFILE%\.conclave\credentials.json`
+(or `~/.config/conclave/credentials.json` on Unix, chmod 600), and
+every subsequent `conclave` subcommand — including the `conclave
+autofix` subprocess spawn of `conclave review --json` — resolves keys
+from that file without any shell env-var dance.
+
+**CI is unaffected.** Env vars still win over stored credentials, so
+GitHub Actions workflows that export `ANTHROPIC_API_KEY` from
+`${{ secrets.ANTHROPIC_API_KEY }}` behave exactly as before.
+
+## New command — `conclave config`
+
+```
+conclave config                           # interactive TUI — set up all keys in one go
+conclave config set <key> <value>         # programmatic set
+conclave config set <key> -               # read value from stdin (pipe-friendly)
+conclave config get <key> [--show-raw]    # print value (masked by default)
+conclave config list                      # list keys with lengths + last-4 chars
+conclave config unset <key>               # remove a key
+conclave config path                      # print storage path
+conclave config migrate                   # import current env-var values into storage
+```
+
+Supported keys:
+
+| name              | env var(s)                             | used by          |
+| ----------------- | -------------------------------------- | ---------------- |
+| `anthropic`       | `ANTHROPIC_API_KEY`                    | Claude, Design, ClaudeWorker, plain-summary, visual-review judge |
+| `openai`          | `OPENAI_API_KEY`                       | OpenAI agent     |
+| `gemini`          | `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) | Gemini agent     |
+| `conclave-token`  | `CONCLAVE_TOKEN`                       | Telegram central-plane notifier |
+| `xai`             | `XAI_API_KEY`                          | Grok agent       |
+
+## Storage
+
+- **Windows**: `%USERPROFILE%\.conclave\credentials.json`. On write we
+  shell out to `icacls` to strip inherited ACLs and grant the current
+  user exclusively. If `icacls` is absent (stripped-down Server images),
+  a one-line warning prints to stderr — the file is still under the
+  per-user profile which is private by default.
+- **macOS / Linux**: `~/.config/conclave/credentials.json`, chmod 0600
+  after write (atomic rename semantics so a crash mid-write never
+  leaves a half-populated file).
+
+File format (version 1, plain JSON — a panicked user with a text
+editor can always repair it):
+
+```json
+{
+  "version": 1,
+  "keys": {
+    "anthropic": "sk-ant-api03-...",
+    "openai": "sk-proj-...",
+    "gemini": "AIza...",
+    "conclave-token": "c_..."
+  },
+  "createdAt": "2026-04-20T00:00:00.000Z",
+  "updatedAt": "2026-04-20T00:00:00.000Z"
+}
+```
+
+No encryption at rest in v0.7.4. File-mode 0600 on Unix, ACL-restricted
+on Windows. A master-password unlock and OS Keychain / Credential
+Manager integration are both tracked for v0.8+.
+
+## Key resolution order (every `conclave` subcommand)
+
+1. **Env var** (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / …) —
+   takes precedence when set. CI / CD keep working unchanged.
+2. **Stored config** (`credentials.json`) — populated via
+   `conclave config`. Trimmed on read; whitespace-only env is treated
+   as absent.
+3. **Nothing** — downstream agent is skipped with the existing
+   "key not set" log, exactly as before.
+
+At CLI start-time (any subcommand other than `config` itself), the
+process environment is hydrated from storage for any env var that
+isn't already set. This means:
+
+- `integration-telegram`'s existing `process.env["CONCLAVE_TOKEN"]`
+  check sees the stored value — no package-level changes needed.
+- The `conclave autofix` → `conclave review --json` subprocess spawn
+  inherits the hydrated env; the subprocess additionally re-reads
+  storage at its own startup, so both paths converge.
+
+## Subprocess env propagation
+
+Before v0.7.4:
+
+```powershell
+$env:ANTHROPIC_API_KEY = "sk-ant-api03-..."
+$env:CONCLAVE_TOKEN = "c_..."
+conclave autofix --pr 21
+```
+
+The parent shell must export every key the subprocess needs, because
+`conclave autofix` spawns `conclave review --pr N --json` as a real
+child process that reads `process.env["ANTHROPIC_API_KEY"]` fresh.
+Fresh PowerShell session = retyped paste = leak risk.
+
+After v0.7.4 (one-time):
+
+```powershell
+conclave config
+# → prompts for each key, masked input; writes credentials.json
+```
+
+Every session afterwards:
+
+```powershell
+conclave autofix --pr 21
+# → works. No env dance.
+```
+
+## Wiring changes
+
+### New files
+
+- `packages/cli/src/lib/credentials.ts` — the storage layer.
+  `loadCredentials`, `saveCredentials`, `resolveKey(name)`,
+  `maskKey`, `migrateFromEnv`, `setKey`, `unsetKey`,
+  `hydrateEnvFromStorage`, `credentialsPath`, `primaryEnvVar`.
+- `packages/cli/src/commands/config.ts` — the command itself.
+  Interactive TUI + all 7 subcommands.
+- `packages/cli/test/credentials.test.mjs` — 21 tests.
+- `packages/cli/test/config-command.test.mjs` — 12 tests.
+
+### Migrated call sites
+
+Every CLI call site that read API keys from `process.env` directly
+now routes through `resolveKey()` and passes the resolved value
+explicitly via `opts.apiKey`:
+
+- `packages/cli/src/commands/review.ts` — `buildAgent()` for all
+  five agent types (claude / design / openai / gemini / grok).
+- `packages/cli/src/commands/audit.ts` — `buildAgents()`.
+- `packages/cli/src/commands/autofix.ts` — `buildWorker()`.
+- `packages/cli/src/commands/rework.ts` — `buildWorker()`.
+- `packages/cli/src/lib/plain-summary-llm.ts` —
+  `ClaudeHaikuPlainSummaryLlm` constructor.
+
+The agent-package internals (`agent-claude`, `agent-openai`, etc.)
+still accept `opts.apiKey ?? process.env[...]` and therefore remain
+backward-compatible for anyone importing the package directly. The
+CLI just stops *relying* on the env-var fallback.
+
+### Entry-point hydration
+
+`packages/cli/src/index.ts#run` calls `hydrateEnvFromStorage()`
+before dispatching to any subcommand (except `config` itself, so that
+`config list` / `config get` can honestly distinguish env-set from
+stored). This means packages that read `process.env` directly
+(like `integration-telegram`'s `CONCLAVE_TOKEN` check) pick up
+stored credentials without a package-level code change.
+
+## Behavior preservation — env vars STILL win
+
+This is the core contract: **CI's existing workflows must keep working
+identically**. Verified by tests:
+
+- `resolveKey: env var wins over stored value` — when both are set,
+  the env value is returned.
+- `resolveKey: trims whitespace from env values` — matches existing
+  `TelegramNotifier` trim-to-detect-empty behavior.
+- `hydrateEnvFromStorage: does not overwrite already-set env` —
+  user / CI intent wins at CLI startup too.
+
+No changes to `.github/workflows/*.yml`, consumer-repo workflows,
+or the reusable workflow wiring.
+
+## Tests
+
+`corepack pnpm build && corepack pnpm test` — all 47 turbo tasks
+green.
+
+| suite | before | after | delta |
+| ----- | -----: | ----: | ----: |
+| cli   |    276 |   309 |   +33 |
+
+33 new CLI tests (credentials + config-command):
+
+- `loadCredentials` / `saveCredentials` round-trip
+- env-var precedence over stored
+- stored fallback when env is absent
+- undefined when neither is set
+- auto-mkdir for the credentials directory
+- chmod 0600 on Unix (skipped on Windows — Windows uses ACL via icacls)
+- Windows file lands under `%USERPROFILE%\.conclave`
+- malformed JSON throws clear error, does NOT wipe file
+- `config migrate` imports env → storage
+- `config list` masks secrets (length + last 4 chars; no full secret ever to stdout)
+- `config get` masked by default; `--show-raw` for full value
+- `config set <k> <v>` programmatic
+- `config set <k> -` stdin-piped
+- `config unset <k>` removes
+- `config path` prints storage path
+- `config migrate` dry-run / empty-env
+- TUI round-trip via injected prompter (5-key walk, Enter-to-keep)
+- `conclave-token` → `CONCLAVE_TOKEN` env-name mapping
+- `setKey` refuses empty value
+- `unsetKey` returns false on second call
+- `hydrateEnvFromStorage` fills missing env / preserves user-set env
+- `createdAt` preservation across updates
+- `GOOGLE_API_KEY` accepted as `gemini` alias; primary wins when both present
+
+## What did NOT change
+
+- The agent-package constructor signatures (`ClaudeAgent`, `OpenAIAgent`,
+  …). They still accept `opts.apiKey ?? process.env[...]`.
+- The `conclave init` wizard (it writes `.conclaverc.json`, not
+  credentials). `credentials.json` is separate and per-user.
+- `.conclaverc.json` — unchanged. Credentials are NOT stored there
+  (that file is per-repo, can be committed; credentials are per-user).
+- CI workflows — env vars still win.
+- Log redaction — all log output masks secrets to `len=N ...LAST4`.
+  No full secret ever reaches stdout / stderr / telemetry.
+
+## Migration path for Bae's daily flow
+
+```powershell
+# one-time, right after npm install -g @conclave-ai/cli@0.7.4:
+conclave config
+#   anthropic (ANTHROPIC_API_KEY) → <paste>
+#   openai (OPENAI_API_KEY)       → <paste>
+#   gemini (GEMINI_API_KEY)       → Enter (skip if not using)
+#   conclave-token (CONCLAVE_TOKEN) → <paste>
+#   xai (XAI_API_KEY)             → Enter (skip)
+
+# every subsequent PowerShell session (no env-var dance):
+conclave autofix --pr 21
+conclave review --pr 21
+conclave audit
+```
+
+Alternatively, if env vars are already set in the current shell:
+
+```powershell
+conclave config migrate
+# → imported 4 key(s) → C:\Users\ADMIN\.conclave\credentials.json
+```
+
+## What's NOT in v0.7.4 (deferred to v0.8+)
+
+- Master-password encryption at rest
+- OS Credential Manager / Keychain integration
+- Per-project credential overrides
+- `conclave config rotate` for key-rotation workflows
+- A `--no-store` flag to explicitly refuse stored lookup for paranoid runs
+
+These are all additive on top of the v0.7.4 shape.
+
+## Bump
+
+- `@conclave-ai/cli` 0.7.3 → 0.7.4
+- No other packages bumped (nothing else consumes `resolveKey`).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conclave-ai/cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Conclave AI CLI — the `conclave` binary.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -55,6 +55,7 @@ import {
 } from "../lib/audit-output.js";
 import { ClaudeHaikuPlainSummaryLlm } from "../lib/plain-summary-llm.js";
 import { renderPlainSummarySection } from "../lib/output.js";
+import { resolveKey } from "../lib/credentials.js";
 
 const execFile = promisify(execFileCb);
 
@@ -216,24 +217,28 @@ function buildAgentsForDomain(
   // coverage wins).
   const resolved: "code" | "design" | "mixed" = domain === "auto" ? "mixed" : domain;
 
+  // v0.7.4 — resolveKey checks env, then stored credentials (~/.config/
+  // conclave/credentials.json). After `conclave config` the file path is
+  // sufficient, so audit runs without the shell re-exporting keys.
   const addClaude = () => {
-    if (process.env["ANTHROPIC_API_KEY"]) agents.push(new ClaudeAgent({ gate }));
-    else skipped.push("claude (ANTHROPIC_API_KEY not set)");
+    const key = resolveKey("anthropic");
+    if (key) agents.push(new ClaudeAgent({ apiKey: key, gate }));
+    else skipped.push("claude (anthropic key not set — run `conclave config`)");
   };
   const addOpenAI = () => {
-    if (process.env["OPENAI_API_KEY"]) agents.push(new OpenAIAgent({ gate }));
-    else skipped.push("openai (OPENAI_API_KEY not set)");
+    const key = resolveKey("openai");
+    if (key) agents.push(new OpenAIAgent({ apiKey: key, gate }));
+    else skipped.push("openai (openai key not set — run `conclave config`)");
   };
   const addGemini = () => {
-    if (process.env["GOOGLE_API_KEY"] || process.env["GEMINI_API_KEY"]) {
-      agents.push(new GeminiAgent({ gate }));
-    } else {
-      skipped.push("gemini (GOOGLE_API_KEY not set)");
-    }
+    const key = resolveKey("gemini");
+    if (key) agents.push(new GeminiAgent({ apiKey: key, gate }));
+    else skipped.push("gemini (gemini key not set — run `conclave config`)");
   };
   const addDesign = () => {
-    if (process.env["ANTHROPIC_API_KEY"]) agents.push(new DesignAgent({ gate }));
-    else skipped.push("design (ANTHROPIC_API_KEY not set)");
+    const key = resolveKey("anthropic");
+    if (key) agents.push(new DesignAgent({ apiKey: key, gate }));
+    else skipped.push("design (anthropic key not set — run `conclave config`)");
   };
 
   if (resolved === "code") {

--- a/packages/cli/src/commands/autofix.ts
+++ b/packages/cli/src/commands/autofix.ts
@@ -34,6 +34,7 @@ import { fetchPrState, type GhRunner, type PullRequestState } from "@conclave-ai
 import { loadConfig, resolveMemoryRoot, type ConclaveConfig } from "../lib/config.js";
 import { runPerBlocker, type GitLike, type WorkerLike } from "../lib/autofix-worker.js";
 import { runSpecialHandlers } from "../lib/autofix-handlers/index.js";
+import { resolveKey } from "../lib/credentials.js";
 import {
   detectCommand,
   runCommand,
@@ -1102,9 +1103,14 @@ function buildWorker(deps: AutofixDeps, config: ConclaveConfig): WorkerLike {
     budget: new BudgetTracker({ perPrUsd }),
     metrics: new MetricsRecorder(),
   });
-  const apiKey = process.env["ANTHROPIC_API_KEY"];
+  // v0.7.4 — resolves from env, then stored credentials. Subprocess
+  // spawns of `conclave review` inherit this too, so the daily paste of
+  // $env:ANTHROPIC_API_KEY is gone once `conclave config` has been run.
+  const apiKey = resolveKey("anthropic");
   if (!apiKey) {
-    throw new Error("autofix: ANTHROPIC_API_KEY is not set (the worker agent needs it)");
+    throw new Error(
+      "autofix: anthropic key not set — run `conclave config` once, or export ANTHROPIC_API_KEY in CI.",
+    );
   }
   const factory = deps.workerFactory ?? ((opts: ClaudeWorkerOptions) => new ClaudeWorker(opts));
   return factory({ apiKey, gate });

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,328 @@
+/**
+ * `conclave config` — persistent per-user credential storage (v0.7.4).
+ *
+ * Eliminates the daily API-key-paste friction. One-time interactive setup
+ * via `conclave config`; programmatic access via `conclave config set/get/
+ * list/unset/path/migrate`. Values live in %USERPROFILE%\.conclave\
+ * credentials.json (Windows) or ~/.config/conclave/credentials.json
+ * (Unix, chmod 600). Env vars keep winning, so CI is unaffected.
+ */
+import {
+  ALL_KEY_NAMES,
+  credentialsPath,
+  loadCredentials,
+  maskKey,
+  migrateFromEnv,
+  primaryEnvVar,
+  resolveKey,
+  setKey,
+  unsetKey,
+  type Credentials,
+  type CredentialKeyName,
+} from "../lib/credentials.js";
+import { createPrompter, type Prompter } from "./init/prompts.js";
+
+const HELP = `conclave config — persistent per-user credential storage (v0.7.4)
+
+Usage:
+  conclave config                              # interactive TUI — set all keys
+  conclave config set <key> [<value>]          # programmatic set (prompts if value omitted)
+  conclave config set <key> -                  # read value from stdin
+  conclave config get <key> [--show-raw]       # print value (masked by default)
+  conclave config list                         # list keys with length + last-4 chars
+  conclave config unset <key>                  # remove a key
+  conclave config path                         # print storage path
+  conclave config migrate                      # import current env-var values into storage
+
+Supported keys:
+  anthropic          (ANTHROPIC_API_KEY)
+  openai             (OPENAI_API_KEY)
+  gemini             (GEMINI_API_KEY or GOOGLE_API_KEY)
+  conclave-token     (CONCLAVE_TOKEN — central plane bearer)
+  xai                (XAI_API_KEY)
+
+Resolution order for every conclave command:
+  1. Env var           — CI / CD keep working unchanged
+  2. Stored config     — populated by this command
+  3. Nothing           — agent skipped
+
+Storage:
+  Windows: %USERPROFILE%\\.conclave\\credentials.json (ACL: current user only)
+  Unix:    ~/.config/conclave/credentials.json (chmod 600)
+
+No encryption at rest in v0.7.4. Master-password + OS keychain integration
+tracked for v0.8+.
+`;
+
+type SubCommand = "set" | "get" | "list" | "unset" | "path" | "migrate" | "tui";
+
+export interface ConfigDeps {
+  prompterFactory?: () => Prompter;
+  /** Override stdin read for the "read from stdin" path. */
+  readStdin?: () => Promise<string>;
+  /** Override environment for tests. */
+  env?: NodeJS.ProcessEnv;
+}
+
+function parseKeyName(raw: string): CredentialKeyName {
+  if ((ALL_KEY_NAMES as readonly string[]).includes(raw)) {
+    return raw as CredentialKeyName;
+  }
+  throw new Error(
+    `conclave config: unknown key "${raw}". Supported: ${ALL_KEY_NAMES.join(", ")}`,
+  );
+}
+
+async function readStdinAll(): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let buf = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      buf += chunk;
+    });
+    process.stdin.on("end", () => resolve(buf));
+    process.stdin.on("error", reject);
+    process.stdin.resume();
+  });
+}
+
+/**
+ * Interactive TUI — walks each supported key, shows current status,
+ * lets the user keep / replace / skip. Default path for `conclave
+ * config` with no args.
+ */
+async function runTui(
+  deps: ConfigDeps,
+  existing: Credentials,
+): Promise<{ updated: Credentials; changed: CredentialKeyName[] }> {
+  const prompter = (deps.prompterFactory ?? createPrompter)();
+  const changed: CredentialKeyName[] = [];
+  const next: Credentials = { ...existing };
+  try {
+    process.stdout.write(
+      `conclave config — interactive setup\n\n` +
+        `For each key, press Enter to keep the existing value (or skip if unset),\n` +
+        `or paste a new value (masked). Ctrl+C aborts without saving.\n\n`,
+    );
+    for (const name of ALL_KEY_NAMES) {
+      const current = existing[name];
+      const envName = primaryEnvVar(name);
+      const statusLine = current
+        ? `  current: stored (${maskKey(current)})`
+        : `  current: not set`;
+      process.stdout.write(`${name} (${envName})\n${statusLine}\n`);
+      const entered = await prompter.askSecret(`  new value`);
+      if (!entered) {
+        process.stdout.write(`  → keeping existing\n\n`);
+        continue;
+      }
+      next[name] = entered;
+      changed.push(name);
+      process.stdout.write(`  → saved (${maskKey(entered)})\n\n`);
+    }
+  } finally {
+    prompter.close();
+  }
+  return { updated: next, changed };
+}
+
+export async function config(
+  argv: string[],
+  deps: ConfigDeps = {},
+): Promise<void> {
+  if (argv.length === 0) {
+    // Interactive TUI path.
+    const existing = safeLoad();
+    const { updated, changed } = await runTui(deps, existing);
+    if (changed.length === 0) {
+      process.stdout.write(
+        `conclave config: no changes. keys stored in ${credentialsPath()}\n`,
+      );
+      return;
+    }
+    // saveCredentials is called via setKey per-entry would be chatty —
+    // instead persist once at the end for fewer disk writes.
+    const { saveCredentials } = await import("../lib/credentials.js");
+    saveCredentials(updated);
+    process.stdout.write(
+      `conclave config: ${changed.length} key(s) stored in ${credentialsPath()} ` +
+        `(${process.platform === "win32" ? "ACL: user-only" : "mode 600"})\n`,
+    );
+    return;
+  }
+  const [sub, ...rest] = argv;
+  if (sub === "--help" || sub === "-h" || sub === "help") {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  const subCommand: SubCommand =
+    sub === "set" ||
+    sub === "get" ||
+    sub === "list" ||
+    sub === "unset" ||
+    sub === "path" ||
+    sub === "migrate"
+      ? sub
+      : (() => {
+          throw new Error(
+            `conclave config: unknown subcommand "${sub}"\n\n${HELP}`,
+          );
+        })();
+
+  switch (subCommand) {
+    case "set":
+      await runSet(rest, deps);
+      return;
+    case "get":
+      await runGet(rest, deps);
+      return;
+    case "list":
+      await runList(deps);
+      return;
+    case "unset":
+      await runUnset(rest);
+      return;
+    case "path":
+      process.stdout.write(`${credentialsPath()}\n`);
+      return;
+    case "migrate":
+      await runMigrate(deps);
+      return;
+    default:
+      process.stdout.write(HELP);
+  }
+}
+
+async function runSet(rest: string[], deps: ConfigDeps): Promise<void> {
+  const rawName = rest[0];
+  if (!rawName) {
+    throw new Error(
+      `conclave config set: missing key name. Usage: conclave config set <key> [<value>|-]`,
+    );
+  }
+  const name = parseKeyName(rawName);
+  const valueArg = rest[1];
+  let value: string;
+  if (valueArg === "-") {
+    const reader = deps.readStdin ?? readStdinAll;
+    value = (await reader()).trim();
+    if (!value) {
+      throw new Error(`conclave config set: stdin was empty for "${name}"`);
+    }
+  } else if (valueArg !== undefined) {
+    value = valueArg;
+  } else {
+    // Interactive secret prompt.
+    const prompter = (deps.prompterFactory ?? createPrompter)();
+    try {
+      value = await prompter.askSecret(`${name} (${primaryEnvVar(name)})`, {
+        required: true,
+      });
+    } finally {
+      prompter.close();
+    }
+  }
+  setKey(name, value);
+  process.stdout.write(
+    `conclave config set ${name}: stored (${maskKey(value)})\n`,
+  );
+}
+
+async function runGet(rest: string[], _deps: ConfigDeps): Promise<void> {
+  const rawName = rest[0];
+  if (!rawName) {
+    throw new Error(
+      `conclave config get: missing key name. Usage: conclave config get <key> [--show-raw]`,
+    );
+  }
+  const name = parseKeyName(rawName);
+  const showRaw = rest.includes("--show-raw");
+  const stored = safeLoad();
+  const value = stored[name];
+  if (value === undefined) {
+    // Fall through to env so users can verify what resolveKey would pick.
+    const envFallback = resolveKey(name);
+    if (envFallback === undefined) {
+      process.stderr.write(
+        `conclave config get: "${name}" is not set (neither env nor stored)\n`,
+      );
+      process.exit(1);
+      return;
+    }
+    process.stdout.write(
+      showRaw
+        ? `${envFallback} (from env: ${primaryEnvVar(name)})\n`
+        : `${maskKey(envFallback)} (from env: ${primaryEnvVar(name)})\n`,
+    );
+    return;
+  }
+  process.stdout.write(showRaw ? `${value}\n` : `${maskKey(value)}\n`);
+}
+
+async function runList(_deps: ConfigDeps): Promise<void> {
+  const stored = safeLoad();
+  process.stdout.write(`conclave config — ${credentialsPath()}\n`);
+  for (const name of ALL_KEY_NAMES) {
+    const envName = primaryEnvVar(name);
+    const envVal = process.env[envName];
+    const storedVal = stored[name];
+    if (envVal && envVal.trim().length > 0) {
+      process.stdout.write(
+        `  ${name.padEnd(16)} env ${envName}   ${maskKey(envVal.trim())}${storedVal ? ` (also stored)` : ""}\n`,
+      );
+    } else if (storedVal) {
+      process.stdout.write(
+        `  ${name.padEnd(16)} stored ${envName}   ${maskKey(storedVal)}\n`,
+      );
+    } else {
+      process.stdout.write(
+        `  ${name.padEnd(16)} not set (${envName} unset, no stored value)\n`,
+      );
+    }
+  }
+}
+
+async function runUnset(rest: string[]): Promise<void> {
+  const rawName = rest[0];
+  if (!rawName) {
+    throw new Error(
+      `conclave config unset: missing key name. Usage: conclave config unset <key>`,
+    );
+  }
+  const name = parseKeyName(rawName);
+  const removed = unsetKey(name);
+  if (removed) {
+    process.stdout.write(`conclave config unset ${name}: removed\n`);
+  } else {
+    process.stdout.write(
+      `conclave config unset ${name}: nothing to remove (not stored)\n`,
+    );
+  }
+}
+
+async function runMigrate(deps: ConfigDeps): Promise<void> {
+  const { imported } = migrateFromEnv(deps.env ?? process.env);
+  if (imported.length === 0) {
+    process.stdout.write(
+      `conclave config migrate: no supported env vars set; nothing to import.\n`,
+    );
+    return;
+  }
+  process.stdout.write(
+    `conclave config migrate: imported ${imported.length} key(s) → ${credentialsPath()}\n` +
+      imported.map((k) => `  - ${k} (${primaryEnvVar(k)})\n`).join(""),
+  );
+}
+
+function safeLoad(): Credentials {
+  try {
+    return loadCredentials();
+  } catch (err) {
+    process.stderr.write(
+      `conclave config: ${(err as Error).message}\n` +
+        `  using empty storage for this run; fix the file to recover stored keys.\n`,
+    );
+    return {};
+  }
+}

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -48,6 +48,7 @@ import {
 import { ClaudeHaikuPlainSummaryLlm } from "../lib/plain-summary-llm.js";
 import { resolveTierIds } from "../lib/tier-resolver.js";
 import { buildReviewJson, serializeReviewJson } from "../lib/review-json-output.js";
+import { resolveKey } from "../lib/credentials.js";
 
 type ReviewDomainInput = "code" | "design";
 interface ReviewArgs {
@@ -267,31 +268,38 @@ export async function review(argv: string[]): Promise<void> {
 
   function buildAgent(id: string, modelOverride?: string): Agent | null {
     const modelOpt = modelOverride ? { model: modelOverride } : {};
+    // v0.7.4 — credentials resolve from env FIRST, then the stored file
+    // (~/.config/conclave/credentials.json). One-time `conclave config`
+    // populates storage; subsequent runs + subprocess spawns pick it up
+    // without the parent shell setting any env var.
     if (id === "claude") {
-      if (!process.env["ANTHROPIC_API_KEY"]) return null;
-      return new ClaudeAgent({ gate, ...modelOpt });
+      const key = resolveKey("anthropic");
+      if (!key) return null;
+      return new ClaudeAgent({ apiKey: key, gate, ...modelOpt });
     }
     if (id === "design") {
-      if (!process.env["ANTHROPIC_API_KEY"]) {
-        process.stderr.write("conclave review: ANTHROPIC_API_KEY not set — skipping Design agent\n");
+      const key = resolveKey("anthropic");
+      if (!key) {
+        process.stderr.write("conclave review: anthropic key not set (env or `conclave config`) — skipping Design agent\n");
         return null;
       }
-      return new DesignAgent({ gate, ...modelOpt });
+      return new DesignAgent({ apiKey: key, gate, ...modelOpt });
     }
     if (id === "openai") {
-      if (!process.env["OPENAI_API_KEY"]) {
-        process.stderr.write("conclave review: OPENAI_API_KEY not set — skipping OpenAI agent\n");
+      const key = resolveKey("openai");
+      if (!key) {
+        process.stderr.write("conclave review: openai key not set (env or `conclave config`) — skipping OpenAI agent\n");
         return null;
       }
-      return new OpenAIAgent({ gate, ...modelOpt });
+      return new OpenAIAgent({ apiKey: key, gate, ...modelOpt });
     }
     if (id === "gemini") {
-      const hasKey = !!(process.env["GOOGLE_API_KEY"] || process.env["GEMINI_API_KEY"]);
-      if (!hasKey) {
-        process.stderr.write("conclave review: GOOGLE_API_KEY / GEMINI_API_KEY not set — skipping Gemini agent\n");
+      const key = resolveKey("gemini");
+      if (!key) {
+        process.stderr.write("conclave review: gemini key not set (env or `conclave config`) — skipping Gemini agent\n");
         return null;
       }
-      return new GeminiAgent({ gate, ...modelOpt });
+      return new GeminiAgent({ apiKey: key, gate, ...modelOpt });
     }
     if (id === "ollama") {
       // Ollama has no API key; we assume the daemon is running at
@@ -299,11 +307,12 @@ export async function review(argv: string[]): Promise<void> {
       return new OllamaAgent({ gate, ...modelOpt });
     }
     if (id === "grok") {
-      if (!process.env["XAI_API_KEY"]) {
-        process.stderr.write("conclave review: XAI_API_KEY not set — skipping Grok agent\n");
+      const key = resolveKey("xai");
+      if (!key) {
+        process.stderr.write("conclave review: xai key not set (env or `conclave config`) — skipping Grok agent\n");
         return null;
       }
-      return new GrokAgent({ gate, ...modelOpt });
+      return new GrokAgent({ apiKey: key, gate, ...modelOpt });
     }
     return null;
   }

--- a/packages/cli/src/commands/rework.ts
+++ b/packages/cli/src/commands/rework.ts
@@ -19,6 +19,7 @@ import { ClaudeWorker, type ClaudeWorkerOptions, type FileSnapshot, type WorkerO
 import { fetchPrState, type GhRunner, type PullRequestState } from "@conclave-ai/scm-github";
 import { formatFinding, scanPatch, type ScanResult } from "@conclave-ai/secret-guard";
 import { loadConfig, resolveMemoryRoot, type ConclaveConfig } from "../lib/config.js";
+import { resolveKey } from "../lib/credentials.js";
 
 const execFile = promisify(execFileCallback);
 
@@ -396,10 +397,11 @@ function buildWorker(deps: ReworkDeps, config: ConclaveConfig): { work: (ctx: Pa
     budget: new BudgetTracker({ perPrUsd }),
     metrics: new MetricsRecorder(),
   });
-  const apiKey = process.env["ANTHROPIC_API_KEY"];
+  // v0.7.4 — env first, then stored credentials via `conclave config`.
+  const apiKey = resolveKey("anthropic");
   if (!apiKey) {
     throw new Error(
-      "rework: ANTHROPIC_API_KEY is not set (the worker agent needs it; pass --dry-run only after setting the key)",
+      "rework: anthropic key not set — run `conclave config` once, or export ANTHROPIC_API_KEY in CI.",
     );
   }
   const factory = deps.workerFactory ?? ((opts: ClaudeWorkerOptions) => new ClaudeWorker(opts));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { init } from "./commands/init.js";
 import { review } from "./commands/review.js";
 import { audit } from "./commands/audit.js";
+import { config } from "./commands/config.js";
 import { recordOutcome } from "./commands/record-outcome.js";
 import { rework } from "./commands/rework.js";
 import { autofix } from "./commands/autofix.js";
@@ -11,6 +12,7 @@ import { scores } from "./commands/scores.js";
 import { sync } from "./commands/sync.js";
 import { mcpServer } from "./commands/mcp-server.js";
 import { CLI_VERSION } from "./version.js";
+import { hydrateEnvFromStorage } from "./lib/credentials.js";
 
 const HELP = `conclave — Conclave AI CLI
 
@@ -19,6 +21,7 @@ Usage:
 
 Commands:
   init                  Set up conclave in the current repo (config + skeleton)
+  config                Persistent per-user credential storage — set API keys once (v0.7.4)
   audit                 Full-project health check across the current codebase (v0.6+)
   review                Run a council review on the current branch
   rework                Apply a worker-generated patch for a pending council "rework" verdict
@@ -35,6 +38,8 @@ Commands:
 
 Examples:
   conclave init
+  conclave config                         # one-time interactive setup — stores API keys persistently (v0.7.4)
+  conclave config list                    # show which keys are set and where
   conclave audit                          # run right after init — full-project health check
   conclave audit --dry-run --scope ui     # preview which files would be audited
   conclave review --pr 42 --visual
@@ -59,9 +64,26 @@ export async function run(argv: string[]): Promise<void> {
     return;
   }
 
+  // v0.7.4 — hydrate process.env from stored credentials BEFORE any
+  // command runs so downstream packages that still read `process.env`
+  // directly (integration-telegram's CONCLAVE_TOKEN check, visual-review
+  // judge, etc.) see the stored value. Env vars always win — this only
+  // fills blanks. `config` commands skip hydration so `list` / `get`
+  // can tell apart env-vs-stored precedence honestly.
+  if (cmd !== "config") {
+    try {
+      hydrateEnvFromStorage();
+    } catch {
+      // Never block a command start on credential-file issues.
+    }
+  }
+
   switch (cmd) {
     case "init":
       await init(rest);
+      return;
+    case "config":
+      await config(rest);
       return;
     case "audit":
       await audit(rest);

--- a/packages/cli/src/lib/credentials.ts
+++ b/packages/cli/src/lib/credentials.ts
@@ -1,0 +1,413 @@
+/**
+ * credentials.ts — persistent per-user API key storage (v0.7.4).
+ *
+ * Eliminates the daily "paste API key into PowerShell" friction that has
+ * leaked keys multiple times. Keys are stored once via `conclave config`
+ * and then resolved from disk for every subsequent `conclave` invocation
+ * (including autofix's subprocess spawns of `conclave review`).
+ *
+ * Storage layout (JSON, file mode 0600 / Windows ACL current-user-only):
+ *
+ *   Windows:       %USERPROFILE%\.conclave\credentials.json
+ *   macOS / Linux: ~/.config/conclave/credentials.json
+ *
+ * Resolution order for `resolveKey(name)`:
+ *
+ *   1. Env var (ANTHROPIC_API_KEY etc.)   — CI keeps working unchanged
+ *   2. On-disk credentials.json            — populated via `conclave config`
+ *   3. undefined                           — downstream treats as "agent skip"
+ *
+ * No encryption at rest for v0.7.4. File-mode 0600 on Unix, Windows ACL
+ * restriction via `icacls` on Windows. Encryption + Credential Manager
+ * integration is tracked for v0.8+.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export type CredentialKeyName =
+  | "anthropic"
+  | "openai"
+  | "gemini"
+  | "conclave-token"
+  | "xai";
+
+export const ALL_KEY_NAMES: readonly CredentialKeyName[] = [
+  "anthropic",
+  "openai",
+  "gemini",
+  "conclave-token",
+  "xai",
+] as const;
+
+/**
+ * On-disk format (version 1). Kept boring on purpose — plain JSON so a
+ * panicked user with a text editor can still repair / clear it.
+ */
+export interface CredentialsFile {
+  version: 1;
+  keys: Partial<Record<CredentialKeyName, string>>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * In-memory view of stored credentials. Returned by `loadCredentials()`.
+ * Missing keys are absent rather than empty-string to simplify the
+ * "is this key set?" check downstream.
+ */
+export interface Credentials {
+  anthropic?: string;
+  openai?: string;
+  gemini?: string;
+  "conclave-token"?: string;
+  xai?: string;
+}
+
+/**
+ * Map each credential name to the env var(s) that take precedence.
+ * `gemini` accepts either GEMINI_API_KEY or GOOGLE_API_KEY (SDK accepts
+ * both historically — resolving from either kept parity with the old
+ * direct-env behavior in review.ts).
+ */
+const ENV_VAR_MAP: Record<CredentialKeyName, readonly string[]> = {
+  anthropic: ["ANTHROPIC_API_KEY"],
+  openai: ["OPENAI_API_KEY"],
+  gemini: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+  "conclave-token": ["CONCLAVE_TOKEN"],
+  xai: ["XAI_API_KEY"],
+};
+
+/**
+ * Returns the OS-appropriate directory that holds `credentials.json`.
+ * Windows goes under %USERPROFILE%\.conclave (dotfile style, parallels
+ * ~/.conclave on Unix for people moving between platforms). macOS / Linux
+ * follows XDG-ish `~/.config/conclave`.
+ */
+export function credentialsDir(): string {
+  if (process.platform === "win32") {
+    const home = process.env["USERPROFILE"] ?? os.homedir();
+    return path.join(home, ".conclave");
+  }
+  const xdg = process.env["XDG_CONFIG_HOME"];
+  const base = xdg && xdg.length > 0 ? xdg : path.join(os.homedir(), ".config");
+  return path.join(base, "conclave");
+}
+
+export function credentialsPath(): string {
+  return path.join(credentialsDir(), "credentials.json");
+}
+
+/**
+ * Read the stored credentials file. Missing file → empty object (fresh
+ * install, first run). Malformed JSON throws with a clear message and
+ * does NOT nuke the file — we'd rather fail loud than silently wipe keys.
+ */
+export function loadCredentials(): Credentials {
+  const p = credentialsPath();
+  if (!fs.existsSync(p)) return {};
+  let raw: string;
+  try {
+    raw = fs.readFileSync(p, "utf8");
+  } catch (err) {
+    throw new Error(
+      `credentials: failed to read ${p} — ${(err as Error).message}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `credentials: malformed JSON in ${p} — ${(err as Error).message}. Fix or remove the file; keys were NOT wiped.`,
+    );
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    !("keys" in parsed) ||
+    typeof (parsed as { keys: unknown }).keys !== "object"
+  ) {
+    throw new Error(
+      `credentials: ${p} is missing the required "keys" object. Fix or remove the file.`,
+    );
+  }
+  const keys = (parsed as { keys: Record<string, unknown> }).keys;
+  const out: Credentials = {};
+  for (const name of ALL_KEY_NAMES) {
+    const v = keys[name];
+    if (typeof v === "string" && v.length > 0) {
+      out[name] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Write the credentials file with restrictive permissions. On Unix we
+ * chmod 0600 after write. On Windows we shell out to `icacls` to strip
+ * inherited ACLs and grant only the current user — failures here are
+ * logged to stderr but do NOT abort the write; the file still exists
+ * under %USERPROFILE% which is already user-private on standard setups.
+ */
+export function saveCredentials(
+  creds: Credentials,
+  opts: { createdAt?: string } = {},
+): void {
+  const dir = credentialsDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const p = credentialsPath();
+  const now = new Date().toISOString();
+  let createdAt = opts.createdAt ?? now;
+  // Preserve the original createdAt if the file already exists.
+  if (!opts.createdAt && fs.existsSync(p)) {
+    try {
+      const prev = JSON.parse(fs.readFileSync(p, "utf8")) as {
+        createdAt?: string;
+      };
+      if (typeof prev.createdAt === "string") createdAt = prev.createdAt;
+    } catch {
+      // corrupted previous file — fall through, treat as fresh.
+    }
+  }
+  const keysObj: Partial<Record<CredentialKeyName, string>> = {};
+  for (const name of ALL_KEY_NAMES) {
+    const v = creds[name];
+    if (typeof v === "string" && v.length > 0) keysObj[name] = v;
+  }
+  const payload: CredentialsFile = {
+    version: 1,
+    keys: keysObj,
+    createdAt,
+    updatedAt: now,
+  };
+  // Write atomically via rename so a mid-write crash never leaves a
+  // half-written credentials file.
+  const tmp = `${p}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(payload, null, 2) + "\n", "utf8");
+  try {
+    // Permission-tighten BEFORE the rename so the final inode is already
+    // locked-down. If the rename races something, the permissions stick.
+    if (process.platform !== "win32") {
+      fs.chmodSync(tmp, 0o600);
+    }
+    fs.renameSync(tmp, p);
+    if (process.platform === "win32") {
+      restrictWindowsAcl(p);
+    }
+  } catch (err) {
+    // Best-effort cleanup; rethrow.
+    try {
+      fs.rmSync(tmp, { force: true });
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+}
+
+/**
+ * Strip inherited ACLs and grant the credentials file exclusively to the
+ * current user. Silent-skips if icacls is missing (very stripped-down
+ * Windows Server images); the file still lives under %USERPROFILE%
+ * which is user-private by default.
+ */
+function restrictWindowsAcl(filePath: string): void {
+  const user = process.env["USERNAME"] ?? process.env["USER"];
+  if (!user) return;
+  try {
+    // /inheritance:r removes inherited ACEs; then grant current user :F (full).
+    execFileSync("icacls", [filePath, "/inheritance:r"], { stdio: "ignore" });
+    execFileSync("icacls", [filePath, "/grant:r", `${user}:F`], {
+      stdio: "ignore",
+    });
+  } catch {
+    // icacls unavailable or denied — filesystem ACL fallback to %USERPROFILE%
+    // inheritance (still user-private). Surface a one-line diagnostic to
+    // stderr so security-conscious users notice.
+    process.stderr.write(
+      `conclave config: icacls restriction failed (file is still in your user profile, but verify ACLs manually)\n`,
+    );
+  }
+}
+
+/**
+ * Resolve a credential by name: env var wins, then stored, then undefined.
+ *
+ * Downstream agents treat `undefined` as "skip this agent" — matching the
+ * pre-v0.7.4 behavior where an unset env var also skipped the agent.
+ */
+export function resolveKey(
+  name: CredentialKeyName,
+  opts: { env?: NodeJS.ProcessEnv; stored?: Credentials } = {},
+): string | undefined {
+  const env = opts.env ?? process.env;
+  for (const envName of ENV_VAR_MAP[name]) {
+    const v = env[envName];
+    if (typeof v === "string" && v.trim().length > 0) return v.trim();
+  }
+  const stored = opts.stored ?? safeLoad();
+  const fromStored = stored[name];
+  if (typeof fromStored === "string" && fromStored.length > 0) return fromStored;
+  return undefined;
+}
+
+/**
+ * loadCredentials() wrapped so a malformed file doesn't break `resolveKey`
+ * for callers that just want a best-effort read. We still honor env vars
+ * when the file is broken.
+ */
+function safeLoad(): Credentials {
+  try {
+    return loadCredentials();
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Mask a secret for display: shows length + last 4 chars. Never prints
+ * the full key. Called from `config list` / `config get` (without
+ * --show-raw) and anywhere a stored key ends up in CLI output.
+ */
+export function maskKey(value: string): string {
+  if (value.length === 0) return "(empty)";
+  if (value.length <= 4) return `len=${value.length} ${"*".repeat(value.length)}`;
+  const tail = value.slice(-4);
+  return `len=${value.length} ...${tail}`;
+}
+
+/**
+ * Pull env var values into the stored credentials file — used by
+ * `conclave config migrate` to one-shot convert an existing shell-env
+ * setup into persistent storage. Only writes keys that are actually
+ * present in env; existing stored keys are preserved when env is empty
+ * (non-destructive merge).
+ */
+export function migrateFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): { imported: CredentialKeyName[]; stored: Credentials } {
+  const existing = (() => {
+    try {
+      return loadCredentials();
+    } catch {
+      return {};
+    }
+  })();
+  const imported: CredentialKeyName[] = [];
+  const next: Credentials = { ...existing };
+  for (const name of ALL_KEY_NAMES) {
+    for (const envName of ENV_VAR_MAP[name]) {
+      const v = env[envName];
+      if (typeof v === "string" && v.trim().length > 0) {
+        next[name] = v.trim();
+        imported.push(name);
+        break;
+      }
+    }
+  }
+  if (imported.length > 0) saveCredentials(next);
+  return { imported, stored: next };
+}
+
+/**
+ * Remove a single key and persist. Returns true if something was removed.
+ */
+export function unsetKey(name: CredentialKeyName): boolean {
+  const existing = (() => {
+    try {
+      return loadCredentials();
+    } catch {
+      return {};
+    }
+  })();
+  if (existing[name] === undefined) return false;
+  const next: Credentials = { ...existing };
+  delete next[name];
+  saveCredentials(next);
+  return true;
+}
+
+/**
+ * Set a single key and persist. Empty / whitespace-only values throw —
+ * if a user wants to clear a key they should use `unsetKey`.
+ */
+export function setKey(name: CredentialKeyName, value: string): void {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(
+      `credentials: refusing to store empty value for "${name}" (use 'conclave config unset' to remove)`,
+    );
+  }
+  const existing = (() => {
+    try {
+      return loadCredentials();
+    } catch {
+      return {};
+    }
+  })();
+  const next: Credentials = { ...existing, [name]: trimmed };
+  saveCredentials(next);
+}
+
+/**
+ * Map a stored-key name back to the canonical env var it shadows. Used
+ * by `config list` to show users "this key maps to ANTHROPIC_API_KEY"
+ * when they're debugging env-vs-stored precedence.
+ */
+export function primaryEnvVar(name: CredentialKeyName): string {
+  const vars = ENV_VAR_MAP[name];
+  const first = vars[0];
+  if (first === undefined) {
+    throw new Error(`credentials: no env var registered for ${name}`);
+  }
+  return first;
+}
+
+/**
+ * Populate env vars from stored credentials when the env is empty.
+ *
+ * Rationale: several downstream packages (integration-telegram, agent-*
+ * readmes, visual-review judge) read `process.env[...]` directly. Rather
+ * than plumb `resolveKey` through every package (which would balloon this
+ * PR), we hydrate the process env from storage at CLI entry points. The
+ * precedence contract holds — env wins, we only fill blanks.
+ *
+ * Returns the list of env var names that were populated from storage
+ * (empty if env was already set or storage was empty). Primarily used
+ * for diagnostics.
+ *
+ * IMPORTANT: do NOT call this from library code that might be used
+ * outside the CLI — it's scoped to the `conclave` binary on purpose.
+ */
+export function hydrateEnvFromStorage(
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  let stored: Credentials;
+  try {
+    stored = loadCredentials();
+  } catch {
+    return [];
+  }
+  const populated: string[] = [];
+  for (const name of ALL_KEY_NAMES) {
+    const value = stored[name];
+    if (!value) continue;
+    const envVars = ENV_VAR_MAP[name];
+    // If ANY of the mapped env vars is already set (and non-empty), leave
+    // the env alone — user / CI intent wins.
+    const alreadySet = envVars.some((v) => {
+      const existing = env[v];
+      return typeof existing === "string" && existing.trim().length > 0;
+    });
+    if (alreadySet) continue;
+    // Only populate the primary env var. Gemini's GOOGLE_API_KEY alias
+    // is read-only from the user's side; we don't shadow it.
+    const primary = envVars[0];
+    if (!primary) continue;
+    env[primary] = value;
+    populated.push(primary);
+  }
+  return populated;
+}

--- a/packages/cli/src/lib/plain-summary-llm.ts
+++ b/packages/cli/src/lib/plain-summary-llm.ts
@@ -10,6 +10,7 @@
  *     build its own without a core change.
  */
 import type { PlainSummaryLlm } from "@conclave-ai/core";
+import { resolveKey } from "./credentials.js";
 
 const DEFAULT_MODEL = "claude-haiku-4-5";
 const DEFAULT_MAX_TOKENS = 512;
@@ -53,10 +54,11 @@ export class ClaudeHaikuPlainSummaryLlm implements PlainSummaryLlm {
   private clientPromise: Promise<AnthropicLike> | null;
 
   constructor(opts: ClaudeHaikuPlainSummaryLlmOptions = {}) {
-    const key = opts.apiKey ?? process.env["ANTHROPIC_API_KEY"] ?? "";
+    // v0.7.4 — resolveKey honors env first, then stored credentials.
+    const key = opts.apiKey ?? resolveKey("anthropic") ?? "";
     if (!key && !opts.client) {
       throw new Error(
-        "ClaudeHaikuPlainSummaryLlm: ANTHROPIC_API_KEY not set (pass opts.apiKey or opts.client)",
+        "ClaudeHaikuPlainSummaryLlm: anthropic key not set (run `conclave config` or pass opts.apiKey)",
       );
     }
     this.apiKey = key;

--- a/packages/cli/test/config-command.test.mjs
+++ b/packages/cli/test/config-command.test.mjs
@@ -1,0 +1,311 @@
+/**
+ * config-command.test.mjs — CLI-level behavior of `conclave config`
+ * (v0.7.4). Exercises set/get/list/unset/path/migrate plus the TUI
+ * round-trip via injected prompter.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const cred = await import("../dist/lib/credentials.js");
+const { config } = await import("../dist/commands/config.js");
+
+function mkSandbox() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aic-cfgcmd-"));
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  process.env.HOME = dir;
+  process.env.USERPROFILE = dir;
+  delete process.env.XDG_CONFIG_HOME;
+  return {
+    dir,
+    restore() {
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+      else delete process.env.HOME;
+      if (prevUserProfile !== undefined) process.env.USERPROFILE = prevUserProfile;
+      else delete process.env.USERPROFILE;
+      if (prevXdg !== undefined) process.env.XDG_CONFIG_HOME = prevXdg;
+      fs.rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function captureStdout(fn) {
+  const chunks = [];
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  const errChunks = [];
+  process.stdout.write = (c) => {
+    chunks.push(String(c));
+    return true;
+  };
+  process.stderr.write = (c) => {
+    errChunks.push(String(c));
+    return true;
+  };
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    })
+    .then(() => ({ stdout: chunks.join(""), stderr: errChunks.join("") }));
+}
+
+test("config list: empty storage shows all keys as not set", async () => {
+  const sb = mkSandbox();
+  const savedEnv = {};
+  for (const name of [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "CONCLAVE_TOKEN",
+    "XAI_API_KEY",
+  ]) {
+    savedEnv[name] = process.env[name];
+    delete process.env[name];
+  }
+  try {
+    const { stdout } = await captureStdout(() => config(["list"]));
+    assert.match(stdout, /anthropic.*not set/);
+    assert.match(stdout, /openai.*not set/);
+    assert.match(stdout, /gemini.*not set/);
+    assert.match(stdout, /conclave-token.*not set/);
+    assert.match(stdout, /xai.*not set/);
+  } finally {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v !== undefined) process.env[k] = v;
+    }
+    sb.restore();
+  }
+});
+
+test("config list: stored values are masked (length + last 4)", async () => {
+  const sb = mkSandbox();
+  const savedEnv = {};
+  for (const name of [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "CONCLAVE_TOKEN",
+    "XAI_API_KEY",
+  ]) {
+    savedEnv[name] = process.env[name];
+    delete process.env[name];
+  }
+  try {
+    cred.saveCredentials({
+      anthropic: "sk-ant-api03-LONGCAFE",
+      openai: "sk-proj-LONGBEEF",
+      gemini: "AIzaLONGDEAD",
+      "conclave-token": "c_LONGFEED",
+      xai: "xai-LONGFACE",
+    });
+    const { stdout } = await captureStdout(() => config(["list"]));
+    // Ensure no full secret ever hits stdout.
+    assert.ok(!stdout.includes("sk-ant-api03-LONGCAFE"));
+    assert.ok(!stdout.includes("sk-proj-LONGBEEF"));
+    // All five keys should show with their len= prefix + last 4.
+    assert.match(stdout, /anthropic.*len=21 \.\.\.CAFE/);
+    assert.match(stdout, /openai.*len=16 \.\.\.BEEF/);
+    assert.match(stdout, /gemini.*len=12 \.\.\.DEAD/);
+    assert.match(stdout, /conclave-token.*len=10 \.\.\.FEED/);
+    assert.match(stdout, /xai.*len=12 \.\.\.FACE/);
+  } finally {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v !== undefined) process.env[k] = v;
+    }
+    sb.restore();
+  }
+});
+
+test("config set <key> <value>: programmatic set", async () => {
+  const sb = mkSandbox();
+  try {
+    const { stdout } = await captureStdout(() =>
+      config(["set", "anthropic", "sk-ant-api03-DEADBEEF"]),
+    );
+    assert.match(stdout, /stored/);
+    // Stored value must NOT appear raw.
+    assert.ok(!stdout.includes("sk-ant-api03-DEADBEEF"));
+    const loaded = cred.loadCredentials();
+    assert.equal(loaded.anthropic, "sk-ant-api03-DEADBEEF");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("config set <key> -: reads value from stdin", async () => {
+  const sb = mkSandbox();
+  try {
+    const { stdout } = await captureStdout(() =>
+      config(["set", "openai", "-"], {
+        readStdin: async () => "sk-proj-STDINVALUE\n",
+      }),
+    );
+    assert.match(stdout, /stored/);
+    const loaded = cred.loadCredentials();
+    assert.equal(loaded.openai, "sk-proj-STDINVALUE");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("config set <key> -: empty stdin throws", async () => {
+  const sb = mkSandbox();
+  try {
+    await assert.rejects(
+      () =>
+        captureStdout(() =>
+          config(["set", "anthropic", "-"], {
+            readStdin: async () => "   \n",
+          }),
+        ),
+      /stdin was empty/,
+    );
+  } finally {
+    sb.restore();
+  }
+});
+
+test("config get <key>: masked by default, --show-raw prints full", async () => {
+  const sb = mkSandbox();
+  const saved = process.env.ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  try {
+    cred.saveCredentials({ anthropic: "sk-ant-api03-SECRETVAL" });
+    const masked = await captureStdout(() => config(["get", "anthropic"]));
+    assert.match(masked.stdout, /len=\d+ \.\.\.TVAL/);
+    assert.ok(!masked.stdout.includes("sk-ant-api03-SECRETVAL"));
+    const raw = await captureStdout(() =>
+      config(["get", "anthropic", "--show-raw"]),
+    );
+    assert.match(raw.stdout, /sk-ant-api03-SECRETVAL/);
+  } finally {
+    if (saved !== undefined) process.env.ANTHROPIC_API_KEY = saved;
+    sb.restore();
+  }
+});
+
+test("config unset <key>: removes stored key", async () => {
+  const sb = mkSandbox();
+  try {
+    cred.saveCredentials({ anthropic: "sk-abc", openai: "sk-def" });
+    const { stdout } = await captureStdout(() =>
+      config(["unset", "anthropic"]),
+    );
+    assert.match(stdout, /removed/);
+    const loaded = cred.loadCredentials();
+    assert.equal(loaded.anthropic, undefined);
+    assert.equal(loaded.openai, "sk-def");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("config path: prints storage path", async () => {
+  const sb = mkSandbox();
+  try {
+    const { stdout } = await captureStdout(() => config(["path"]));
+    const expected = cred.credentialsPath();
+    assert.equal(stdout.trim(), expected);
+  } finally {
+    sb.restore();
+  }
+});
+
+test("config migrate: imports env vars into storage", async () => {
+  const sb = mkSandbox();
+  try {
+    const { stdout } = await captureStdout(() =>
+      config(["migrate"], {
+        env: {
+          ANTHROPIC_API_KEY: "sk-migrated-a",
+          CONCLAVE_TOKEN: "c_migrated_t",
+        },
+      }),
+    );
+    assert.match(stdout, /imported 2 key\(s\)/);
+    assert.match(stdout, /anthropic \(ANTHROPIC_API_KEY\)/);
+    assert.match(stdout, /conclave-token \(CONCLAVE_TOKEN\)/);
+    const loaded = cred.loadCredentials();
+    assert.equal(loaded.anthropic, "sk-migrated-a");
+    assert.equal(loaded["conclave-token"], "c_migrated_t");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("config: unknown subcommand throws helpful error", async () => {
+  const sb = mkSandbox();
+  try {
+    await assert.rejects(
+      () => captureStdout(() => config(["bogus"])),
+      /unknown subcommand/,
+    );
+  } finally {
+    sb.restore();
+  }
+});
+
+test("config (no args): interactive TUI via injected prompter", async () => {
+  const sb = mkSandbox();
+  try {
+    // Fake prompter returns a new value for anthropic, skips everything else.
+    const answers = {
+      anthropic: "sk-ant-api03-FROMTUI",
+      openai: "",
+      gemini: "",
+      "conclave-token": "",
+      xai: "",
+    };
+    const prompterFactory = () => ({
+      async ask() {
+        return "";
+      },
+      async askSecret() {
+        // Each call maps to the next key in order.
+        const keys = ["anthropic", "openai", "gemini", "conclave-token", "xai"];
+        const nextKey = keys[callIndex++];
+        return answers[nextKey] ?? "";
+      },
+      async confirm() {
+        return true;
+      },
+      close() {
+        /* no-op */
+      },
+    });
+    let callIndex = 0;
+    const { stdout } = await captureStdout(() =>
+      config([], { prompterFactory }),
+    );
+    assert.match(stdout, /1 key\(s\) stored/);
+    const loaded = cred.loadCredentials();
+    assert.equal(loaded.anthropic, "sk-ant-api03-FROMTUI");
+    assert.equal(loaded.openai, undefined);
+  } finally {
+    sb.restore();
+  }
+});
+
+test("config get: falls back to env var when not stored", async () => {
+  const sb = mkSandbox();
+  const saved = process.env.ANTHROPIC_API_KEY;
+  process.env.ANTHROPIC_API_KEY = "sk-ant-ENVFALLBACK";
+  try {
+    const { stdout } = await captureStdout(() =>
+      config(["get", "anthropic", "--show-raw"]),
+    );
+    assert.match(stdout, /sk-ant-ENVFALLBACK \(from env: ANTHROPIC_API_KEY\)/);
+  } finally {
+    if (saved !== undefined) process.env.ANTHROPIC_API_KEY = saved;
+    else delete process.env.ANTHROPIC_API_KEY;
+    sb.restore();
+  }
+});

--- a/packages/cli/test/credentials.test.mjs
+++ b/packages/cli/test/credentials.test.mjs
@@ -1,0 +1,344 @@
+/**
+ * credentials.test.mjs — covers loadCredentials, saveCredentials,
+ * resolveKey, maskKey, migrateFromEnv, unsetKey, setKey,
+ * hydrateEnvFromStorage (v0.7.4).
+ *
+ * We override HOME / USERPROFILE / XDG_CONFIG_HOME to point at a tmpdir
+ * so tests never touch the real user profile. Each test resets these
+ * before running.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Import AFTER we set env so credentialsDir() picks the override.
+const mod = await import("../dist/lib/credentials.js");
+const {
+  ALL_KEY_NAMES,
+  credentialsPath,
+  credentialsDir,
+  hydrateEnvFromStorage,
+  loadCredentials,
+  maskKey,
+  migrateFromEnv,
+  primaryEnvVar,
+  resolveKey,
+  saveCredentials,
+  setKey,
+  unsetKey,
+} = mod;
+
+function mkSandbox() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aic-creds-"));
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  process.env.HOME = dir;
+  process.env.USERPROFILE = dir;
+  delete process.env.XDG_CONFIG_HOME;
+  return {
+    dir,
+    restore() {
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+      else delete process.env.HOME;
+      if (prevUserProfile !== undefined) process.env.USERPROFILE = prevUserProfile;
+      else delete process.env.USERPROFILE;
+      if (prevXdg !== undefined) process.env.XDG_CONFIG_HOME = prevXdg;
+      fs.rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("loadCredentials: returns empty object when no file exists", () => {
+  const sb = mkSandbox();
+  try {
+    const creds = loadCredentials();
+    assert.deepEqual(creds, {});
+  } finally {
+    sb.restore();
+  }
+});
+
+test("saveCredentials + loadCredentials round-trip", () => {
+  const sb = mkSandbox();
+  try {
+    saveCredentials({
+      anthropic: "sk-ant-api03-abcdef",
+      openai: "sk-proj-ghijkl",
+    });
+    const round = loadCredentials();
+    assert.equal(round.anthropic, "sk-ant-api03-abcdef");
+    assert.equal(round.openai, "sk-proj-ghijkl");
+    assert.equal(round.gemini, undefined);
+  } finally {
+    sb.restore();
+  }
+});
+
+test("resolveKey: env var wins over stored value", () => {
+  const sb = mkSandbox();
+  try {
+    saveCredentials({ anthropic: "stored-value" });
+    const fakeEnv = { ANTHROPIC_API_KEY: "env-value" };
+    assert.equal(resolveKey("anthropic", { env: fakeEnv }), "env-value");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("resolveKey: falls back to stored when env is empty", () => {
+  const sb = mkSandbox();
+  try {
+    saveCredentials({ anthropic: "stored-value" });
+    const fakeEnv = {};
+    assert.equal(resolveKey("anthropic", { env: fakeEnv }), "stored-value");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("resolveKey: returns undefined when neither env nor stored is set", () => {
+  const sb = mkSandbox();
+  try {
+    const fakeEnv = {};
+    assert.equal(resolveKey("anthropic", { env: fakeEnv }), undefined);
+    assert.equal(resolveKey("openai", { env: fakeEnv }), undefined);
+  } finally {
+    sb.restore();
+  }
+});
+
+test("saveCredentials: creates parent dir if missing", () => {
+  const sb = mkSandbox();
+  try {
+    // credentialsDir resolves under sandbox HOME / USERPROFILE which we
+    // just created empty — no .conclave / .config sub-tree yet.
+    const dir = credentialsDir();
+    assert.equal(fs.existsSync(dir), false);
+    saveCredentials({ anthropic: "sk-test" });
+    assert.equal(fs.existsSync(dir), true);
+    assert.equal(fs.existsSync(credentialsPath()), true);
+  } finally {
+    sb.restore();
+  }
+});
+
+test("saveCredentials: file mode is 0600 on Unix", { skip: process.platform === "win32" }, () => {
+  const sb = mkSandbox();
+  try {
+    saveCredentials({ anthropic: "sk-test" });
+    const stat = fs.statSync(credentialsPath());
+    // Mask to permission bits only (strip file-type).
+    const mode = stat.mode & 0o777;
+    assert.equal(mode, 0o600, `expected 0600, got ${mode.toString(8)}`);
+  } finally {
+    sb.restore();
+  }
+});
+
+test("saveCredentials: Windows storage lands under USERPROFILE\\.conclave", { skip: process.platform !== "win32" }, () => {
+  const sb = mkSandbox();
+  try {
+    saveCredentials({ anthropic: "sk-test" });
+    const cpath = credentialsPath();
+    // The file must be a descendant of USERPROFILE.
+    assert.ok(
+      cpath.toLowerCase().startsWith(String(process.env.USERPROFILE).toLowerCase()),
+      `expected ${cpath} under ${process.env.USERPROFILE}`,
+    );
+    // Windows Explorer ACLs are tested via integration (icacls) — here we
+    // just confirm the file exists and is readable by the current user.
+    const raw = fs.readFileSync(cpath, "utf8");
+    assert.ok(raw.includes("sk-test"));
+  } finally {
+    sb.restore();
+  }
+});
+
+test("loadCredentials: malformed JSON throws clear error and doesn't wipe the file", () => {
+  const sb = mkSandbox();
+  try {
+    const dir = credentialsDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(credentialsPath(), "{not valid json", "utf8");
+    assert.throws(
+      () => loadCredentials(),
+      /malformed JSON/,
+    );
+    // File must still exist (unchanged) — critical so users can edit/fix.
+    assert.equal(fs.existsSync(credentialsPath()), true);
+    const raw = fs.readFileSync(credentialsPath(), "utf8");
+    assert.equal(raw, "{not valid json");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("migrateFromEnv: imports set env vars into storage", () => {
+  const sb = mkSandbox();
+  try {
+    const { imported } = migrateFromEnv({
+      ANTHROPIC_API_KEY: "sk-env-a",
+      OPENAI_API_KEY: "sk-env-o",
+      GEMINI_API_KEY: "ai-env-g",
+      CONCLAVE_TOKEN: "c_env_t",
+      XAI_API_KEY: "sk-xai-x",
+    });
+    assert.deepEqual(
+      imported.sort(),
+      ["anthropic", "conclave-token", "gemini", "openai", "xai"].sort(),
+    );
+    const stored = loadCredentials();
+    assert.equal(stored.anthropic, "sk-env-a");
+    assert.equal(stored.openai, "sk-env-o");
+    assert.equal(stored.gemini, "ai-env-g");
+    assert.equal(stored["conclave-token"], "c_env_t");
+    assert.equal(stored.xai, "sk-xai-x");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("migrateFromEnv: does not overwrite with empty env", () => {
+  const sb = mkSandbox();
+  try {
+    saveCredentials({ anthropic: "pre-existing" });
+    const { imported } = migrateFromEnv({});
+    assert.deepEqual(imported, []);
+    const stored = loadCredentials();
+    assert.equal(stored.anthropic, "pre-existing");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("maskKey: shows length and last 4 chars", () => {
+  assert.equal(maskKey("sk-ant-api03-abcd1234"), "len=21 ...1234");
+  assert.equal(maskKey("abc"), "len=3 ***");
+  assert.equal(maskKey(""), "(empty)");
+});
+
+test("conclave-token key maps to CONCLAVE_TOKEN env var", () => {
+  const sb = mkSandbox();
+  try {
+    assert.equal(primaryEnvVar("conclave-token"), "CONCLAVE_TOKEN");
+    saveCredentials({ "conclave-token": "c_stored" });
+    assert.equal(resolveKey("conclave-token", { env: {} }), "c_stored");
+    assert.equal(
+      resolveKey("conclave-token", { env: { CONCLAVE_TOKEN: "c_env" } }),
+      "c_env",
+    );
+  } finally {
+    sb.restore();
+  }
+});
+
+test("ALL_KEY_NAMES covers every supported key", () => {
+  assert.deepEqual(
+    [...ALL_KEY_NAMES].sort(),
+    ["anthropic", "conclave-token", "gemini", "openai", "xai"].sort(),
+  );
+});
+
+test("setKey: refuses empty value", () => {
+  const sb = mkSandbox();
+  try {
+    assert.throws(() => setKey("anthropic", ""), /empty/i);
+    assert.throws(() => setKey("anthropic", "   "), /empty/i);
+  } finally {
+    sb.restore();
+  }
+});
+
+test("unsetKey: removes stored key and returns true", () => {
+  const sb = mkSandbox();
+  try {
+    saveCredentials({ anthropic: "sk-a", openai: "sk-o" });
+    const removed = unsetKey("anthropic");
+    assert.equal(removed, true);
+    const stored = loadCredentials();
+    assert.equal(stored.anthropic, undefined);
+    assert.equal(stored.openai, "sk-o");
+    // Second call returns false (nothing left to remove).
+    assert.equal(unsetKey("anthropic"), false);
+  } finally {
+    sb.restore();
+  }
+});
+
+test("hydrateEnvFromStorage: fills missing env from storage", () => {
+  const sb = mkSandbox();
+  try {
+    saveCredentials({ anthropic: "stored-a", openai: "stored-o" });
+    const env = {};
+    const populated = hydrateEnvFromStorage(env);
+    assert.deepEqual(populated.sort(), ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]);
+    assert.equal(env.ANTHROPIC_API_KEY, "stored-a");
+    assert.equal(env.OPENAI_API_KEY, "stored-o");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("hydrateEnvFromStorage: does not overwrite already-set env", () => {
+  const sb = mkSandbox();
+  try {
+    saveCredentials({ anthropic: "stored-a" });
+    const env = { ANTHROPIC_API_KEY: "user-set" };
+    const populated = hydrateEnvFromStorage(env);
+    assert.deepEqual(populated, []);
+    assert.equal(env.ANTHROPIC_API_KEY, "user-set");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("saveCredentials: preserves createdAt across updates", () => {
+  const sb = mkSandbox();
+  try {
+    saveCredentials({ anthropic: "first" });
+    const raw1 = JSON.parse(fs.readFileSync(credentialsPath(), "utf8"));
+    const firstCreated = raw1.createdAt;
+    // Sleep isn't needed — updatedAt still moves forward on the second write.
+    saveCredentials({ anthropic: "second" });
+    const raw2 = JSON.parse(fs.readFileSync(credentialsPath(), "utf8"));
+    assert.equal(raw2.createdAt, firstCreated);
+    assert.ok(raw2.updatedAt >= firstCreated);
+    assert.equal(raw2.keys.anthropic, "second");
+  } finally {
+    sb.restore();
+  }
+});
+
+test("resolveKey: trims whitespace from env values", () => {
+  assert.equal(
+    resolveKey("anthropic", { env: { ANTHROPIC_API_KEY: "  sk-x  " } }),
+    "sk-x",
+  );
+  // Whitespace-only env is treated as absent.
+  assert.equal(
+    resolveKey("anthropic", { env: { ANTHROPIC_API_KEY: "   " } }),
+    undefined,
+  );
+});
+
+test("resolveKey: GOOGLE_API_KEY works as gemini alias", () => {
+  const sb = mkSandbox();
+  try {
+    assert.equal(
+      resolveKey("gemini", { env: { GOOGLE_API_KEY: "g-x" } }),
+      "g-x",
+    );
+    // Primary wins when both present.
+    assert.equal(
+      resolveKey("gemini", {
+        env: { GEMINI_API_KEY: "g-primary", GOOGLE_API_KEY: "g-alias" },
+      }),
+      "g-primary",
+    );
+  } finally {
+    sb.restore();
+  }
+});


### PR DESCRIPTION
## Summary

One-time `conclave config` writes API keys to `%USERPROFILE%\.conclave\credentials.json` (Windows, ACL-restricted to current user via `icacls`) or `~/.config/conclave/credentials.json` (Unix, chmod 600). Every subsequent `conclave` subcommand — including `conclave autofix` spawning `conclave review --json` as a subprocess — resolves keys from storage. **CI unaffected**: env vars always win over stored credentials.

## Why

Bae has pasted API keys into fresh PowerShell sessions 4+ times today. Every paste is a leak surface. The subprocess spawn in autofix means even setting `$env:ANTHROPIC_API_KEY` in the parent shell isn't enough if anything re-execs the CLI.

## Example session (post-merge, post-npm install)

```powershell
# ONE TIME, ever:
PS> conclave config
conclave config — interactive setup

anthropic (ANTHROPIC_API_KEY)
  current: not set
  new value: ********************...  → saved (len=108 ...EXYW)

openai (OPENAI_API_KEY)
  current: not set
  new value: ********************...  → saved (len=162 ...P7PN)

gemini (GEMINI_API_KEY)
  current: not set
  new value:  → keeping existing

conclave-token (CONCLAVE_TOKEN)
  current: not set
  new value: *********  → saved (len=9 ...8wUv)

xai (XAI_API_KEY)
  current: not set
  new value:  → keeping existing

conclave config: 3 key(s) stored in C:\Users\ADMIN\.conclave\credentials.json (ACL: user-only)

# Every subsequent session — fresh PowerShell, no env-var dance:
PS> conclave autofix --pr 21
# ✅ works. resolveKey pulls from storage.
PS> conclave review --pr 21
# ✅ works too.
```

## Command surface

```
conclave config                           # interactive TUI — set up all keys
conclave config set <key> [<value>]       # programmatic (prompts if value omitted)
conclave config set <key> -                # reads value from stdin (pipe-friendly)
conclave config get <key> [--show-raw]    # masked by default
conclave config list                      # length + last-4 chars, never full secret
conclave config unset <key>               # remove a key
conclave config path                      # print storage path
conclave config migrate                   # import current env-var values
```

Supported keys: `anthropic`, `openai`, `gemini` (accepts `GOOGLE_API_KEY` alias), `conclave-token`, `xai`.

## Key resolution order (for every conclave subcommand)

1. **Env var** — CI / CD keeps working unchanged
2. **Stored `credentials.json`** — populated by `conclave config`
3. **Nothing** — agent skipped with existing log

CLI entry-point hydrates `process.env` from storage before dispatching any subcommand (except `config` itself, so `list` / `get` can honestly distinguish env-vs-stored). This means `integration-telegram`'s `process.env["CONCLAVE_TOKEN"]` check and other packages that read env directly pick up stored values without per-package changes.

## Security

- File format: plain JSON (boring on purpose — panicked user can repair with a text editor)
- Unix: `chmod 0600` after atomic-rename write
- Windows: `icacls /inheritance:r` + `/grant:r %USERNAME%:F` to strip inherited ACLs and grant current user only
- NEVER logs the full secret. All output masks to `len=N ...LAST4`
- `config get` masked by default; explicit `--show-raw` required for the full value
- No encryption at rest in v0.7.4 (master-password + OS Keychain tracked for v0.8+)

## Test plan

- [x] `corepack pnpm build` green (47 turbo tasks)
- [x] `corepack pnpm test` green (309 cli tests, +33 new; 0 failing, 1 skipped on Windows for the chmod 0600 check)
- [x] Smoke test: `node packages/cli/dist/bin/conclave.js --version` prints `0.7.4`
- [x] Smoke test: `conclave config path` prints `C:\Users\ADMIN\.conclave\credentials.json`
- [x] Smoke test: `conclave --help` shows `config` in the command list
- [ ] End-to-end: run `conclave config`, then `conclave autofix --pr N` in a fresh PowerShell session (no env vars exported). **Bae to verify.**
- [ ] Regression: existing CI workflow on a consumer repo (env vars from GH secrets) keeps passing. **Bae to verify post-merge.**

## What did NOT change

- Agent package constructor signatures (`ClaudeAgent`, `OpenAIAgent`, etc.) — still accept `opts.apiKey ?? process.env[...]`
- `conclave init` — separate from `conclave config`. `init` writes repo-level `.conclaverc.json`; `config` writes user-level credentials.
- `.conclaverc.json` shape — unchanged. Credentials are NOT stored there (it's per-repo / committable).
- CI / GitHub Actions workflows — env vars still win.
- Log redaction — preserved; secrets never reach stdout/stderr/telemetry.

## Bump

- `@conclave-ai/cli` 0.7.3 → 0.7.4
- No other packages bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)