### PR TITLE
chore: scrub owner name from public-facing surfaces

### DIFF
--- a/apps/central-plane/migrations/0009_saas_v1.sql
+++ b/apps/central-plane/migrations/0009_saas_v1.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS saas_users (
   github_login    TEXT NOT NULL,                     -- e.g., "seunghunbae-3svs"
   email           TEXT,                              -- optional, from GH email scope
   tier            TEXT NOT NULL DEFAULT 'free',      -- free | solo | pro
-  byo_anthropic   INTEGER NOT NULL DEFAULT 0,        -- 0=Bae key, 1=BYO Anthropic key
+  byo_anthropic   INTEGER NOT NULL DEFAULT 0,        -- 0=platform-managed key, 1=BYO Anthropic key
   data_share_opt_in INTEGER NOT NULL DEFAULT 1,      -- federated catalog contribution; default ON
   created_at      TEXT NOT NULL,
   last_active_at  TEXT NOT NULL

--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -94,7 +94,7 @@ function Hero() {
         </div>
 
         <p className="mt-6 text-sm text-neutral-500">
-          Open beta · BYO Anthropic key for free unlimited usage · Bae-key trial: 5 reviews/month
+          Open beta · BYO Anthropic key for free unlimited usage · Trial: 5 reviews/month, no card
         </p>
       </div>
     </section>
@@ -254,7 +254,7 @@ function Pricing() {
         />
       </div>
       <p className="mt-8 text-xs text-neutral-500 max-w-prose">
-        Trial tier (5 reviews / 2 autofix per month, Bae-managed key) available without a card while we run open beta.
+        Trial tier (5 reviews / 2 autofix per month, platform-managed key) available without a card while we run open beta.
         Stripe metering ships once moat data accumulates from real usage.
       </p>
     </section>
@@ -389,7 +389,7 @@ function Footer() {
           >
             Install GitHub App
           </a>
-          <a href="mailto:seunghunbae@3svs.com" className="block hover:text-accent-900">Contact</a>
+          <a href="mailto:hi@conclave-ai.dev" className="block hover:text-accent-900">Contact</a>
         </nav>
       </div>
       <p className="mx-auto max-w-5xl px-6 mt-10 text-xs text-neutral-400">


### PR DESCRIPTION
Repo is public — landing copy and DB schema comment shouldn't carry the owner's nickname. Renames "Bae-key"→"platform-managed key", scrubs landing footer email. Internal CHANGELOG / status / doctor refs unchanged (those reflect commit history, not user surfaces). GitHub username in repo URL is unavoidable until possible org transfer; flagged separately.