### PR TITLE
docs: Stage 90B — app.trysimsa.com activation record + CORS follow-up

### DIFF
--- a/conclave-builder-pack/out/stage-90b-app-domain-activation.md
+++ b/conclave-builder-pack/out/stage-90b-app-domain-activation.md
@@ -1,0 +1,38 @@
+# Stage 90B — app.trysimsa.com Domain Activation (executed)
+
+**Date:** 2026-06-22
+**Scope:** Activate `app.trysimsa.com` as the dashboard production domain + deploy Stage 89 CORS allowlist to central-plane (manual, gated). No apex/simsa.dev routing, no generated-link switch, no migration.
+
+## Result — all steps PASS
+1. **Domains registered** (operator): `trysimsa.com` + `simsa.dev` purchased on the same Vercel account → Registrar = Vercel, **Nameservers = Vercel (auto-managed DNS)**.
+2. **Custom domain added**: `vercel domains add app.trysimsa.com` (linked project `conclave-dashboard`; single-arg form — passing the project name is rejected by the CLI when a project is linked).
+3. **DNS auto-managed + verified**: public resolvers (1.1.1.1, 8.8.8.8) resolve `app.trysimsa.com` to Vercel Edge; NS delegation confirmed (`ns1/ns2.vercel-dns.com √`); SSL cert issued (`cert_…` for `app.trysimsa.com`).
+   - Note: edge cert propagation lagged a few minutes (initial TLS handshake failed on both schannel-curl and openssl = control-plane issued ≠ edge serving). Resolved after short propagation.
+4. **Dashboard smoke**: `https://app.trysimsa.com` → **200**, valid TLS (`CN=app.trysimsa.com`), `<title>Simsa — The acceptance layer for AI-built software.</title>`. Legacy `https://conclave-dashboard.vercel.app` → **200** (fallback intact).
+5. **central-plane manual deploy** (Actions → deploy-central-plane → Run workflow, `confirm=deploy`, `apply-migrations=false`): success. "Confirm deploy intent" skipped (guard passed), **"Apply D1 migrations" skipped (no migration ran)**, Deploy Worker + smoke success. → Stage 89 CORS allowlist now live.
+6. **CORS smoke** (core, CORS-enabled endpoints): preflight from `https://app.trysimsa.com` → `204` + `Access-Control-Allow-Origin: https://app.trysimsa.com`; `GET /workspace/projects` actual response also echoes ACAO; `evil.com` not echoed; legacy `conclave-dashboard.vercel.app` + apex `trysimsa.com` allowed (exact match).
+7. **OAuth returnTo smoke** (live): `app.trysimsa.com` → `302 → github.com` (accepted); `evil.com` → `400` (rejected); legacy → `302`. GitHub App callback is worker-based → no GitHub App change needed.
+
+## ⚠️ Follow-up (pre-existing CORS gap — recommend Stage 91)
+CORS is per-route-file (`corsHeaders` + `ALLOWED_ORIGINS`); there is **no global CORS middleware** (`router.ts` mounts each module). These route files have **no CORS headers at all** (every origin, not specific to app.trysimsa.com):
+- `workspace-experiment.ts` (experiments, evolution-action-packs, evolution-learning/timeline, decision, benchmark-from-experiment)
+- `workspace-benchmark.ts`
+- `workspace-credits.ts`
+- `workspace-admin-credits.ts`
+- `workspace-admin-stats.ts`
+
+Effect: browser-client (CORS-enforced) calls to those features are blocked **from any origin** (including the existing `conclave-dashboard.vercel.app`). curl / MCP / server-side calls are unaffected. **Stage 91**: add `corsHeaders` (same allowlist incl. `app.trysimsa.com`) to these files, with tests.
+
+## Not done (per scope / prohibitions)
+trysimsa.com apex routing ✗ · simsa.dev routing ✗ · generated-link footer switch ✗ (still `conclave-ai.dev`) · GitHub App / Telegram rename ✗ · D1 migration ✗ (skipped) · token/secret printed ✗.
+
+## Rollback readiness
+- Keep `conclave-dashboard.vercel.app` as fallback (untouched).
+- If app.trysimsa.com breaks: `vercel domains rm app.trysimsa.com` (or remove from project) — DNS reverts; dashboard still on legacy URL.
+- central-plane CORS deploy revert only if needed: re-dispatch deploy of the prior commit.
+- No DB rollback (no migration ran).
+
+## Remaining follow-ups
+- Stage 91: CORS coverage for the 5 route files above.
+- Later: generated-link transition (PR comment footer etc.) to the live Simsa domain.
+- Later (separate, explicit): trysimsa.com apex (redirect vs landing) + simsa.dev docs.

