### PR TITLE
fix(cors): Stage 91 — route-level CORS coverage for Simsa app domain

### DIFF
--- a/apps/central-plane/src/routes/cors.ts
+++ b/apps/central-plane/src/routes/cors.ts
@@ -1,0 +1,59 @@
+/**
+ * routes/cors.ts — Stage 91
+ *
+ * Single source of truth for browser-facing CORS on central-plane.
+ *
+ * Before Stage 91 the allowlist + corsHeaders were duplicated in
+ * workspace.ts / workspace-github.ts / workspace-notifications.ts, and several
+ * browser-facing route modules (experiment, benchmark, credits, admin-credits,
+ * admin-stats) shipped NO CORS at all — so the dashboard's client-side calls to
+ * those features were blocked from every origin. This module centralizes the
+ * allowlist and provides a Hono middleware those modules can mount.
+ *
+ * Exact origins only — NO wildcards. The `.conclave-ai.dev` suffix is kept for
+ * legacy dashboard subdomains.
+ */
+import type { MiddlewareHandler } from "hono";
+import type { Env } from "../env.js";
+
+export const ALLOWED_ORIGINS = [
+  "http://localhost:3002",
+  "http://localhost:3000",
+  "https://dashboard.conclave-ai.dev",
+  "https://conclave-dashboard.vercel.app", // Vercel production dashboard (beta QA)
+  "https://app.trysimsa.com", // Stage 89/91: Simsa dashboard app domain (exact origin)
+  "https://trysimsa.com", // Stage 89/91: Simsa marketing domain (exact origin)
+];
+
+/** Returns CORS headers for `origin`; disallowed origins fall back to the first
+ * allowed origin (never echoed). */
+export function corsHeaders(origin: string | null): Record<string, string> {
+  const allowed: string =
+    origin && (ALLOWED_ORIGINS.includes(origin) || origin.endsWith(".conclave-ai.dev"))
+      ? origin
+      : (ALLOWED_ORIGINS[0] as string);
+  return {
+    "Access-Control-Allow-Origin": allowed,
+    "Access-Control-Allow-Methods": "GET, POST, PATCH, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Max-Age": "86400",
+    Vary: "Origin",
+  };
+}
+
+/**
+ * Hono middleware: answers preflight OPTIONS with 204 + CORS, and attaches CORS
+ * headers to every other response (incl. error responses). Mount per
+ * browser-facing module: `app.use("*", corsMiddleware)`.
+ */
+export const corsMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
+  const origin = c.req.header("origin") ?? null;
+  if (c.req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders(origin) });
+  }
+  await next();
+  const headers = corsHeaders(origin);
+  for (const [key, value] of Object.entries(headers)) {
+    c.res.headers.set(key, value);
+  }
+};

--- a/apps/central-plane/src/routes/workspace-admin-credits.ts
+++ b/apps/central-plane/src/routes/workspace-admin-credits.ts
@@ -16,6 +16,7 @@
  * actualDebitsEnabled is always false.
  */
 import { Hono } from "hono";
