### PR TITLE
ci(deploy): Stage 90A — gate central-plane deploy to manual dispatch only

### DIFF
--- a/.github/workflows/deploy-central-plane.yml
+++ b/.github/workflows/deploy-central-plane.yml
@@ -1,16 +1,17 @@
 name: deploy-central-plane
 
-# v0.16 (Problem 3) — auto-deploy the central-plane Worker to Cloudflare
-# whenever apps/central-plane/** changes land on main. Replaces the
-# manual `pnpm -C apps/central-plane ship` step so SaaS endpoint changes
-# go live without a developer's machine + Docker dependencies.
+# Stage 90A — MANUAL deploy only. This workflow NO LONGER auto-deploys on push
+# to main. Merging apps/central-plane/** (or packages/core/**) to main runs CI
+# (ci.yml) for validation but does NOT deploy. Production deploy is an explicit,
+# human-triggered action:
+#   Actions → deploy-central-plane → Run workflow (workflow_dispatch, on main).
 #
-# How it works:
-#   1. Detect that a push to main touched apps/central-plane/** (or this
-#      workflow file).
-#   2. Build the central-plane TS → JS via the standard monorepo build.
-#   3. Run wrangler deploy with the CF API token from secrets.
-#   4. Apply pending D1 migrations (forward-only, idempotent).
+# Why: this separates "code merged" from "code deployed" so a code-only merge can
+# never accidentally ship to production. (Stage 89 hit exactly this: a docs/config
+# merge auto-triggered a deploy that had to be cancelled mid-run.)
+#
+# On dispatch it builds → (optionally) applies pending D1 migrations → wrangler
+# deploy → smoke. Migrations are forward-only + idempotent.
 #
 # Required repo secrets:
 #   CLOUDFLARE_API_TOKEN  — token with "Edit Cloudflare Workers" + "D1 Edit"
@@ -22,18 +23,17 @@ name: deploy-central-plane
 #                            (also embedded in any worker URL)
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'apps/central-plane/**'
-      - 'packages/core/**'
-      - '.github/workflows/deploy-central-plane.yml'
+  # No `push` trigger by design — see header. Deploy is manual-only.
   workflow_dispatch:
     inputs:
       apply-migrations:
         description: 'Apply D1 migrations after deploy (default: true)'
         required: false
         default: 'true'
+      confirm:
+        description: 'Type "deploy" to confirm a production deploy'
+        required: true
+        default: ''
 
 concurrency:
   group: deploy-central-plane
@@ -44,6 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Confirm deploy intent
+        if: inputs.confirm != 'deploy'
+        run: |
+          echo "Refusing to deploy: the 'confirm' input must be exactly 'deploy'."
+          echo "Re-run via Actions → deploy-central-plane → Run workflow and type 'deploy'."
+          exit 1
+
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v5
@@ -57,7 +64,7 @@ jobs:
         run: pnpm turbo run build --filter @conclave-ai/central-plane
 
       - name: Apply D1 migrations
