### PR TITLE
feat(landing): Stage 93 — minimal Simsa entry surface for trysimsa.com

### DIFF
--- a/apps/simsa-landing/.eslintrc.json
+++ b/apps/simsa-landing/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/apps/simsa-landing/.gitignore
+++ b/apps/simsa-landing/.gitignore
@@ -1,0 +1,9 @@
+# Next.js build output
+.next/
+out/
+node_modules/
+.env*.local
+.DS_Store
+.vercel
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/simsa-landing/next.config.mjs
+++ b/apps/simsa-landing/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  // Static marketing entry — keep the build artifact tiny.
+  images: { unoptimized: true },
+};
+export default nextConfig;

--- a/apps/simsa-landing/package.json
+++ b/apps/simsa-landing/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@conclave-ai/simsa-landing",
+  "version": "0.16.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev --port 3005",
+    "build": "next build",
+    "start": "next start --port 3005",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "15.5.16",
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "^15.5.19",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/simsa-landing/src/app/globals.css
+++ b/apps/simsa-landing/src/app/globals.css
@@ -1,0 +1,88 @@
+:root {
+  --bg: #faf8f3;
+  --fg: #18181b;        /* zinc-900 */
+  --muted: #52525b;     /* zinc-600 */
+  --accent: #15803d;    /* deep green (dashboard brand-600) */
+  --accent-hover: #166534;
+  --border: #e7e5e4;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.wrap {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.card {
+  max-width: 34rem;
+}
+
+.wordmark {
+  font-size: 0.9rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 600;
+  margin: 0 0 1.25rem;
+}
+
+.tagline {
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  line-height: 1.15;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 0 0 1rem;
+}
+
+.lede {
+  font-size: 1.05rem;
+  line-height: 1.5;
+  color: var(--muted);
+  margin: 0 0 2rem;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.5rem;
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: background-color 0.15s ease;
+}
+
+.cta:hover {
+  background: var(--accent-hover);
+}
+
+.foot {
+  font-size: 0.8rem;
+  color: var(--muted);
+}

--- a/apps/simsa-landing/src/app/layout.tsx
+++ b/apps/simsa-landing/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Simsa — The acceptance layer for AI-built software.",
+  description: "Review, compare, and accept AI-built software with evidence.",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/simsa-landing/src/app/page.tsx
+++ b/apps/simsa-landing/src/app/page.tsx
@@ -1,0 +1,22 @@
+// Stage 93 — minimal Simsa marketing entry surface for trysimsa.com.
+// Static, host-agnostic. CTA points at the live app domain. Kept intentionally
+// small (separate Vercel project; the dashboard is untouched).
+const APP_URL = "https://app.trysimsa.com";
+
+export default function Home() {
+  return (
+    <main className="wrap">
+      <section className="card">
+        <p className="wordmark">Simsa</p>
+        <h1 className="tagline">The acceptance layer for AI-built software.</h1>
+        <p className="lede">
+          Review, compare, and accept AI-built software with evidence.
+        </p>
+        <a className="cta" href={APP_URL}>
+          Open Simsa
+        </a>
+      </section>
+      <footer className="foot">Built for AI-built software acceptance.</footer>
+    </main>
+  );
+}

--- a/apps/simsa-landing/tsconfig.json
+++ b/apps/simsa-landing/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/apps/simsa-landing/vercel.json
+++ b/apps/simsa-landing/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs"
+}

