### PR TITLE
feat: CLI polish + landing page MVP

### DIFF
--- a/apps/landing/.gitignore
+++ b/apps/landing/.gitignore
@@ -1,0 +1,9 @@
+# Next.js build output
+.next/
+out/
+node_modules/
+.env*.local
+.DS_Store
+.vercel
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/landing/next.config.mjs
+++ b/apps/landing/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  // No image optimization yet — keep build artifact tiny.
+  images: { unoptimized: true },
+};
+export default nextConfig;

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@conclave-ai/landing",
+  "version": "0.16.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev --port 3001",
+    "build": "next build",
+    "start": "next start --port 3001",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "15.5.4",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.13",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/landing/postcss.config.mjs
+++ b/apps/landing/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/landing/public/favicon.svg
+++ b/apps/landing/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <!-- Conclave AI mark: outer ring + 3 dots in triangle -->
+  <circle cx="12" cy="12" r="10" stroke="#0a3a5e" stroke-width="1.6" fill="#ffffff"/>
+  <circle cx="12" cy="7.5" r="1.6" fill="#0a3a5e"/>
+  <circle cx="15.897" cy="14.25" r="1.6" fill="#0a3a5e"/>
+  <circle cx="8.103" cy="14.25" r="1.6" fill="#0a3a5e"/>
+</svg>

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -1,0 +1,29 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+html {
+  font-feature-settings: "rlig" 1, "calt" 1, "ss01" 1;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background: #f7f7f5;
+  color: #0e1116;
+}
+
+/* Slim selection style to match the "serious dev tool" tone. */
+::selection {
+  background: #0a3a5e;
+  color: #fff;
+}
+
+/* Very subtle dotted background that shows through the content edges. */
+.bg-grid {
+  background-image: radial-gradient(rgba(10, 58, 94, 0.08) 1px, transparent 1px);
+  background-size: 20px 20px;
+}

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Conclave AI — multi-agent code review for your PRs",
+  description:
+    "A council of AI agents reviews every PR against your PRD. Catches real blockers, then auto-fixes them.",
+  openGraph: {
+    title: "Conclave AI",
+    description:
+      "A council of AI agents reviews every PR against your PRD. Catches real blockers, then auto-fixes them.",
+    type: "website",
+  },
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="antialiased font-sans">{children}</body>
+    </html>
+  );
+}

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -1,15 +1,29 @@
 import type { Metadata } from "next";
 import "./globals.css";
 
+const SITE_URL = "https://conclave-ai.dev";
+
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "Conclave AI — multi-agent code review for your PRs",
   description:
     "A council of AI agents reviews every PR against your PRD. Catches real blockers, then auto-fixes them.",
+  icons: {
+    icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
+  },
   openGraph: {
     title: "Conclave AI",
     description:
       "A council of AI agents reviews every PR against your PRD. Catches real blockers, then auto-fixes them.",
     type: "website",
+    url: SITE_URL,
+    siteName: "Conclave AI",
+  },
+  twitter: {
+    card: "summary",
+    title: "Conclave AI",
+    description:
+      "A council of AI agents reviews every PR against your PRD. Catches real blockers, then auto-fixes them.",
   },
 };
 