-        if: github.event_name != 'workflow_dispatch' || inputs.apply-migrations != 'false'
+        if: inputs.apply-migrations != 'false'
         working-directory: apps/central-plane
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/conclave-builder-pack/out/stage-90-domain-activation-deploy-gate.md
+++ b/conclave-builder-pack/out/stage-90-domain-activation-deploy-gate.md
@@ -1,0 +1,85 @@
+# Stage 90 — Domain Activation + Deploy Gate
+
+**Date:** 2026-06-22
+**Split:** 90A (Deploy Gate PR) → **then** 90B (Domain Activation Execution, separate approval).
+
+---
+
+## Stage 90A — Deploy Gate (this PR)
+
+### Problem
+`deploy-central-plane.yml` auto-deployed on every push to `main` that touched
+`apps/central-plane/**` / `packages/core/**`. A code-only merge therefore triggered a
+production deploy. Stage 89 hit this: the docs/config merge auto-started a deploy that
+had to be cancelled mid-run (Worker deploy was cancelled before it shipped; the migration
+step was a no-op — "No migrations to apply!").
+
+### Change (Option A — workflow_dispatch-only)
+`.github/workflows/deploy-central-plane.yml`:
+- **Removed the `push:` trigger entirely.** The workflow now runs **only** on
+  `workflow_dispatch`.
+- Added a required `confirm` input + a first **"Confirm deploy intent"** step that
+  fails fast unless `confirm == "deploy"`. Guards against accidental dispatch.
+- Migration step condition simplified to `inputs.apply-migrations != 'false'`
+  (the `push`-event branch is gone).
+- Kept `apply-migrations` input, build → migrations → deploy → smoke steps unchanged.
+
+### Trigger behavior — before / after
+| | Before | After |
+|---|---|---|
+| Merge central-plane code to main | **auto production deploy** | CI only (`ci.yml`); **no deploy** |
+| Production deploy | implicit on merge | **manual**: Actions → deploy-central-plane → Run workflow → type `deploy` |
+| Code merged vs deployed | coupled | **decoupled** |
+
+### Verification
+- YAML parses cleanly; `on` = `[workflow_dispatch]` only (no `push`); inputs = `apply-migrations`, `confirm`; first step = "Confirm deploy intent" (`if: inputs.confirm != 'deploy'`).
+- No deploy / migration / domain / DNS executed.
+
+### 90A success criterion — met
+central-plane production deploy no longer runs automatically on main push; it runs only
+via explicit manual dispatch (with a typed confirm). ✓
+
+---
+
+## Stage 90B — Domain Activation Execution (DO NOT RUN until 90A merged + approved)
+
+### Preconditions
+- 90A merged; `deploy-central-plane` is manual/gated.
+- `main` includes Stage 89 code (CORS + OAuth allowlists for app.trysimsa.com / trysimsa.com).
+- Bae confirms DNS/Vercel UI access.
+- No uncommitted local changes.
+
+### Step 1 — Vercel custom domain
+- Target Vercel project: the one serving `conclave-dashboard.vercel.app` (`conclave-dashboard`).
+- Add `app.trysimsa.com` as a custom domain; configure DNS **CNAME** per Vercel's instruction; wait for verification (SSL issued).
+- **Do NOT remove `conclave-dashboard.vercel.app`** (kept as fallback).
+
+### Step 2 — dashboard domain smoke
+- `https://app.trysimsa.com` loads dashboard, `<title>` = Simsa, valid TLS.
+- `https://conclave-dashboard.vercel.app` still works.
+
+### Step 3 — central-plane deploy (manual, gated)
+- Actions → deploy-central-plane → Run workflow on `main`, type `confirm = deploy`.
+- Activates the Stage 89 CORS allowlist (app.trysimsa.com, trysimsa.com).
+- No new migrations expected; if the migration step runs it must report a no-op
+  ("No migrations to apply!").
+
+### Step 4 — app.trysimsa.com API smoke
+- Dashboard at app.trysimsa.com calls central-plane successfully (CORS preflight returns the exact echoed origin).
+- userKey/auth flow works.
+- GitHub connect returnTo flow works from app.trysimsa.com (returnTo allowlisted in Stage 89; OAuth callback is worker-based → no GitHub App change needed) — or document the failure reason.
+
+### Step 5 — rollback
+- Keep `conclave-dashboard.vercel.app` as fallback.
+- If broken: remove/disable `app.trysimsa.com` from Vercel.
+- Revert central-plane CORS deploy only if necessary (re-dispatch a deploy of the prior commit).
+
+### Remaining link-transition follow-ups (later stage)
+- Switch generated links (PR comment footer `conclave-ai.dev`, Telegram, export) to the live Simsa domain only **after** app.trysimsa.com is confirmed live.
+- Decide trysimsa.com apex (redirect → app vs landing) and simsa.dev docs.
+
+---
+
+## Security
+- No token values printed or stored. Vercel token was rotated/revoked by operator (R11).
+- Cloudflare deploy uses repo secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) inside Actions — never echoed.

