### PR TITLE
Stage 94~100 — Simsa Public Trust & Beta Entry Surface

### DIFF
--- a/apps/simsa-dev/.eslintrc.json
+++ b/apps/simsa-dev/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/apps/simsa-dev/.gitignore
+++ b/apps/simsa-dev/.gitignore
@@ -1,0 +1,9 @@
+# Next.js build output
+.next/
+out/
+node_modules/
+.env*.local
+.DS_Store
+.vercel
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/simsa-dev/next.config.mjs
+++ b/apps/simsa-dev/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  // Static developer placeholder — keep the build artifact tiny.
+  images: { unoptimized: true },
+};
+export default nextConfig;

--- a/apps/simsa-dev/package.json
+++ b/apps/simsa-dev/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@conclave-ai/simsa-dev",
+  "version": "0.16.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev --port 3006",
+    "build": "next build",
+    "start": "next start --port 3006",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "15.5.16",
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "^15.5.19",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/simsa-dev/src/app/globals.css
+++ b/apps/simsa-dev/src/app/globals.css
@@ -123,4 +123,14 @@ body {
 .foot {
   font-size: 0.8rem;
   color: var(--muted);
+  line-height: 1.6;
+}
+
+.foot a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.foot a:hover {
+  text-decoration: underline;
 }

--- a/apps/simsa-dev/src/app/globals.css
+++ b/apps/simsa-dev/src/app/globals.css
@@ -1,0 +1,126 @@
+:root {
+  --bg: #faf8f3;
+  --fg: #18181b;        /* zinc-900 */
+  --muted: #52525b;     /* zinc-600 */
+  --faint: #a1a1aa;     /* zinc-400 (disabled/coming-soon) */
+  --accent: #15803d;    /* deep green (dashboard brand-600) */
+  --accent-hover: #166534;
+  --border: #e7e5e4;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.wrap {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.card {
+  max-width: 36rem;
+}
+
+.wordmark {
+  font-size: 0.9rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 600;
+  margin: 0 0 1.25rem;
+}
+
+.tagline {
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  line-height: 1.15;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 0 0 1rem;
+}
+
+.lede {
+  font-size: 1.05rem;
+  line-height: 1.5;
+  color: var(--muted);
+  margin: 0 0 2rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.5rem;
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: background-color 0.15s ease;
+}
+
+.cta:hover {
+  background: var(--accent-hover);
+}
+
+.cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: #ffffff;
+  color: var(--fg);
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: background-color 0.15s ease;
+}
+
+.cta-secondary:hover {
+  background: #f4f4f5;
+}
+
+.soon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.4rem;
+  font-size: 0.95rem;
+  color: var(--faint);
+  cursor: default;
+}
+
+.foot {
+  font-size: 0.8rem;
+  color: var(--muted);
+}

--- a/apps/simsa-dev/src/app/layout.tsx
+++ b/apps/simsa-dev/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Simsa for Developers",
+  description:
+    "Developer docs for Simsa — review, compare, and accept AI-built software with evidence.",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/simsa-dev/src/app/page.tsx
+++ b/apps/simsa-dev/src/app/page.tsx
@@ -6,6 +6,10 @@ const APP_URL = "https://app.trysimsa.com";
 const REPO_URL = "https://github.com/3SVS/conclave-ai"; // public repo
 // Real contact mailbox (operator-provided), shared with the trysimsa.com surface.
 const CONTACT_EMAIL = "seunghunbae@b2w.kr";