--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -1,0 +1,405 @@
+/**
+ * Conclave AI — landing page MVP.
+ *
+ * Tone: Linear/Vercel-flavored "serious dev tool". No marketing fluff,
+ * no hype animations. Honest copy: "council of agents reviews against
+ * your PRD; catches what single-LLM review misses."
+ *
+ * Sections (top → bottom):
+ *   1. Top bar — wordmark + sign-in CTA
+ *   2. Hero — pitch + 1 install line + screencast placeholder
+ *   3. How it works — 3 steps
+ *   4. Why a council (not just Claude alone) — moat data
+ *   5. Pricing — Free BYO / Solo $19 / Pro $49
+ *   6. FAQ — 4 questions
+ *   7. Footer — github + login + email
+ *
+ * Structure prioritizes "what does this do?" → "how do I get it?"
+ * → "what's the pricing?" → trust signals. No carousel, no testimonials
+ * (we don't have any yet — fabricating those is the worst kind of lie).
+ */
+const CLI_ENDPOINT = process.env.NEXT_PUBLIC_API_BASE ?? "https://conclave-ai.seunghunbae.workers.dev";
+
+const LOGIN_URL = `${CLI_ENDPOINT}/auth/device`;
+
+export default function Home() {
+  return (
+    <>
+      <TopBar />
+      <main className="mx-auto max-w-5xl px-6">
+        <Hero />
+        <HowItWorks />
+        <CouncilEvidence />
+        <Pricing />
+        <FAQ />
+      </main>
+      <Footer />
+    </>
+  );
+}
+
+// --- Top bar ----------------------------------------------------------------
+
+function TopBar() {
+  return (
+    <header className="border-b border-neutral-200 bg-white/70 backdrop-blur-sm sticky top-0 z-50">
+      <div className="mx-auto max-w-5xl px-6 py-4 flex items-center justify-between">
+        <a href="/" className="flex items-center gap-2 group">
+          <Wordmark />
+        </a>
+        <nav className="flex items-center gap-6 text-sm text-neutral-700">
+          <a href="#how" className="hover:text-accent-900">How</a>
+          <a href="#pricing" className="hover:text-accent-900">Pricing</a>
+          <a href="#faq" className="hover:text-accent-900">FAQ</a>
+          <a
+            href="https://github.com/seunghunbae-3svs/conclave-ai"
+            className="hover:text-accent-900"
+            target="_blank"
+            rel="noreferrer"
+          >
+            GitHub
+          </a>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+function Wordmark() {
+  return (
+    <span className="font-mono text-base tracking-tight text-accent-900 group-hover:text-accent-700 transition-colors">
+      <span className="text-neutral-400">{">"}</span> conclave<span className="text-accent-500">.ai</span>
+    </span>
+  );
+}
+
+// --- Hero -------------------------------------------------------------------
+
+function Hero() {
+  return (
+    <section className="bg-grid -mx-6 px-6 py-24 border-b border-neutral-200">
+      <div className="mx-auto max-w-5xl">
+        <p className="font-mono text-sm text-accent-700 mb-6">
+          v0.16 · code review SaaS · multi-agent + PRD-aware
+        </p>
+        <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-neutral-900 leading-[1.05]">
+          A council of AI agents reviews your PRs<br />
+          <span className="text-accent-900">against your PRD.</span>
+        </h1>
+        <p className="mt-6 text-lg text-neutral-600 max-w-prose leading-relaxed">
+          Three frontier models — Claude, GPT-5, and Gemini — independently review every
+          pull request. Disagreement surfaces blockers no single model catches alone. When
+          you attach a PRD, agents flag spec-mismatches as first-class blockers — not just
+          code-quality issues.
+        </p>
+
+        <div className="mt-10 grid gap-4 md:grid-cols-2 max-w-2xl">
+          <InstallCommand />
+          <SignInButton />
+        </div>
+
+        <p className="mt-6 text-sm text-neutral-500">
+          Open beta · BYO Anthropic key for free unlimited usage · Bae-key trial: 5 reviews/month
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function InstallCommand() {
+  return (
+    <div className="rounded-md border border-neutral-300 bg-neutral-900 text-neutral-100 font-mono text-sm">
+      <div className="px-4 py-2 border-b border-neutral-700 text-neutral-400 text-xs uppercase tracking-wider">
+        install
+      </div>
+      <pre className="px-4 py-3 overflow-x-auto">
+        <span className="text-accent-300">$</span> npm i -g @conclave-ai/cli
+      </pre>
+    </div>
+  );
+}
+
+function SignInButton() {
+  return (
+    <a
+      href={LOGIN_URL}
+      className="rounded-md bg-accent-900 hover:bg-accent-700 transition-colors text-white px-5 py-3 flex items-center justify-center gap-2 font-medium"
+    >
+      <span>Sign in with GitHub</span>
+      <span aria-hidden="true">→</span>
+    </a>
+  );
+}
+
+// --- How it works -----------------------------------------------------------
+
+function HowItWorks() {
+  const steps: Array<{ n: string; title: string; body: string }> = [
+    {
+      n: "01",
+      title: "Install the GitHub App",
+      body:
+        "One click. The Conclave AI Code Council app subscribes to your repo's pull-request events. Nothing runs in CI; the work happens in our sandbox.",
+    },
+    {
+      n: "02",
+      title: "Drop a PRD into your repo",
+      body:
+        "Add .conclave/prd.md describing what the PR is supposed to do — acceptance criteria, out-of-scope, non-functional requirements. Agents read it and flag mismatches.",
+    },
+    {
+      n: "03",
+      title: "Open a PR — get a verdict",
+      body:
+        "Three agents independently review. Disagreements escalate. Verdict + blockers land as a PR check + Telegram message. If verdict is rework, the worker agent autofixes and pushes back automatically.",
+    },
+  ];
+  return (
+    <section id="how" className="py-24 border-b border-neutral-200">
+      <h2 className="text-3xl font-bold text-neutral-900 mb-2">How it works</h2>
+      <p className="text-neutral-500 mb-12">Three steps. No CI changes. No keys to manage on your end (unless you want to).</p>
+      <div className="grid gap-8 md:grid-cols-3">
+        {steps.map((s) => (
+          <article key={s.n} className="border border-neutral-200 rounded-lg p-6 bg-white">
+            <p className="font-mono text-xs text-accent-700 mb-3">{s.n}</p>
+            <h3 className="font-semibold text-neutral-900 mb-2">{s.title}</h3>
+            <p className="text-sm text-neutral-600 leading-relaxed">{s.body}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// --- Council evidence -------------------------------------------------------
+
+function CouncilEvidence() {
+  return (
+    <section className="py-24 border-b border-neutral-200">
+      <h2 className="text-3xl font-bold text-neutral-900 mb-2">Why a council, not Claude alone</h2>
+      <p className="text-neutral-500 mb-12 max-w-prose">
+        From our own dogfood (2026-05-06, 15 synthetic-bug PRs across 5 vibe-coder Next.js
+        templates). Honest numbers; no marketing math.
+      </p>
+      <div className="grid gap-6 md:grid-cols-3">
+        <Stat label="Catch rate" value="100%" sub="conclave 3-agent council, vs 100% Claude alone — both catch obvious bugs" />
+        <Stat label="Blockers per PR" value="10.93" sub="vs 3.80 Claude alone — 3× deeper findings, including issues lost on a single model" />
+        <Stat label="Spec-mismatch flags" value="9.0/PR" sub="(Claude alone + PRD): blocker categories that no plain code review surfaces" />
+      </div>
+      <p className="mt-12 text-sm text-neutral-500 max-w-prose leading-relaxed">
+        The moat isn't "smarter than Claude" — it's <span className="font-medium text-neutral-700">multi-agent
+        depth + PRD-aware spec compliance</span>. Three models reading your PR and PRD together catch
+        scope creep, route mismatches, and forgotten acceptance criteria that one model alone misses.
+      </p>
+    </section>
+  );
+}
+
+function Stat({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <article className="border border-neutral-200 rounded-lg p-6 bg-white">
+      <p className="text-xs uppercase tracking-wider text-neutral-500 mb-2">{label}</p>
+      <p className="text-3xl font-bold text-accent-900 mb-3 font-mono">{value}</p>
+      <p className="text-sm text-neutral-600 leading-relaxed">{sub}</p>
+    </article>
+  );
+}
+
+// --- Pricing ----------------------------------------------------------------
+
+function Pricing() {
+  return (
+    <section id="pricing" className="py-24 border-b border-neutral-200">
+      <h2 className="text-3xl font-bold text-neutral-900 mb-2">Pricing</h2>
+      <p className="text-neutral-500 mb-12 max-w-prose">
+        Hard cutoffs, no overage bills. Booster top-ups instead of surprise invoices.
+      </p>
+      <div className="grid gap-6 md:grid-cols-3">
+        <PriceCard
+          tier="Free (BYO key)"
+          price="$0"
+          sub="bring your own Anthropic API key"
+          features={[
+            "Unlimited reviews",
+            "Unlimited autofix",
+            "Anonymous failure-pattern sharing",
+            "All council features",
+          ]}
+          cta="Sign in with GitHub"
+          ctaHref={LOGIN_URL}
+        />
+        <PriceCard
+          tier="Solo"
+          price="$19"
+          sub="per month"
+          highlight
+          features={[
+            "30 reviews / month",
+            "10 autofix cycles / month",
+            "Council + PRD layer",
+            "Telegram + PR comment delivery",
+            "$5 booster: +5 reviews",
+          ]}
+          cta="Start with Solo"
+          ctaHref={LOGIN_URL}
+        />
+        <PriceCard
+          tier="Pro"
+          price="$49"
+          sub="per month"
+          features={[
+            "80 reviews / month",
+            "30 autofix cycles / month",
+            "Priority sandbox queue",
+            "Private mode (no data sharing)",
+            "$5 booster",
+          ]}
+          cta="Start with Pro"
+          ctaHref={LOGIN_URL}
+        />
+      </div>
+      <p className="mt-8 text-xs text-neutral-500 max-w-prose">
+        Trial tier (5 reviews / 2 autofix per month, Bae-managed key) available without a card while we run open beta.
+        Stripe metering ships once moat data accumulates from real usage.
+      </p>
+    </section>
+  );
+}
+
+function PriceCard({
+  tier,
+  price,
+  sub,
+  features,
+  cta,
+  ctaHref,
+  highlight = false,
+}: {
+  tier: string;
+  price: string;
+  sub: string;
+  features: string[];
+  cta: string;
+  ctaHref: string;
+  highlight?: boolean;
+}) {
+  return (
+    <article
+      className={`rounded-lg p-6 border ${
+        highlight
+          ? "border-accent-700 bg-accent-50 ring-1 ring-accent-700"
+          : "border-neutral-200 bg-white"
+      }`}
+    >
+      <p className="text-sm font-semibold text-neutral-900">{tier}</p>
+      <p className="mt-3 flex items-baseline gap-2">
+        <span className="text-3xl font-bold text-accent-900 font-mono">{price}</span>
+        <span className="text-sm text-neutral-500">{sub}</span>
+      </p>
+      <ul className="mt-6 space-y-2 text-sm text-neutral-700">
+        {features.map((f) => (
+          <li key={f} className="flex gap-2">
+            <span className="text-accent-700">✓</span>
+            <span>{f}</span>
+          </li>
+        ))}
+      </ul>
+      <a
+        href={ctaHref}
+        className={`mt-6 block text-center rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+          highlight
+            ? "bg-accent-900 text-white hover:bg-accent-700"
+            : "border border-neutral-300 text-neutral-900 hover:bg-neutral-50"
+        }`}
+      >
+        {cta}
+      </a>
+    </article>
+  );
+}
+
+// --- FAQ --------------------------------------------------------------------
+
+function FAQ() {
+  const items: Array<{ q: string; a: string }> = [
+    {
+      q: "How is this different from Claude Code or Cursor?",
+      a:
+        "Those are IDE assistants. Conclave AI runs at the PR layer with three independent agents and reads your PRD. Different layer, different value: catches what single-agent review misses + flags spec deviations no plain code review can produce.",
+    },
+    {
+      q: "What does Conclave AI see from my repo?",
+      a:
+        "Only the diff and the files referenced in blockers — same as a human reviewer would. Code never leaves our sandbox. Federated learning shares only anonymized signals (kind/category/severity hash, day-bucket, sha256). See docs/federated-sync.md.",
+    },
+    {
+      q: "Do I have to install anything in CI?",
+      a:
+        "No. The GitHub App receives webhooks; review and autofix run in our Cloudflare Containers sandbox. Your CI stays untouched.",
+    },
+    {
+      q: "Can I bring my own Anthropic key?",
+      a:
+        "Yes — the free tier is BYO-key with unlimited usage. You opt into anonymous failure-pattern sharing in exchange. The trade is honest: we get data to make the federated catalog smarter; you get unlimited free reviews.",
+    },
+  ];
+  return (
+    <section id="faq" className="py-24">
+      <h2 className="text-3xl font-bold text-neutral-900 mb-12">FAQ</h2>
+      <div className="space-y-6">
+        {items.map((item) => (
+          <article key={item.q}>
+            <h3 className="font-semibold text-neutral-900 mb-2">{item.q}</h3>
+            <p className="text-sm text-neutral-600 leading-relaxed max-w-prose">{item.a}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// --- Footer -----------------------------------------------------------------
+
+function Footer() {
+  return (
+    <footer className="border-t border-neutral-200 mt-12 py-12">
+      <div className="mx-auto max-w-5xl px-6 grid gap-8 md:grid-cols-3 text-sm text-neutral-600">
+        <div>
+          <Wordmark />
+          <p className="mt-3 text-xs text-neutral-500 max-w-xs">
+            Multi-agent code review against your PRD. Open beta on Cloudflare.
+          </p>
+        </div>
+        <nav className="space-y-2">
+          <p className="font-semibold text-neutral-900">Product</p>
+          <a href="#how" className="block hover:text-accent-900">How it works</a>
+          <a href="#pricing" className="block hover:text-accent-900">Pricing</a>
+          <a href="#faq" className="block hover:text-accent-900">FAQ</a>
+        </nav>
+        <nav className="space-y-2">
+          <p className="font-semibold text-neutral-900">Resources</p>
+          <a
+            href="https://github.com/seunghunbae-3svs/conclave-ai"
+            className="block hover:text-accent-900"
+            target="_blank"
+            rel="noreferrer"
+          >
+            GitHub repo
+          </a>
+          <a
+            href="https://github.com/apps/conclave-ai-code-council"
+            className="block hover:text-accent-900"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Install GitHub App
+          </a>
+          <a href="mailto:seunghunbae@3svs.com" className="block hover:text-accent-900">Contact</a>
+        </nav>
+      </div>
+      <p className="mx-auto max-w-5xl px-6 mt-10 text-xs text-neutral-400">
+        © {new Date().getFullYear()} 3SVS. All rights reserved.
+      </p>
+    </footer>
+  );
+}

--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -18,7 +18,10 @@
  * → "what's the pricing?" → trust signals. No carousel, no testimonials
  * (we don't have any yet — fabricating those is the worst kind of lie).
  */
+import { Logo, LogoIcon, Wordmark as WordmarkComponent } from "../components/Logo";
+
 const CLI_ENDPOINT = process.env.NEXT_PUBLIC_API_BASE ?? "https://conclave-ai.seunghunbae.workers.dev";
+const SITE_URL = "https://conclave-ai.dev";
 
 const LOGIN_URL = `${CLI_ENDPOINT}/auth/device`;
 
@@ -44,8 +47,8 @@ function TopBar() {
   return (
     <header className="border-b border-neutral-200 bg-white/70 backdrop-blur-sm sticky top-0 z-50">
       <div className="mx-auto max-w-5xl px-6 py-4 flex items-center justify-between">
-        <a href="/" className="flex items-center gap-2 group">
-          <Wordmark />
+        <a href="/" className="flex items-center group">
+          <Logo size={22} className="group-hover:opacity-80 transition-opacity" />
         </a>
         <nav className="flex items-center gap-6 text-sm text-neutral-700">
           <a href="#how" className="hover:text-accent-900">How</a>
@@ -62,14 +65,6 @@ function TopBar() {
         </nav>
       </div>
     </header>
-  );
-}
-
-function Wordmark() {
-  return (
-    <span className="font-mono text-base tracking-tight text-accent-900 group-hover:text-accent-700 transition-colors">
-      <span className="text-neutral-400">{">"}</span> conclave<span className="text-accent-500">.ai</span>
-    </span>
   );
 }
 
@@ -365,7 +360,7 @@ function Footer() {
     <footer className="border-t border-neutral-200 mt-12 py-12">
       <div className="mx-auto max-w-5xl px-6 grid gap-8 md:grid-cols-3 text-sm text-neutral-600">
         <div>
-          <Wordmark />
+          <Logo size={20} />
           <p className="mt-3 text-xs text-neutral-500 max-w-xs">
             Multi-agent code review against your PRD. Open beta on Cloudflare.
           </p>

--- a/apps/landing/src/components/Logo.tsx
+++ b/apps/landing/src/components/Logo.tsx
@@ -1,0 +1,86 @@
+/**
+ * Conclave AI logo — icon + wordmark.
+ *
+ * Concept: three filled dots in triangle layout inside a circle outline.
+ *   - 3 dots = 3 agents (Claude / OpenAI / Gemini) — the council
+ *   - triangle = balanced council, no center
+ *   - outer ring = "conclave" (Latin root: "with key" → closed gathering)
+ *   - geometric only, zero ornament — fits "serious dev tool" tone
+ *
+ * Designed by hand in SVG; scalable to any size. The icon is independent
+ * of the wordmark — use <LogoIcon /> alone for favicon / app icon, or
+ * <Logo /> for inline header (icon + text).
+ *
+ * Single-color: pass `color` prop (defaults to currentColor so it inherits
+ * from text-COLOR Tailwind classes on the parent).
+ */
+
+interface LogoProps {
+  size?: number;
+  className?: string;
+  /** Override stroke/fill color. Defaults to currentColor. */
+  color?: string;
+}
+
+/**
+ * The icon mark alone — three dots inside an outline circle.
+ * 24x24 viewBox, scales cleanly to favicon (16) all the way up to hero (96+).
+ */
+export function LogoIcon({ size = 24, className, color = "currentColor" }: LogoProps) {
+  // Triangle vertices for three council dots, inscribed inside the ring.
+  // Computed: circle radius 9 from center (12,12), dots at angles
+  // -90°, 30°, 150° from center, dot radius 1.8.
+  const cx = 12;
+  const cy = 12;
+  const r = 4.5;
+  const top = { x: cx, y: cy - r };
+  const right = { x: cx + r * Math.cos((30 * Math.PI) / 180), y: cy + r * Math.sin((30 * Math.PI) / 180) };
+  const left = { x: cx - r * Math.cos((30 * Math.PI) / 180), y: cy + r * Math.sin((30 * Math.PI) / 180) };
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+    >
+      <circle cx={cx} cy={cy} r="10" stroke={color} strokeWidth="1.4" />
+      <circle cx={top.x} cy={top.y} r="1.6" fill={color} />
+      <circle cx={right.x} cy={right.y} r="1.6" fill={color} />
+      <circle cx={left.x} cy={left.y} r="1.6" fill={color} />
+    </svg>
+  );
+}
+
+/**
+ * Inline horizontal logo: icon + wordmark "conclave-ai".
+ * The "-ai" suffix is colored with the Tailwind accent palette so it
+ * pops against the dark wordmark in light mode + reads as "the SaaS".
+ */
+export function Logo({ size = 22, className }: { size?: number; className?: string }) {
+  return (
+    <span className={`inline-flex items-center gap-2 ${className ?? ""}`}>
+      <LogoIcon size={size} className="text-accent-900" />
+      <span className="font-mono tracking-tight text-base">
+        <span className="text-neutral-900">conclave</span>
+        <span className="text-accent-700">-ai</span>
+      </span>
+    </span>
+  );
+}
+
+/**
+ * Wordmark only (no icon) — for the footer or small contexts where the
+ * mark would crowd the surrounding type.
+ */
+export function Wordmark({ className }: { className?: string }) {
+  return (
+    <span className={`font-mono tracking-tight text-base ${className ?? ""}`}>
+      <span className="text-neutral-900">conclave</span>
+      <span className="text-accent-700">-ai</span>
+    </span>
+  );
+}

--- a/apps/landing/tailwind.config.ts
+++ b/apps/landing/tailwind.config.ts
@@ -1,0 +1,36 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      // Single accent color (deep blue) — swap when Bae picks final brand color.
+      colors: {
+        accent: {
+          50: "#eef4f9",
+          100: "#d6e3ed",
+          200: "#aec7da",
+          300: "#7fa4be",
+          400: "#5b87a3",
+          500: "#3c6a89",
+          600: "#2c536e",
+          700: "#234058",
+          800: "#1c3145",
+          900: "#0a3a5e",
+          950: "#06243d",
+        },
+      },
+      fontFamily: {
+        // System fonts for tech-tool feel; swap when designer picks one.
+        sans: ['"Inter"', 'system-ui', '-apple-system', 'Segoe UI', 'Roboto', 'sans-serif'],
+        mono: ['"JetBrains Mono"', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+      },
+      maxWidth: {
+        prose: "65ch",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -17,6 +17,7 @@
  */
 import { execFile } from "node:child_process";
 import { saveAuthToken, defaultEndpoint } from "../lib/auth-token.js";
+import { c, isInteractive, kv, nextAction, renderBanner, step } from "../lib/style.js";
 
 const HELP = `conclave login — authenticate the CLI with the Conclave AI SaaS
 
@@ -69,7 +70,12 @@ export async function login(argv: string[]): Promise<void> {
   const out = process.stdout;
   const err = process.stderr;
 
-  out.write(`conclave login: requesting device code from ${args.endpoint}/auth/device …\n`);
+  if (isInteractive()) {
+    out.write(renderBanner() + "\n\n");
+  }
+
+  out.write(step("pending", `Requesting device code from ${c.dim(args.endpoint)} …`) + "\n");
+
   let session: {
     device_code: string;
     user_code: string;
@@ -85,23 +91,25 @@ export async function login(argv: string[]): Promise<void> {
     });
     if (!r.ok) {
       const tail = await r.text();
-      err.write(`conclave login: ${r.status} from /auth/device — ${tail.slice(0, 200)}\n`);
+      err.write(`\n${step("err", `Server returned ${r.status} from /auth/device`)}\n`);
+      err.write(`  ${c.dim(tail.slice(0, 200))}\n`);
       process.exit(1);
       return;
     }
     session = (await r.json()) as typeof session;
   } catch (e) {
-    err.write(`conclave login: cannot reach ${args.endpoint} — ${(e as Error).message}\n`);
+    err.write(`\n${step("err", `Cannot reach ${args.endpoint}`)}\n`);
+    err.write(`  ${c.dim((e as Error).message)}\n`);
     process.exit(1);
     return;
   }
 
   out.write("\n");
-  out.write(`  Open this URL in your browser:\n`);
-  out.write(`  ${session.verification_uri}\n\n`);
-  out.write(`  Enter this code if asked:\n`);
-  out.write(`  ${session.user_code}\n\n`);
-  out.write(`  (waiting for you to complete the login — Ctrl-C to cancel)\n\n`);
+  out.write(`  ${c.bold("Open this URL in your browser:")}\n`);
+  out.write(`  ${c.accent(session.verification_uri)}\n\n`);
+  out.write(`  ${c.bold("Enter this code if asked:")}\n`);
+  out.write(`  ${c.accent(session.user_code)}\n\n`);
+  out.write(`  ${c.dim(`waiting for authorization (Ctrl-C to cancel) …`)}\n\n`);
 
   if (args.open) {
     openUrl(session.verification_uri);
@@ -122,7 +130,8 @@ export async function login(argv: string[]): Promise<void> {
         body: JSON.stringify({ device_code: session.device_code }),
       });
     } catch (e) {
-      err.write(`conclave login: poll failed (transient) — ${(e as Error).message}\n`);
+      // Transient — keep polling.
+      err.write(`${c.dim(`(transient: ${(e as Error).message})`)}\n`);
       continue;
     }
     if (r.ok) {
@@ -133,9 +142,12 @@ export async function login(argv: string[]): Promise<void> {
         endpoint: args.endpoint,
         ...(me?.github_login ? { githubLogin: me.github_login } : {}),
       });
-      const who = me?.github_login ? ` as ${me.github_login}` : "";
-      out.write(`✓ Logged in${who}. Token saved.\n`);
-      out.write(`  Run \`conclave whoami\` to confirm, or \`conclave logout\` to revoke.\n`);
+      const who = me?.github_login ?? "(anonymous)";
+      out.write(step("ok", `Logged in as ${c.bold(who)}`) + "\n");
+      out.write(`  ${c.dim(`token saved to ~/.conclave/auth.json`)}\n`);
+      out.write("\n");
+      out.write(nextAction(`run ${c.code("conclave whoami")} to confirm`) + "\n");
+      out.write(nextAction(`run ${c.code("conclave logout")} to revoke`) + "\n");
       return;
     }
     const body = (await r.json().catch(() => ({}))) as { error?: string; error_description?: string };
@@ -144,13 +156,13 @@ export async function login(argv: string[]): Promise<void> {
       pollIntervalMs += 1000;
       continue;
     }
-    err.write(
-      `\nconclave login: ${body.error ?? "unknown error"}${body.error_description ? " — " + body.error_description : ""}\n`,
-    );
+    err.write(`\n${step("err", body.error_description ?? body.error ?? "unknown error")}\n`);
+    err.write(nextAction(`run ${c.code("conclave login")} to retry`) + "\n");
     process.exit(1);
     return;
   }
-  err.write(`\nconclave login: device code expired after ${session.expires_in}s. Run \`conclave login\` again.\n`);
+  err.write(`\n${step("err", `Device code expired after ${session.expires_in}s`)}\n`);
+  err.write(nextAction(`run ${c.code("conclave login")} to start a new session`) + "\n");
   process.exit(1);
 }
 

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -4,13 +4,15 @@
  * run when there's no stored token.
  */
 import { clearAuthToken, loadAuthToken } from "../lib/auth-token.js";
+import { c, nextAction, step } from "../lib/style.js";
 
 export async function logout(_argv: string[]): Promise<void> {
   const out = process.stdout;
   const err = process.stderr;
   const stored = loadAuthToken();
   if (!stored) {
-    out.write(`conclave logout: not logged in (no token at ~/.conclave/auth.json)\n`);
+    out.write(step("ok", "Not logged in.") + "\n");
+    out.write(`  ${c.dim("nothing to revoke")}\n`);
     return;
   }
   // Best-effort revoke server-side. If the network is down we still wipe
@@ -21,11 +23,14 @@ export async function logout(_argv: string[]): Promise<void> {
       headers: { authorization: `Bearer ${stored.token}` },
     });
     if (!r.ok && r.status !== 401) {
-      err.write(`conclave logout: server returned ${r.status} (token wiped locally anyway)\n`);
+      err.write(step("warn", `Server returned ${r.status} (token wiped locally anyway)`) + "\n");
     }
   } catch (e) {
-    err.write(`conclave logout: revoke call failed (${(e as Error).message}); wiping local token only\n`);
+    err.write(step("warn", `Revoke call failed (${(e as Error).message})`) + "\n");
+    err.write(`  ${c.dim("wiping local token only")}\n`);
   }
   clearAuthToken();
-  out.write(`✓ Logged out${stored.githubLogin ? ` (was ${stored.githubLogin})` : ""}. Token removed.\n`);
+  const who = stored.githubLogin ? ` (was ${c.bold(stored.githubLogin)})` : "";
+  out.write(step("ok", `Logged out${who}`) + "\n");
+  out.write(nextAction(`run ${c.code("conclave login")} to sign back in`) + "\n");
 }

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -4,13 +4,15 @@
  * ~/.conclave/auth.json (run `conclave login` first).
  */
 import { loadAuthToken } from "../lib/auth-token.js";
+import { c, kv, nextAction, step } from "../lib/style.js";
 
 export async function whoami(_argv: string[]): Promise<void> {
   const out = process.stdout;
   const err = process.stderr;
   const stored = loadAuthToken();
   if (!stored) {
-    err.write(`conclave whoami: not logged in. Run \`conclave login\` first.\n`);
+    err.write(step("err", "Not logged in.") + "\n");
+    err.write(nextAction(`run ${c.code("conclave login")}`) + "\n");
     process.exit(1);
     return;
   }
@@ -19,12 +21,13 @@ export async function whoami(_argv: string[]): Promise<void> {
       headers: { authorization: `Bearer ${stored.token}` },
     });
     if (r.status === 401) {
-      err.write(`conclave whoami: token rejected by server (revoked or expired). Run \`conclave login\` again.\n`);
+      err.write(step("err", "Token rejected (revoked or expired).") + "\n");
+      err.write(nextAction(`run ${c.code("conclave login")} to re-authenticate`) + "\n");
       process.exit(1);
       return;
     }
     if (!r.ok) {
-      err.write(`conclave whoami: ${r.status} from ${stored.endpoint}/saas/me\n`);
+      err.write(step("err", `Server returned ${r.status} from /saas/me`) + "\n");
       process.exit(1);
       return;
     }
@@ -34,13 +37,16 @@ export async function whoami(_argv: string[]): Promise<void> {
       byo_anthropic?: boolean;
       data_share_opt_in?: boolean;
     };
-    out.write(`logged in as: ${me.github_login ?? "(unknown)"}\n`);
-    out.write(`tier:         ${me.tier ?? "free"}\n`);
-    out.write(`BYO key:      ${me.byo_anthropic ? "yes" : "no"}\n`);
-    out.write(`data-share:   ${me.data_share_opt_in ? "yes" : "no (opt-out)"}\n`);
-    out.write(`endpoint:     ${stored.endpoint}\n`);
+    out.write("\n");
+    out.write(kv("logged in as", c.bold(me.github_login ?? "(unknown)")) + "\n");
+    out.write(kv("tier", c.accent(me.tier ?? "free")) + "\n");
+    out.write(kv("BYO key", me.byo_anthropic ? "yes" : "no") + "\n");
+    out.write(kv("data-share", me.data_share_opt_in ? c.ok("yes") : c.warn("no (opt-out)")) + "\n");
+    out.write(kv("endpoint", c.dim(stored.endpoint)) + "\n");
+    out.write("\n");
   } catch (e) {
-    err.write(`conclave whoami: cannot reach ${stored.endpoint} — ${(e as Error).message}\n`);
+    err.write(step("err", `Cannot reach ${stored.endpoint}`) + "\n");
+    err.write(`  ${c.dim((e as Error).message)}\n`);
     process.exit(1);
   }
 }

--- a/packages/cli/src/lib/style.ts
+++ b/packages/cli/src/lib/style.ts
@@ -1,0 +1,120 @@
+/**
+ * v0.16 (Problem 3) — CLI visual style tokens.
+ *
+ * Tone: Linear / Vercel no-bullshit. Direct words. No marketing fluff.
+ * Use color sparingly — accent (one) + severity (four) + grayscale.
+ * Emoji only in human-facing first-run / login confirmation paths;
+ * machine-parseable output (--json, exit codes, stdin pipes) stays clean.
+ *
+ * The terminal capability check (`isColorTerminal`) respects:
+ *   - NO_COLOR env var (https://no-color.org/)
+ *   - non-TTY stdout (e.g. piped to `tee` or a log file)
+ *   - TERM=dumb
+ *
+ * When color is off, every `c.X(s)` returns the bare string.
+ */
+
+const NO_COLOR =
+  typeof process !== "undefined" &&
+  ((process.env["NO_COLOR"] !== undefined && process.env["NO_COLOR"] !== "") ||
+    process.env["TERM"] === "dumb");
+
+function isColorTerminal(stream?: NodeJS.WriteStream): boolean {
+  if (NO_COLOR) return false;
+  const s = stream ?? process.stdout;
+  return Boolean(s.isTTY);
+}
+
+const useColor = isColorTerminal();
+
+function wrap(open: number, close: number): (s: string) => string {
+  if (!useColor) return (s) => s;
+  return (s) => `\x1b[${open}m${s}\x1b[${close}m`;
+}
+
+// 8 + 16-color basics, plus a few 256-color picks for the accent.
+// Why 256-color: the deep-blue accent looks washed-out on plain ANSI 16.
+// Falls back automatically on terminals that don't support 256 — they
+// just render the closest 16-color match.
+function wrap256(fg: number): (s: string) => string {
+  if (!useColor) return (s) => s;
+  return (s) => `\x1b[38;5;${fg}m${s}\x1b[39m`;
+}
+
+export const c = {
+  // Severity palette — used in review/audit output. NOT decorative.
+  blocker: wrap(31, 39), // red
+  major: wrap(33, 39), // yellow
+  minor: wrap(36, 39), // cyan
+  nit: wrap(90, 39), // bright black
+  // Status / outcome
+  ok: wrap(32, 39), // green — login success, approve
+  warn: wrap(33, 39), // yellow
+  err: wrap(31, 39), // red
+  // Accent (brand) — deep blue 256-color slot. Replace when Bae picks a brand color.
+  accent: wrap256(33),
+  // De-emphasis
+  dim: wrap(2, 22),
+  // Structural emphasis
+  bold: wrap(1, 22),
+  // Inline code
+  code: wrap(36, 39),
+};
+
+/** ASCII wordmark for first-run / login banners. ~6 lines tall. */
+export const BANNER = [
+  "  ╭─────────────────────────────────────────────╮",
+  "  │  ▐▌▗▖ ▗▖ ▐▌  ▟█▙ ▝█▘█▌▟█▙ ▗▖▟▙ █                │",
+  "  │   conclave-ai  ·  multi-agent code review  │",
+  "  ╰─────────────────────────────────────────────╯",
+];
+
+/** Render the banner with accent color. Returns the full string. */
+export function renderBanner(): string {
+  return BANNER.map((line) => c.accent(line)).join("\n");
+}
+
+/**
+ * Format a step indicator line:
+ *   →  Loading PRD …
+ *   ✓  Loaded PRD (412 chars)
+ *   ✗  PRD missing
+ *
+ * Use for multi-line interactive flows (login, review startup, etc.).
+ */
+export function step(state: "pending" | "ok" | "err" | "warn", msg: string): string {
+  const glyphs = { pending: "→", ok: "✓", err: "✗", warn: "!" };
+  const colors = {
+    pending: c.dim,
+    ok: c.ok,
+    err: c.err,
+    warn: c.warn,
+  };
+  return `${colors[state](glyphs[state])} ${msg}`;
+}
+
+/**
+ * Format a "next action" arrow pointer for error messages:
+ *   error: token rejected by server (revoked or expired).
+ *   → run `conclave login`
+ */
+export function nextAction(action: string): string {
+  return `${c.dim("→")} ${action}`;
+}
+
+/**
+ * Render a key/value pair right-aligned in a fixed column for the
+ * `whoami` / `status` style output:
+ *   logged in as:   seunghunbae-3svs
+ *   tier:           free
+ *   endpoint:       https://...
+ */
+export function kv(label: string, value: string, labelWidth: number = 14): string {
+  return `${c.dim(label.padEnd(labelWidth))} ${value}`;
+}
+
+/** True when stdout is a TTY and color is enabled. CLI commands check this
+ * to decide whether to print banners (skip on pipe-to-jq runs). */
+export function isInteractive(): boolean {
+  return useColor;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,40 @@ importers:
         specifier: ^4.83.0
         version: 4.83.0(@cloudflare/workers-types@4.20260420.1)
 
+  apps/landing:
+    dependencies:
+      next:
+        specifier: 15.5.4
+        version: 15.5.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react:
+        specifier: 19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: 19.0.0
+        version: 19.0.0(react@19.0.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.17
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.14)
+      postcss:
+        specifier: ^8.4.47
+        version: 8.5.14
+      tailwindcss:
+        specifier: ^3.4.13
+        version: 3.4.19
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/agent-claude:
     dependencies:
       '@anthropic-ai/sdk':
@@ -390,6 +424,10 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@anthropic-ai/sdk@0.65.0':
     resolution: {integrity: sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==}
@@ -768,12 +806,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -787,6 +831,69 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@next/env@15.5.4':
+    resolution: {integrity: sha512-27SQhYp5QryzIT5uO8hq99C69eLQ7qkzkDPsk3N+GuS2XgOgoYEeOav7Pf8Tn4drECOVDsDg8oj+/DVy8qQL2A==}
+
+  '@next/swc-darwin-arm64@15.5.4':
+    resolution: {integrity: sha512-nopqz+Ov6uvorej8ndRX6HlxCYWCO3AHLfKK2TYvxoSB2scETOcfm/HSS3piPqc3A+MUgyHoqE6je4wnkjfrOA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.5.4':
+    resolution: {integrity: sha512-QOTCFq8b09ghfjRJKfb68kU9k2K+2wsC4A67psOiMn849K9ZXgCSRQr0oVHfmKnoqCbEmQWG1f2h1T2vtJJ9mA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.5.4':
+    resolution: {integrity: sha512-eRD5zkts6jS3VfE/J0Kt1VxdFqTnMc3QgO5lFE5GKN3KDI/uUpSyK3CjQHmfEkYR4wCOl0R0XrsjpxfWEA++XA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@15.5.4':
+    resolution: {integrity: sha512-TOK7iTxmXFc45UrtKqWdZ1shfxuL4tnVAOuuJK4S88rX3oyVV4ZkLjtMT85wQkfBrOOvU55aLty+MV8xmcJR8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@15.5.4':
+    resolution: {integrity: sha512-7HKolaj+481FSW/5lL0BcTkA4Ueam9SPYWyN/ib/WGAFZf0DGAN8frNpNZYFHtM4ZstrHZS3LY3vrwlIQfsiMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@15.5.4':
+    resolution: {integrity: sha512-nlQQ6nfgN0nCO/KuyEUwwOdwQIGjOs4WNMjEUtpIQJPR2NUfmGpW2wkJln1d4nJ7oUzd1g4GivH5GoEPBgfsdw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-win32-arm64-msvc@15.5.4':
+    resolution: {integrity: sha512-PcR2bN7FlM32XM6eumklmyWLLbu2vs+D7nJX8OAIoWy69Kef8mfiN4e8TUv2KohprwifdpFKPzIP1njuCjD0YA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.4':
+    resolution: {integrity: sha512-1ur2tSHZj8Px/KMAthmuI9FMp/YFusMMGoRNJaRZMOlSkgvLjzosSdQI0cJAKogdHl3qXUQKL9MGaYvKwA7DXg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -803,6 +910,9 @@ packages:
 
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@turbo/darwin-64@2.9.6':
     resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
@@ -846,6 +956,14 @@ packages:
   '@types/pngjs@6.0.5':
     resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -873,17 +991,43 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.10.27:
+    resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
@@ -891,6 +1035,15 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -911,9 +1064,27 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -952,6 +1123,14 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -973,6 +1152,12 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -982,6 +1167,9 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  electron-to-chromium@1.5.351:
+    resolution: {integrity: sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -1018,6 +1206,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
@@ -1053,8 +1245,28 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -1074,6 +1286,9 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -1102,6 +1317,14 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
 
   google-auth-library@9.15.1:
     resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
@@ -1168,6 +1391,26 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -1177,6 +1420,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
@@ -1222,6 +1469,10 @@ packages:
     resolution: {integrity: sha512-MAmBAASSzJtmK1O9HQegA1mFsQhT8Yf+OJRGvE7FXkyv3g/eiBE0glLD0Ohg3pkxhoPdggM5SejK7ue9ctlaMA==}
     engines: {node: '>=18'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -1236,6 +1487,14 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1265,9 +1524,39 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  next@15.5.4:
+    resolution: {integrity: sha512-xH4Yjhb82sFYQfY3vbkJfgSDgXvBB6a8xPs9i35k6oZJRoQRihZH+4s9Yo2qsWpzBmZ3lPXaJ2KPXLfkvW4LnA==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -1283,9 +1572,20 @@ packages:
       encoding:
         optional: true
 
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1330,6 +1630,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -1341,6 +1644,22 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
 
   pixelmatch@6.0.0:
     resolution: {integrity: sha512-FYpL4XiIWakTnIqLqvt3uN4L9B3TsuHIvhLILzTiJZMJUsGvmKNeL4H3b6I99LRyerK9W4IuOXw+N28AtRgK2g==}
@@ -1364,6 +1683,57 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
+  postcss-selector-parser@6.1.2:
+    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1371,6 +1741,9 @@ packages:
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -1380,6 +1753,22 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react-dom@19.0.0:
+    resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
+    peerDependencies:
+      react: ^19.0.0
+
+  react@19.0.0:
+    resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
+    engines: {node: '>=0.10.0'}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1388,15 +1777,30 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.25.0:
+    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1442,13 +1846,59 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -1459,6 +1909,9 @@ packages:
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1492,6 +1945,15 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -1573,6 +2035,8 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@anthropic-ai/sdk@0.65.0(zod@3.25.76)':
     dependencies:
@@ -1814,9 +2278,19 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -1845,6 +2319,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@next/env@15.5.4': {}
+
+  '@next/swc-darwin-arm64@15.5.4':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.4':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.4':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.4':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.4':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.5.4':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.4':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.4':
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -1860,6 +2372,10 @@ snapshots:
   '@sindresorhus/is@7.2.0': {}
 
   '@speed-highlight/core@1.2.15': {}
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
 
   '@turbo/darwin-64@2.9.6':
     optional: true
@@ -1896,6 +2412,14 @@ snapshots:
     dependencies:
       '@types/node': 22.19.17
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -1922,13 +2446,35 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  arg@5.0.2: {}
+
   argparse@2.0.1: {}
 
   asynckit@0.4.0: {}
 
+  autoprefixer@10.5.0(postcss@8.5.14):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001792
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.14
+      postcss-value-parser: 4.2.0
+
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.10.27: {}
+
   bignumber.js@9.3.1: {}
+
+  binary-extensions@2.3.0: {}
 
   blake3-wasm@2.1.5: {}
 
@@ -1946,6 +2492,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.27
+      caniuse-lite: 1.0.30001792
+      electron-to-chromium: 1.5.351
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   buffer-equal-constant-time@1.0.1: {}
 
   bytes@3.1.2: {}
@@ -1962,9 +2520,29 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase-css@2.0.1: {}
+
+  caniuse-lite@1.0.30001792: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  client-only@0.0.1: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@4.1.1: {}
 
   content-disposition@1.1.0: {}
 
@@ -1996,6 +2574,10 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssesc@3.0.0: {}
+
+  csstype@3.2.3: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -2005,6 +2587,10 @@ snapshots:
   depd@2.0.0: {}
 
   detect-libc@2.1.2: {}
+
+  didyoumean@1.2.2: {}
+
+  dlv@1.1.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2017,6 +2603,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
+
+  electron-to-chromium@1.5.351: {}
 
   encodeurl@2.0.0: {}
 
@@ -2072,6 +2660,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  escalade@3.2.0: {}
+
   escape-html@1.0.3: {}
 
   etag@1.8.1: {}
@@ -2126,7 +2716,27 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-uri@3.1.0: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   finalhandler@2.1.1:
     dependencies:
@@ -2155,6 +2765,8 @@ snapshots:
       web-streams-polyfill: 4.0.0-beta.3
 
   forwarded@0.2.0: {}
+
+  fraction.js@5.3.4: {}
 
   fresh@2.0.0: {}
 
@@ -2200,6 +2812,14 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
 
   google-auth-library@9.15.1:
     dependencies:
@@ -2273,11 +2893,29 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.3
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
   is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
   isexe@2.0.0: {}
+
+  jiti@1.21.7: {}
 
   jose@6.2.2: {}
 
@@ -2323,6 +2961,8 @@ snapshots:
     dependencies:
       langfuse-core: 3.38.20
 
+  lilconfig@3.1.3: {}
+
   lines-and-columns@1.2.4: {}
 
   math-intrinsics@1.1.0: {}
@@ -2330,6 +2970,13 @@ snapshots:
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -2359,7 +3006,38 @@ snapshots:
 
   mustache@4.2.0: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.12: {}
+
   negotiator@1.0.0: {}
+
+  next@15.5.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@next/env': 15.5.4
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001792
+      postcss: 8.4.31
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      styled-jsx: 5.1.6(react@19.0.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.4
+      '@next/swc-darwin-x64': 15.5.4
+      '@next/swc-linux-arm64-gnu': 15.5.4
+      '@next/swc-linux-arm64-musl': 15.5.4
+      '@next/swc-linux-x64-gnu': 15.5.4
+      '@next/swc-linux-x64-musl': 15.5.4
+      '@next/swc-win32-arm64-msvc': 15.5.4
+      '@next/swc-win32-x64-msvc': 15.5.4
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
 
   node-domexception@1.0.0: {}
 
@@ -2367,7 +3045,13 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  node-releases@2.0.38: {}
+
+  normalize-path@3.0.0: {}
+
   object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -2411,6 +3095,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-parse@1.0.7: {}
+
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.4.2: {}
@@ -2418,6 +3104,14 @@ snapshots:
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  pify@2.3.0: {}
+
+  pirates@4.0.7: {}
 
   pixelmatch@6.0.0:
     dependencies:
@@ -2435,6 +3129,49 @@ snapshots:
 
   pngjs@7.0.0: {}
 
+  postcss-import@15.1.0(postcss@8.5.14):
+    dependencies:
+      postcss: 8.5.14
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-js@4.1.0(postcss@8.5.14):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.14
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.14
+
+  postcss-nested@6.2.0(postcss@8.5.14):
+    dependencies:
+      postcss: 8.5.14
+      postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -2443,6 +3180,8 @@ snapshots:
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
+
+  queue-microtask@1.2.3: {}
 
   range-parser@1.2.1: {}
 
@@ -2453,9 +3192,33 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  react-dom@19.0.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      scheduler: 0.25.0
+
+  react@19.0.0: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  reusify@1.1.0: {}
 
   router@2.2.0:
     dependencies:
@@ -2467,9 +3230,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  scheduler@0.25.0: {}
 
   semver@7.7.4: {}
 
@@ -2565,9 +3334,73 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  source-map-js@1.2.1: {}
+
   statuses@2.0.2: {}
 
+  styled-jsx@5.1.6(react@19.0.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.0.0
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.16
+      ts-interface-checker: 0.1.13
+
   supports-color@10.2.2: {}
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwindcss@3.4.19:
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.14
+      postcss-import: 15.1.0(postcss@8.5.14)
+      postcss-js: 4.1.0(postcss@8.5.14)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)
+      postcss-nested: 6.2.0(postcss@8.5.14)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.12
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   toidentifier@1.0.1: {}
 
@@ -2575,8 +3408,9 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  tslib@2.8.1:
-    optional: true
+  ts-interface-checker@0.1.13: {}
+
+  tslib@2.8.1: {}
 
   turbo@2.9.6:
     optionalDependencies:
@@ -2606,6 +3440,14 @@ snapshots:
       pathe: 2.0.3
 
   unpipe@1.0.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
## Summary
Two deliverables in one PR — both unblock the "feels like a real product" gap before paying users land:

1. **CLI polish** — `lib/style.ts` color tokens + ASCII wordmark + step glyphs + friendly error arrows; `login`/`logout`/`whoami` re-skinned in Linear/Vercel "serious dev tool" tone.
2. **Landing page MVP** — `apps/landing/` Next.js 15 + Tailwind, single static page (102KB First Load JS), no fabricated testimonials, honest dogfood numbers in the "why a council" section.

## Tone choice
"진지한 dev tool" interpreted as Linear/Vercel-flavored: direct words, no marketing fluff, but not stiff. Split:
- Technical output (review verdicts, blockers): strict serious mode (no emoji, severity-keyed color only)
- First-run / error paths: slightly warmer (`→ run \`conclave login\`` next-action arrows, friendly copy)

## Pending Bae decisions

- **Domain** — currently still `conclave-ai.seunghunbae.workers.dev`. When picked, just one DNS swap.
- **Brand color** — landing uses deep-blue placeholder palette (`accent.50-950` in `tailwind.config.ts`). Single-line swap when Bae's final color is in.
- **Logo / wordmark** — current is plain monospace `> conclave.ai` text. Easy to replace with a real wordmark/icon when Bae's design lands.

## Test plan
- [x] CLI: 47/47 task suites pass; `conclave whoami` output cleaner with kv-aligned layout
- [x] Landing: `next build` green, 102KB First Load JS, fully static prerender
- [ ] After merge: deploy landing to Vercel under Bae's chosen domain
- [ ] After Bae's color/logo: 2 swaps (accent palette + Wordmark component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)