--- a/docs/HANDOFF-2026-06-22.md
+++ b/docs/HANDOFF-2026-06-22.md
@@ -79,3 +79,22 @@ central-plane + dashboard 라이브 배포 및 smoke 통과.
 **검증**: central 1135/1135, dashboard 191/191, typecheck clean, lint 기존경고만. 배포 없음.
 
 **다음 (운영, 승인하에)**: Vercel custom domain `app.trysimsa.com` + DNS CNAME → central-plane deploy(CORS 활성) → app.trysimsa.com에서 GitHub connect 검증 → (후속 stage) PR comment footer 등 generated link를 라이브 Simsa 도메인으로 전환. 상세 체크리스트/롤백 = `conclave-builder-pack/out/stage-89-simsa-domain-routing-launch-surface.md`.
+
+---
+
+## Stage 90A — Deploy Gate (2026-06-22)
+
+> Branch `chore/stage-90a-deploy-gate`. `.github/workflows/deploy-central-plane.yml`만 수정 + 문서. **deploy/migration/domain/DNS 없음.**
+
+**문제**: 이 workflow가 `apps/central-plane/**` main push마다 **자동 production deploy** → 코드만 머지·배포 보류가 불가능(Stage 89 near-miss: 머지 직후 자동 deploy를 mid-run 취소).
+
+**변경 (Option A — workflow_dispatch-only)**:
+- `push:` trigger **완전 제거** → 이제 deploy는 **manual dispatch에서만** 실행. main 머지는 `ci.yml`만 돌고 배포 안 됨.
+- 필수 `confirm` 입력 + 첫 step "Confirm deploy intent"(`if: inputs.confirm != 'deploy'`)로 오발 방지.
+- migration step 조건 `inputs.apply-migrations != 'false'`로 정리. build→migrations→deploy→smoke 동작 동일.
+
+**before→after**: 코드 머지 시 자동배포 → CI만(배포X). production deploy = Actions→deploy-central-plane→Run workflow→`confirm: deploy`.
+
+**검증**: YAML 파싱 OK, triggers=[workflow_dispatch](push 없음). 배포 없음.
+
+**Stage 90B (별도 승인 후)**: Vercel `app.trysimsa.com` custom domain+CNAME → dashboard smoke → central-plane **manual** deploy(CORS 활성, migration no-op 기대) → app.trysimsa.com API/CORS/OAuth smoke → rollback은 vercel custom domain 제거 + conclave-dashboard.vercel.app fallback. 상세 = `conclave-builder-pack/out/stage-90-domain-activation-deploy-gate.md`.


### PR DESCRIPTION
## Summary
**Stage 90A** — stop `deploy-central-plane.yml` from auto-deploying on push to `main`. Production deploy becomes **manual-only** via `workflow_dispatch`, guarded by a typed confirm. This decouples *code merged* from *code deployed*.

**Why:** Stage 89 hit a near-miss — a docs/config merge touching `apps/central-plane/**` auto-triggered a production deploy that had to be cancelled mid-run (Worker deploy cancelled before shipping; migration step was a no-op).

## Change — `.github/workflows/deploy-central-plane.yml`
- **Remove the `push:` trigger entirely** → runs only on `workflow_dispatch`.
- Add required `confirm` input + first step **"Confirm deploy intent"** (`if: inputs.confirm != 'deploy'`) that fails fast unless `confirm == "deploy"`.
- Simplify migration step condition to `inputs.apply-migrations != 'false'`.
- build → migrations → deploy → smoke steps unchanged.

## Trigger behavior — before / after
| | Before | After |
|---|---|---|
| Merge central-plane code to main | **auto production deploy** | CI only (`ci.yml`); no deploy |
| Production deploy | implicit on merge | manual: Actions → deploy-central-plane → Run workflow → type `deploy` |

## Verification
- YAML parsed locally: `on` = `[workflow_dispatch]` only (no `push`); inputs = `apply-migrations`, `confirm`; first step = "Confirm deploy intent".
- **No deploy / migration / domain / DNS executed.**

## Not in this PR (Stage 90B, separate approval)
- Vercel `app.trysimsa.com` custom domain + DNS CNAME
- central-plane manual deploy to activate Stage 89 CORS allowlist
- app.trysimsa.com API/CORS/OAuth smoke
- See `conclave-builder-pack/out/stage-90-domain-activation-deploy-gate.md`.