+// Stage 97: mailto-based early access — no backend / DB / email provider.
+const EARLY_ACCESS_MAILTO = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
+  "Simsa early access request",
+)}`;
 
 export default function Home() {
   return (
@@ -34,7 +38,8 @@ export default function Home() {
         </div>
       </section>
       <footer className="foot">
-        Questions or early access?{" "}
+        <a href={EARLY_ACCESS_MAILTO}>Request early access</a>
+        {" · "}
         <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
         <br />
         Built for AI-built software acceptance.

--- a/apps/simsa-dev/src/app/page.tsx
+++ b/apps/simsa-dev/src/app/page.tsx
@@ -42,6 +42,8 @@ export default function Home() {
         {" · "}
         <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
         <br />
+        <a href="https://trysimsa.com/demo">View public demo</a>
+        <br />
         <a href="https://trysimsa.com/privacy">Privacy</a>
         {" · "}
         <a href="https://trysimsa.com/terms">Terms</a>

--- a/apps/simsa-dev/src/app/page.tsx
+++ b/apps/simsa-dev/src/app/page.tsx
@@ -1,0 +1,38 @@
+// Stage 94 — minimal developer surface for simsa.dev.
+// Static, host-agnostic, separate Vercel project. Intentionally a placeholder:
+// no API/SDK/MCP docs are promised (MCP package is not yet published), and the
+// "coming soon" item is plain text, not a broken link.
+const APP_URL = "https://app.trysimsa.com";
+const REPO_URL = "https://github.com/3SVS/conclave-ai"; // public repo
+
+export default function Home() {
+  return (
+    <main className="wrap">
+      <section className="card">
+        <p className="wordmark">Simsa for Developers</p>
+        <h1 className="tagline">Developer docs are coming soon.</h1>
+        <p className="lede">
+          Simsa helps teams review, compare, and accept AI-built software with
+          evidence.
+        </p>
+        <div className="actions">
+          <a className="cta" href={APP_URL}>
+            Open Simsa
+          </a>
+          <a
+            className="cta-secondary"
+            href={REPO_URL}
+            target="_blank"
+            rel="noreferrer"
+          >
+            View on GitHub
+          </a>
+          <span className="soon">MCP package — coming soon</span>
+        </div>
+      </section>
+      <footer className="foot">
+        Built for AI-built software acceptance.
+      </footer>
+    </main>
+  );
+}

--- a/apps/simsa-dev/src/app/page.tsx
+++ b/apps/simsa-dev/src/app/page.tsx
@@ -4,6 +4,8 @@
 // "coming soon" item is plain text, not a broken link.
 const APP_URL = "https://app.trysimsa.com";
 const REPO_URL = "https://github.com/3SVS/conclave-ai"; // public repo
+// Real contact mailbox (operator-provided), shared with the trysimsa.com surface.
+const CONTACT_EMAIL = "seunghunbae@b2w.kr";
 
 export default function Home() {
   return (
@@ -31,6 +33,9 @@ export default function Home() {
         </div>
       </section>
       <footer className="foot">
+        Questions or early access?{" "}
+        <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+        <br />
         Built for AI-built software acceptance.
       </footer>
     </main>

--- a/apps/simsa-dev/src/app/page.tsx
+++ b/apps/simsa-dev/src/app/page.tsx
@@ -42,6 +42,10 @@ export default function Home() {
         {" · "}
         <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
         <br />
+        <a href="https://trysimsa.com/privacy">Privacy</a>
+        {" · "}
+        <a href="https://trysimsa.com/terms">Terms</a>
+        <br />
         Built for AI-built software acceptance.
       </footer>
     </main>

--- a/apps/simsa-dev/src/app/page.tsx
+++ b/apps/simsa-dev/src/app/page.tsx
@@ -14,8 +14,9 @@ export default function Home() {
         <p className="wordmark">Simsa for Developers</p>
         <h1 className="tagline">Developer docs are coming soon.</h1>
         <p className="lede">
-          Simsa helps teams review, compare, and accept AI-built software with
-          evidence.
+          Simsa accepts ideas, PRDs, repos, and AI-built apps as input, then
+          turns them into staged acceptance workflows — review, compare, and
+          decide what to accept, fix, or rerun with evidence.
         </p>
         <div className="actions">
           <a className="cta" href={APP_URL}>

--- a/apps/simsa-dev/tsconfig.json
+++ b/apps/simsa-dev/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/apps/simsa-dev/vercel.json
+++ b/apps/simsa-dev/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs"
+}

--- a/apps/simsa-landing/src/app/demo/page.tsx
+++ b/apps/simsa-landing/src/app/demo/page.tsx
@@ -1,0 +1,207 @@
+// Stage 99 — static, login-free narrative demo. Everything here is a FICTIONAL
+// illustrative example (no real customer/project data, no live dashboard, no
+// backend). It shows the transformation: AI-built draft -> staged acceptance.
+import type { Metadata } from "next";
+import Link from "next/link";
+
+const APP_URL = "https://app.trysimsa.com";
+const CONTACT_EMAIL = "seunghunbae@b2w.kr";
+const EARLY_ACCESS_MAILTO = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
+  "Simsa early access request",
+)}`;
+
+export const metadata: Metadata = {
+  title: "Public demo — Simsa",
+  description:
+    "A fictional example of how Simsa turns an AI-built draft into a staged acceptance workflow.",
+};
+
+const ACCEPTANCE_ITEMS = [
+  "A new user can create a task without errors.",
+  "Empty states explain what to do next.",
+  "Shared task links do not expose private data.",
+  "Failed save actions show a clear recovery path.",
+  "Basic mobile layout remains usable.",
+  "There is a release checklist before sharing with users.",
+];
+
+const STAGES = [
+  "Product intent review",
+  "Onboarding and empty states",
+  "Task creation acceptance check",
+  "Sharing and permission review",
+  "Error and recovery states",
+  "Mobile layout check",
+  "Release readiness decision",
+];
+
+const OUTPUT = [
+  "Acceptance map",
+  "Stage plan",
+  "Fix instructions",
+  "Evidence checklist",
+  "Release decision",
+];
+
+export default function Demo() {
+  return (
+    <main>
+      <section className="hero">
+        <div className="container">
+          <span className="demo-label">Public demo · Fictional example</span>
+          <h1 className="tagline">
+            From AI-built draft to staged acceptance workflow.
+          </h1>
+          <p className="lede">
+            This example shows how Simsa turns an existing draft into acceptance
+            items, stages, evidence, and decisions. It is illustrative — not real
+            customer data.
+          </p>
+          <div className="hero-actions">
+            <a className="cta" href={APP_URL}>
+              Open Simsa
+            </a>
+            <a className="cta-secondary" href={EARLY_ACCESS_MAILTO}>
+              Request early access
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <h2>Input artifact</h2>
+          <div className="demo-card">
+            <dl className="kv">
+              <dt>Type</dt>
+              <dd>AI-built app</dd>
+              <dt>Context</dt>
+              <dd>A founder has a task app generated with an AI coding agent.</dd>
+              <dt>Goal</dt>
+              <dd>Decide whether it is ready for early users.</dd>
+              <dt>Current concern</dt>
+              <dd>
+                It looks complete, but onboarding, permissions, error states, and
+                release checks are unclear.
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <h2>Product understanding</h2>
+          <div className="demo-card">
+            <dl className="kv">
+              <dt>What it is</dt>
+              <dd>
+                A lightweight task workspace where users create, organize, and
+                share tasks.
+              </dd>
+              <dt>Primary user</dt>
+              <dd>A founder or small-team member managing early product work.</dd>
+              <dt>Core risk</dt>
+              <dd>
+                The app appears usable, but important acceptance conditions are
+                not verified.
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <h2>Acceptance items</h2>
+          <p>The criteria this draft has to meet before sharing with users.</p>
+          <ul className="outputs">
+            {ACCEPTANCE_ITEMS.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <h2>Stage plan</h2>
+          <ol className="steps">
+            {STAGES.map((stage) => (
+              <li key={stage}>{stage}</li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <h2>Evidence &amp; decision</h2>
+          <div className="demo-card">
+            <div className="ev-group ev-accepted">
+              <h3>Accepted</h3>
+              <ul>
+                <li>Task creation flow works in the happy path.</li>
+              </ul>
+            </div>
+            <div className="ev-group ev-fix">
+              <h3>Needs fix</h3>
+              <ul>
+                <li>Empty state does not guide first-time users.</li>
+                <li>Failed save has no visible recovery.</li>
+              </ul>
+            </div>
+            <div className="ev-group ev-unverified">
+              <h3>Not verified</h3>
+              <ul>
+                <li>Shared link privacy.</li>
+                <li>Mobile layout on narrow screens.</li>
+              </ul>
+            </div>
+            <div className="decision">
+              <strong>Decision (illustrative)</strong>
+              Do not release yet. Create a focused fix stage for empty states,
+              recovery flows, and sharing-permission checks.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <h2>Simsa output</h2>
+          <ul className="outputs">
+            {OUTPUT.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <h2>Bring your own</h2>
+          <p>
+            Bring your idea, PRD, repo, or AI-built app. Simsa turns it into a
+            staged acceptance workflow like the one above.
+          </p>
+          <a className="cta" href={EARLY_ACCESS_MAILTO}>
+            Request early access
+          </a>
+        </div>
+      </section>
+
+      <footer className="foot">
+        <div className="container">
+          <nav className="foot-links">
+            <Link href="/">Home</Link>
+            <Link href="/privacy">Privacy</Link>
+            <Link href="/terms">Terms</Link>
+            <a href={`mailto:${CONTACT_EMAIL}`}>Contact</a>
+          </nav>
+          <p className="foot-tag">Built for AI-built software acceptance.</p>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/apps/simsa-landing/src/app/globals.css
+++ b/apps/simsa-landing/src/app/globals.css
@@ -237,7 +237,89 @@ a {
 .foot {
   padding: 2.5rem 0 3rem;
   text-align: center;
+  border-top: 1px solid var(--border);
+}
+
+.foot-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 0.75rem;
+}
+
+.foot-links a {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.foot-links a:hover {
+  text-decoration: underline;
+}
+
+.foot-tag {
+  margin: 0;
   font-size: 0.8rem;
   color: var(--faint);
-  border-top: 1px solid var(--border);
+}
+
+/* Legal-lite pages (/privacy, /terms) */
+.legal {
+  padding: 3rem 0 4rem;
+}
+
+.back {
+  display: inline-block;
+  margin-bottom: 1.5rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.back:hover {
+  text-decoration: underline;
+}
+
+.legal h1 {
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.5rem;
+}
+
+.legal .status {
+  font-size: 0.9rem;
+  color: var(--faint);
+  margin: 0 0 1.75rem;
+}
+
+.legal h2 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 1.75rem 0 0.5rem;
+}
+
+.legal p {
+  font-size: 0.98rem;
+  color: var(--fg);
+  margin: 0 0 0.75rem;
+  max-width: 40rem;
+}
+
+.legal ul {
+  margin: 0 0 0.75rem;
+  padding-left: 1.25rem;
+  color: var(--muted);
+  font-size: 0.98rem;
+}
+
+.legal ul li {
+  margin: 0.3rem 0;
+}
+
+.legal a {
+  color: var(--accent);
 }

--- a/apps/simsa-landing/src/app/globals.css
+++ b/apps/simsa-landing/src/app/globals.css
@@ -5,6 +5,7 @@
   --faint: #71717a;     /* zinc-500 */
   --accent: #15803d;    /* deep green (dashboard brand-600) */
   --accent-hover: #166534;
+  --accent-soft: #f0f7f2;
   --border: #e7e5e4;
   --panel: #ffffff;
 }
@@ -34,7 +35,7 @@ a {
 
 .container {
   width: 100%;
-  max-width: 44rem;
+  max-width: 46rem;
   margin: 0 auto;
   padding: 0 1.5rem;
 }
@@ -59,13 +60,21 @@ a {
   line-height: 1.12;
   font-weight: 600;
   letter-spacing: -0.02em;
-  margin: 0 0 1rem;
+  margin: 0 0 0.75rem;
+}
+
+.subline {
+  font-size: clamp(1.05rem, 2.5vw, 1.25rem);
+  font-weight: 600;
+  color: var(--accent);
+  margin: 0 0 0.75rem;
 }
 
 .lede {
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   color: var(--muted);
-  margin: 0 0 2rem;
+  margin: 0 auto 2rem;
+  max-width: 34rem;
 }
 
 .cta {
@@ -88,7 +97,7 @@ a {
 
 /* Sections */
 .section {
-  padding: 2.25rem 0;
+  padding: 2.5rem 0;
   border-top: 1px solid var(--border);
 }
 
@@ -96,13 +105,59 @@ a {
   font-size: 1.25rem;
   font-weight: 600;
   letter-spacing: -0.01em;
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.5rem;
 }
 
 .section p {
   font-size: 1rem;
   color: var(--muted);
-  margin: 0 0 0.5rem;
+  margin: 0 0 1rem;
+  max-width: 38rem;
+}
+
+/* Input chips ("start from anything") */
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel);
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--fg);
+}
+
+/* Output grid ("what Simsa creates") */
+.outputs {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.outputs li {
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--panel);
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+@media (max-width: 30rem) {
+  .outputs {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* How it works */
@@ -113,17 +168,24 @@ a {
 }
 
 .steps li {
-  margin: 0.4rem 0;
+  margin: 0.45rem 0;
 }
 
 .steps li span {
   color: var(--muted);
 }
 
-/* Contact */
+/* Trust / contact */
+.note {
+  font-size: 1rem;
+  color: var(--fg);
+  margin: 0 0 1rem;
+  max-width: 38rem;
+}
+
 .contact-link {
   display: inline-block;
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
   color: var(--accent);
   font-weight: 600;
   text-decoration: none;

--- a/apps/simsa-landing/src/app/globals.css
+++ b/apps/simsa-landing/src/app/globals.css
@@ -265,6 +265,100 @@ a {
   color: var(--faint);
 }
 
+/* Public demo (/demo) */
+.demo-label {
+  display: inline-block;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+  margin-bottom: 1rem;
+}
+
+.demo-card {
+  border: 1px solid var(--border);
+  border-radius: 0.6rem;
+  background: var(--panel);
+  padding: 1.1rem 1.2rem;
+  margin-top: 0.75rem;
+}
+
+.kv {
+  margin: 0;
+}
+
+.kv dt {
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--faint);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 0.7rem;
+}
+
+.kv dt:first-child {
+  margin-top: 0;
+}
+
+.kv dd {
+  margin: 0.15rem 0 0;
+  font-size: 0.97rem;
+  color: var(--fg);
+}
+
+.ev-group {
+  margin-top: 1.1rem;
+}
+
+.ev-group h3 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 0 0 0.35rem;
+}
+
+.ev-accepted h3 {
+  color: var(--accent);
+}
+
+.ev-fix h3 {
+  color: #b45309; /* amber-700 */
+}
+
+.ev-unverified h3 {
+  color: var(--faint);
+}
+
+.ev-group ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--muted);
+  font-size: 0.96rem;
+}
+
+.ev-group ul li {
+  margin: 0.25rem 0;
+}
+
+.decision {
+  margin-top: 1.35rem;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 0.5rem;
+  background: var(--accent-soft);
+  padding: 0.9rem 1.1rem;
+  font-size: 0.97rem;
+}
+
+.decision strong {
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
 /* Legal-lite pages (/privacy, /terms) */
 .legal {
   padding: 3rem 0 4rem;

--- a/apps/simsa-landing/src/app/globals.css
+++ b/apps/simsa-landing/src/app/globals.css
@@ -95,6 +95,44 @@ a {
   background: var(--accent-hover);
 }
 
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: center;
+}
+
+.cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--fg);
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: background-color 0.15s ease;
+}
+
+.cta-secondary:hover {
+  background: #f4f4f5;
+}
+
+/* Early access guidance */
+.guidance {
+  margin: 0.5rem 0 1.25rem;
+  padding: 0 0 0 1.25rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.guidance li {
+  margin: 0.3rem 0;
+}
+
 /* Sections */
 .section {
   padding: 2.5rem 0;

--- a/apps/simsa-landing/src/app/globals.css
+++ b/apps/simsa-landing/src/app/globals.css
@@ -2,9 +2,11 @@
   --bg: #faf8f3;
   --fg: #18181b;        /* zinc-900 */
   --muted: #52525b;     /* zinc-600 */
+  --faint: #71717a;     /* zinc-500 */
   --accent: #15803d;    /* deep green (dashboard brand-600) */
   --accent-hover: #166534;
   --border: #e7e5e4;
+  --panel: #ffffff;
 }
 
 * {
@@ -23,21 +25,24 @@ body {
   font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
     Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
+  line-height: 1.5;
 }
 
-.wrap {
-  min-height: 100dvh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 2.5rem;
-  padding: 2rem;
+a {
+  color: inherit;
+}
+
+.container {
+  width: 100%;
+  max-width: 44rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* Hero */
+.hero {
+  padding: 5.5rem 0 3rem;
   text-align: center;
-}
-
-.card {
-  max-width: 34rem;
 }
 
 .wordmark {
@@ -50,16 +55,15 @@ body {
 }
 
 .tagline {
-  font-size: clamp(1.6rem, 4vw, 2.4rem);
-  line-height: 1.15;
+  font-size: clamp(1.7rem, 4.5vw, 2.5rem);
+  line-height: 1.12;
   font-weight: 600;
   letter-spacing: -0.02em;
   margin: 0 0 1rem;
 }
 
 .lede {
-  font-size: 1.05rem;
-  line-height: 1.5;
+  font-size: 1.1rem;
   color: var(--muted);
   margin: 0 0 2rem;
 }
@@ -82,7 +86,58 @@ body {
   background: var(--accent-hover);
 }
 
-.foot {
-  font-size: 0.8rem;
+/* Sections */
+.section {
+  padding: 2.25rem 0;
+  border-top: 1px solid var(--border);
+}
+
+.section h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0 0 0.75rem;
+}
+
+.section p {
+  font-size: 1rem;
   color: var(--muted);
+  margin: 0 0 0.5rem;
+}
+
+/* How it works */
+.steps {
+  margin: 0.5rem 0 0;
+  padding: 0 0 0 1.25rem;
+  color: var(--fg);
+}
+
+.steps li {
+  margin: 0.4rem 0;
+}
+
+.steps li span {
+  color: var(--muted);
+}
+
+/* Contact */
+.contact-link {
+  display: inline-block;
+  margin-top: 0.5rem;
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.contact-link:hover {
+  text-decoration: underline;
+}
+
+/* Footer */
+.foot {
+  padding: 2.5rem 0 3rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--faint);
+  border-top: 1px solid var(--border);
 }

--- a/apps/simsa-landing/src/app/page.tsx
+++ b/apps/simsa-landing/src/app/page.tsx
@@ -1,10 +1,28 @@
-// Stage 93 — minimal Simsa marketing entry for trysimsa.com.
-// Stage 95 — added a minimal trust + how-it-works + contact surface below the
-// hero. Static, host-agnostic, no new dependencies. CTA points at the live app.
+// Simsa marketing entry for trysimsa.com.
+// Stage 93 hero · Stage 95 trust/contact · Stage 96 staged-acceptance positioning.
+// Static, host-agnostic, no new dependencies. Tone: clear, serious, non-hype.
 const APP_URL = "https://app.trysimsa.com";
 // Real contact mailbox (operator-provided). No trysimsa.com mailbox is wired
 // yet — do not invent hi@trysimsa.com until it exists.
 const CONTACT_EMAIL = "seunghunbae@b2w.kr";
+
+const INPUTS = [
+  "Idea",
+  "PRD / spec",
+  "Product URL",
+  "GitHub repo",
+  "Pull request",
+  "AI-built app",
+];
+
+const OUTPUTS = [
+  "Product understanding",
+  "Acceptance items",
+  "Stage plan",
+  "Review evidence",
+  "Accept / fix / rerun decisions",
+  "Release readiness",
+];
 
 export default function Home() {
   return (
@@ -13,8 +31,11 @@ export default function Home() {
         <div className="container">
           <p className="wordmark">Simsa</p>
           <h1 className="tagline">The acceptance layer for AI-built software.</h1>
+          <p className="subline">From fast AI-built drafts to accepted product work.</p>
           <p className="lede">
-            Review, compare, and accept AI-built software with evidence.
+            AI coding agents can create a first draft fast. Simsa helps teams
+            review, compare, and decide what to accept, fix, or rerun — with
+            evidence.
           </p>
           <a className="cta" href={APP_URL}>
             Open Simsa
@@ -24,35 +45,59 @@ export default function Home() {
 
       <section className="section">
         <div className="container">
-          <h2>For teams building with AI coding agents.</h2>
+          <h2>Start from anything</h2>
           <p>
-            Built for founders, product teams, and agencies using AI coding
-            agents. Simsa turns raw AI-built output into reviewable, comparable,
-            acceptance-ready product work — with acceptance criteria, evidence,
-            and decision history.
+            Bring an idea, a PRD, a product URL, a GitHub repo, a pull request,
+            or an AI-built app. Simsa turns it into a staged acceptance workflow.
           </p>
+          <div className="chips">
+            {INPUTS.map((input) => (
+              <span className="chip" key={input}>
+                {input}
+              </span>
+            ))}
+          </div>
         </div>
       </section>
 
       <section className="section">
         <div className="container">
-          <h2>How it works</h2>
+          <h2>What Simsa creates</h2>
+          <p>
+            Raw AI-built output becomes reviewable, comparable, acceptance-ready
+            product work.
+          </p>
+          <ul className="outputs">
+            {OUTPUTS.map((output) => (
+              <li key={output}>{output}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <h2>How the workflow runs</h2>
           <ol className="steps">
             <li>
-              Define acceptance items.{" "}
+              Understand what exists.{" "}
+              <span>Idea, spec, repo, or AI-built draft.</span>
+            </li>
+            <li>
+              Turn it into acceptance items.{" "}
               <span>The criteria a change has to meet.</span>
             </li>
             <li>
-              Review PRs and agent outputs.{" "}
+              Review builds and agent outputs.{" "}
               <span>Against those criteria, with evidence.</span>
             </li>
             <li>
-              Compare runs with evidence.{" "}
-              <span>See what each attempt actually changed.</span>
+              Decide what to accept, fix, or rerun.{" "}
+              <span>Compare runs and choose.</span>
             </li>
             <li>
-              Decide what to accept, fix, or rerun.{" "}
-              <span>And keep the decision history.</span>
+              Keep evidence and release history.{" "}
+              <span>So decisions stay reviewable.</span>
             </li>
           </ol>
         </div>
@@ -60,10 +105,14 @@ export default function Home() {
 
       <section className="section">
         <div className="container">
-          <h2>Early access &amp; partnership</h2>
-          <p>
-            For early access or partnership inquiries, contact the team.
+          <h2>For teams building with AI coding agents</h2>
+          <p className="note">
+            Built for founders, product teams, and agencies. Simsa runs the
+            acceptance process on top of fast AI-built drafts — staged review,
+            evidence, and release decisions — so you can tell what is actually
+            ready to accept, fix, or rerun.
           </p>
+          <p>For early access or partnership inquiries, contact the team.</p>
           <a className="contact-link" href={`mailto:${CONTACT_EMAIL}`}>
             {CONTACT_EMAIL}
           </a>

--- a/apps/simsa-landing/src/app/page.tsx
+++ b/apps/simsa-landing/src/app/page.tsx
@@ -59,6 +59,9 @@ export default function Home() {
             <a className="cta" href={APP_URL}>
               Open Simsa
             </a>
+            <Link className="cta-secondary" href="/demo">
+              View demo
+            </Link>
             <a className="cta-secondary" href={EARLY_ACCESS_MAILTO}>
               Request early access
             </a>
@@ -166,6 +169,7 @@ export default function Home() {
       <footer className="foot">
         <div className="container">
           <nav className="foot-links">
+            <Link href="/demo">Demo</Link>
             <Link href="/privacy">Privacy</Link>
             <Link href="/terms">Terms</Link>
             <a href={`mailto:${CONTACT_EMAIL}`}>Contact</a>

--- a/apps/simsa-landing/src/app/page.tsx
+++ b/apps/simsa-landing/src/app/page.tsx
@@ -1,6 +1,8 @@
 // Simsa marketing entry for trysimsa.com.
 // Stage 93 hero · 95 trust/contact · 96 staged-acceptance positioning ·
 // 97 early-access request path. Static, host-agnostic, no new dependencies.
+import Link from "next/link";
+
 const APP_URL = "https://app.trysimsa.com";
 // Real contact mailbox (operator-provided). No trysimsa.com mailbox is wired
 // yet — do not invent hi@trysimsa.com until it exists.
@@ -162,7 +164,14 @@ export default function Home() {
       </section>
 
       <footer className="foot">
-        <div className="container">Built for AI-built software acceptance.</div>
+        <div className="container">
+          <nav className="foot-links">
+            <Link href="/privacy">Privacy</Link>
+            <Link href="/terms">Terms</Link>
+            <a href={`mailto:${CONTACT_EMAIL}`}>Contact</a>
+          </nav>
+          <p className="foot-tag">Built for AI-built software acceptance.</p>
+        </div>
       </footer>
     </main>
   );

--- a/apps/simsa-landing/src/app/page.tsx
+++ b/apps/simsa-landing/src/app/page.tsx
@@ -1,22 +1,78 @@
-// Stage 93 — minimal Simsa marketing entry surface for trysimsa.com.
-// Static, host-agnostic. CTA points at the live app domain. Kept intentionally
-// small (separate Vercel project; the dashboard is untouched).
+// Stage 93 — minimal Simsa marketing entry for trysimsa.com.
+// Stage 95 — added a minimal trust + how-it-works + contact surface below the
+// hero. Static, host-agnostic, no new dependencies. CTA points at the live app.
 const APP_URL = "https://app.trysimsa.com";
+// Real contact mailbox (operator-provided). No trysimsa.com mailbox is wired
+// yet — do not invent hi@trysimsa.com until it exists.
+const CONTACT_EMAIL = "seunghunbae@b2w.kr";
 
 export default function Home() {
   return (
-    <main className="wrap">
-      <section className="card">
-        <p className="wordmark">Simsa</p>
-        <h1 className="tagline">The acceptance layer for AI-built software.</h1>
-        <p className="lede">
-          Review, compare, and accept AI-built software with evidence.
-        </p>
-        <a className="cta" href={APP_URL}>
-          Open Simsa
-        </a>
+    <main>
+      <section className="hero">
+        <div className="container">
+          <p className="wordmark">Simsa</p>
+          <h1 className="tagline">The acceptance layer for AI-built software.</h1>
+          <p className="lede">
+            Review, compare, and accept AI-built software with evidence.
+          </p>
+          <a className="cta" href={APP_URL}>
+            Open Simsa
+          </a>
+        </div>
       </section>
-      <footer className="foot">Built for AI-built software acceptance.</footer>
+
+      <section className="section">
+        <div className="container">
+          <h2>For teams building with AI coding agents.</h2>
+          <p>
+            Built for founders, product teams, and agencies using AI coding
+            agents. Simsa turns raw AI-built output into reviewable, comparable,
+            acceptance-ready product work — with acceptance criteria, evidence,
+            and decision history.
+          </p>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <h2>How it works</h2>
+          <ol className="steps">
+            <li>
+              Define acceptance items.{" "}
+              <span>The criteria a change has to meet.</span>
+            </li>
+            <li>
+              Review PRs and agent outputs.{" "}
+              <span>Against those criteria, with evidence.</span>
+            </li>
+            <li>
+              Compare runs with evidence.{" "}
+              <span>See what each attempt actually changed.</span>
+            </li>
+            <li>
+              Decide what to accept, fix, or rerun.{" "}
+              <span>And keep the decision history.</span>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <h2>Early access &amp; partnership</h2>
+          <p>
+            For early access or partnership inquiries, contact the team.
+          </p>
+          <a className="contact-link" href={`mailto:${CONTACT_EMAIL}`}>
+            {CONTACT_EMAIL}
+          </a>
+        </div>
+      </section>
+
+      <footer className="foot">
+        <div className="container">Built for AI-built software acceptance.</div>
+      </footer>
     </main>
   );
 }

--- a/apps/simsa-landing/src/app/page.tsx
+++ b/apps/simsa-landing/src/app/page.tsx
@@ -1,10 +1,26 @@
 // Simsa marketing entry for trysimsa.com.
-// Stage 93 hero · Stage 95 trust/contact · Stage 96 staged-acceptance positioning.
-// Static, host-agnostic, no new dependencies. Tone: clear, serious, non-hype.
+// Stage 93 hero · 95 trust/contact · 96 staged-acceptance positioning ·
+// 97 early-access request path. Static, host-agnostic, no new dependencies.
 const APP_URL = "https://app.trysimsa.com";
 // Real contact mailbox (operator-provided). No trysimsa.com mailbox is wired
 // yet — do not invent hi@trysimsa.com until it exists.
 const CONTACT_EMAIL = "seunghunbae@b2w.kr";
+
+// Stage 97: mailto-based early access — no backend / DB / email provider.
+const EARLY_ACCESS_SUBJECT = "Simsa early access request";
+const EARLY_ACCESS_BODY = `Hi Simsa team,
+
+I'd like early access.
+
+What I'm building:
+
+What I already have (idea / PRD / repo / URL / AI-built app):
+
+What I need Simsa to help with:
+`;
+const EARLY_ACCESS_MAILTO = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
+  EARLY_ACCESS_SUBJECT,
+)}&body=${encodeURIComponent(EARLY_ACCESS_BODY)}`;
 
 const INPUTS = [
   "Idea",
@@ -37,9 +53,14 @@ export default function Home() {
             review, compare, and decide what to accept, fix, or rerun — with
             evidence.
           </p>
-          <a className="cta" href={APP_URL}>
-            Open Simsa
-          </a>
+          <div className="hero-actions">
+            <a className="cta" href={APP_URL}>
+              Open Simsa
+            </a>
+            <a className="cta-secondary" href={EARLY_ACCESS_MAILTO}>
+              Request early access
+            </a>
+          </div>
         </div>
       </section>
 
@@ -112,9 +133,30 @@ export default function Home() {
             evidence, and release decisions — so you can tell what is actually
             ready to accept, fix, or rerun.
           </p>
-          <p>For early access or partnership inquiries, contact the team.</p>
+          <p>For partnership inquiries, contact the team.</p>
           <a className="contact-link" href={`mailto:${CONTACT_EMAIL}`}>
             {CONTACT_EMAIL}
+          </a>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <h2>Request early access</h2>
+          <p>
+            Have an idea, PRD, GitHub repo, or AI-built app you want to turn into
+            accepted product work? Send a short note and we will review whether
+            Simsa is a good fit.
+          </p>
+          <p>Include:</p>
+          <ul className="guidance">
+            <li>what you are building</li>
+            <li>what you already have</li>
+            <li>where the current work lives, if shareable</li>
+            <li>what you need to decide next</li>
+          </ul>
+          <a className="cta" href={EARLY_ACCESS_MAILTO}>
+            Request early access
           </a>
         </div>
       </section>

--- a/apps/simsa-landing/src/app/privacy/page.tsx
+++ b/apps/simsa-landing/src/app/privacy/page.tsx
@@ -1,0 +1,78 @@
+// Stage 98 — early-access Privacy Note. Plain-English, non-lawyerly, static.
+// Not a final/lawyer-reviewed policy; no legal entity invented.
+import type { Metadata } from "next";
+import Link from "next/link";
+
+const CONTACT_EMAIL = "seunghunbae@b2w.kr";
+
+export const metadata: Metadata = {
+  title: "Privacy Note — Simsa",
+  description: "Early access privacy note for Simsa.",
+};
+
+export default function Privacy() {
+  return (
+    <main>
+      <article className="legal container">
+        <Link className="back" href="/">
+          ← Simsa
+        </Link>
+        <h1>Privacy Note</h1>
+        <p className="status">
+          Early access note. This page may be updated as Simsa evolves.
+        </p>
+
+        <h2>What you may share</h2>
+        <ul>
+          <li>
+            ideas, PRDs, product URLs, GitHub repo links, pull requests, or
+            AI-built app context
+          </li>
+          <li>early access inquiry details sent by email</li>
+          <li>technical metadata needed to review or operate the service</li>
+        </ul>
+
+        <h2>How it is used</h2>
+        <ul>
+          <li>to understand the product or project context</li>
+          <li>
+            to create acceptance items, stage plans, review notes, and next-step
+            recommendations
+          </li>
+          <li>to respond to early access or partnership inquiries</li>
+          <li>to improve the product experience</li>
+        </ul>
+
+        <h2>What not to send</h2>
+        <ul>
+          <li>secrets, API keys, passwords, or production credentials</li>
+          <li>sensitive customer data, unless explicitly agreed</li>
+        </ul>
+
+        <h2>Third-party services</h2>
+        <p>
+          Simsa relies on hosting, version control, AI model providers, and
+          infrastructure services to operate the product. These may change as
+          the product evolves.
+        </p>
+
+        <h2>Contact</h2>
+        <p>
+          Questions about this note:{" "}
+          <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+        </p>
+      </article>
+
+      <footer className="foot">
+        <div className="container">
+          <nav className="foot-links">
+            <Link href="/privacy">Privacy</Link>
+            <Link href="/terms">Terms</Link>
+            <a href={`mailto:${CONTACT_EMAIL}`}>Contact</a>
+          </nav>
+          <p className="foot-tag">Built for AI-built software acceptance.</p>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/apps/simsa-landing/src/app/terms/page.tsx
+++ b/apps/simsa-landing/src/app/terms/page.tsx
@@ -1,0 +1,73 @@
+// Stage 98 — early-access Terms Note. Plain-English, non-lawyerly, static.
+// Not a final/lawyer-reviewed agreement; no paid plans or billing terms.
+import type { Metadata } from "next";
+import Link from "next/link";
+
+const CONTACT_EMAIL = "seunghunbae@b2w.kr";
+
+export const metadata: Metadata = {
+  title: "Terms Note — Simsa",
+  description: "Early access terms note for Simsa.",
+};
+
+export default function Terms() {
+  return (
+    <main>
+      <article className="legal container">
+        <Link className="back" href="/">
+          ← Simsa
+        </Link>
+        <h1>Terms Note</h1>
+        <p className="status">
+          Early access note. Simsa is evolving and these terms may be updated.
+        </p>
+
+        <h2>Use of Simsa</h2>
+        <ul>
+          <li>Simsa helps review and organize AI-built software work.</li>
+          <li>Simsa provides acceptance workflows, evidence, and recommendations.</li>
+          <li>
+            Simsa does not guarantee that software is bug-free, secure,
+            compliant, or production-ready.
+          </li>
+        </ul>
+
+        <h2>User responsibility</h2>
+        <ul>
+          <li>review outputs before relying on them</li>
+          <li>do not submit secrets or credentials</li>
+          <li>have the right to share the materials you provide</li>
+        </ul>
+
+        <h2>Early access</h2>
+        <ul>
+          <li>access may change while the product is being developed</li>
+          <li>features may be incomplete, experimental, or changed over time</li>
+        </ul>
+
+        <h2>No professional guarantee</h2>
+        <p>
+          Simsa is not a substitute for legal, security, compliance, or
+          professional engineering review.
+        </p>
+
+        <h2>Contact</h2>
+        <p>
+          Questions about this note:{" "}
+          <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+        </p>
+      </article>
+
+      <footer className="foot">
+        <div className="container">
+          <nav className="foot-links">
+            <Link href="/privacy">Privacy</Link>
+            <Link href="/terms">Terms</Link>
+            <a href={`mailto:${CONTACT_EMAIL}`}>Contact</a>
+          </nav>
+          <p className="foot-tag">Built for AI-built software acceptance.</p>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/conclave-builder-pack/out/stage-100-public-trust-train-checkpoint.md
+++ b/conclave-builder-pack/out/stage-100-public-trust-train-checkpoint.md
@@ -1,0 +1,73 @@
+# Stage 100 — Public Trust Train Checkpoint
+
+**Date:** 2026-06-23
+**Train branch:** `feat/stage-94-simsa-dev` · **PR #141** (OPEN) · HEAD `8575e49`
+**Base:** `origin/main` `cbd4ea2` (Stage 93 landing).
+
+## Summary
+A public-surface-only train (Stages 94–100): a developer placeholder for `simsa.dev`, and a fuller trust / positioning / early-access / legal-lite / demo surface for the `trysimsa.com` landing. **No backend, DB, central-plane, dashboard, auth, billing, migration, or npm-publish changes.** Public product name **Simsa**; internal `@conclave-ai/*` namespace frozen.
+
+## Included stages
+- **94 — simsa.dev Developer Surface**: new standalone `apps/simsa-dev` placeholder ("Simsa for Developers / docs coming soon", Open Simsa, View on GitHub (public repo), "MCP package — coming soon").
+- **95 — Public Trust & Contact Surface**: trust + how-it-works + contact sections (`mailto:seunghunbae@b2w.kr`).
+- **96 — Staged Acceptance Positioning**: start-from-anything → what Simsa creates → how the workflow runs.
+- **97 — Early Access Request Path**: mailto-based early access (hero CTA + dedicated section, prefilled mailto + guidance).
+- **98 — Legal-lite Pages**: `/privacy` + `/terms` early-access notes (not final legal docs), footer links.
+- **99 — Public Demo Project**: static, login-free, fully-fictional `/demo` ("AI-built Task App") showing input → understanding → acceptance items → stage plan → evidence & decision → output.
+- **100 — Checkpoint** (this document).
+
+## Surfaces changed
+- `apps/simsa-landing/` — routes `/`, `/demo`, `/privacy`, `/terms`; `globals.css`.
+- `apps/simsa-dev/` — new app (placeholder + contact/demo/legal footer links).
+- `pnpm-lock.yaml` (new `@conclave-ai/simsa-dev` package).
+- `conclave-builder-pack/out/stage-94-simsa-dev.md` + this checkpoint doc.
+  (Stages 95–99 are documented in the PR description + memory rather than per-stage repo files.)
+
+## Surfaces intentionally unchanged
+`apps/dashboard`, `apps/central-plane`, `packages/*`, `database/migrations`, `.github/workflows` — **no diff** (audited via `git diff --name-only origin/main...HEAD`). Internal namespace (`@conclave-ai/*`, `CONCLAVE_*`, `workspace_*` tables, `/workspace/*` routes, `.conclave/*`, `ConclaveSandbox`) untouched. `app.trysimsa.com` (dashboard project) and `conclave-dashboard.vercel.app` untouched.
+
+## Verification
+- `apps/simsa-landing` + `apps/simsa-dev`: build (all routes static-prerendered: `/`, `/demo`, `/privacy`, `/terms` on landing; `/` on dev), typecheck, lint — **all green**.
+- Monorepo-wide `turbo run typecheck`: **56/56 packages pass**.
+- Secret/token literal scan of `origin/main...HEAD` diff: **none found**.
+- Changed-surface audit: only the two simsa apps + lockfile + docs. **No unexpected files.**
+
+## No-go / out of scope (not in this train)
+production deploy · Vercel project/domain attach · DNS · D1 migration · billing/payment · auth · central-plane/dashboard changes · internal namespace rename · npm publish · analytics/cookie banner/third-party scripts · backend form/DB/email-provider.
+
+## Deploy plan (post-merge, each under explicit approval)
+1. **trysimsa.com landing** — the `simsa-landing` Vercel project + `trysimsa.com` already exist (Stage 93B). Redeploy `apps/simsa-landing` to production → ships the new `/demo`, `/privacy`, `/terms`, and updated home copy. Low risk.
+2. **simsa.dev developer surface (Stage 94B, still PENDING)** — no Vercel project/domain exists yet. Create a new `simsa-dev` Vercel project (root `apps/simsa-dev`), assign `simsa.dev`, deploy. This is the only step that creates new infra.
+
+No central-plane deploy, dashboard deploy, or D1 migration required.
+
+## Smoke plan (after deploy)
+| URL | Expected |
+|-----|----------|
+| `https://trysimsa.com` | landing (hero + trust + positioning + early access) |
+| `https://trysimsa.com/demo` | fictional demo |
+| `https://trysimsa.com/privacy` | Privacy Note |
+| `https://trysimsa.com/terms` | Terms Note |
+| `https://simsa.dev` | developer placeholder (after Stage 94B) |
+| `https://app.trysimsa.com` | dashboard (unchanged) |
+| `https://conclave-dashboard.vercel.app` | legacy dashboard fallback (unchanged) |
+
+Also confirm no "Conclave" public copy on the new surfaces and that internal links (Privacy/Terms/Demo) resolve.
+
+## Rollback
+- Landing breaks → redeploy the previous `simsa-landing` production deployment (instant rollback in Vercel), or revert the landing files. `app.trysimsa.com` unaffected.
+- simsa.dev breaks → unassign `simsa.dev` from the `simsa-dev` project (or leave it unassigned). Landing + dashboard unaffected.
+- No DB / migration → no server-side rollback.
+
+## Recommendation
+**Ready to merge.** No blockers: scope is public-surface-only, all checks green, no unintended changes, no secrets.
+
+Suggested sequence:
+1. **Merge PR #141** (squash). No auto-deploy fires (these apps aren't wired to the central-plane deploy workflow).
+2. **Deploy landing first** (project + domain already exist) — lowest risk, immediately ships /demo + legal + new copy to trysimsa.com.
+3. **Then Stage 94B** (create simsa-dev Vercel project + assign simsa.dev + deploy) as a separate approved step, since it creates new infra.
+
+Merge and deploy await Bae's approval.
+
+## Status
+Merge: NOT executed. Deploy: NOT executed. Domain/DNS: NOT changed. Awaiting approval.

--- a/conclave-builder-pack/out/stage-94-simsa-dev.md
+++ b/conclave-builder-pack/out/stage-94-simsa-dev.md
@@ -1,0 +1,48 @@
+# Stage 94 — simsa.dev Developer Docs Surface
+
+**Date:** 2026-06-23
+**Branch:** `feat/stage-94-simsa-dev`
+**Scope:** Minimal developer/docs placeholder for `simsa.dev`. Code PR only (94A) — Vercel project + domain + deploy are post-merge, gated (94B).
+
+## Implementation
+Mirrors the Stage 93 pattern: a new standalone static Next app `apps/simsa-dev` → its own Vercel project `simsa-dev` → `simsa.dev` (post-merge). The dashboard, landing, central-plane, and internal `@conclave-ai/*` namespace are all **untouched**.
+
+## Files (new app — `apps/simsa-dev/`)
+- `package.json` (`@conclave-ai/simsa-dev`, private, next 15.5.16 / react 19.2.6, plain CSS — no Tailwind/Google fonts)
+- `tsconfig.json`, `.eslintrc.json`, `next.config.mjs`, `.gitignore`, `vercel.json`
+- `src/app/layout.tsx` — metadata `Simsa for Developers`
+- `src/app/page.tsx` — placeholder dev surface
+- `src/app/globals.css` — same Linear-minimal neutral + deep-green (`#15803d`) system as the landing, no emoji
+- `pnpm-lock.yaml` updated (new package)
+
+## Content (deliberately a placeholder — no overpromising)
+```
+Simsa for Developers
+Developer docs are coming soon.
+Simsa helps teams review, compare, and accept AI-built software with evidence.
+[ Open Simsa ]  → https://app.trysimsa.com
+[ View on GitHub ] → https://github.com/3SVS/conclave-ai   (repo is PUBLIC — verified)
+MCP package — coming soon   (plain text; @conclave-ai/mcp-workspace is NOT yet on npm — no link)
+Built for AI-built software acceptance.
+```
+- No API/SDK/MCP docs promised. The "coming soon" item is plain muted text, not a broken link.
+- GitHub link verified public (`gh repo view 3SVS/conclave-ai` → PUBLIC). The repo keeps the frozen internal `conclave-ai` name.
+
+## Local verification
+- `apps/simsa-dev` build **green** (`/` static prerender), typecheck clean, lint **no warnings/errors**.
+- No host-aware routing → no routing tests. Dashboard / landing / central-plane untouched.
+
+## Deploy / domain — NOT performed in PR stage
+No Vercel project created, no `simsa.dev` assigned, no DNS change, no deploy in this PR.
+
+## Post-merge plan (94B, after merge + explicit approval)
+1. Create Vercel project `simsa-dev` (root directory = `apps/simsa-dev`); deploy via CLI from `apps/simsa-dev` (standalone, like the landing).
+2. Assign `simsa.dev` to the **new** project (do not attach to dashboard or landing projects).
+3. Smoke: `simsa.dev` → 200/TLS/`Simsa for Developers`, CTA → app.trysimsa.com, no Conclave public copy, no broken docs link; `trysimsa.com` still landing; `app.trysimsa.com` still dashboard.
+
+## Rollback
+- If broken: remove `simsa.dev` from the `simsa-dev` project; `trysimsa.com` + `app.trysimsa.com` untouched.
+- No DB / migration → nothing to roll back server-side.
+
+## Not changed (frozen)
+`@conclave-ai/*` package names · MCP package name · `CONCLAVE_*` env · DB/routes/internal namespace · central-plane (no deploy) · GitHub App · Telegram bot · generated links · billing. No npm publish.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,37 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  apps/simsa-dev:
+    dependencies:
+      next:
+        specifier: 15.5.16
+        version: 15.5.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.17
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      eslint:
+        specifier: ^8.57.1
+        version: 8.57.1
+      eslint-config-next:
+        specifier: ^15.5.19
+        version: 15.5.19(eslint@8.57.1)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   apps/simsa-landing:
     dependencies:
       next:


### PR DESCRIPTION
# Stage 94~100 — Simsa Public Trust & Beta Entry Surface

## Summary
Public-surface-only train: a `simsa.dev` developer placeholder + a fuller `trysimsa.com` landing (trust, staged-acceptance positioning, early-access, legal-lite notes, and a fictional demo). **No backend / DB / central-plane / dashboard / auth / billing / migration / npm-publish changes.** Public product name **Simsa**; internal `@conclave-ai/*` namespace frozen.

## Included stages
- **94** simsa.dev Developer Surface (`apps/simsa-dev`)
- **95** Public Trust & Contact Surface
- **96** Staged Acceptance Positioning
- **97** Early Access Request Path (mailto)
- **98** Legal-lite Pages (`/privacy`, `/terms`)
- **99** Public Demo Project (`/demo`, fictional)
- **100** Checkpoint (this PR)

## Surfaces changed
`apps/simsa-landing/` (`/`, `/demo`, `/privacy`, `/terms`, `globals.css`) · `apps/simsa-dev/` (new app) · `pnpm-lock.yaml` · `conclave-builder-pack/out/stage-94…` + `stage-100…` docs.

## Surfaces intentionally unchanged
`apps/dashboard`, `apps/central-plane`, `packages/*`, `database/migrations`, `.github/workflows` — no diff. `app.trysimsa.com` + `conclave-dashboard.vercel.app` untouched. Internal namespace frozen.

## Verification
- Both apps: build (all routes static-prerendered) / typecheck / lint — green.
- Monorepo `turbo run typecheck`: **56/56 pass**.
- Secret/token scan of the diff: none. Changed-surface audit: only the two simsa apps + lockfile + docs.

## No-go / out of scope
production deploy · Vercel project/domain attach · DNS · D1 migration · billing · auth · central-plane/dashboard · internal rename · npm publish · analytics/backend.

## Deploy plan (post-merge, gated)
1. Redeploy `apps/simsa-landing` → trysimsa.com (project + domain already exist; ships /demo, /privacy, /terms, new copy).
2. **Stage 94B (pending)**: create `simsa-dev` Vercel project (root `apps/simsa-dev`) + assign `simsa.dev` + deploy. No central-plane/dashboard deploy, no migration.

## Smoke plan
trysimsa.com → landing · /demo → fictional demo · /privacy, /terms → notes · simsa.dev → dev placeholder (after 94B) · app.trysimsa.com → dashboard (unchanged) · conclave-dashboard.vercel.app → legacy fallback (unchanged).

## Rollback
Landing: redeploy previous Vercel production (instant) or revert files — app.trysimsa.com unaffected. simsa.dev: unassign domain. No DB rollback.

## Recommendation
**Ready to merge.** No blockers. Suggested: merge (squash) → deploy landing first → then Stage 94B (simsa.dev) as a separate approved step. Merge/deploy await approval.

Full detail: `conclave-builder-pack/out/stage-100-public-trust-train-checkpoint.md`.