--- a/docs/HANDOFF-2026-06-22.md
+++ b/docs/HANDOFF-2026-06-22.md
@@ -98,3 +98,20 @@ central-plane + dashboard 라이브 배포 및 smoke 통과.
 **검증**: YAML 파싱 OK, triggers=[workflow_dispatch](push 없음). 배포 없음.
 
 **Stage 90B (별도 승인 후)**: Vercel `app.trysimsa.com` custom domain+CNAME → dashboard smoke → central-plane **manual** deploy(CORS 활성, migration no-op 기대) → app.trysimsa.com API/CORS/OAuth smoke → rollback은 vercel custom domain 제거 + conclave-dashboard.vercel.app fallback. 상세 = `conclave-builder-pack/out/stage-90-domain-activation-deploy-gate.md`.
+
+---
+
+## Stage 90B — app.trysimsa.com Activation (실행 완료, 2026-06-22)
+
+> Bae가 trysimsa.com+simsa.dev를 Vercel에서 구매(NS=Vercel 자동관리) → 활성화 실행. 상세 = `conclave-builder-pack/out/stage-90b-app-domain-activation.md`.
+
+**결과 (전 Step PASS)**:
+- `app.trysimsa.com` → conclave-dashboard 프로젝트 custom domain 추가, Vercel 자동 DNS + NS √ + SSL 발급. (edge cert 전파 수분 지연 후 serving.)
+- dashboard smoke: **https://app.trysimsa.com 200 / TLS(CN=app.trysimsa.com) / title Simsa**. legacy conclave-dashboard.vercel.app 200 유지.
+- central-plane **수동** deploy(confirm=deploy, apply-migrations=false): success, **migration step skipped(미실행)**, Worker deploy+smoke success → Stage 89 CORS 라이브 활성.
+- CORS: 코어 엔드포인트가 app.trysimsa.com ACAO echo(preflight 204 + 실응답), evil 거부, legacy+apex 허용.
+- OAuth returnTo: app.trysimsa.com→302 github, evil→400, legacy→302. GitHub App 콜백 worker기반→변경 없음.
+
+**★Follow-up (Stage 91, 기존 결함)**: `workspace-experiment.ts`·`workspace-benchmark.ts`·`workspace-credits.ts`·`workspace-admin-credits.ts`·`workspace-admin-stats.ts`에 **corsHeaders 없음** → browser-client에서 experiment/benchmark/evolution/credits/admin 호출은 **모든 origin에서 CORS 차단**(글로벌 cors 미들웨어 없음). curl/server-side는 영향 없음. → 해당 파일에 corsHeaders(동일 allowlist) 추가 필요.
+
+**미실행**: apex routing / simsa.dev / generated-link 전환 / GitHub App·Telegram rename / D1 migration — 전부 안 함.


### PR DESCRIPTION
## Summary
Docs-only record of **Stage 90B** (app.trysimsa.com activation, executed). No code, no deploy in this PR.

## What happened (Stage 90B, already executed)
- `app.trysimsa.com` added to the `conclave-dashboard` Vercel project; Vercel-managed DNS + NS verified + SSL issued.
- Dashboard smoke: `https://app.trysimsa.com` → **200**, valid TLS, title **Simsa**. Legacy `conclave-dashboard.vercel.app` → 200 (fallback intact).
- central-plane **manual** deploy (`confirm=deploy`, `apply-migrations=false` → migration step **skipped**) → Stage 89 CORS allowlist now live.
- CORS smoke: preflight + actual-response ACAO echo for `app.trysimsa.com`; `evil.com` rejected; legacy + apex allowed (exact match).
- OAuth returnTo: `app.trysimsa.com` accepted (302 → github), `evil.com` rejected (400). GitHub App callback is worker-based → no GitHub App change.

## ⚠️ Follow-up (pre-existing, recommend Stage 91)
No global CORS middleware — it's per-route-file. These files have **no `corsHeaders`**: `workspace-experiment.ts`, `workspace-benchmark.ts`, `workspace-credits.ts`, `workspace-admin-credits.ts`, `workspace-admin-stats.ts`. Browser-client calls to experiment/benchmark/evolution/credits/admin features are CORS-blocked **from any origin** (not specific to app.trysimsa.com; curl/server-side unaffected). Add `corsHeaders` (same allowlist) to these files with tests.

## Files
- `conclave-builder-pack/out/stage-90b-app-domain-activation.md` (new)
- `docs/HANDOFF-2026-06-22.md` (Stage 90B section)