--- a/conclave-builder-pack/out/stage-93-trysimsa-landing.md
+++ b/conclave-builder-pack/out/stage-93-trysimsa-landing.md
@@ -1,0 +1,58 @@
+# Stage 93 — trysimsa.com Apex Landing
+
+**Date:** 2026-06-22
+**Branch:** `feat/stage-93-trysimsa-landing`
+**Scope:** Minimal public entry surface for `trysimsa.com`. Code PR only — domain assignment + deploy are post-merge, gated.
+
+## Implementation path chosen
+**Separate minimal landing project** (Bae's choice). A new tiny static Next app `apps/simsa-landing` → its own Vercel project → `trysimsa.com` assigned there.
+
+Why not the alternatives:
+- **Same dashboard project**: the dashboard root layout wraps *every* page in the app chrome (sidebar + i18n), so a clean apex landing would require either moving all routes into a `(dashboard)` route group or forcing global dynamic rendering via `headers()` — a non-trivial refactor of the production dashboard. Rejected for risk.
+- **Reuse `apps/landing`**: that app is Conclave-branded + a full marketing site (hero/pricing/screenshots); rebranding is out of this stage's minimal scope.
+- **Redirect-only**: safe but Bae prefers a real entry page over forcing visitors into the dashboard.
+
+The separate project keeps the dashboard **completely untouched** (zero regression risk) and cleanly separates the marketing domain from the app domain.
+
+## Files (new app — `apps/simsa-landing/`)
+- `package.json` (`@conclave-ai/simsa-landing`, private, next 15.5.16 / react 19.2.6 — same versions as `apps/landing`, no Tailwind/postcss — plain CSS)
+- `tsconfig.json`, `.eslintrc.json` (`next/core-web-vitals`), `next.config.mjs`, `.gitignore`, `vercel.json` (`framework: nextjs`)
+- `src/app/layout.tsx` — metadata = Simsa title/description, no dashboard chrome
+- `src/app/page.tsx` — wordmark **Simsa** · tagline · one-sentence explanation · **Open Simsa** CTA → `https://app.trysimsa.com` · small footer
+- `src/app/globals.css` — Linear-minimal, neutral (`#faf8f3` bg, zinc text), deep-green accent `#15803d` (dashboard brand-600), centered, **no emoji, no violet**, system font stack (no Google-font fetch → builds anywhere)
+- `pnpm-lock.yaml` updated (new package registered; CI `--frozen-lockfile`)
+
+## Copy
+```
+Simsa
+The acceptance layer for AI-built software.
+Review, compare, and accept AI-built software with evidence.
+[ Open Simsa ]   → https://app.trysimsa.com
+Built for AI-built software acceptance.
+```
+
+## Tests / verification (local)
+- `apps/simsa-landing` build **green** (`/` static prerender), typecheck clean, lint **no warnings/errors**.
+- No host-aware routing implemented (separate project) → no routing tests needed.
+- Dashboard / central-plane untouched → their suites unaffected.
+
+## Deploy / domain changes performed
+**None in this PR.** No Vercel project created, no domain assigned, no DNS change, no deploy.
+
+## Post-merge plan (after merge + explicit Bae approval)
+1. Create a new Vercel project from `apps/simsa-landing` (root directory = `apps/simsa-landing`), deploy via CLI.
+2. Assign `trysimsa.com` (apex) to the **new** project (move the apex domain off any default; `app.trysimsa.com` stays on the dashboard project — untouched).
+3. Smoke: `https://trysimsa.com` → 200, TLS valid, shows Simsa entry (not dashboard); `https://app.trysimsa.com` still dashboard; `https://conclave-dashboard.vercel.app` still dashboard.
+
+## Risks / rollback
+- `app.trysimsa.com` is on the dashboard project and is **not modified** by this stage → no risk to the live app.
+- If the landing project misbehaves: unassign `trysimsa.com` from it (apex falls back to unconfigured/registrar) or point it elsewhere; the dashboard + app domain are unaffected.
+- No DB / no migration → nothing to roll back server-side.
+
+## Statuses
+- `trysimsa.com`: code ready; **not yet assigned/deployed** (post-merge).
+- `app.trysimsa.com`: dashboard live (unchanged).
+- legacy `conclave-dashboard.vercel.app`: dashboard fallback (unchanged).
+
+## Recommendation for simsa.dev
+Defer to a later stage. Options once addressed: redirect `simsa.dev` → `app.trysimsa.com` (or a future docs site), or a dedicated developer/docs surface. Do **not** point it at production until intended. Out of Stage 93 scope.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,37 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  apps/simsa-landing:
+    dependencies:
+      next:
+        specifier: 15.5.16
+        version: 15.5.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.17
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      eslint:
+        specifier: ^8.57.1
+        version: 8.57.1
+      eslint-config-next:
+        specifier: ^15.5.19
+        version: 15.5.19(eslint@8.57.1)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/agent-claude:
     dependencies:
       '@anthropic-ai/sdk':


### PR DESCRIPTION
## Why
`trysimsa.com` had no entry surface. This adds a minimal, clean Simsa landing so the apex isn't blank — separate from the dashboard.

## Implementation path
**Separate minimal landing project** (chosen). New `apps/simsa-landing` (tiny static Next page) → its own Vercel project → `trysimsa.com` (post-merge). The **dashboard is untouched** (zero regression risk).

Rejected: same-project (dashboard root layout wraps every page in chrome → needs route-group refactor / global dynamic = prod risk); reuse `apps/landing` (Conclave-branded full marketing site, out of scope); redirect-only (Bae prefers a real entry page).

## What it shows
```
Simsa
The acceptance layer for AI-built software.
Review, compare, and accept AI-built software with evidence.
[ Open Simsa ]  → https://app.trysimsa.com
Built for AI-built software acceptance.
```
Linear-minimal, neutral (`#faf8f3`/zinc) + deep-green `#15803d`, no emoji, no violet, plain CSS (no Google-font fetch).

## Files
`apps/simsa-landing/**` (9 files) + `pnpm-lock.yaml` (new package) + stage-93 doc. No dashboard / central-plane changes.

## Verification
build green (`/` static prerender), typecheck clean, lint no warnings/errors.

## No deploy / domain / DNS in this PR
Post-merge + explicit approval: create the Vercel project from `apps/simsa-landing`, assign `trysimsa.com` to it (apex only; `app.trysimsa.com` stays on the dashboard project), then smoke. Rollback = unassign the apex domain; dashboard + app domain unaffected.

## simsa.dev
Deferred to a later stage.