### PR TITLE
chore: Stage 87 — post-release housekeeping (Stage 77~85 handoff + .vercel ignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ build/
 .env.local
 .env.*.local
 
+# Vercel (project link + local auth artifacts — never commit)
+.vercel
+
 # Logs
 *.log
 npm-debug.log*

--- a/docs/HANDOFF-2026-06-22.md
+++ b/docs/HANDOFF-2026-06-22.md
@@ -1,0 +1,60 @@
+# HANDOFF — 2026-06-22
+
+> Source of truth for this handoff = 터미널 Claude Code 쪽 최종 release 결과.
+
+## TL;DR
+**Stage 77~85 production release 완료.** PR #133 merged → `main` HEAD **`39a6fa9`**.
+Product가 공개적으로 **Simsa**로 리브랜드됨 (내부 namespace는 `conclave` 유지).
+central-plane + dashboard 라이브 배포 및 smoke 통과.
+
+## 최종 상태
+- **PR #133: MERGED** (squash). `main` HEAD = `39a6fa9` — "Release: Stage 77~85 (#133 squash)".
+- Stage 77~85 = 9 commits (origin/main 대비 9 ahead였음 → 머지로 main 반영).
+- ⚠️ **Stage 85 해시 정정**: `f00c9c6`(타 workspace 로컬, 이 repo에 없음)가 아니라 **`abc85a6`** 로 머지됨.
+- **Public product name: `Simsa`** (한글 "심사"). Tagline: "The acceptance layer for AI-built software."
+  - 마케팅 도메인 `trysimsa.com`, dev 도메인 `simsa.dev` — **DNS 미연결** (frozen).
+- **Internal namespace: `conclave` 유지** (npm 패키지, env, D1 테이블, route path, localStorage, CLI 바이너리, Telegram bot username `@Conclave_AI`, Worker DO class, GitHub App, `.conclave/` 데이터, legacy 도메인 `conclave-ai.dev`). PERMANENT 결정.
+- **D1 migrations `0044`/`0045` applied** (`deploy-central-plane.yml`의 Apply D1 migrations step success).
+- **central-plane deployed**: `https://conclave-ai.seunghunbae.workers.dev/healthz` → `{ok:true, db:"up", environment:"production"}`.
+- **dashboard production deployed**: `https://conclave-dashboard.vercel.app` → `<title>Simsa — The acceptance layer for AI-built software.</title>` 확인 (307→200).
+- **Guardrail smoke**: Stage 77/81/82 route 모두 `400 userKey_required` (배포·핸들러 실행 확인).
+- ⬜ **populated 데이터 UI**(experiment/benchmark/evolution 카드) 실제 렌더는 **Bae 추후 육안 확인 예정**.
+
+## 배포 메커니즘 (다음에 재사용)
+- **central-plane**: `main` push가 `apps/central-plane/**` 또는 `packages/core/**`를 건드리면 `deploy-central-plane.yml` **자동 trigger** → build → `wrangler d1 migrations apply --remote conclave-ai` → `wrangler deploy` → healthz/webhook smoke. (workflow_dispatch도 가능.)
+- **dashboard**: Vercel **Git 미연결**. `vercel deploy --prod --yes`를 **repo root에서** 실행.
+  - 주의: Vercel project Root Directory = `apps/dashboard`. `apps/dashboard`에서 실행하면 `apps/dashboard/apps/dashboard` 경로 오류 발생 → 반드시 **root에서**.
+  - root에 `.vercel/project.json` 링크 필요 (projectName `conclave-dashboard`).
+  - CLI는 저장 로그인(`seunghunbae-3svs`) 사용 → 토큰 env 불필요.
+  - MCP `deploy_to_vercel`는 직접 배포하지 않고 CLI 실행 안내만 함.
+
+## Multi-workspace sync note (중요)
+- 다른 workspace는 이제 **PR branch가 아니라 `main` 기준**으로 동기화한다.
+- 작업 시작 전 실행:
+  ```bash
+  git fetch origin && git checkout main && git pull --ff-only
+  ```
+- **신규 Stage는 새 branch에서 시작**한다.
+- `claude/stage-79-82-evolution-loop`는 **merged 상태** → 신규 작업에 **재사용하지 않는다**.
+
+## 다음 세션 pickup / pending
+1. **`.vercel` housekeeping PR (별도 작은 PR)**
+   - 현재 `.gitignore`에 `.vercel` 추가가 **로컬 uncommitted 변경**(`M .gitignore`)으로 남아 있음.
+   - 이유: dashboard 배포를 위해 root `.vercel/` 링크를 생성해야 했고, Rule 3(secret safety)에 따라 `.vercel`을 ignore 처리.
+   - 지시서:
+     ```bash
+     git checkout main && git pull --ff-only
+     git checkout -b chore/gitignore-vercel
+     # .gitignore에 ".vercel" 한 줄 추가 (이미 로컬에 적용돼 있으면 그대로 commit)
+     git add .gitignore
+     git commit -m "chore: gitignore .vercel (project link + local auth artifacts)"
+     git push origin chore/gitignore-vercel
+     # PR 생성 → CI green → merge
+     ```
+   - ⚠️ **지금 main 직접 push 금지.** 반드시 별도 브랜치 + PR.
+   - 참고: `apps/dashboard/.vercel`은 과거에도 git에 tracked된 적 없음(확인 완료).
+2. **populated 데이터 UI 육안 확인** (Bae) — 라이브 dashboard에서 experiment/benchmark/evolution 카드 실제 렌더 1회 확인.
+
+## 보안
+- **Vercel token**: 값은 기록하지 않음. exposed/old Vercel token revoke/rotate는 **operator(Bae)가 완료했다고 확인함 (R11)**. 이번 dashboard 배포는 CLI 저장 로그인 사용이라 에이전트가 다룬 토큰 secret 없음 — 추가로 폐기할 secret 없음.
+- safety flags(actual debit 등)는 이번 release 범위 밖 — 기존 OFF 상태 유지.


### PR DESCRIPTION
## Summary

Small post-release housekeeping after the **Stage 77~85 production release** (PR #133, `main` `39a6fa9`).

- **Stage 77~85 release handoff** recorded: `docs/HANDOFF-2026-06-22.md` (PR #133 merged, Simsa public name / `conclave` internal namespace, D1 migrations 0044/0045 applied, central-plane + dashboard deployed and smoked, multi-workspace now syncs on `main`).
- **`.vercel` local deployment link ignore**: added `.vercel` to `.gitignore`. The root `.vercel/` link is required to run `vercel deploy --prod` from repo root (Vercel project Root Directory = `apps/dashboard`); it holds the project link + local auth artifacts and must never be committed.
- **No runtime code changes.**
- **No deploy needed** (docs + gitignore only).

## Changes
- `docs/HANDOFF-2026-06-22.md` (new)
- `.gitignore` (+`.vercel`)

## Verification
- `git diff --cached` = exactly 2 files; no secret/token literals in the diff; `.vercel/` itself not staged.
- No tests affected (no runtime code).