### PR TITLE
chore(brand): Stage 92 — update Simsa generated link surface

### DIFF
--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -107,7 +107,7 @@ export interface Env {
    *   WORKSPACE_GH_CLIENT_ID = "..."
    *   WORKSPACE_GH_REDIRECT_URI = "..."  (defaults to workers.dev/callback if unset)
    *   WORKSPACE_GH_SCOPES = "read:user public_repo"  (optional, has default)
-   *   WORKSPACE_GH_DASHBOARD_URL = "https://dashboard.conclave-ai.dev"  (optional)
+   *   WORKSPACE_GH_DASHBOARD_URL = "https://app.trysimsa.com"  (optional; Stage 92 default)
    *
    * Set via `wrangler secret put` (client secret must NOT be in wrangler.toml):
    *   WORKSPACE_GH_CLIENT_SECRET = "..."
@@ -119,7 +119,7 @@ export interface Env {
   WORKSPACE_GH_DASHBOARD_URL?: string;
   /**
    * Stage 17 — base URL of the dashboard. Used when building Telegram notification
-   * message links. Defaults to https://dashboard.conclave-ai.dev when unset.
+   * message links. Defaults to https://app.trysimsa.com when unset (Stage 92).
    * Set via wrangler.toml [vars] or `wrangler secret put DASHBOARD_BASE_URL`.
    */
   DASHBOARD_BASE_URL?: string;

--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -22,6 +22,7 @@
 import { Hono } from "hono";
 import type { Env } from "../env.js";
 import { ALLOWED_ORIGINS } from "./cors.js";
+import { BRAND } from "../workspace/brand.js";
 import type { FetchLike } from "../github.js";
 import { encryptToken, decryptToken } from "../crypto.js";
 import {
@@ -90,7 +91,11 @@ function corsHeaders(origin: string | null): Record<string, string> {
   };
 }
 
-const DEFAULT_DASHBOARD_URL = "https://dashboard.conclave-ai.dev";
+// Stage 92: default to the live Simsa app domain (app.trysimsa.com) for
+// user-facing post-connect redirects / Telegram links when WORKSPACE_GH_DASHBOARD_URL
+// (or DASHBOARD_BASE_URL) is unset. The old default (dashboard.conclave-ai.dev)
+// never had DNS. Production env, if set, still takes precedence.
+const DEFAULT_DASHBOARD_URL = BRAND.appUrl;
 
 function json(data: unknown, status = 200, origin: string | null = null): Response {
   return new Response(JSON.stringify(data), {

--- a/apps/central-plane/src/workspace/brand.ts
+++ b/apps/central-plane/src/workspace/brand.ts
@@ -30,6 +30,11 @@ export const BRAND = {
   tagline: "The acceptance layer for AI-built software.",
   actionPackHeading: "Simsa Evolution Action Pack",
   prCommentHeading: "Simsa Review",
+  // Stage 92: live public app/dashboard URL. app.trysimsa.com is wired
+  // (Stage 90B) and serves the Simsa dashboard. Used in user-facing generated
+  // links (PR comment footer, dashboard-link fallback). NOT trysimsa.com apex
+  // / simsa.dev (no routing yet). Internal infra hostnames stay `conclave-*`.
+  appUrl: "https://app.trysimsa.com",
 } as const;
 
 export type BrandKey = keyof typeof BRAND;

--- a/apps/central-plane/src/workspace/pr-comment.ts
+++ b/apps/central-plane/src/workspace/pr-comment.ts
@@ -9,6 +9,7 @@
  */
 import type { FetchLike } from "../github.js";
 import type { SpecificRunComparison } from "./pr-review-compare.js";
+import { BRAND } from "./brand.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -294,10 +295,9 @@ function buildFooterPart(): string {
     "<details>",
     "<summary>이 코멘트에 대하여</summary>",
     "",
-    // The Simsa product name is current; the legacy `conclave-ai.dev` domain
-    // remains the live URL until DNS for trysimsa.com / simsa.dev is wired
-    // in a separate operational stage. Stage 85 ships the rename, not DNS.
-    "이 코멘트는 [Simsa](https://conclave-ai.dev)에서 PR 코드 확인 결과를 바탕으로 자동 생성했습니다.  ",
+    // Stage 92: link to the live Simsa app domain (app.trysimsa.com, wired in
+    // Stage 90B). Sourced from BRAND.appUrl so the brand + URL move in lockstep.
+    `이 코멘트는 [${BRAND.productName}](${BRAND.appUrl})에서 PR 코드 확인 결과를 바탕으로 자동 생성했습니다.  `,
     "이 단계에서는 코드를 자동으로 고치지 않습니다.",
     "",
     "</details>",

--- a/apps/central-plane/test/brand.test.mjs
+++ b/apps/central-plane/test/brand.test.mjs
@@ -18,6 +18,8 @@ test("BRAND exports the spec keys with the current Simsa values", () => {
   assert.equal(BRAND.actionPackHeading, "Simsa Evolution Action Pack");
   assert.equal(BRAND.prCommentHeading, "Simsa Review");
   assert.equal(BRAND.tagline, "The acceptance layer for AI-built software.");
+  // Stage 92: live public app URL used in user-facing generated links.
+  assert.equal(BRAND.appUrl, "https://app.trysimsa.com");
 });
 
 test("DEFAULT_EVOLUTION_STRINGS.packHeading is sourced from BRAND.actionPackHeading", () => {

--- a/apps/central-plane/test/workspace-pr-comment-comparison.test.mjs
+++ b/apps/central-plane/test/workspace-pr-comment-comparison.test.mjs
@@ -395,7 +395,10 @@ describe("buildCommentBody — comparison section", () => {
       includeComparison: true,
       comparisonData: COMPARISON_DATA,
     });
-    assert.ok(body.includes("conclave-ai.dev"), "footer present");
+    // Stage 92: footer now links to the live Simsa app domain (was conclave-ai.dev).
+    assert.ok(body.includes("https://app.trysimsa.com"), "footer links to Simsa app domain");
+    assert.ok(body.includes("[Simsa]"), "footer carries the Simsa label");
+    assert.ok(!body.includes("conclave-ai.dev"), "footer no longer points to legacy conclave-ai.dev");
   });
 });
 

--- a/conclave-builder-pack/out/stage-92-simsa-link-surface.md
+++ b/conclave-builder-pack/out/stage-92-simsa-link-surface.md
@@ -1,0 +1,55 @@
+# Stage 92 — Simsa Link Surface Cleanup
+
+**Date:** 2026-06-22
+**Branch:** `chore/stage-92-simsa-link-surface`
+**Scope:** Point user-facing **generated links** at the live Simsa app domain. Link surface only — no product logic, no DNS/Vercel/deploy/migration.
+
+## Audit summary
+`rg` across central-plane for `conclave-ai.dev` / `conclave-dashboard.vercel.app`. Classified:
+- **A. user-facing generated link** — PR comment footer (`pr-comment.ts`): `[Simsa](https://conclave-ai.dev)` → **switch**.
+- **B/D. dashboard-link fallback** — `workspace-github.ts` `DEFAULT_DASHBOARD_URL = https://dashboard.conclave-ai.dev` (never had DNS) → **switch** (used for OAuth post-connect redirect, Telegram message links, status link when env unset).
+- **C. CORS / OAuth allowlist** (`cors.ts`, `workspace*.ts`, `github-oauth.ts`) — **frozen, kept** (these *allow* legacy origins for fallback; not generated links).
+- **F. contact email** — `billing.ts` `hi@conclave-ai.dev` — **frozen** (no Simsa mailbox; it's an email, not an app link).
+- **G. internal/frozen** — `@conclave-ai/*`, `CONCLAVE_*`, worker URL, DB, routes, Telegram bot username — **unchanged**.
+
+## Link destination policy applied
+- `app.trysimsa.com` → authenticated app / dashboard links **(used here)**
+- `trysimsa.com` apex → marketing only — **not used** (no apex routing yet)
+- `simsa.dev` → docs — **not used** (no routing yet)
+- `conclave-dashboard.vercel.app` → legacy fallback — not used in new copy
+- `conclave-ai.dev` → legacy/frozen — replaced where destination is the app
+
+## Files changed (central-plane only; dashboard untouched)
+- `src/workspace/brand.ts` — add `appUrl: "https://app.trysimsa.com"` (single source).
+- `src/workspace/pr-comment.ts` — footer now `[${BRAND.productName}](${BRAND.appUrl})` (import BRAND).
+- `src/routes/workspace-github.ts` — `DEFAULT_DASHBOARD_URL = BRAND.appUrl`.
+- `src/env.ts` — doc comments updated to the new default.
+- `test/brand.test.mjs` — pin `BRAND.appUrl`.
+- `test/workspace-pr-comment-comparison.test.mjs` — footer asserts `app.trysimsa.com` + `[Simsa]` + NOT `conclave-ai.dev`.
+
+## Generated surfaces updated
+- **PR comment footer**: now `이 코멘트는 [Simsa](https://app.trysimsa.com)에서 …`.
+- **OAuth post-connect redirect / Telegram dashboard links / GitHub status link**: default base now `https://app.trysimsa.com` (when `WORKSPACE_GH_DASHBOARD_URL` / `DASHBOARD_BASE_URL` unset; prod env, if set, still wins).
+
+## Surfaces intentionally left legacy/frozen
+- CORS + OAuth returnTo allowlists keep `dashboard.conclave-ai.dev` / `.conclave-ai.dev` suffix / `conclave-dashboard.vercel.app` (fallback).
+- `billing.ts` contact email `hi@conclave-ai.dev` (no Simsa mailbox).
+- All internal namespace (`@conclave-ai/*`, `CONCLAVE_*`, worker host, DB, routes, `Conclave_AI` bot username, `.conclave/` data).
+- Pre-Stage-85 saved artifacts keep their Conclave-era headings (immutable-artifact policy).
+
+## Tests / verification
+- central-plane **1144/1144** pass, typecheck clean. (no lint task on central-plane.)
+- dashboard untouched → no dashboard test/deploy.
+- No deploy / migration performed.
+
+## Deploy not executed
+No production deploy, no D1 migration, no DNS/Vercel change in this PR.
+
+## Post-merge deploy recommendation
+Generated-link changes are in central-plane code → **require a central-plane deploy to take effect** (gated, manual, Bae-approved): `deploy-central-plane` workflow_dispatch with `confirm=deploy`, `apply-migrations=false`. No dashboard deploy needed. After deploy, a new PR review comment footer will link to `app.trysimsa.com`.
+
+## Remaining follow-ups
+- trysimsa.com apex routing (redirect vs landing) — separate stage.
+- simsa.dev docs routing — separate stage.
+- (optional) align prod `WORKSPACE_GH_DASHBOARD_URL` / `DASHBOARD_BASE_URL` env to `https://app.trysimsa.com` (operator) so links are consistent even where env is set.
+- (optional) Simsa contact email to replace `hi@conclave-ai.dev` once a mailbox exists.


### PR DESCRIPTION
## Why
`app.trysimsa.com` is live (Stage 90B). Point user-facing **generated links** at it instead of the legacy `conclave-ai.dev` (which never had DNS). Link surface only — no product logic.

## Link surfaces changed
- **PR comment footer**: `이 코멘트는 [Simsa](https://app.trysimsa.com)에서 …` (was `conclave-ai.dev`).
- **OAuth post-connect redirect / Telegram dashboard links / GitHub status link**: default base → `https://app.trysimsa.com` when `WORKSPACE_GH_DASHBOARD_URL`/`DASHBOARD_BASE_URL` unset (prod env still wins).
- New `BRAND.appUrl` single source in `brand.ts`.

## Files
`brand.ts`, `pr-comment.ts`, `workspace-github.ts`, `env.ts` (comments), `test/brand.test.mjs`, `test/workspace-pr-comment-comparison.test.mjs`, stage-92 doc. **Dashboard untouched.**

## Stayed legacy/frozen
CORS + OAuth returnTo allowlists (still allow legacy origins for fallback), `billing.ts` contact email `hi@conclave-ai.dev` (no Simsa mailbox), all internal namespace (`@conclave-ai/*`, `CONCLAVE_*`, worker host, DB, routes, `Conclave_AI` bot username), pre-Stage-85 saved artifacts (immutable).

## No DNS / Vercel / migration / deploy
None performed in this PR.

## Tests
central-plane **1144/1144** pass, typecheck clean. PR footer asserts `app.trysimsa.com` + `[Simsa]` + NOT `conclave-ai.dev`; `BRAND.appUrl` pinned.

## Post-merge
Generated-link change is central-plane code → **requires a gated manual `deploy-central-plane`** (`confirm=deploy`, `apply-migrations=false`) to take effect. No dashboard deploy. Deploy only after explicit approval.