### PR TITLE
feat(config): default council to claude+openai+gemini

### DIFF
--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -326,7 +326,15 @@ export type ConclaveConfig = z.infer<typeof ConclaveConfigSchema>;
 
 export const DEFAULT_CONFIG: ConclaveConfig = {
   version: 1,
-  agents: ["claude"],
+  // Council needs ≥3 distinct vendor perspectives to surface disagreement
+  // signal. Phase-1 retrospective (2026-05-06) confirmed multi-agent moat
+  // on real eventbadge PRs: openai-only catches included a supply-chain
+  // pin (`@conclave-ai/cli@latest` with write-creds) and a CI reliability
+  // bomb that claude alone missed. Gemini is included to fill that third
+  // perspective slot. Agents whose API key is unset are skipped silently
+  // by buildAgent (see commands/review.ts), so this is safe even when a
+  // user has only one provider key configured.
+  agents: ["claude", "openai", "gemini"],
   budget: { perPrUsd: 0.5 },
   efficiency: {
     cacheEnabled: true,


### PR DESCRIPTION
## Summary
- `DEFAULT_CONFIG.agents` was `["claude"]` (single-agent council fallback when no `.conclaverc.json`)
- Phase-1 retrospective (20 eventbadge episodes, 2026-05-06) confirmed multi-agent moat: 8.7% of blocking-severity bugs caught by one agent only, openai-only catches included supply-chain + CI reliability bugs claude alone missed
- Switching default to all 3 — `buildAgent` skips silently when a key is missing, so it's safe for users with only one provider key

## Why now
SaaS users won't author `.conclaverc.json` themselves. The default needs to give them the multi-agent value out of the box, not require config to unlock the moat.

## Test plan
- [x] 1479/1479 cli tests pass on Windows
- [x] Gemini smoke test ($0.0036): caught both supply-chain `@latest` bug + missing `useCallback` import in single review call
- [ ] Phase 2 dogfood with 4-agent council (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)