+import { corsMiddleware } from "./cors.js";
 import type { Env } from "../env.js";
 import {
   listCreditBalances,
@@ -54,6 +55,9 @@ const VALID_CREDIT_TYPES: CreditType[] = ["review", "fix", "workspace"];
 
 export function createWorkspaceAdminCreditsRoutes(): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
+
+  // Stage 91: browser-facing CORS (preflight + headers on every response).
+  app.use("*", corsMiddleware);
 
   /**
    * GET /admin/credits?userKey=...

--- a/apps/central-plane/src/routes/workspace-admin-stats.ts
+++ b/apps/central-plane/src/routes/workspace-admin-stats.ts
@@ -10,6 +10,7 @@
  * No billing, no credit deduction — read-only analytics + dry-run billing estimate.
  */
 import { Hono } from "hono";
+import { corsMiddleware } from "./cors.js";
 import type { Env } from "../env.js";
 import { getBillingRule, estimateCredits } from "../workspace/billing-rules.js";
 import type { BillingStatus, CreditType } from "../workspace/billing-rules.js";
@@ -242,6 +243,9 @@ function computeDryRunBilling(
 
 export function createWorkspaceAdminStatsRoutes(): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
+
+  // Stage 91: browser-facing CORS (preflight + headers on every response).
+  app.use("*", corsMiddleware);
 
   /**
    * GET /admin/usage-stats?range=24h|7d|30d

--- a/apps/central-plane/src/routes/workspace-benchmark.ts
+++ b/apps/central-plane/src/routes/workspace-benchmark.ts
@@ -13,6 +13,7 @@
  * userKey that created them.
  */
 import { Hono } from "hono";
+import { corsMiddleware } from "./cors.js";
 import type { Env } from "../env.js";
 import { getReviewRunById } from "../workspace/pr-review-db.js";
 import {
@@ -67,6 +68,9 @@ function parseResultItems(resultJson: string | undefined): ReviewItemInput[] {
 
 export function createWorkspaceBenchmarkRoutes(): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
+
+  // Stage 91: browser-facing CORS (preflight + headers on every response).
+  app.use("*", corsMiddleware);
 
   // ── POST /workspace/projects/:id/agent-benchmarks ──────────────────────────
   app.post("/workspace/projects/:id/agent-benchmarks", async (c) => {

--- a/apps/central-plane/src/routes/workspace-credits.ts
+++ b/apps/central-plane/src/routes/workspace-credits.ts
@@ -12,6 +12,7 @@
  * Ledger rows, sourceEventId, and internal status are NOT exposed.
  */
 import { Hono } from "hono";
+import { corsMiddleware } from "./cors.js";
 import type { Env } from "../env.js";
 import { listCreditBalances } from "../workspace/credits.js";
 import type { CreditType } from "../workspace/credits.js";
@@ -26,6 +27,9 @@ const VALID_CREDIT_TYPES: CreditType[] = ["review", "fix", "workspace"];
 
 export function createWorkspaceCreditsRoutes(): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
+
+  // Stage 91: browser-facing CORS (preflight + headers on every response).
+  app.use("*", corsMiddleware);
 
   /**
    * GET /workspace/credits?userKey=...

--- a/apps/central-plane/src/routes/workspace-experiment.ts
+++ b/apps/central-plane/src/routes/workspace-experiment.ts
@@ -12,6 +12,7 @@
  * PATCH  /workspace/projects/:id/agent-experiments/:experimentId/candidates/:candidateId
  */
 import { Hono } from "hono";
+import { corsMiddleware } from "./cors.js";
 import type { Env } from "../env.js";
 import { getReviewRunById } from "../workspace/pr-review-db.js";
 import { getAgentBenchmarkById, insertAgentBenchmark } from "../workspace/agent-benchmark-db.js";
@@ -208,6 +209,9 @@ async function loadImpactForActionPack(
 
 export function createWorkspaceExperimentRoutes(): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
+
+  // Stage 91: browser-facing CORS (preflight + headers on every response).
+  app.use("*", corsMiddleware);
 
   // ── POST create ────────────────────────────────────────────────────────────
   app.post("/workspace/projects/:id/agent-experiments", async (c) => {

--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -21,6 +21,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
+import { ALLOWED_ORIGINS } from "./cors.js";
 import type { FetchLike } from "../github.js";
 import { encryptToken, decryptToken } from "../crypto.js";
 import {
@@ -74,14 +75,7 @@ import {
 
 // ─── CORS helpers (shared with workspace.ts) ──────────────────────────────────
 
-const ALLOWED_ORIGINS = [
-  "http://localhost:3002",
-  "http://localhost:3000",
-  "https://dashboard.conclave-ai.dev",
-  "https://conclave-dashboard.vercel.app", // Vercel production dashboard (beta QA)
-  "https://app.trysimsa.com", // Stage 89: Simsa dashboard app domain (exact origin)
-  "https://trysimsa.com", // Stage 89: Simsa marketing domain (exact origin)
-];
+// ALLOWED_ORIGINS centralized in ./cors.ts (Stage 91) — imported at top.
 
 function corsHeaders(origin: string | null): Record<string, string> {
   const allowed =

--- a/apps/central-plane/src/routes/workspace-notifications.ts
+++ b/apps/central-plane/src/routes/workspace-notifications.ts
@@ -10,6 +10,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
+import { ALLOWED_ORIGINS } from "./cors.js";
 import type { FetchLike } from "../github.js";
 import {
   upsertNotificationSettings,
@@ -21,14 +22,7 @@ import {
 } from "../workspace/notification-db.js";
 import { sendWorkspaceTelegramMessage } from "../workspace/telegram-notify.js";
 
-const ALLOWED_ORIGINS = [
-  "http://localhost:3002",
-  "http://localhost:3000",
-  "https://dashboard.conclave-ai.dev",
-  "https://conclave-dashboard.vercel.app", // Vercel production dashboard (beta QA)
-  "https://app.trysimsa.com", // Stage 89: Simsa dashboard app domain (exact origin)
-  "https://trysimsa.com", // Stage 89: Simsa marketing domain (exact origin)
-];
+// ALLOWED_ORIGINS centralized in ./cors.ts (Stage 91) — imported at top.
 
 function corsHeaders(origin: string | null): Record<string, string> {
   const allowed =

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -12,6 +12,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
+import { ALLOWED_ORIGINS } from "./cors.js";
 import { generateIdeaToSpecDraft, type IdeaToSpecDraftRequest } from "../workspace/generate.js";
 import {
   generateCheckDraft,
@@ -44,14 +45,7 @@ import { insertUsageEvent } from "../workspace/usage-events-db.js";
 
 const DEFAULT_LIMIT_PER_HOUR = 20;
 
-const ALLOWED_ORIGINS = [
-  "http://localhost:3002",
-  "http://localhost:3000",
-  "https://dashboard.conclave-ai.dev",
-  "https://conclave-dashboard.vercel.app", // Vercel production dashboard (beta QA)
-  "https://app.trysimsa.com", // Stage 89: Simsa dashboard app domain (exact origin)
-  "https://trysimsa.com", // Stage 89: Simsa marketing domain (exact origin)
-];
+// ALLOWED_ORIGINS centralized in ./cors.ts (Stage 91) — imported at top.
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/apps/central-plane/test/workspace-cors.test.mjs
+++ b/apps/central-plane/test/workspace-cors.test.mjs
@@ -1,0 +1,87 @@
+// Stage 91 — route-level CORS coverage.
+//
+// Before Stage 91, the experiment / benchmark / credits / admin-credits /
+// admin-stats route modules shipped NO CORS headers, so the dashboard's
+// browser-side calls to those features were blocked from every origin. These
+// tests pin that those routes now return exact-origin CORS for the Simsa app
+// domain + legacy dashboard origin, never echo a disallowed origin, and answer
+// preflight OPTIONS. (Fails before the fix, passes after.)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../dist/router.js";
+
+const CTX = { waitUntil() {}, passThroughOnException() {} };
+
+// Minimal DB mock — the routes under test validate userKey / admin key and
+// return early (4xx) before touching the DB, so queries should not run; the
+// mock just guarantees nothing throws if one does.
+function makeEnv() {
+  return {
+    ENVIRONMENT: "test",
+    DB: {
+      prepare() {
+        return {
+          bind() {
+            return {
+              async first() { return null; },
+              async run() { return { success: true }; },
+              async all() { return { results: [] }; },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+async function req(path, { method = "GET", origin } = {}) {
+  const headers = {};
+  if (origin) headers.origin = origin;
+  return createApp().fetch(new Request("http://x" + path, { method, headers }), makeEnv(), CTX);
+}
+
+const APP = "https://app.trysimsa.com";
+const LEGACY = "https://conclave-dashboard.vercel.app";
+const EVIL = "https://evil.com";
+const FALLBACK = "http://localhost:3002"; // ALLOWED_ORIGINS[0]
+
+// One representative path per previously-uncovered browser-facing module.
+const ROUTES = [
+  ["/workspace/projects/p_smoke/evolution-learning", "experiment (evolution-learning)"],
+  ["/workspace/projects/p_smoke/agent-benchmarks", "benchmark"],
+  ["/workspace/credits", "credits"],
+  ["/admin/credits", "admin-credits"],
+  ["/admin/usage-stats", "admin-stats"],
+];
+
+for (const [path, label] of ROUTES) {
+  test(`Stage 91 CORS: ${label} echoes app.trysimsa.com`, async () => {
+    const res = await req(path, { origin: APP });
+    assert.equal(res.headers.get("access-control-allow-origin"), APP);
+  });
+}
+
+test("Stage 91 CORS: legacy dashboard origin still echoed (experiment route)", async () => {
+  const res = await req("/workspace/projects/p_smoke/evolution-learning", { origin: LEGACY });
+  assert.equal(res.headers.get("access-control-allow-origin"), LEGACY);
+});
+
+test("Stage 91 CORS: disallowed origin is NOT echoed (fallback, not evil.com)", async () => {
+  const res = await req("/workspace/projects/p_smoke/evolution-learning", { origin: EVIL });
+  const acao = res.headers.get("access-control-allow-origin");
+  assert.notEqual(acao, EVIL);
+  assert.equal(acao, FALLBACK);
+});
+
+test("Stage 91 CORS: OPTIONS preflight 204 + ACAO on a previously-missing route (benchmark)", async () => {
+  const res = await req("/workspace/projects/p_smoke/agent-benchmarks", { method: "OPTIONS", origin: APP });
+  assert.equal(res.status, 204);
+  assert.equal(res.headers.get("access-control-allow-origin"), APP);
+});
+
+test("Stage 91 CORS: admin route carries ACAO even on guard response when Origin allowed", async () => {
+  // /admin/credits without an admin key returns a 4xx guard response, but it
+  // must still carry the CORS header so the dashboard can read the error.
+  const res = await req("/admin/credits", { origin: APP });
+  assert.equal(res.headers.get("access-control-allow-origin"), APP);
+});

--- a/conclave-builder-pack/out/stage-91-route-cors-coverage.md
+++ b/conclave-builder-pack/out/stage-91-route-cors-coverage.md
@@ -1,0 +1,61 @@
+# Stage 91 — Route-level CORS Coverage for app.trysimsa.com
+
+**Date:** 2026-06-22
+**Branch:** `fix/stage-91-cors-coverage`
+**Scope:** Make every browser-facing central-plane route return exact-origin CORS. Code PR only — **no deploy / migration / domain / DNS / generated-link / rename** in this stage.
+
+## Why
+Stage 90B verified app.trysimsa.com CORS works for the **core** routes (workspace.ts, github, notifications), but found that several browser-facing modules shipped **no CORS at all** — so the dashboard's client-side calls to those features were blocked from **every** origin (including the existing `conclave-dashboard.vercel.app`), not just app.trysimsa.com. There is no global CORS middleware; CORS was per-route-file and the allowlist was duplicated.
+
+## Audit (before)
+| Route module | Browser-facing | CORS before |
+|---|---|---|
+| workspace.ts | yes (core) | ✅ |
+| workspace-github.ts | yes | ✅ |
+| workspace-notifications.ts | yes | ✅ |
+| workspace-experiment.ts (experiments, benchmark-from-exp, evolution action-packs/impact/learning/timeline, decision) | yes | ❌ |
+| workspace-benchmark.ts | yes | ❌ |
+| workspace-credits.ts | yes | ❌ |
+| workspace-admin-credits.ts | yes (admin dashboard) | ❌ |
+| workspace-admin-stats.ts | yes (admin dashboard) | ❌ |
+
+## Change
+- **New `apps/central-plane/src/routes/cors.ts`** — single source of truth:
+  - `ALLOWED_ORIGINS` (exact origins; `.conclave-ai.dev` suffix kept; **no wildcards**) incl. `https://app.trysimsa.com` + `https://trysimsa.com`.
+  - `corsHeaders(origin)` — disallowed origins fall back to the first allowed origin (never echoed).
+  - `corsMiddleware` — Hono middleware: answers preflight `OPTIONS` (204 + CORS) and attaches CORS headers to every response (incl. errors).
+- **5 previously-uncovered modules** now `app.use("*", corsMiddleware)`: experiment, benchmark, credits, admin-credits, admin-stats.
+- **3 existing modules** (workspace, github, notifications) now import `ALLOWED_ORIGINS` from `cors.ts` (removed their duplicated local copies — **single allowlist, no drift**). Their existing per-handler `corsHeaders` + OPTIONS handlers are unchanged (behavior preserved).
+
+## CORS behavior — before / after
+| | Before | After |
+|---|---|---|
+| `app.trysimsa.com` → experiment/benchmark/credits/admin routes | no ACAO (blocked) | **ACAO echoes app.trysimsa.com** |
+| legacy `conclave-dashboard.vercel.app` | core only | all browser routes |
+| disallowed origin (evil.com) | n/a | **not echoed** (fallback `localhost:3002`) |
+| OPTIONS preflight on those routes | not handled | **204 + ACAO** |
+| allowlist source | duplicated in 3 files | **1 file (`cors.ts`)** |
+
+No wildcard CORS. Exact origin only.
+
+## Tests (`apps/central-plane/test/workspace-cors.test.mjs`, 9 cases)
+- ACAO echoes `app.trysimsa.com` on experiment / benchmark / credits / admin-credits / admin-stats.
+- legacy origin still echoed.
+- disallowed origin (`evil.com`) NOT echoed (fallback).
+- OPTIONS preflight 204 + ACAO on a previously-missing route.
+- admin route carries ACAO even on its guard (4xx) response.
+
+## Local verification
+- central-plane **1144/1144** pass (+9), typecheck clean. (central-plane has no lint task.)
+- No deploy / migration performed.
+
+## After merge (requires explicit Bae approval)
+1. Manual `deploy-central-plane` (`confirm=deploy`, `apply-migrations=false`).
+2. Smoke from app.trysimsa.com: experiment/benchmark/credits routes now return ACAO; OPTIONS preflight 204; legacy origin still allowed; evil origin not echoed.
+
+## Out of scope / not done
+domain/DNS/Vercel ✗ · GitHub App ✗ · generated-link footer ✗ · Telegram rename ✗ · package/env/DB/internal namespace ✗ · D1 migration ✗ · billing ✗.
+
+## Remaining follow-ups
+- (later) generated-link transition (PR comment footer etc.) to the live Simsa domain.
+- (later, explicit) trysimsa.com apex (redirect vs landing) + simsa.dev docs.


### PR DESCRIPTION
## Why
Stage 90B verified app.trysimsa.com CORS for the **core** routes, but found several browser-facing central-plane modules ship **no CORS at all** — so the dashboard's client-side calls to those features are blocked from **every** origin (incl. `conclave-dashboard.vercel.app`), not just app.trysimsa.com. No global CORS middleware; the allowlist was duplicated per file.

## Routes fixed (now CORS-covered)
`workspace-experiment` (experiments, evolution action-packs/impact/learning/timeline, decision, benchmark-from-exp), `workspace-benchmark`, `workspace-credits`, `workspace-admin-credits`, `workspace-admin-stats`.

## Change
- **New `routes/cors.ts`** — single source of truth: `ALLOWED_ORIGINS` (exact origins, **no wildcard**, incl. `app.trysimsa.com` + `trysimsa.com`), `corsHeaders(origin)` (disallowed → fallback, never echoed), and `corsMiddleware` (preflight 204 + headers on every response).
- 5 uncovered modules: `app.use("*", corsMiddleware)`.
- `workspace` / `workspace-github` / `workspace-notifications`: import `ALLOWED_ORIGINS` from `cors.ts` (drop duplicated local copies — single allowlist, no drift; existing per-handler behavior preserved).

## Exact origins preserved · no wildcard CORS
`http://localhost:3002/3000`, `https://dashboard.conclave-ai.dev` (+`.conclave-ai.dev` suffix), `https://conclave-dashboard.vercel.app`, `https://app.trysimsa.com`, `https://trysimsa.com`. No `*`, no `*.vercel.app`, no `*.trysimsa.com`.

## Tests (9, `workspace-cors.test.mjs`)
ACAO echoes app.trysimsa.com on all 5 newly-covered routes · legacy origin echoed · disallowed origin NOT echoed (fallback) · OPTIONS preflight 204 + ACAO · admin guard response still carries ACAO.

## Verification
- central-plane **1144/1144** pass (+9), typecheck clean. (no lint task on central-plane)
- **No migration. No deploy performed.**

## After merge (requires explicit approval)
Manual `deploy-central-plane` (`confirm=deploy`, `apply-migrations=false`) to activate, then smoke from app.trysimsa.com (experiment/benchmark/credits routes return ACAO; preflight 204; legacy allowed; evil not echoed).