### PR TITLE
feat(domain): Stage 89 — Simsa domain routing & launch surface

### DIFF
--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -79,6 +79,8 @@ const ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "https://dashboard.conclave-ai.dev",
   "https://conclave-dashboard.vercel.app", // Vercel production dashboard (beta QA)
+  "https://app.trysimsa.com", // Stage 89: Simsa dashboard app domain (exact origin)
+  "https://trysimsa.com", // Stage 89: Simsa marketing domain (exact origin)
 ];
 
 function corsHeaders(origin: string | null): Record<string, string> {

--- a/apps/central-plane/src/routes/workspace-notifications.ts
+++ b/apps/central-plane/src/routes/workspace-notifications.ts
@@ -26,6 +26,8 @@ const ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "https://dashboard.conclave-ai.dev",
   "https://conclave-dashboard.vercel.app", // Vercel production dashboard (beta QA)
+  "https://app.trysimsa.com", // Stage 89: Simsa dashboard app domain (exact origin)
+  "https://trysimsa.com", // Stage 89: Simsa marketing domain (exact origin)
 ];
 
 function corsHeaders(origin: string | null): Record<string, string> {

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -49,6 +49,8 @@ const ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "https://dashboard.conclave-ai.dev",
   "https://conclave-dashboard.vercel.app", // Vercel production dashboard (beta QA)
+  "https://app.trysimsa.com", // Stage 89: Simsa dashboard app domain (exact origin)
+  "https://trysimsa.com", // Stage 89: Simsa marketing domain (exact origin)
 ];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/apps/central-plane/src/workspace/github-oauth.ts
+++ b/apps/central-plane/src/workspace/github-oauth.ts
@@ -16,6 +16,8 @@ const ALLOWED_RETURN_ORIGINS = [
   "http://localhost:3002",
   "https://dashboard.conclave-ai.dev",
   "https://conclave-dashboard.vercel.app", // Vercel production dashboard (beta QA)
+  "https://app.trysimsa.com", // Stage 89: Simsa dashboard app domain (exact origin, no wildcard)
+  "https://trysimsa.com", // Stage 89: Simsa marketing domain (exact origin)
 ];
 
 export type GitHubUser = {

--- a/apps/central-plane/test/workspace-github.test.mjs
+++ b/apps/central-plane/test/workspace-github.test.mjs
@@ -112,6 +112,14 @@ describe("github-oauth helpers", () => {
     assert.ok(!isAllowedReturnTo("https://evil-dashboard.vercel.app/projects/x"));
   });
 
+  it("isAllowedReturnTo accepts the Simsa launch origins (exact, no wildcard) — Stage 89", () => {
+    assert.ok(isAllowedReturnTo("https://app.trysimsa.com/projects/x/github"));
+    assert.ok(isAllowedReturnTo("https://trysimsa.com/projects/x"));
+    // exact-match only — a look-alike subdomain must still be rejected
+    assert.ok(!isAllowedReturnTo("https://evil.trysimsa.com/projects/x"));
+    assert.ok(!isAllowedReturnTo("https://app.trysimsa.com.evil.com/projects/x"));
+  });
+
   it("appendGitHubConnected adds query param", () => {
     assert.equal(
       appendGitHubConnected("/projects/abc", "https://dashboard.conclave-ai.dev"),

--- a/apps/dashboard/src/lib/brand.d.mts
+++ b/apps/dashboard/src/lib/brand.d.mts
@@ -8,6 +8,8 @@ export type Brand = {
   metadataDescription: string;
   primaryDomain: string;
   developerDomain: string;
+  appDomain: string;
+  legacyDashboardDomain: string;
 };
 
 export const BRAND: Brand;

--- a/apps/dashboard/src/lib/brand.mjs
+++ b/apps/dashboard/src/lib/brand.mjs
@@ -35,4 +35,10 @@ export const BRAND = {
     "Review, compare, and accept AI-built software with evidence.",
   primaryDomain: "trysimsa.com",
   developerDomain: "simsa.dev",
+  // Stage 89: launch-surface domains recorded for later wiring. The dashboard
+  // app will be served at appDomain once DNS + Vercel custom domain are live;
+  // legacyDashboardDomain stays as a permanent fallback. Stage 89 does NOT wire
+  // DNS — these are config constants only (see operator checklist in the stage doc).
+  appDomain: "app.trysimsa.com",
+  legacyDashboardDomain: "conclave-dashboard.vercel.app",
 };

--- a/apps/dashboard/test/brand.test.mjs
+++ b/apps/dashboard/test/brand.test.mjs
@@ -13,6 +13,9 @@ test("BRAND exports the current Simsa product strings", () => {
   assert.equal(BRAND.tagline, "The acceptance layer for AI-built software.");
   assert.equal(BRAND.primaryDomain, "trysimsa.com");
   assert.equal(BRAND.developerDomain, "simsa.dev");
+  // Stage 89: launch-surface domains (config constants — DNS wired separately).
+  assert.equal(BRAND.appDomain, "app.trysimsa.com");
+  assert.equal(BRAND.legacyDashboardDomain, "conclave-dashboard.vercel.app");
   // metadataTitle and description are concatenated server-side via Next; assert
   // they stay non-empty so a future rename doesn't accidentally drop them.
   assert.ok(BRAND.metadataTitle && BRAND.metadataTitle.includes(BRAND.productName));

--- a/conclave-builder-pack/out/stage-89-simsa-domain-routing-launch-surface.md
+++ b/conclave-builder-pack/out/stage-89-simsa-domain-routing-launch-surface.md
@@ -1,0 +1,143 @@
+# Stage 89 — Simsa Domain Routing & Launch Surface
+
+**Date:** 2026-06-22
+**Branch:** `chore/stage-89-simsa-domain-routing`
+**Scope:** Domain/routing readiness + minimal additive allowlist code. **No DNS, no deploy, no migration, no GitHub App change in this Stage.**
+
+## Goal
+Prepare the launch surface (trysimsa.com / app.trysimsa.com / simsa.dev) so domain
+activation can be done later under explicit approval — without breaking the existing
+`conclave-dashboard.vercel.app` dashboard or the central-plane worker.
+
+---
+
+## 1. Domain architecture (decision)
+
+| Domain | Role | Stage 89 state |
+|--------|------|----------------|
+| `trysimsa.com` | Marketing / landing (redirect to app initially, landing later) | reserved; allowed as exact origin |
+| `app.trysimsa.com` | Dashboard app — Vercel custom-domain alias of current dashboard | code allowlisted; DNS pending |
+| `simsa.dev` | Developer/docs surface (reserve / redirect) | reserved only; not pointed at prod |
+| `conclave-dashboard.vercel.app` | **Legacy fallback — keep** | unchanged |
+| `conclave-ai.seunghunbae.workers.dev` / `conclave-ai.dev` | central-plane worker + legacy domain | **unchanged / frozen** until an explicit central-plane migration plan |
+
+Invariants honored: existing dashboard URL and worker URL are **not** broken; internal
+namespace (`conclave`) frozen; no wildcard origins.
+
+---
+
+## 2. Audit results (domain/origin references)
+
+108 files matched; the runtime-critical surfaces (A–F):
+
+- **A. Dashboard → central-plane base URL** — `apps/dashboard/src/lib/workspace-api.ts`:
+  `CENTRAL_PLANE_URL = process.env.NEXT_PUBLIC_CENTRAL_PLANE_URL ?? "https://conclave-ai.seunghunbae.workers.dev"`.
+  → **env-driven; moving the dashboard to app.trysimsa.com needs NO code change** (API target is the worker, independent of dashboard origin).
+- **B. central-plane CORS allowlists** — 3 identical `ALLOWED_ORIGINS` arrays:
+  `routes/workspace.ts`, `routes/workspace-github.ts`, `routes/workspace-notifications.ts`.
+  `corsHeaders()` allows exact list ∪ `*.conclave-ai.dev` suffix (legacy, kept).
+- **C. OAuth** — `workspace/github-oauth.ts`:
+  - `redirect_uri = WORKSPACE_GH_REDIRECT_URI ?? ${PUBLIC_BASE_URL or worker}/workspace/github/oauth/callback`
+    → **the GitHub OAuth callback points at the WORKER, not the dashboard origin**.
+    → **Moving the dashboard to app.trysimsa.com does NOT require changing the GitHub App callback URL.**
+  - `ALLOWED_RETURN_ORIGINS` + `isAllowedReturnTo()` (exact origin match) gate where the user is
+    returned after connect — this **does** need app.trysimsa.com.
+- **D. Generated links** — `workspace/pr-comment.ts` footer URL = `https://conclave-ai.dev` (text `[Simsa]`),
+  Telegram `integration-telegram`/`workspace-notifications`, builder-pack export. **Left unchanged this Stage** (see §6).
+- **E. docs / marketing / historical** — not changed.
+- **F. internal/frozen** — `wrangler.toml`, `env.ts`, npm scopes, localStorage keys — not touched.
+
+---
+
+## 3. Code changes (minimal, additive, exact-origin)
+
+All additive; existing origins kept; **no wildcards**.
+
+- `apps/central-plane/src/routes/workspace.ts` — `ALLOWED_ORIGINS` += `https://app.trysimsa.com`, `https://trysimsa.com`
+- `apps/central-plane/src/routes/workspace-github.ts` — same
+- `apps/central-plane/src/routes/workspace-notifications.ts` — same
+- `apps/central-plane/src/workspace/github-oauth.ts` — `ALLOWED_RETURN_ORIGINS` += same two
+- `apps/dashboard/src/lib/brand.mjs` (+`.d.mts`) — `appDomain: "app.trysimsa.com"`, `legacyDashboardDomain: "conclave-dashboard.vercel.app"` (config constants; not yet used in visible copy)
+- Tests:
+  - `apps/central-plane/test/workspace-github.test.mjs` — `isAllowedReturnTo` accepts app.trysimsa.com/trysimsa.com (exact) and **rejects** `evil.trysimsa.com` / `app.trysimsa.com.evil.com`
+  - `apps/dashboard/test/brand.test.mjs` — pins new `appDomain` / `legacyDashboardDomain`
+
+**Effect requires a deploy to go live** — code is staged in this PR only; activation is gated (§7).
+
+---
+
+## 4. CORS / OAuth impact summary
+- CORS: app.trysimsa.com + trysimsa.com will be accepted once central-plane is deployed. Legacy origins retained. Exact-match only.
+- OAuth callback URL (GitHub App setting): **no change needed** (callback is worker-based).
+- OAuth returnTo: app.trysimsa.com now permitted (exact). Look-alike subdomains rejected (tested).
+- `NEXT_PUBLIC_CENTRAL_PLANE_URL`: no change (dashboard keeps calling the worker).
+
+---
+
+## 5. Generated-link policy (Stage 89)
+- **Do NOT switch generated links (PR comment footer / Telegram / export) to trysimsa.com until DNS + custom domain are confirmed live.**
+- PR comment footer currently uses legacy `https://conclave-ai.dev` (text `[Simsa]`). **TODO (post-domain stage):** switch footer URL to the live Simsa domain once activated.
+
+---
+
+## 6. Vercel / DNS operator checklist (do under explicit approval)
+
+```
+Vercel (dashboard project: conclave-dashboard):
+[ ] Add app.trysimsa.com as a custom domain to the dashboard project
+[ ] Configure DNS CNAME for app.trysimsa.com → cname.vercel-dns.com (per Vercel UI)
+[ ] Wait for Vercel domain verification (SSL issued)
+[ ] Confirm https://app.trysimsa.com loads the dashboard (200, title "Simsa …")
+
+trysimsa.com (apex):
+[ ] Decide landing vs redirect (Stage 89 default: redirect apex → app, landing later)
+[ ] If redirect: configure A/redirect per registrar/Vercel
+[ ] If landing: separate marketing surface = a later stage
+
+simsa.dev:
+[ ] Reserve / decide docs redirect; DO NOT point at production app unless intended
+
+Central-plane (deploy gated — separate approval):
+[ ] Deploy central-plane so the new exact CORS origins (app.trysimsa.com, trysimsa.com) take effect
+[ ] Verify OPTIONS/preflight from https://app.trysimsa.com returns the echoed exact origin
+[ ] Keep legacy origin https://conclave-dashboard.vercel.app working
+
+GitHub OAuth:
+[ ] No GitHub App callback change needed (callback is the worker URL)
+[ ] Verify GitHub connect flow end-to-end from https://app.trysimsa.com (returnTo now allowlisted)
+
+Post-domain (later stage):
+[ ] Switch PR comment footer / Telegram / export links to the live Simsa domain
+```
+
+---
+
+## 7. Rollback plan
+- Remove `app.trysimsa.com` custom domain from the Vercel dashboard project → traffic falls back to `conclave-dashboard.vercel.app` (unchanged).
+- The added allowlist origins are inert until deployed and harmless if a domain is removed (no one will send those origins). To fully revert, drop the added lines (pure additive) and redeploy.
+- No DB, no migration, no destructive DNS in this Stage → nothing to roll back DB-side.
+
+## 8. Tests / local verification
+- central-plane: **1135/1135** pass (+1 Stage 89 origin test), typecheck clean.
+- dashboard: **191/191** pass (brand drift-guard extended), typecheck clean.
+- lint: only the pre-existing `export/page.tsx` exhaustive-deps warning (no new issues).
+- No deploy performed.
+
+## 9. Remaining follow-ups
+- Operator: run §6 checklist (Vercel custom domain + DNS) under approval.
+- Deploy central-plane (gated) so CORS origins activate.
+- Post-domain stage: flip generated-link URLs (PR comment footer etc.).
+- Decide trysimsa.com apex behavior (redirect vs landing) and simsa.dev docs.
+
+## 10. Recommendation — actual domain activation
+Proceed in this order, each under explicit Bae approval:
+1. Merge this PR (code only; no live effect yet).
+2. Vercel: add `app.trysimsa.com` custom domain + DNS CNAME; verify it loads.
+3. Deploy central-plane (gated) to activate CORS for the new origins.
+4. Verify GitHub connect + workspace API from `https://app.trysimsa.com`.
+5. Later stage: switch generated links + decide apex/landing + simsa.dev.
+
+## Success criteria — met
+Launch surface for trysimsa.com / app.trysimsa.com / simsa.dev is safely designed;
+required code/config/tests are staged and green; activation can proceed under separate
+approval without breaking existing production URLs. ✓

--- a/docs/HANDOFF-2026-06-22.md
+++ b/docs/HANDOFF-2026-06-22.md
@@ -58,3 +58,24 @@ central-plane + dashboard 라이브 배포 및 smoke 통과.
 ## 보안
 - **Vercel token**: 값은 기록하지 않음. exposed/old Vercel token revoke/rotate는 **operator(Bae)가 완료했다고 확인함 (R11)**. 이번 dashboard 배포는 CLI 저장 로그인 사용이라 에이전트가 다룬 토큰 secret 없음 — 추가로 폐기할 secret 없음.
 - safety flags(actual debit 등)는 이번 release 범위 밖 — 기존 OFF 상태 유지.
+
+---
+
+## Stage 89 — Simsa Domain Routing & Launch Surface (2026-06-22)
+
+> Branch `chore/stage-89-simsa-domain-routing`. 설계 + 최소 additive allowlist 코드. **DNS/deploy/migration/GitHub App 변경 없음.**
+
+**핵심 결정/발견**
+- `app.trysimsa.com` = dashboard app (Vercel custom domain alias), `trysimsa.com` = 마케팅, `simsa.dev` = docs(예약). `conclave-dashboard.vercel.app`·worker URL은 **유지(불변)**.
+- dashboard→central-plane base는 env(`NEXT_PUBLIC_CENTRAL_PLANE_URL`) → 도메인 이동에 코드 변경 불필요.
+- ★OAuth 콜백은 **worker URL** 기반 → dashboard 도메인 이동에 **GitHub App 콜백 변경 불필요**. `returnTo` allowlist만 추가하면 됨.
+
+**코드 변경 (additive, exact-origin, 배포 전엔 무효과)**
+- CORS `ALLOWED_ORIGINS` 3파일(workspace/workspace-github/workspace-notifications) += `https://app.trysimsa.com`, `https://trysimsa.com`
+- OAuth `ALLOWED_RETURN_ORIGINS`(github-oauth.ts) += 동일 2개
+- dashboard `brand.mjs`(+`.d.mts`) += `appDomain`, `legacyDashboardDomain` (config 상수)
+- 테스트: returnTo exact-match(+look-alike 거부) / brand drift-guard 확장
+
+**검증**: central 1135/1135, dashboard 191/191, typecheck clean, lint 기존경고만. 배포 없음.
+
+**다음 (운영, 승인하에)**: Vercel custom domain `app.trysimsa.com` + DNS CNAME → central-plane deploy(CORS 활성) → app.trysimsa.com에서 GitHub connect 검증 → (후속 stage) PR comment footer 등 generated link를 라이브 Simsa 도메인으로 전환. 상세 체크리스트/롤백 = `conclave-builder-pack/out/stage-89-simsa-domain-routing-launch-surface.md`.


### PR DESCRIPTION
## Summary
Prepare the Simsa launch surface (**app.trysimsa.com / trysimsa.com / simsa.dev**) so domain activation can proceed later under explicit approval — **without breaking** `conclave-dashboard.vercel.app` or the central-plane worker. **No DNS, no deploy, no migration, no GitHub App change in this PR.** All code is additive, exact-origin, inert until deployed.

## Changes (10 files, +191)
**central-plane (allowlists — exact origin, no wildcard, legacy kept)**
- `routes/workspace.ts`, `routes/workspace-github.ts`, `routes/workspace-notifications.ts` — `ALLOWED_ORIGINS` += `https://app.trysimsa.com`, `https://trysimsa.com`
- `workspace/github-oauth.ts` — `ALLOWED_RETURN_ORIGINS` += same two

**dashboard**
- `lib/brand.mjs` (+`.d.mts`) — `appDomain: "app.trysimsa.com"`, `legacyDashboardDomain: "conclave-dashboard.vercel.app"` (config constants; not yet in visible copy)

**tests**
- `central-plane/test/workspace-github.test.mjs` — `isAllowedReturnTo` accepts the new exact origins; **rejects** `evil.trysimsa.com` / `app.trysimsa.com.evil.com`
- `dashboard/test/brand.test.mjs` — pins new brand fields

**docs**
- `conclave-builder-pack/out/stage-89-simsa-domain-routing-launch-surface.md` (architecture · CORS/OAuth impact · operator checklist · rollback)
- `docs/HANDOFF-2026-06-22.md` — Stage 89 section

## Key findings
- Dashboard→central-plane base is **env-driven** (`NEXT_PUBLIC_CENTRAL_PLANE_URL`) → moving the dashboard domain needs no code change.
- OAuth callback is **worker-based** → moving the dashboard to app.trysimsa.com needs **no GitHub App callback change**; only `returnTo` allowlist.
- Generated links (PR comment footer etc.) intentionally **not** switched until the domain is live (post-domain stage).

## Verification
- central-plane **1135/1135**, dashboard **191/191**, typecheck clean, lint = pre-existing `export/page.tsx` warning only.
- No deploy / no DNS performed.

## Activation (later, each under approval)
1. Merge this PR (code only; no live effect).
2. Vercel: add `app.trysimsa.com` custom domain + DNS CNAME; verify load.
3. Deploy central-plane (gated) to activate CORS origins.
4. Verify GitHub connect + API from `https://app.trysimsa.com`.
5. Later: switch generated links; decide apex/landing + simsa.dev.

## Rollback
Remove the Vercel custom domain → falls back to `conclave-dashboard.vercel.app`. Allowlist additions are inert/harmless; pure-additive revert + redeploy if needed. No DB/migration to roll back.