### PR TITLE
Stage 101~108 — Core Intake Train

### DIFF
--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -17,27 +17,41 @@ import type {
 } from "@/lib/intake.mjs";
 import { buildPrdIntakePreview, SAMPLE_PRD } from "@/lib/intake-prd.mjs";
 import type { PrdIntakePreview } from "@/lib/intake-prd.mjs";
+import {
+  buildProductUrlIntakePreview,
+  SAMPLE_PRODUCT_URL,
+} from "@/lib/intake-url.mjs";
+import type { ProductUrlIntakePreview } from "@/lib/intake-url.mjs";
 
 export default function IntakePage() {
   const [type, setType] = useState<WorkspaceIntakeType | null>(null);
   const [rawInput, setRawInput] = useState("");
   const [draft, setDraft] = useState<WorkspaceIntakeDraft | null>(null);
   const [prdPreview, setPrdPreview] = useState<PrdIntakePreview | null>(null);
+  const [urlPreview, setUrlPreview] = useState<ProductUrlIntakePreview | null>(null);
 
   const meta = type ? INTAKE_META[type] : null;
+
+  function resetPreviews() {
+    setDraft(null);
+    setPrdPreview(null);
+    setUrlPreview(null);
+  }
 
   function selectType(next: WorkspaceIntakeType) {
     setType(next);
     setRawInput("");
-    setDraft(null);
-    setPrdPreview(null);
+    resetPreviews();
   }
 
   function createDraft() {
     if (!type || !rawInput.trim()) return;
     setDraft(buildIntakeDraft(type, rawInput));
-    // Stage 102: deterministic PRD parsing for the prd type only.
+    // Stage 102/103: deterministic per-type previews (prd / product_url only).
     setPrdPreview(type === "prd" ? buildPrdIntakePreview(rawInput) : null);
+    setUrlPreview(
+      type === "product_url" ? buildProductUrlIntakePreview(rawInput) : null,
+    );
   }
 
   return (
@@ -88,8 +102,7 @@ export default function IntakePage() {
               value={rawInput}
               onChange={(e) => {
                 setRawInput(e.target.value);
-                setDraft(null);
-                setPrdPreview(null);
+                resetPreviews();
               }}
               placeholder={meta.placeholder}
               rows={5}
@@ -104,13 +117,24 @@ export default function IntakePage() {
               >
                 Create intake draft
               </button>
+              {type === "product_url" && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setRawInput(SAMPLE_PRODUCT_URL);
+                    resetPreviews();
+                  }}
+                  className="btn btn-secondary btn-md"
+                >
+                  Use example URL
+                </button>
+              )}
               {type === "prd" && (
                 <button
                   type="button"
                   onClick={() => {
                     setRawInput(SAMPLE_PRD);
-                    setDraft(null);
-                    setPrdPreview(null);
+                    resetPreviews();
                   }}
                   className="btn btn-secondary btn-md"
                 >
@@ -190,6 +214,47 @@ export default function IntakePage() {
             <p className="mt-4 text-xs text-gray-400">
               Preview only — deterministic PRD parsing. Full staged analysis
               arrives in later stages.
+            </p>
+          </div>
+        )}
+
+        {/* Stage 103 — deterministic Product URL preview (product_url type only) */}
+        {urlPreview && (
+          <div className="card mt-6 p-5">
+            <p className="text-xs uppercase tracking-wide text-gray-400">
+              Product URL preview · confidence: {urlPreview.confidence}
+            </p>
+
+            <dl className="mt-3 grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2">
+              <div>
+                <dt className="text-xs text-gray-400">Normalized URL</dt>
+                <dd className="break-all text-sm text-gray-700">
+                  {urlPreview.normalizedUrl || "—"}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-gray-400">Domain</dt>
+                <dd className="text-sm text-gray-700">{urlPreview.domain}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-gray-400">Surface type</dt>
+                <dd className="text-sm text-gray-700">{urlPreview.pathType}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-gray-400">Likely surface</dt>
+                <dd className="text-sm text-gray-700">{urlPreview.likelySurface}</dd>
+              </div>
+            </dl>
+
+            <PrdList title="Review focus areas" items={urlPreview.reviewFocusAreas} />
+            <PrdList
+              title="Candidate acceptance items"
+              items={urlPreview.candidateAcceptanceItems}
+            />
+            <PrdList title="Missing questions" items={urlPreview.missingQuestions} />
+
+            <p className="mt-4 text-xs text-gray-400">
+              Preview only — no live crawl or external fetch.
             </p>
           </div>
         )}

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -15,11 +15,14 @@ import type {
   WorkspaceIntakeType,
   WorkspaceIntakeDraft,
 } from "@/lib/intake.mjs";
+import { buildPrdIntakePreview, SAMPLE_PRD } from "@/lib/intake-prd.mjs";
+import type { PrdIntakePreview } from "@/lib/intake-prd.mjs";
 
 export default function IntakePage() {
   const [type, setType] = useState<WorkspaceIntakeType | null>(null);
   const [rawInput, setRawInput] = useState("");
   const [draft, setDraft] = useState<WorkspaceIntakeDraft | null>(null);
+  const [prdPreview, setPrdPreview] = useState<PrdIntakePreview | null>(null);
 
   const meta = type ? INTAKE_META[type] : null;
 
@@ -27,11 +30,14 @@ export default function IntakePage() {
     setType(next);
     setRawInput("");
     setDraft(null);
+    setPrdPreview(null);
   }
 
   function createDraft() {
     if (!type || !rawInput.trim()) return;
     setDraft(buildIntakeDraft(type, rawInput));
+    // Stage 102: deterministic PRD parsing for the prd type only.
+    setPrdPreview(type === "prd" ? buildPrdIntakePreview(rawInput) : null);
   }
 
   return (
@@ -83,19 +89,35 @@ export default function IntakePage() {
               onChange={(e) => {
                 setRawInput(e.target.value);
                 setDraft(null);
+                setPrdPreview(null);
               }}
               placeholder={meta.placeholder}
               rows={5}
               className="input w-full resize-none rounded-lg"
             />
-            <button
-              type="button"
-              onClick={createDraft}
-              disabled={!rawInput.trim()}
-              className="btn btn-primary btn-md mt-3"
-            >
-              Create intake draft
-            </button>
+            <div className="mt-3 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={createDraft}
+                disabled={!rawInput.trim()}
+                className="btn btn-primary btn-md"
+              >
+                Create intake draft
+              </button>
+              {type === "prd" && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setRawInput(SAMPLE_PRD);
+                    setDraft(null);
+                    setPrdPreview(null);
+                  }}
+                  className="btn btn-secondary btn-md"
+                >
+                  Use example PRD
+                </button>
+              )}
+            </div>
           </div>
         )}
 
@@ -129,7 +151,67 @@ export default function IntakePage() {
             </p>
           </div>
         )}
+
+        {/* Stage 102 — deterministic PRD / spec preview (prd type only) */}
+        {prdPreview && (
+          <div className="card mt-6 p-5">
+            <p className="text-xs uppercase tracking-wide text-gray-400">
+              PRD / spec preview · confidence: {prdPreview.confidence}
+            </p>
+
+            <p className="mt-3 text-sm font-medium text-gray-900">
+              Product intent
+            </p>
+            <p className="mt-1 text-sm text-gray-600">
+              {prdPreview.productIntent}
+            </p>
+
+            <p className="mt-4 text-sm font-medium text-gray-900">
+              Likely users
+            </p>
+            <div className="mt-1 flex flex-wrap gap-1.5">
+              {prdPreview.likelyUsers.map((u) => (
+                <span
+                  key={u}
+                  className="rounded-full border border-gray-200 bg-white px-2.5 py-0.5 text-xs text-gray-600"
+                >
+                  {u}
+                </span>
+              ))}
+            </div>
+
+            <PrdList title="Candidate user flows" items={prdPreview.candidateUserFlows} />
+            <PrdList
+              title="Candidate acceptance items"
+              items={prdPreview.candidateAcceptanceItems}
+            />
+            <PrdList title="Missing questions" items={prdPreview.missingQuestions} />
+
+            <p className="mt-4 text-xs text-gray-400">
+              Preview only — deterministic PRD parsing. Full staged analysis
+              arrives in later stages.
+            </p>
+          </div>
+        )}
       </div>
     </div>
+  );
+}
+
+function PrdList({ title, items }: { title: string; items: string[] }) {
+  return (
+    <>
+      <p className="mt-4 text-sm font-medium text-gray-900">{title}</p>
+      <ul className="mt-1 space-y-1">
+        {items.map((item) => (
+          <li
+            key={item}
+            className="rounded-md border border-gray-100 bg-gray-50 px-3 py-1.5 text-sm text-gray-700"
+          >
+            {item}
+          </li>
+        ))}
+      </ul>
+    </>
   );
 }

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+// Stage 101 — unified intake foundation UI.
+// One front door with multiple starting points. Deterministic local preview
+// only — no backend, no model call, no external fetch. Future stages wire real
+// per-type analysis behind the same model.
+import { useState } from "react";
+import {
+  WORKSPACE_INTAKE_TYPES,
+  INTAKE_META,
+  INTAKE_OUTPUT_LABELS,
+  buildIntakeDraft,
+} from "@/lib/intake.mjs";
+import type {
+  WorkspaceIntakeType,
+  WorkspaceIntakeDraft,
+} from "@/lib/intake.mjs";
+
+export default function IntakePage() {
+  const [type, setType] = useState<WorkspaceIntakeType | null>(null);
+  const [rawInput, setRawInput] = useState("");
+  const [draft, setDraft] = useState<WorkspaceIntakeDraft | null>(null);
+
+  const meta = type ? INTAKE_META[type] : null;
+
+  function selectType(next: WorkspaceIntakeType) {
+    setType(next);
+    setRawInput("");
+    setDraft(null);
+  }
+
+  function createDraft() {
+    if (!type || !rawInput.trim()) return;
+    setDraft(buildIntakeDraft(type, rawInput));
+  }
+
+  return (
+    <div className="flex flex-1 justify-center px-4 py-12">
+      <div className="w-full max-w-2xl">
+        <h1 className="text-2xl font-semibold tracking-tight text-gray-900">
+          What do you want Simsa to review?
+        </h1>
+        <p className="mb-8 mt-2 text-sm text-gray-500">
+          Start from anything. Simsa turns it into a staged acceptance workflow.
+        </p>
+
+        {/* Step 1 — pick a starting point */}
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {WORKSPACE_INTAKE_TYPES.map((t) => {
+            const m = INTAKE_META[t];
+            const selected = t === type;
+            return (
+              <button
+                key={t}
+                type="button"
+                onClick={() => selectType(t)}
+                className={`rounded-lg border px-4 py-3 text-left transition-all ${
+                  selected
+                    ? "border-brand-500 bg-brand-50"
+                    : "border-gray-200 bg-white hover:border-brand-300 hover:bg-brand-50"
+                }`}
+              >
+                <span className="block text-sm font-medium text-gray-900">
+                  {m.label}
+                </span>
+                <span className="mt-0.5 block text-xs text-gray-500">
+                  {m.description}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Step 2 — paste what you have */}
+        {meta && (
+          <div className="mt-8">
+            <label className="mb-2 block text-sm font-medium text-gray-900">
+              Paste what you have.
+            </label>
+            <p className="mb-2 text-xs text-gray-400">{meta.inputHint}</p>
+            <textarea
+              value={rawInput}
+              onChange={(e) => {
+                setRawInput(e.target.value);
+                setDraft(null);
+              }}
+              placeholder={meta.placeholder}
+              rows={5}
+              className="input w-full resize-none rounded-lg"
+            />
+            <button
+              type="button"
+              onClick={createDraft}
+              disabled={!rawInput.trim()}
+              className="btn btn-primary btn-md mt-3"
+            >
+              Create intake draft
+            </button>
+          </div>
+        )}
+
+        {/* Step 3 — deterministic local preview */}
+        {draft && (
+          <div className="card mt-8 p-5">
+            <p className="text-xs uppercase tracking-wide text-gray-400">
+              Intake draft (preview)
+            </p>
+            <h2 className="mt-1 text-base font-semibold text-gray-900">
+              {draft.title}
+            </h2>
+            <p className="mt-1 text-sm text-gray-500">{draft.sourceSummary}</p>
+
+            <p className="mt-5 text-sm font-medium text-gray-900">
+              Simsa will turn this into:
+            </p>
+            <ul className="mt-2 space-y-1">
+              {draft.expectedOutputs.map((out) => (
+                <li
+                  key={out}
+                  className="rounded-md border border-gray-100 bg-gray-50 px-3 py-1.5 text-sm text-gray-700"
+                >
+                  {INTAKE_OUTPUT_LABELS[out]}
+                </li>
+              ))}
+            </ul>
+
+            <p className="mt-4 text-xs text-gray-400">
+              Preview only — staged analysis arrives in later stages.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -32,6 +32,11 @@ import {
   SAMPLE_AI_BUILT_APP,
 } from "@/lib/intake-ai-built-app.mjs";
 import type { AiBuiltAppRecoveryPreview } from "@/lib/intake-ai-built-app.mjs";
+import {
+  buildIntakeAcceptanceMap,
+  NEXT_STEP_LABELS,
+} from "@/lib/intake-acceptance-map.mjs";
+import type { IntakeAcceptanceMap } from "@/lib/intake-acceptance-map.mjs";
 
 export default function IntakePage() {
   const [type, setType] = useState<WorkspaceIntakeType | null>(null);
@@ -41,6 +46,7 @@ export default function IntakePage() {
   const [urlPreview, setUrlPreview] = useState<ProductUrlIntakePreview | null>(null);
   const [repoPreview, setRepoPreview] = useState<GitHubRepoIntakePreview | null>(null);
   const [appPreview, setAppPreview] = useState<AiBuiltAppRecoveryPreview | null>(null);
+  const [acceptanceMap, setAcceptanceMap] = useState<IntakeAcceptanceMap | null>(null);
 
   const meta = type ? INTAKE_META[type] : null;
 
@@ -50,6 +56,7 @@ export default function IntakePage() {
     setUrlPreview(null);
     setRepoPreview(null);
     setAppPreview(null);
+    setAcceptanceMap(null);
   }
 
   function selectType(next: WorkspaceIntakeType) {
@@ -72,6 +79,8 @@ export default function IntakePage() {
     setAppPreview(
       type === "ai_built_app" ? buildAiBuiltAppRecoveryPreview(rawInput) : null,
     );
+    // Stage 106: shared acceptance map for every intake type.
+    setAcceptanceMap(buildIntakeAcceptanceMap({ type, rawInput }));
   }
 
   return (
@@ -400,6 +409,64 @@ export default function IntakePage() {
 
             <p className="mt-4 text-xs text-gray-400">
               Preview only — no live inspection, repo scan, or external fetch.
+            </p>
+          </div>
+        )}
+
+        {/* Stage 106 — shared Acceptance Map (all intake types) */}
+        {acceptanceMap && (
+          <div className="card mt-6 p-5">
+            <p className="text-xs uppercase tracking-wide text-gray-400">
+              Acceptance Map · confidence: {acceptanceMap.confidence}
+            </p>
+            <p className="mt-2 text-sm text-gray-500">
+              Simsa organizes your input into candidate acceptance areas,
+              questions, and next steps.
+            </p>
+
+            <p className="mt-4 text-sm font-medium text-gray-900">Summary</p>
+            <p className="mt-1 text-sm text-gray-600">{acceptanceMap.summary}</p>
+
+            <p className="mt-4 text-sm font-medium text-gray-900">Areas</p>
+            <div className="mt-1 flex flex-wrap gap-1.5">
+              {acceptanceMap.areas.map((a) => (
+                <span
+                  key={a}
+                  className="rounded-full border border-gray-200 bg-white px-2.5 py-0.5 text-xs text-gray-600"
+                >
+                  {a.replace(/_/g, " ")}
+                </span>
+              ))}
+            </div>
+
+            <p className="mt-4 text-sm font-medium text-gray-900">
+              Acceptance items
+            </p>
+            <ul className="mt-1 space-y-1">
+              {acceptanceMap.items.map((it) => (
+                <li
+                  key={it.title}
+                  className="rounded-md border border-gray-100 bg-gray-50 px-3 py-1.5 text-sm text-gray-700"
+                >
+                  <span>{it.title}</span>
+                  <span className="ml-2 text-xs text-gray-400">
+                    · {it.status.replace(/_/g, " ")}
+                  </span>
+                </li>
+              ))}
+            </ul>
+
+            <PrdList title="Missing questions" items={acceptanceMap.missingQuestions} />
+
+            <p className="mt-4 text-sm font-medium text-gray-900">
+              Recommended next step
+            </p>
+            <p className="mt-1 text-sm text-gray-700">
+              {NEXT_STEP_LABELS[acceptanceMap.recommendedNextStep]}
+            </p>
+
+            <p className="mt-4 text-xs text-gray-400">
+              Preview only — acceptance map is deterministic and not yet saved.
             </p>
           </div>
         )}

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -22,6 +22,11 @@ import {
   SAMPLE_PRODUCT_URL,
 } from "@/lib/intake-url.mjs";
 import type { ProductUrlIntakePreview } from "@/lib/intake-url.mjs";
+import {
+  buildGitHubRepoIntakePreview,
+  SAMPLE_GITHUB_REPO,
+} from "@/lib/intake-github-repo.mjs";
+import type { GitHubRepoIntakePreview } from "@/lib/intake-github-repo.mjs";
 
 export default function IntakePage() {
   const [type, setType] = useState<WorkspaceIntakeType | null>(null);
@@ -29,6 +34,7 @@ export default function IntakePage() {
   const [draft, setDraft] = useState<WorkspaceIntakeDraft | null>(null);
   const [prdPreview, setPrdPreview] = useState<PrdIntakePreview | null>(null);
   const [urlPreview, setUrlPreview] = useState<ProductUrlIntakePreview | null>(null);
+  const [repoPreview, setRepoPreview] = useState<GitHubRepoIntakePreview | null>(null);
 
   const meta = type ? INTAKE_META[type] : null;
 
@@ -36,6 +42,7 @@ export default function IntakePage() {
     setDraft(null);
     setPrdPreview(null);
     setUrlPreview(null);
+    setRepoPreview(null);
   }
 
   function selectType(next: WorkspaceIntakeType) {
@@ -51,6 +58,9 @@ export default function IntakePage() {
     setPrdPreview(type === "prd" ? buildPrdIntakePreview(rawInput) : null);
     setUrlPreview(
       type === "product_url" ? buildProductUrlIntakePreview(rawInput) : null,
+    );
+    setRepoPreview(
+      type === "github_repo" ? buildGitHubRepoIntakePreview(rawInput) : null,
     );
   }
 
@@ -127,6 +137,18 @@ export default function IntakePage() {
                   className="btn btn-secondary btn-md"
                 >
                   Use example URL
+                </button>
+              )}
+              {type === "github_repo" && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setRawInput(SAMPLE_GITHUB_REPO);
+                    resetPreviews();
+                  }}
+                  className="btn btn-secondary btn-md"
+                >
+                  Use example repo
                 </button>
               )}
               {type === "prd" && (
@@ -255,6 +277,51 @@ export default function IntakePage() {
 
             <p className="mt-4 text-xs text-gray-400">
               Preview only — no live crawl or external fetch.
+            </p>
+          </div>
+        )}
+
+        {/* Stage 104 — deterministic GitHub repo preview (github_repo type only) */}
+        {repoPreview && (
+          <div className="card mt-6 p-5">
+            <p className="text-xs uppercase tracking-wide text-gray-400">
+              GitHub repo preview · confidence: {repoPreview.confidence}
+            </p>
+
+            <dl className="mt-3 grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2">
+              <div>
+                <dt className="text-xs text-gray-400">Normalized repo</dt>
+                <dd className="text-sm text-gray-700">{repoPreview.normalizedRepo}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-gray-400">Owner</dt>
+                <dd className="text-sm text-gray-700">{repoPreview.owner}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-gray-400">Repository</dt>
+                <dd className="text-sm text-gray-700">{repoPreview.repo}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-gray-400">Likely repo type</dt>
+                <dd className="text-sm text-gray-700">{repoPreview.likelyRepoType}</dd>
+              </div>
+              <div className="sm:col-span-2">
+                <dt className="text-xs text-gray-400">Repo URL</dt>
+                <dd className="break-all text-sm text-gray-700">
+                  {repoPreview.repoUrl || "—"}
+                </dd>
+              </div>
+            </dl>
+
+            <PrdList title="Review focus areas" items={repoPreview.reviewFocusAreas} />
+            <PrdList
+              title="Candidate acceptance items"
+              items={repoPreview.candidateAcceptanceItems}
+            />
+            <PrdList title="Missing questions" items={repoPreview.missingQuestions} />
+
+            <p className="mt-4 text-xs text-gray-400">
+              Preview only — no GitHub API, clone, or remote file fetch.
             </p>
           </div>
         )}

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -27,6 +27,11 @@ import {
   SAMPLE_GITHUB_REPO,
 } from "@/lib/intake-github-repo.mjs";
 import type { GitHubRepoIntakePreview } from "@/lib/intake-github-repo.mjs";
+import {
+  buildAiBuiltAppRecoveryPreview,
+  SAMPLE_AI_BUILT_APP,
+} from "@/lib/intake-ai-built-app.mjs";
+import type { AiBuiltAppRecoveryPreview } from "@/lib/intake-ai-built-app.mjs";
 
 export default function IntakePage() {
   const [type, setType] = useState<WorkspaceIntakeType | null>(null);
@@ -35,6 +40,7 @@ export default function IntakePage() {
   const [prdPreview, setPrdPreview] = useState<PrdIntakePreview | null>(null);
   const [urlPreview, setUrlPreview] = useState<ProductUrlIntakePreview | null>(null);
   const [repoPreview, setRepoPreview] = useState<GitHubRepoIntakePreview | null>(null);
+  const [appPreview, setAppPreview] = useState<AiBuiltAppRecoveryPreview | null>(null);
 
   const meta = type ? INTAKE_META[type] : null;
 
@@ -43,6 +49,7 @@ export default function IntakePage() {
     setPrdPreview(null);
     setUrlPreview(null);
     setRepoPreview(null);
+    setAppPreview(null);
   }
 
   function selectType(next: WorkspaceIntakeType) {
@@ -61,6 +68,9 @@ export default function IntakePage() {
     );
     setRepoPreview(
       type === "github_repo" ? buildGitHubRepoIntakePreview(rawInput) : null,
+    );
+    setAppPreview(
+      type === "ai_built_app" ? buildAiBuiltAppRecoveryPreview(rawInput) : null,
     );
   }
 
@@ -149,6 +159,18 @@ export default function IntakePage() {
                   className="btn btn-secondary btn-md"
                 >
                   Use example repo
+                </button>
+              )}
+              {type === "ai_built_app" && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setRawInput(SAMPLE_AI_BUILT_APP);
+                    resetPreviews();
+                  }}
+                  className="btn btn-secondary btn-md"
+                >
+                  Use example app
                 </button>
               )}
               {type === "prd" && (
@@ -325,7 +347,78 @@ export default function IntakePage() {
             </p>
           </div>
         )}
+
+        {/* Stage 105 — deterministic AI-built app recovery (ai_built_app only) */}
+        {appPreview && (
+          <div className="card mt-6 p-5">
+            <p className="text-xs uppercase tracking-wide text-gray-400">
+              Existing app recovery preview · confidence: {appPreview.confidence}
+            </p>
+
+            <p className="mt-3 text-sm font-medium text-gray-900">
+              Current state summary
+            </p>
+            <p className="mt-1 text-sm text-gray-600">
+              {appPreview.currentStateSummary}
+            </p>
+
+            <p className="mt-4 text-sm font-medium text-gray-900">
+              Likely product surface
+            </p>
+            <p className="mt-1 text-sm text-gray-700">
+              {appPreview.likelyProductSurface}
+            </p>
+
+            <p className="mt-4 text-sm font-medium text-gray-900">
+              Recommended next action
+            </p>
+            <p className="mt-1 text-sm text-gray-700">
+              {appPreview.recommendedNextAction.replace(/_/g, " ")}
+            </p>
+
+            <PrdList title="Recovery focus areas" items={appPreview.recoveryFocusAreas} />
+            <PrdList
+              title="Candidate acceptance items"
+              items={appPreview.candidateAcceptanceItems}
+            />
+            <PrdList title="Likely risks" items={appPreview.likelyRisks} />
+
+            <p className="mt-4 text-sm font-medium text-gray-900">
+              Fix vs rebuild signals
+            </p>
+            <div className="mt-1 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <FixRebuild title="Likely keep" items={appPreview.fixVsRebuildSignals.likelyKeep} />
+              <FixRebuild title="Likely fix" items={appPreview.fixVsRebuildSignals.likelyFix} />
+              <FixRebuild title="Likely rebuild" items={appPreview.fixVsRebuildSignals.likelyRebuild} />
+              <FixRebuild
+                title="Needs verification"
+                items={appPreview.fixVsRebuildSignals.needsVerification}
+              />
+            </div>
+
+            <PrdList title="Missing questions" items={appPreview.missingQuestions} />
+
+            <p className="mt-4 text-xs text-gray-400">
+              Preview only — no live inspection, repo scan, or external fetch.
+            </p>
+          </div>
+        )}
       </div>
+    </div>
+  );
+}
+
+function FixRebuild({ title, items }: { title: string; items: string[] }) {
+  return (
+    <div className="rounded-md border border-gray-100 bg-gray-50 p-3">
+      <p className="text-xs font-medium text-gray-500">{title}</p>
+      <ul className="mt-1 space-y-1">
+        {items.map((item) => (
+          <li key={item} className="text-sm text-gray-700">
+            {item}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -37,6 +37,12 @@ import {
   NEXT_STEP_LABELS,
 } from "@/lib/intake-acceptance-map.mjs";
 import type { IntakeAcceptanceMap } from "@/lib/intake-acceptance-map.mjs";
+import {
+  buildIntakeStagePlan,
+  STAGE_STATUS_LABELS,
+  STAGE_KIND_LABELS,
+} from "@/lib/intake-stage-plan.mjs";
+import type { IntakeStagePlan } from "@/lib/intake-stage-plan.mjs";
 
 export default function IntakePage() {
   const [type, setType] = useState<WorkspaceIntakeType | null>(null);
@@ -47,6 +53,7 @@ export default function IntakePage() {
   const [repoPreview, setRepoPreview] = useState<GitHubRepoIntakePreview | null>(null);
   const [appPreview, setAppPreview] = useState<AiBuiltAppRecoveryPreview | null>(null);
   const [acceptanceMap, setAcceptanceMap] = useState<IntakeAcceptanceMap | null>(null);
+  const [stagePlan, setStagePlan] = useState<IntakeStagePlan | null>(null);
 
   const meta = type ? INTAKE_META[type] : null;
 
@@ -57,6 +64,7 @@ export default function IntakePage() {
     setRepoPreview(null);
     setAppPreview(null);
     setAcceptanceMap(null);
+    setStagePlan(null);
   }
 
   function selectType(next: WorkspaceIntakeType) {
@@ -79,8 +87,9 @@ export default function IntakePage() {
     setAppPreview(
       type === "ai_built_app" ? buildAiBuiltAppRecoveryPreview(rawInput) : null,
     );
-    // Stage 106: shared acceptance map for every intake type.
+    // Stage 106/107: shared acceptance map + ordered stage plan for every type.
     setAcceptanceMap(buildIntakeAcceptanceMap({ type, rawInput }));
+    setStagePlan(buildIntakeStagePlan({ type, rawInput }));
   }
 
   return (
@@ -470,7 +479,79 @@ export default function IntakePage() {
             </p>
           </div>
         )}
+
+        {/* Stage 107 — shared Stage Plan (all intake types) */}
+        {stagePlan && (
+          <div className="card mt-6 p-5">
+            <p className="text-xs uppercase tracking-wide text-gray-400">
+              Stage Plan · confidence: {stagePlan.confidence}
+            </p>
+            <p className="mt-2 text-sm text-gray-500">
+              Simsa turns the acceptance map into an ordered review workflow.
+            </p>
+            <p className="mt-3 text-sm text-gray-700">
+              Recommended start: stage {stagePlan.recommendedStartStage}
+            </p>
+
+            <div className="mt-3 space-y-2">
+              {stagePlan.stages.map((s) => (
+                <div
+                  key={s.number}
+                  className={`rounded-lg border p-3 ${
+                    s.number === stagePlan.recommendedStartStage
+                      ? "border-brand-300 bg-brand-50"
+                      : "border-gray-200 bg-white"
+                  }`}
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-semibold text-gray-900">
+                      Stage {s.number}: {s.title}
+                    </span>
+                    <span className="rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-500">
+                      {STAGE_KIND_LABELS[s.kind]}
+                    </span>
+                    <span className="rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-500">
+                      {STAGE_STATUS_LABELS[s.status]}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-sm text-gray-600">{s.goal}</p>
+                  <StageDetail label="Candidate checks" items={s.candidateChecks} />
+                  <StageDetail label="Evidence to collect" items={s.evidenceToCollect} />
+                  <StageDetail label="Exit criteria" items={s.exitCriteria} />
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-3">
+              <p className="text-sm font-medium text-gray-900">
+                {stagePlan.releaseGate.title}
+              </p>
+              <ul className="mt-1 list-disc space-y-0.5 pl-5 text-sm text-gray-600">
+                {stagePlan.releaseGate.checks.map((c) => (
+                  <li key={c}>{c}</li>
+                ))}
+              </ul>
+            </div>
+
+            <p className="mt-4 text-xs text-gray-400">
+              Preview only — stage plan is deterministic and not yet saved.
+            </p>
+          </div>
+        )}
       </div>
+    </div>
+  );
+}
+
+function StageDetail({ label, items }: { label: string; items: string[] }) {
+  return (
+    <div className="mt-2">
+      <p className="text-xs font-medium text-gray-500">{label}</p>
+      <ul className="mt-0.5 list-disc space-y-0.5 pl-5 text-sm text-gray-600">
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/apps/dashboard/src/lib/intake-acceptance-map.d.mts
+++ b/apps/dashboard/src/lib/intake-acceptance-map.d.mts
@@ -1,0 +1,50 @@
+// Type declarations for intake-acceptance-map.mjs (Stage 106).
+import type { WorkspaceIntakeType } from "./intake.d.mts";
+
+export type AcceptanceMapArea =
+  | "product_intent"
+  | "primary_user_flow"
+  | "onboarding"
+  | "error_recovery"
+  | "data_privacy"
+  | "implementation_readiness"
+  | "release_readiness"
+  | "trust_and_proof"
+  | "decision_history";
+
+export type AcceptanceMapItemStatus =
+  | "candidate"
+  | "missing_detail"
+  | "needs_verification";
+
+export type AcceptanceMapNextStep =
+  | "clarify_product_intent"
+  | "draft_acceptance_items"
+  | "create_stage_plan"
+  | "review_core_flow"
+  | "verify_release_readiness";
+
+export type AcceptanceMapItem = {
+  area: AcceptanceMapArea;
+  title: string;
+  status: AcceptanceMapItemStatus;
+  rationale: string;
+};
+
+export type IntakeAcceptanceMap = {
+  intakeType: WorkspaceIntakeType;
+  title: string;
+  summary: string;
+  areas: AcceptanceMapArea[];
+  items: AcceptanceMapItem[];
+  missingQuestions: string[];
+  recommendedNextStep: AcceptanceMapNextStep;
+  confidence: "low" | "medium" | "high";
+};
+
+export function buildIntakeAcceptanceMap(input: {
+  type: WorkspaceIntakeType;
+  rawInput: string;
+}): IntakeAcceptanceMap;
+
+export const NEXT_STEP_LABELS: Record<AcceptanceMapNextStep, string>;

--- a/apps/dashboard/src/lib/intake-acceptance-map.mjs
+++ b/apps/dashboard/src/lib/intake-acceptance-map.mjs
@@ -1,0 +1,201 @@
+// Stage 106 — shared deterministic Acceptance Map.
+//
+// The bridge between "what the user pasted" and "the staged acceptance workflow
+// Simsa will run". Every intake type converges here. Pure, in-browser; reuses
+// the Stage 102–105 deterministic helpers. NO backend / AI / fetch / DB /
+// persistence — preview only, not saved.
+import { buildIntakeDraft } from "./intake.mjs";
+import { buildPrdIntakePreview } from "./intake-prd.mjs";
+import { buildProductUrlIntakePreview } from "./intake-url.mjs";
+import { buildGitHubRepoIntakePreview } from "./intake-github-repo.mjs";
+import { buildAiBuiltAppRecoveryPreview } from "./intake-ai-built-app.mjs";
+
+const MIN_ITEMS = 5;
+const MAX_ITEMS = 10;
+
+function unique(arr) {
+  return [...new Set(arr)];
+}
+
+/**
+ * Turn a list of acceptance-style strings into map items with statuses.
+ * @param {string[]} titles
+ * @param {import("./intake-acceptance-map.d.mts").AcceptanceMapArea} area
+ * @param {import("./intake-acceptance-map.d.mts").AcceptanceMapItemStatus} status
+ * @param {string} rationale
+ */
+function toItems(titles, area, status, rationale) {
+  return unique(titles)
+    .filter(Boolean)
+    .map((title) => ({ area, title, status, rationale }));
+}
+
+// Generic product-quality acceptance items every map can fall back to.
+const GENERIC_ITEMS = [
+  { area: "primary_user_flow", title: "The primary flow can be completed without unclear states." },
+  { area: "onboarding", title: "A first-time user can understand what to do next." },
+  { area: "error_recovery", title: "Failed actions show a clear recovery path." },
+  { area: "data_privacy", title: "Private data is not exposed unintentionally." },
+  { area: "release_readiness", title: "Release readiness is checked before sharing with users." },
+];
+
+/** Clamp items to [MIN_ITEMS, MAX_ITEMS], topping up from GENERIC_ITEMS. */
+function normalizeItems(items) {
+  let out = [];
+  const seenTitles = new Set();
+  for (const it of items) {
+    if (it && it.title && !seenTitles.has(it.title)) {
+      seenTitles.add(it.title);
+      out.push(it);
+    }
+  }
+  for (const g of GENERIC_ITEMS) {
+    if (out.length >= MIN_ITEMS) break;
+    if (!seenTitles.has(g.title)) {
+      seenTitles.add(g.title);
+      out.push({ ...g, status: "candidate", rationale: "Baseline product-quality acceptance item." });
+    }
+  }
+  return out.slice(0, MAX_ITEMS);
+}
+
+function areasOf(items, extra = []) {
+  return unique([...items.map((i) => i.area), ...extra]);
+}
+
+/**
+ * @param {{ type: import("./intake.d.mts").WorkspaceIntakeType, rawInput: string }} input
+ * @returns {import("./intake-acceptance-map.d.mts").IntakeAcceptanceMap}
+ */
+export function buildIntakeAcceptanceMap(input) {
+  const type = input?.type;
+  const rawInput = typeof input?.rawInput === "string" ? input.rawInput : "";
+  const draft = buildIntakeDraft(type, rawInput); // throws on unknown type (by design)
+
+  let summary = draft.sourceSummary;
+  let items = [];
+  let missingQuestions = [];
+  let extraAreas = [];
+  /** @type {import("./intake-acceptance-map.d.mts").AcceptanceMapNextStep} */
+  let recommendedNextStep = "draft_acceptance_items";
+  let confidence = "low";
+
+  if (type === "prd") {
+    const p = buildPrdIntakePreview(rawInput);
+    summary = p.productIntent;
+    confidence = p.confidence;
+    missingQuestions = p.missingQuestions;
+    items = [
+      ...toItems(p.candidateAcceptanceItems, "primary_user_flow", "candidate", "Inferred from the PRD/spec."),
+    ];
+    extraAreas = ["product_intent"];
+    recommendedNextStep =
+      p.missingQuestions.length >= 5 ? "clarify_product_intent" : "draft_acceptance_items";
+  } else if (type === "product_url") {
+    const p = buildProductUrlIntakePreview(rawInput);
+    summary = p.likelySurface;
+    confidence = p.confidence;
+    missingQuestions = p.missingQuestions;
+    items = [
+      ...toItems(p.reviewFocusAreas, "trust_and_proof", "needs_verification", "Surface review focus from the URL shape."),
+      ...toItems(p.candidateAcceptanceItems, "primary_user_flow", "candidate", "Inferred from the product surface."),
+    ];
+    extraAreas = ["product_intent"];
+    recommendedNextStep = ["demo", "pricing", "app"].includes(p.pathType)
+      ? "verify_release_readiness"
+      : "review_core_flow";
+  } else if (type === "github_repo") {
+    const p = buildGitHubRepoIntakePreview(rawInput);
+    summary = `Likely ${p.likelyRepoType} repo (${p.normalizedRepo}).`;
+    confidence = p.confidence;
+    missingQuestions = p.missingQuestions;
+    items = [
+      ...toItems(p.reviewFocusAreas, "implementation_readiness", "needs_verification", "Implementation review focus from the repo shape."),
+      ...toItems(p.candidateAcceptanceItems, "release_readiness", "candidate", "Inferred from the repo reference."),
+    ];
+    extraAreas = ["implementation_readiness", "release_readiness"];
+    recommendedNextStep = p.likelyRepoType === "app" ? "review_core_flow" : "create_stage_plan";
+  } else if (type === "ai_built_app") {
+    const p = buildAiBuiltAppRecoveryPreview(rawInput);
+    summary = p.currentStateSummary;
+    confidence = p.confidence;
+    missingQuestions = p.missingQuestions;
+    const rationale = p.likelyRisks[0] ?? "Inferred from the described AI-built draft.";
+    items = [
+      ...toItems(p.recoveryFocusAreas, "primary_user_flow", "needs_verification", rationale),
+      ...toItems(p.candidateAcceptanceItems, "primary_user_flow", "candidate", rationale),
+    ];
+    extraAreas = ["product_intent"];
+    recommendedNextStep = mapRecoveryAction(p.recommendedNextAction);
+  } else if (type === "pull_request") {
+    summary = "A proposed change (pull request) to review against acceptance items.";
+    missingQuestions = [
+      "What acceptance item should this PR prove?",
+      "Which flows could this change affect?",
+      "What evidence shows the change is safe to merge?",
+      "What should be verified before release?",
+    ];
+    extraAreas = [
+      "primary_user_flow",
+      "implementation_readiness",
+      "error_recovery",
+      "decision_history",
+      "release_readiness",
+    ];
+    items = []; // generic top-up below
+    recommendedNextStep = "review_core_flow";
+    confidence = rawInput.trim() ? "medium" : "low";
+  } else {
+    // idea
+    missingQuestions = [
+      "Who is the primary user?",
+      "What is the first action they need to complete?",
+      "What counts as a successful outcome?",
+      "What needs to be true before sharing this with users?",
+    ];
+    extraAreas = ["product_intent", "primary_user_flow", "onboarding", "release_readiness"];
+    items = [];
+    recommendedNextStep = "clarify_product_intent";
+    confidence = rawInput.trim().length >= 40 ? "medium" : "low";
+  }
+
+  const normalizedItems = normalizeItems(items);
+
+  return {
+    intakeType: type,
+    title: draft.title,
+    summary,
+    areas: areasOf(normalizedItems, extraAreas),
+    items: normalizedItems,
+    missingQuestions: unique(missingQuestions).slice(0, 6),
+    recommendedNextStep,
+    confidence,
+  };
+}
+
+/**
+ * @param {import("./intake-ai-built-app.d.mts").AiBuiltAppRecommendedAction} action
+ * @returns {import("./intake-acceptance-map.d.mts").AcceptanceMapNextStep}
+ */
+function mapRecoveryAction(action) {
+  switch (action) {
+    case "create_acceptance_map":
+      return "draft_acceptance_items";
+    case "review_core_flow":
+      return "review_core_flow";
+    case "create_fix_stage":
+      return "create_stage_plan";
+    case "verify_release_readiness":
+      return "verify_release_readiness";
+    default:
+      return "draft_acceptance_items";
+  }
+}
+
+export const NEXT_STEP_LABELS = {
+  clarify_product_intent: "Clarify product intent",
+  draft_acceptance_items: "Draft acceptance items",
+  create_stage_plan: "Create stage plan",
+  review_core_flow: "Review core flow",
+  verify_release_readiness: "Verify release readiness",
+};

--- a/apps/dashboard/src/lib/intake-ai-built-app.d.mts
+++ b/apps/dashboard/src/lib/intake-ai-built-app.d.mts
@@ -1,0 +1,41 @@
+// Type declarations for intake-ai-built-app.mjs
+// (Stage 105 — Existing App Recovery Assessment).
+
+export type AiBuiltAppSurface =
+  | "landing"
+  | "web_app"
+  | "dashboard"
+  | "mobile"
+  | "api"
+  | "prototype"
+  | "unknown";
+
+export type AiBuiltAppRecommendedAction =
+  | "create_acceptance_map"
+  | "review_core_flow"
+  | "create_fix_stage"
+  | "verify_release_readiness";
+
+export type AiBuiltAppFixVsRebuild = {
+  likelyKeep: string[];
+  likelyFix: string[];
+  likelyRebuild: string[];
+  needsVerification: string[];
+};
+
+export type AiBuiltAppRecoveryPreview = {
+  currentStateSummary: string;
+  likelyProductSurface: AiBuiltAppSurface;
+  recoveryFocusAreas: string[];
+  candidateAcceptanceItems: string[];
+  likelyRisks: string[];
+  fixVsRebuildSignals: AiBuiltAppFixVsRebuild;
+  missingQuestions: string[];
+  recommendedNextAction: AiBuiltAppRecommendedAction;
+  confidence: "low" | "medium" | "high";
+};
+
+export function buildAiBuiltAppRecoveryPreview(
+  rawInput: string,
+): AiBuiltAppRecoveryPreview;
+export const SAMPLE_AI_BUILT_APP: string;

--- a/apps/dashboard/src/lib/intake-ai-built-app.mjs
+++ b/apps/dashboard/src/lib/intake-ai-built-app.mjs
@@ -1,0 +1,168 @@
+// Stage 105 — deterministic Existing App Recovery Assessment.
+//
+// Pure, in-browser. NO live app inspection / URL fetch / screenshot / browser
+// automation / GitHub API / repo clone / upload / backend / DB. Heuristics over
+// the user's own description only — never claims to know actual app behavior.
+//
+// Framing: AI can create the first draft fast; Simsa helps decide what to
+// accept, fix, rebuild, or verify next. Helpful, not judgmental.
+
+function unique(arr) {
+  return [...new Set(arr)];
+}
+
+const BASE_FOCUS = [
+  "Core user journey",
+  "Onboarding and empty states",
+  "Error and recovery states",
+  "Data privacy expectations",
+  "Release readiness",
+];
+
+const BASE_ITEMS = [
+  "A first-time user can understand what the app does and what to do next.",
+  "The primary flow can be completed without unclear states.",
+  "Empty states guide users instead of leaving blank screens.",
+  "Failed actions show a clear recovery path.",
+  "Private or sensitive data is not exposed unintentionally.",
+  "The app has a release readiness checklist before sharing with users.",
+];
+
+const BASE_RISKS = [
+  "Looks complete but core flows may not be verified.",
+  "Missing empty/error states may block first-time users.",
+  "Private data or permissions may not be clearly tested.",
+  "Deployment or environment assumptions may not be documented.",
+];
+
+/**
+ * @param {string} lower
+ * @returns {import("./intake-ai-built-app.d.mts").AiBuiltAppSurface}
+ */
+function detectSurface(lower) {
+  if (/\b(ios|android|mobile)\b/.test(lower)) return "mobile";
+  if (/\b(dashboard|workspace|portal)\b/.test(lower)) return "dashboard";
+  if (/\b(web app|webapp|web application|app)\b/.test(lower)) return "web_app";
+  if (/\b(api|backend|endpoint|server)\b/.test(lower)) return "api";
+  if (/\b(landing|homepage|marketing)\b/.test(lower)) return "landing";
+  if (/\b(prototype|demo|mvp|vibe[- ]?coded|ai[- ]?built)\b/.test(lower))
+    return "prototype";
+  return "unknown";
+}
+
+/**
+ * @param {string} rawInput
+ * @returns {import("./intake-ai-built-app.d.mts").AiBuiltAppRecoveryPreview}
+ */
+export function buildAiBuiltAppRecoveryPreview(rawInput) {
+  const text = typeof rawInput === "string" ? rawInput.trim() : "";
+  const lower = text.toLowerCase();
+
+  const has = {
+    auth: /\b(auth|login|log in|sign in|sign-in|session|account)\b/.test(lower),
+    payment: /\b(payment|pay|checkout|billing|subscription)\b/.test(lower),
+    sharing: /\b(share|sharing|invite|link)\b/.test(lower),
+    ai: /\b(ai|llm|model|gpt|prompt|agent)\b/.test(lower),
+    deploy: /\b(github|repo|deploy|deployment|env|environment)\b/.test(lower),
+    broken: /\b(messy|unusable|does ?n'?t work|broken|cannot build|can'?t build|buggy|bugs?|errors?)\b/.test(lower),
+    launch: /\b(launch|release|ship|share|users|customers|early access)\b/.test(lower),
+    coreFlow: /\b(user journey|main flow|core flow|primary flow|happy path)\b/.test(lower),
+  };
+
+  const likelyProductSurface = detectSurface(lower);
+
+  const currentStateSummary = text
+    ? `An AI-built ${
+        likelyProductSurface === "unknown" ? "product draft" : likelyProductSurface.replace("_", " ")
+      } described as: "${
+        text.length > 160 ? `${text.slice(0, 157)}…` : text
+      }". It needs structured acceptance review before it can be confidently shared or released.`
+    : "This appears to be an AI-built product draft that needs structured acceptance review before it can be confidently shared or released.";
+
+  // Focus areas
+  const focus = [...BASE_FOCUS];
+  if (has.auth) focus.push("Account and session behavior");
+  if (has.payment) focus.push("Payment and billing flow");
+  if (has.sharing) focus.push("Sharing and permission boundaries");
+  if (has.ai) focus.push("AI output quality and fallback behavior");
+  if (has.deploy) focus.push("Build, deploy, and environment verification");
+  const recoveryFocusAreas = unique(focus);
+
+  // Acceptance items
+  const items = [...BASE_ITEMS];
+  if (has.payment) items.push("A payment failure gives the user a clear next step.");
+  if (has.auth) items.push("A signed-out user is handled without losing context.");
+  if (has.sharing) items.push("Shared links expose only the intended information.");
+  if (has.ai)
+    items.push("AI-generated output has a fallback or review path when confidence is low.");
+  const candidateAcceptanceItems = unique(items);
+
+  // Risks
+  const risks = [...BASE_RISKS];
+  if (has.payment) risks.push("Payment edge cases (failure, refund) may be unhandled.");
+  if (has.sharing) risks.push("Shared links may leak more than intended.");
+  if (has.ai) risks.push("AI output may be unreliable without a fallback.");
+  const likelyRisks = unique(risks);
+
+  // Fix vs rebuild
+  const fixVsRebuildSignals = {
+    likelyKeep: [
+      "Existing draft can serve as a starting point if the main user journey is visible.",
+    ],
+    likelyFix: [
+      "Onboarding, empty states, and error recovery should be reviewed before release.",
+    ],
+    likelyRebuild: has.broken
+      ? [
+          "Some areas may need rebuilding — review whether the core flow and architecture allow safe iteration first.",
+        ]
+      : [
+          "Rebuild only if the core product flow is unclear or the architecture prevents safe iteration.",
+        ],
+    needsVerification: [
+      "Core flow",
+      "Data privacy",
+      "Build/deploy path",
+      "Release readiness",
+    ],
+  };
+
+  // Recommended next action
+  let recommendedNextAction;
+  if (!text || text.length < 40) recommendedNextAction = "create_acceptance_map";
+  else if (has.broken) recommendedNextAction = "create_fix_stage";
+  else if (has.launch) recommendedNextAction = "verify_release_readiness";
+  else if (has.coreFlow) recommendedNextAction = "review_core_flow";
+  else recommendedNextAction = "create_acceptance_map";
+
+  // Missing questions
+  const missingQuestions = unique([
+    "What is the primary user journey?",
+    "What already works today?",
+    "What feels uncertain or unreliable?",
+    "What should happen when the main flow fails?",
+    "What data must stay private?",
+    "What needs to be true before sharing this with users?",
+  ]).slice(0, 6);
+
+  // Confidence: more recognized context => higher
+  const signalCount =
+    (likelyProductSurface !== "unknown" ? 1 : 0) +
+    Object.values(has).filter(Boolean).length;
+  const confidence = signalCount >= 3 ? "high" : signalCount >= 1 ? "medium" : "low";
+
+  return {
+    currentStateSummary,
+    likelyProductSurface,
+    recoveryFocusAreas,
+    candidateAcceptanceItems,
+    likelyRisks,
+    fixVsRebuildSignals,
+    missingQuestions,
+    recommendedNextAction,
+    confidence,
+  };
+}
+
+export const SAMPLE_AI_BUILT_APP =
+  "I used an AI coding agent to build a task dashboard. It has a landing page, login, task creation, and sharing links. It looks usable, but I am not sure if onboarding, failed saves, mobile layout, and private shared links are safe enough to show early users.";

--- a/apps/dashboard/src/lib/intake-github-repo.d.mts
+++ b/apps/dashboard/src/lib/intake-github-repo.d.mts
@@ -1,0 +1,27 @@
+// Type declarations for intake-github-repo.mjs (Stage 104 — GitHub repo intake).
+
+export type GitHubRepoType =
+  | "app"
+  | "docs"
+  | "api"
+  | "library"
+  | "monorepo"
+  | "unknown";
+
+export type GitHubRepoIntakePreview = {
+  normalizedRepo: string;
+  owner: string;
+  repo: string;
+  repoUrl: string;
+  repoNameSignals: string[];
+  likelyRepoType: GitHubRepoType;
+  reviewFocusAreas: string[];
+  candidateAcceptanceItems: string[];
+  missingQuestions: string[];
+  confidence: "low" | "medium" | "high";
+};
+
+export function buildGitHubRepoIntakePreview(
+  rawInput: string,
+): GitHubRepoIntakePreview;
+export const SAMPLE_GITHUB_REPO: string;

--- a/apps/dashboard/src/lib/intake-github-repo.mjs
+++ b/apps/dashboard/src/lib/intake-github-repo.mjs
@@ -1,0 +1,194 @@
+// Stage 104 — deterministic GitHub Repo intake preview.
+//
+// Pure, in-browser. NO GitHub API, clone, remote file fetch, package.json fetch,
+// dependency/security scan, or auth. A repo is an implementation artifact mapped
+// back to product acceptance: from owner/repo (and path hints) we build a review
+// PLAN. We never claim to know the repo contents (they aren't fetched).
+
+const NAME_SIGNALS = [
+  "dashboard",
+  "app",
+  "web",
+  "frontend",
+  "api",
+  "server",
+  "worker",
+  "backend",
+  "docs",
+  "documentation",
+  "landing",
+  "mcp",
+  "sdk",
+  "package",
+  "lib",
+  "library",
+  "client",
+  "monorepo",
+  "workspace",
+];
+
+const FOCUS_AREAS = {
+  app: [
+    "Product flow and navigation",
+    "Onboarding and empty states",
+    "Error and recovery states",
+    "Environment / config expectations",
+    "Release readiness",
+  ],
+  api: [
+    "Endpoint contract clarity",
+    "Error handling",
+    "Auth and permission boundaries",
+    "Rate limits and abuse handling",
+    "Deployment and environment requirements",
+  ],
+  docs: [
+    "Getting started path",
+    "Installation or setup accuracy",
+    "Examples and expected outputs",
+    "Version / support expectations",
+    "Developer trust",
+  ],
+  library: [
+    "Public API shape",
+    "Usage examples",
+    "Versioning and compatibility",
+    "Test coverage expectations",
+    "Release / package readiness",
+  ],
+  monorepo: [
+    "App / package boundaries",
+    "Shared model consistency",
+    "Build / test commands",
+    "Deployment surfaces",
+    "Release coordination",
+  ],
+  unknown: [
+    "Repo purpose",
+    "Primary product surface",
+    "Build / test evidence",
+    "Environment requirements",
+    "Release readiness",
+  ],
+};
+
+const CANDIDATE_ITEMS = [
+  "The repo has a clear purpose and primary product surface.",
+  "A reviewer can identify how to build and test the project.",
+  "Required environment variables are documented without exposing secrets.",
+  "Main user or API flows have acceptance checks.",
+  "Error states and edge cases are represented in the review plan.",
+  "Release readiness is reviewed before sharing with users.",
+];
+
+function unique(arr) {
+  return [...new Set(arr)];
+}
+
+/**
+ * Throw-free parse of `owner/repo`, a github URL, or a PR/tree URL.
+ * @param {string} raw
+ */
+function parseRepoSafe(raw) {
+  const trimmed = (typeof raw === "string" ? raw : "").trim();
+  if (!trimmed) return { ok: false, owner: "", repo: "", isPr: false };
+
+  let path = trimmed;
+  // Strip scheme + github.com host if present.
+  const m = trimmed.match(/^(?:https?:\/\/)?(?:www\.)?github\.com\/(.+)$/i);
+  if (m) path = m[1];
+  path = path.replace(/^\/+/, "").replace(/[?#].*$/, "");
+  const segs = path.split("/").filter(Boolean);
+  if (segs.length < 2) return { ok: false, owner: "", repo: "", isPr: false };
+
+  const owner = segs[0];
+  const repo = segs[1].replace(/\.git$/i, "");
+  // valid-ish owner/repo characters
+  if (!/^[A-Za-z0-9._-]+$/.test(owner) || !/^[A-Za-z0-9._-]+$/.test(repo)) {
+    return { ok: false, owner: "", repo: "", isPr: false };
+  }
+  const isPr = segs[2] === "pull";
+  return { ok: true, owner, repo, isPr };
+}
+
+/**
+ * @param {string} owner
+ * @param {string} repo
+ * @returns {{ type: import("./intake-github-repo.d.mts").GitHubRepoType, signals: string[] }}
+ */
+function detectRepoType(owner, repo) {
+  const hay = `${owner}/${repo}`.toLowerCase();
+  const signals = unique(NAME_SIGNALS.filter((s) => hay.includes(s)));
+  let type = "unknown";
+  if (/docs|documentation/.test(hay)) type = "docs";
+  else if (/api|server|worker|backend/.test(hay)) type = "api";
+  else if (/sdk|package|\blib\b|library|client/.test(hay)) type = "library";
+  else if (/monorepo|workspace/.test(hay)) type = "monorepo";
+  else if (/app|web|dashboard|landing|frontend/.test(hay)) type = "app";
+  return { type, signals };
+}
+
+/**
+ * @param {string} rawInput
+ * @returns {import("./intake-github-repo.d.mts").GitHubRepoIntakePreview}
+ */
+export function buildGitHubRepoIntakePreview(rawInput) {
+  const parsed = parseRepoSafe(rawInput);
+
+  if (!parsed.ok) {
+    return {
+      normalizedRepo: (typeof rawInput === "string" ? rawInput : "").trim(),
+      owner: "Unknown",
+      repo: "Unknown",
+      repoUrl: "",
+      repoNameSignals: [],
+      likelyRepoType: "unknown",
+      reviewFocusAreas: FOCUS_AREAS.unknown,
+      candidateAcceptanceItems: CANDIDATE_ITEMS,
+      missingQuestions: baseQuestions("unknown", false),
+      confidence: "low",
+    };
+  }
+
+  const { owner, repo, isPr } = parsed;
+  const { type, signals } = detectRepoType(owner, repo);
+  const confidence = type === "unknown" ? "medium" : "high";
+
+  return {
+    normalizedRepo: `${owner}/${repo}`,
+    owner,
+    repo,
+    repoUrl: `https://github.com/${owner}/${repo}`,
+    repoNameSignals: signals,
+    likelyRepoType: type,
+    reviewFocusAreas: FOCUS_AREAS[type],
+    candidateAcceptanceItems: CANDIDATE_ITEMS,
+    missingQuestions: baseQuestions(type, isPr),
+    confidence,
+  };
+}
+
+/**
+ * @param {import("./intake-github-repo.d.mts").GitHubRepoType} type
+ * @param {boolean} isPr
+ */
+function baseQuestions(type, isPr) {
+  const q = [
+    "What is the primary product or package in this repo?",
+    "What command builds and tests the project?",
+    "Which flows must work before release?",
+    "What environment variables are required?",
+  ];
+  // PR-vs-repo is the highest-signal question — add it before type-specific ones
+  // so it survives the 6-question cap.
+  if (isPr)
+    q.push("This looks like a pull request URL. Should Simsa review the PR change or the whole repo?");
+  if (type === "app") q.push("What is the first user journey to verify?");
+  if (type === "api") q.push("Which endpoints are required for the first release?");
+  if (type === "library") q.push("What is the minimum supported usage example?");
+  if (type === "monorepo") q.push("Which app/package is the release target?");
+  q.push("What evidence should prove this repo is ready?");
+  return unique(q).slice(0, 6);
+}
+
+export const SAMPLE_GITHUB_REPO = "example/ai-built-task-app";

--- a/apps/dashboard/src/lib/intake-prd.d.mts
+++ b/apps/dashboard/src/lib/intake-prd.d.mts
@@ -1,0 +1,13 @@
+// Type declarations for intake-prd.mjs (Stage 102 — PRD/spec intake preview).
+
+export type PrdIntakePreview = {
+  productIntent: string;
+  likelyUsers: string[];
+  candidateUserFlows: string[];
+  candidateAcceptanceItems: string[];
+  missingQuestions: string[];
+  confidence: "low" | "medium" | "high";
+};
+
+export function buildPrdIntakePreview(rawInput: string): PrdIntakePreview;
+export const SAMPLE_PRD: string;

--- a/apps/dashboard/src/lib/intake-prd.mjs
+++ b/apps/dashboard/src/lib/intake-prd.mjs
@@ -1,0 +1,171 @@
+// Stage 102 — deterministic PRD / spec intake preview.
+//
+// Heuristic, pure, in-browser. NO AI, no backend, no fetch, no DB. Turns pasted
+// PRD/spec text into a draft preview: product intent, likely users, candidate
+// flows, candidate acceptance items, and missing questions. A PRD is an
+// artifact Simsa converts into acceptance work — not the final source of truth,
+// so everything here is "candidate / likely / preview".
+
+const INTENT_SIGNALS = [
+  "goal",
+  "problem",
+  "overview",
+  "summary",
+  "purpose",
+  "objective",
+  "we need",
+  "we want",
+];
+
+const USER_SIGNALS = [
+  "user",
+  "admin",
+  "owner",
+  "team",
+  "customer",
+  "mentor",
+  "founder",
+  "operator",
+  "manager",
+  "member",
+  "guest",
+];
+
+// action -> flow phrasing
+const ACTION_FLOWS = {
+  create: "create the main item",
+  submit: "submit a request",
+  invite: "invite others",
+  login: "log in",
+  "sign up": "sign up",
+  signup: "sign up",
+  upload: "upload content",
+  connect: "connect an external source",
+  review: "review results",
+  approve: "approve work",
+  reject: "reject work",
+  pay: "pay or check out",
+  share: "share with others",
+  export: "export data",
+  download: "download data",
+  comment: "leave a comment",
+};
+
+function cap(s) {
+  return s.length ? s[0].toUpperCase() + s.slice(1) : s;
+}
+
+function unique(arr) {
+  return [...new Set(arr)];
+}
+
+/**
+ * @param {string} rawInput
+ * @returns {import("./intake-prd.d.mts").PrdIntakePreview}
+ */
+export function buildPrdIntakePreview(rawInput) {
+  const text = typeof rawInput === "string" ? rawInput.trim() : "";
+  const lower = text.toLowerCase();
+  const lines = text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  let signals = 0;
+
+  // ── Product intent ─────────────────────────────────────────────────────────
+  const intentLine = lines.find((l) =>
+    INTENT_SIGNALS.some((sig) => l.toLowerCase().includes(sig)),
+  );
+  let productIntent;
+  if (intentLine) {
+    signals += 1;
+    // strip a leading "Label:" prefix if present
+    productIntent = intentLine.replace(/^[A-Za-z /]+:\s*/, "").trim() || intentLine;
+  } else {
+    productIntent =
+      "This PRD describes a product or feature that needs to be converted into acceptance items and staged review work.";
+  }
+
+  // ── Likely users ───────────────────────────────────────────────────────────
+  const likelyUsers = unique(
+    USER_SIGNALS.filter((u) => lower.includes(u)).map((u) => cap(u)),
+  );
+  if (likelyUsers.length) signals += 1;
+  const users = likelyUsers.length ? likelyUsers : ["User", "Operator"];
+
+  // ── Candidate user flows ───────────────────────────────────────────────────
+  const detectedActions = Object.keys(ACTION_FLOWS).filter((a) =>
+    lower.includes(a),
+  );
+  const actorForFlow = users[0] ?? "User";
+  let candidateUserFlows;
+  if (detectedActions.length) {
+    signals += 1;
+    candidateUserFlows = unique(
+      detectedActions.map((a) => `${actorForFlow} can ${ACTION_FLOWS[a]}.`),
+    );
+  } else {
+    candidateUserFlows = [
+      `${actorForFlow} can complete the product's main action.`,
+    ];
+  }
+
+  // ── Candidate acceptance items ─────────────────────────────────────────────
+  const flowItems = detectedActions.length
+    ? [
+        "A user can complete the main action without errors.",
+        "The system records the user's decision or submission.",
+        "The user receives clear feedback after submission.",
+      ]
+    : [];
+  const genericItems = [
+    "Primary flow is clear on first use.",
+    "Empty and error states explain what to do next and are recoverable.",
+    "Sensitive data is not exposed unintentionally.",
+    "Release readiness is reviewed before sharing with users.",
+  ];
+  const candidateAcceptanceItems = unique([...flowItems, ...genericItems]);
+
+  // ── Missing questions ──────────────────────────────────────────────────────
+  const missingQuestions = [];
+  if (!likelyUsers.length) missingQuestions.push("Who is the primary user?");
+  if (!detectedActions.length)
+    missingQuestions.push("What is the first action they need to complete?");
+  missingQuestions.push("What counts as a successful outcome?");
+  missingQuestions.push("What should happen when the flow fails?");
+  missingQuestions.push("What data should be private?");
+  missingQuestions.push("What needs to be verified before release?");
+  if (/\b(pay|payment|checkout|billing|subscription)\b/.test(lower)) {
+    missingQuestions.push(
+      "How are payment failures and refunds handled?",
+    );
+  }
+  if (/\b(github|repo|repository|pull request|\bpr\b)\b/.test(lower)) {
+    missingQuestions.push(
+      "Which repository or branch is the source of truth for implementation?",
+    );
+  }
+  // keep it to 3–6 useful questions
+  const trimmedQuestions = unique(missingQuestions).slice(0, 6);
+
+  // ── Confidence ─────────────────────────────────────────────────────────────
+  const confidence = signals >= 3 ? "high" : signals === 2 ? "medium" : "low";
+
+  return {
+    productIntent,
+    likelyUsers: users,
+    candidateUserFlows,
+    candidateAcceptanceItems,
+    missingQuestions: trimmedQuestions,
+    confidence,
+  };
+}
+
+export const SAMPLE_PRD = [
+  "Overview: We want to help founders review AI-built apps before launch.",
+  "Users: Founder, product operator.",
+  "Main flow: A founder submits a GitHub repo or product URL, reviews acceptance items, and decides what to fix before release.",
+  "Success: The founder receives a staged plan with evidence-backed next steps.",
+  "Risks: The app may miss onboarding, error states, privacy checks, or release readiness.",
+].join("\n");

--- a/apps/dashboard/src/lib/intake-stage-plan.d.mts
+++ b/apps/dashboard/src/lib/intake-stage-plan.d.mts
@@ -1,0 +1,50 @@
+// Type declarations for intake-stage-plan.mjs (Stage 107).
+import type { WorkspaceIntakeType } from "./intake.d.mts";
+import type { AcceptanceMapArea } from "./intake-acceptance-map.d.mts";
+
+export type IntakeStagePlanStatus =
+  | "planned"
+  | "needs_clarification"
+  | "needs_evidence"
+  | "deferred";
+
+export type IntakeStagePlanKind =
+  | "clarify"
+  | "acceptance"
+  | "review"
+  | "fix"
+  | "evidence"
+  | "release";
+
+export type IntakeStagePlanStage = {
+  number: number;
+  title: string;
+  kind: IntakeStagePlanKind;
+  status: IntakeStagePlanStatus;
+  goal: string;
+  acceptanceAreas: AcceptanceMapArea[];
+  candidateChecks: string[];
+  evidenceToCollect: string[];
+  exitCriteria: string[];
+};
+
+export type IntakeStagePlan = {
+  intakeType: WorkspaceIntakeType;
+  title: string;
+  summary: string;
+  stages: IntakeStagePlanStage[];
+  recommendedStartStage: number;
+  releaseGate: {
+    title: string;
+    checks: string[];
+  };
+  confidence: "low" | "medium" | "high";
+};
+
+export function buildIntakeStagePlan(input: {
+  type: WorkspaceIntakeType;
+  rawInput: string;
+}): IntakeStagePlan;
+
+export const STAGE_STATUS_LABELS: Record<IntakeStagePlanStatus, string>;
+export const STAGE_KIND_LABELS: Record<IntakeStagePlanKind, string>;

--- a/apps/dashboard/src/lib/intake-stage-plan.mjs
+++ b/apps/dashboard/src/lib/intake-stage-plan.mjs
@@ -1,0 +1,264 @@
+// Stage 107 — deterministic Stage Plan from the Acceptance Map.
+//
+// Acceptance Map → ordered review workflow. Pure, in-browser; reuses Stage 106's
+// buildIntakeAcceptanceMap. NO backend / AI / fetch / DB / persistence — a
+// compact (4–7 stage) preview plan, not saved, not executed.
+import { buildIntakeAcceptanceMap } from "./intake-acceptance-map.mjs";
+
+const MIN_STAGES = 4;
+const MAX_STAGES = 7;
+
+function unique(arr) {
+  return [...new Set(arr)];
+}
+
+// Stage templates keyed by a stable id. Each is added to the plan when relevant;
+// the always-on set guarantees the 4-stage spine.
+function clarifyStage(map) {
+  return {
+    kind: "clarify",
+    status: map.confidence === "low" ? "needs_clarification" : "planned",
+    title:
+      map.intakeType === "idea"
+        ? "Clarify product intent"
+        : "Clarify scope and intent",
+    goal: "Make the product intent and review scope explicit.",
+    acceptanceAreas: ["product_intent"],
+    candidateChecks: [
+      "The primary user is identified.",
+      "The main action is described in user terms.",
+      "Open questions are captured.",
+    ],
+    evidenceToCollect: ["Notes from clarification."],
+    exitCriteria: ["The next action is clear."],
+  };
+}
+
+function acceptanceStage(map) {
+  return {
+    kind: "acceptance",
+    status: "planned",
+    title:
+      map.intakeType === "prd"
+        ? "Convert input into acceptance items"
+        : "Draft and confirm acceptance items",
+    goal: "Turn the input into specific, reviewable acceptance items.",
+    acceptanceAreas: ["primary_user_flow", "onboarding"],
+    candidateChecks: [
+      "Each acceptance item is specific enough to review.",
+      "The flow has a clear success condition.",
+    ],
+    evidenceToCollect: ["A short acceptance item list."],
+    exitCriteria: ["Acceptance items are specific enough to review."],
+  };
+}
+
+function reviewStage(map) {
+  const isApp =
+    map.intakeType === "ai_built_app" ||
+    map.intakeType === "product_url" ||
+    map.intakeType === "github_repo";
+  return {
+    kind: "review",
+    status: "needs_evidence",
+    title: "Review the primary flow",
+    goal: "Check the main user flow against acceptance items, with evidence.",
+    acceptanceAreas: ["primary_user_flow", "error_recovery"],
+    candidateChecks: [
+      "The main flow can be completed without unclear states.",
+      "Empty and error states are handled.",
+      ...(isApp ? ["The surface behaves as the input describes."] : []),
+    ].slice(0, 4),
+    evidenceToCollect: [
+      "Screenshot or walkthrough of the main flow.",
+      "Review notes showing what was checked.",
+    ],
+    exitCriteria: ["The primary flow can be reviewed with evidence."],
+  };
+}
+
+function releaseStage() {
+  return {
+    kind: "release",
+    status: "deferred",
+    title: "Verify release readiness",
+    goal: "Confirm the work is ready to share with users.",
+    acceptanceAreas: ["data_privacy", "release_readiness"],
+    candidateChecks: [
+      "Private data is not exposed unintentionally.",
+      "Release blockers are resolved or accepted.",
+    ],
+    evidenceToCollect: ["A release readiness checklist."],
+    exitCriteria: ["Release blockers are known and decided."],
+  };
+}
+
+// Context stages by intake type (inserted before the release stage).
+function contextStages(map) {
+  switch (map.intakeType) {
+    case "prd":
+      return [
+        {
+          kind: "clarify",
+          status: "needs_clarification",
+          title: "Resolve missing product questions",
+          goal: "Answer the open questions the PRD leaves unclear.",
+          acceptanceAreas: ["product_intent"],
+          candidateChecks: [
+            "Missing questions are resolved before implementation review.",
+            "Each answer is specific enough to act on.",
+          ],
+          evidenceToCollect: ["Answers to the missing questions."],
+          exitCriteria: ["No blocking product questions remain."],
+        },
+      ];
+    case "product_url":
+      return [
+        {
+          kind: "evidence",
+          status: "needs_evidence",
+          title: "Check CTA and user-journey evidence",
+          goal: "Verify the public surface promise against what a visitor can do.",
+          acceptanceAreas: ["trust_and_proof"],
+          candidateChecks: [
+            "The primary CTA explains the next step.",
+            "Claims are supported by visible evidence or clear limitations.",
+          ],
+          evidenceToCollect: ["Walkthrough of the public surface."],
+          exitCriteria: ["The surface promise is supported by evidence."],
+        },
+      ];
+    case "github_repo":
+      return [
+        {
+          kind: "evidence",
+          status: "needs_evidence",
+          title: "Review build/test evidence",
+          goal: "Map implementation to product acceptance with build/test evidence.",
+          acceptanceAreas: ["implementation_readiness"],
+          candidateChecks: [
+            "Build and test commands are known.",
+            "Main flows map to acceptance items.",
+          ],
+          evidenceToCollect: ["Build/test result.", "Repo or commit link."],
+          exitCriteria: ["Implementation maps to acceptance items with evidence."],
+        },
+      ];
+    case "ai_built_app":
+      return [
+        {
+          kind: "fix",
+          status: "planned",
+          title: "Fix or rebuild decision",
+          goal: "Decide what to keep, fix, rebuild, or verify next.",
+          acceptanceAreas: ["primary_user_flow", "error_recovery"],
+          candidateChecks: [
+            "Keep/fix/rebuild signals are reviewed.",
+            "The core flow is verified before further work.",
+          ],
+          evidenceToCollect: ["Notes on the fix-vs-rebuild decision."],
+          exitCriteria: ["A fix-or-rebuild decision is recorded."],
+        },
+      ];
+    case "pull_request":
+      return [
+        {
+          kind: "evidence",
+          status: "needs_evidence",
+          title: "Map the PR change to an acceptance item",
+          goal: "Tie the proposed change to the acceptance item it should prove.",
+          acceptanceAreas: ["implementation_readiness", "decision_history"],
+          candidateChecks: [
+            "The acceptance item the PR proves is identified.",
+            "Evidence shows the changed behavior works.",
+          ],
+          evidenceToCollect: ["PR or commit link.", "Review notes showing what changed."],
+          exitCriteria: ["The PR maps to a reviewable acceptance item."],
+        },
+      ];
+    default:
+      return [];
+  }
+}
+
+/**
+ * @param {{ type: import("./intake.d.mts").WorkspaceIntakeType, rawInput: string }} input
+ * @returns {import("./intake-stage-plan.d.mts").IntakeStagePlan}
+ */
+export function buildIntakeStagePlan(input) {
+  const map = buildIntakeAcceptanceMap(input); // throws on unknown type (by design)
+
+  // Spine (always present) + context stages, then release at the end.
+  const ordered = [
+    clarifyStage(map),
+    acceptanceStage(map),
+    ...contextStages(map),
+    reviewStage(map),
+    releaseStage(),
+  ].slice(0, MAX_STAGES);
+
+  // Guarantee the minimum even if something trimmed (shouldn't happen).
+  while (ordered.length < MIN_STAGES) {
+    ordered.splice(ordered.length - 1, 0, reviewStage(map));
+  }
+
+  const stages = ordered.map((s, i) => ({ ...s, number: i + 1 }));
+
+  const recommendedStartStage = pickStartStage(map, stages);
+
+  return {
+    intakeType: map.intakeType,
+    title: map.title,
+    summary: "Simsa turns the acceptance map into an ordered review workflow.",
+    stages,
+    recommendedStartStage,
+    releaseGate: {
+      title: "Release gate",
+      checks: unique([
+        "All non-deferred stages have evidence or an accepted exception.",
+        "Private data exposure is checked.",
+        "Known release blockers are resolved or explicitly accepted.",
+      ]),
+    },
+    confidence: map.confidence,
+  };
+}
+
+function pickStartStage(map, stages) {
+  if (map.confidence === "low") return 1;
+  switch (map.recommendedNextStep) {
+    case "clarify_product_intent":
+      return 1;
+    case "draft_acceptance_items":
+      return Math.min(2, stages.length);
+    case "review_core_flow": {
+      const idx = stages.findIndex((s) => s.kind === "review");
+      return idx >= 0 ? idx + 1 : 1;
+    }
+    case "create_stage_plan":
+      return Math.min(2, stages.length);
+    case "verify_release_readiness": {
+      // release readiness should still be preceded by an evidence/review stage
+      const idx = stages.findIndex((s) => s.kind === "evidence" || s.kind === "review");
+      return idx >= 0 ? idx + 1 : 1;
+    }
+    default:
+      return 1;
+  }
+}
+
+export const STAGE_STATUS_LABELS = {
+  planned: "Planned",
+  needs_clarification: "Needs clarification",
+  needs_evidence: "Needs evidence",
+  deferred: "Deferred",
+};
+
+export const STAGE_KIND_LABELS = {
+  clarify: "Clarify",
+  acceptance: "Acceptance",
+  review: "Review",
+  fix: "Fix",
+  evidence: "Evidence",
+  release: "Release",
+};

--- a/apps/dashboard/src/lib/intake-url.d.mts
+++ b/apps/dashboard/src/lib/intake-url.d.mts
@@ -1,0 +1,26 @@
+// Type declarations for intake-url.mjs (Stage 103 — Product URL intake preview).
+
+export type ProductUrlPathType =
+  | "homepage"
+  | "pricing"
+  | "docs"
+  | "app"
+  | "demo"
+  | "blog"
+  | "unknown";
+
+export type ProductUrlIntakePreview = {
+  normalizedUrl: string;
+  domain: string;
+  pathType: ProductUrlPathType;
+  likelySurface: string;
+  reviewFocusAreas: string[];
+  candidateAcceptanceItems: string[];
+  missingQuestions: string[];
+  confidence: "low" | "medium" | "high";
+};
+
+export function buildProductUrlIntakePreview(
+  rawInput: string,
+): ProductUrlIntakePreview;
+export const SAMPLE_PRODUCT_URL: string;

--- a/apps/dashboard/src/lib/intake-url.mjs
+++ b/apps/dashboard/src/lib/intake-url.mjs
@@ -1,0 +1,176 @@
+// Stage 103 — deterministic Product URL intake preview.
+//
+// Pure, in-browser, NO live crawl / fetch / screenshot / HTML parse / API / DB.
+// A URL is a product artifact: from its shape (domain + path + subdomain) we
+// build a review PLAN — what to check before this surface can be accepted,
+// fixed, or released. We never claim to know the real page content.
+
+const PATH_SURFACE = {
+  homepage: "Public landing surface",
+  pricing: "Pricing and conversion surface",
+  docs: "Developer or documentation surface",
+  app: "Product application surface",
+  demo: "Public demo surface",
+  blog: "Content or education surface",
+  unknown: "Product surface",
+};
+
+const FOCUS_AREAS = {
+  homepage: [
+    "Value proposition clarity",
+    "Primary user and use case",
+    "Call-to-action clarity",
+    "Trust and proof",
+    "Product promise vs available evidence",
+  ],
+  pricing: [
+    "Plan clarity",
+    "Feature-to-price mapping",
+    "Billing expectations",
+    "Refund / cancellation clarity",
+    "Conversion friction",
+  ],
+  docs: [
+    "Getting started path",
+    "API / key handling guidance",
+    "Examples and integration steps",
+    "Developer trust",
+    "Version or support expectations",
+  ],
+  app: [
+    "Onboarding",
+    "Empty states",
+    "Error states",
+    "Account / session behavior",
+    "Data privacy expectations",
+  ],
+  demo: [
+    "Fictional vs real data labeling",
+    "Demo completeness",
+    "Next-step CTA",
+    "Evidence and limitations",
+  ],
+  blog: [
+    "Content intent and audience",
+    "Accuracy and claims",
+    "Calls to action",
+    "Links and navigation",
+  ],
+  unknown: [
+    "Product intent",
+    "Primary flow",
+    "User promise",
+    "Risk areas",
+    "Release readiness",
+  ],
+};
+
+const CANDIDATE_ITEMS = [
+  "A first-time visitor can understand who the product is for.",
+  "The primary CTA clearly explains the next step.",
+  "Claims on the page are supported by visible evidence or clear limitations.",
+  "Error, empty, and unavailable states are handled where relevant.",
+  "The surface does not expose private or misleading information.",
+];
+
+function unique(arr) {
+  return [...new Set(arr)];
+}
+
+/**
+ * Best-effort, throw-free URL parse. Returns null shape pieces on failure.
+ * @param {string} raw
+ */
+function parseUrlSafe(raw) {
+  const trimmed = (typeof raw === "string" ? raw : "").trim();
+  if (!trimmed) return { ok: false, normalizedUrl: "", host: "", pathname: "/" };
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  try {
+    const u = new URL(withScheme);
+    if (!u.hostname.includes(".")) {
+      return { ok: false, normalizedUrl: trimmed, host: "", pathname: "/" };
+    }
+    return {
+      ok: true,
+      normalizedUrl: u.toString().replace(/\/$/, "") || u.toString(),
+      host: u.hostname.toLowerCase(),
+      pathname: u.pathname || "/",
+    };
+  } catch {
+    return { ok: false, normalizedUrl: trimmed, host: "", pathname: "/" };
+  }
+}
+
+/**
+ * @param {string} host
+ * @param {string} pathname
+ * @returns {import("./intake-url.d.mts").ProductUrlPathType}
+ */
+function detectPathType(host, pathname) {
+  if (host.startsWith("app.")) return "app";
+  const p = pathname.toLowerCase().replace(/\/+$/, "");
+  if (p === "" || p === "/") return "homepage";
+  if (/^\/pricing/.test(p)) return "pricing";
+  if (/^\/(docs|developers?|documentation)/.test(p)) return "docs";
+  if (/^\/app(\/|$)/.test(p)) return "app";
+  if (/^\/demo/.test(p)) return "demo";
+  if (/^\/blog/.test(p)) return "blog";
+  return "unknown";
+}
+
+/**
+ * @param {string} rawInput
+ * @returns {import("./intake-url.d.mts").ProductUrlIntakePreview}
+ */
+export function buildProductUrlIntakePreview(rawInput) {
+  const parsed = parseUrlSafe(rawInput);
+
+  if (!parsed.ok) {
+    return {
+      normalizedUrl: parsed.normalizedUrl,
+      domain: "Unknown",
+      pathType: "unknown",
+      likelySurface: PATH_SURFACE.unknown,
+      reviewFocusAreas: FOCUS_AREAS.unknown,
+      candidateAcceptanceItems: CANDIDATE_ITEMS,
+      missingQuestions: baseQuestions("unknown"),
+      confidence: "low",
+    };
+  }
+
+  const pathType = detectPathType(parsed.host, parsed.pathname);
+  const confidence = pathType === "unknown" ? "medium" : "high";
+
+  return {
+    normalizedUrl: parsed.normalizedUrl,
+    domain: parsed.host,
+    pathType,
+    likelySurface: PATH_SURFACE[pathType],
+    reviewFocusAreas: FOCUS_AREAS[pathType],
+    candidateAcceptanceItems: CANDIDATE_ITEMS,
+    missingQuestions: baseQuestions(pathType),
+    confidence,
+  };
+}
+
+/** @param {import("./intake-url.d.mts").ProductUrlPathType} pathType */
+function baseQuestions(pathType) {
+  const q = [
+    "What is the primary action this page should drive?",
+    "Who is the intended user?",
+    "What claims need evidence?",
+    "What should be verified before sharing this surface publicly?",
+    "What data, if any, should remain private?",
+  ];
+  if (pathType === "pricing")
+    q.push("What billing terms need to be explained before launch?");
+  if (pathType === "app")
+    q.push("What should happen for new users with no data?");
+  if (pathType === "docs")
+    q.push("What is the first successful developer action?");
+  return unique(q).slice(0, 6);
+}
+
+export const SAMPLE_PRODUCT_URL = "https://trysimsa.com/demo";

--- a/apps/dashboard/src/lib/intake.d.mts
+++ b/apps/dashboard/src/lib/intake.d.mts
@@ -1,0 +1,44 @@
+// Type declarations for intake.mjs (Stage 101 — unified intake model).
+
+export type WorkspaceIntakeType =
+  | "idea"
+  | "prd"
+  | "product_url"
+  | "github_repo"
+  | "pull_request"
+  | "ai_built_app";
+
+export type WorkspaceIntakeOutput =
+  | "product_understanding"
+  | "acceptance_items"
+  | "stage_plan"
+  | "review_evidence"
+  | "decision"
+  | "release_readiness";
+
+export type WorkspaceIntakeDraft = {
+  type: WorkspaceIntakeType;
+  title: string;
+  sourceSummary: string;
+  rawInput: string;
+  expectedOutputs: WorkspaceIntakeOutput[];
+};
+
+export type WorkspaceIntakeMeta = {
+  type: WorkspaceIntakeType;
+  label: string;
+  description: string;
+  placeholder: string;
+  inputHint: string;
+};
+
+export const WORKSPACE_INTAKE_TYPES: WorkspaceIntakeType[];
+export const INTAKE_OUTPUTS: WorkspaceIntakeOutput[];
+export const INTAKE_OUTPUT_LABELS: Record<WorkspaceIntakeOutput, string>;
+export const INTAKE_META: Record<WorkspaceIntakeType, WorkspaceIntakeMeta>;
+
+export function isWorkspaceIntakeType(value: unknown): value is WorkspaceIntakeType;
+export function buildIntakeDraft(
+  type: WorkspaceIntakeType,
+  rawInput: string,
+): WorkspaceIntakeDraft;

--- a/apps/dashboard/src/lib/intake.mjs
+++ b/apps/dashboard/src/lib/intake.mjs
@@ -1,0 +1,112 @@
+// Stage 101 — unified intake model.
+//
+// One intake system with multiple starting points. Every intake type produces
+// the SAME downstream outputs, so the product has one acceptance pipeline rather
+// than six separate products. This module is pure + deterministic — no backend,
+// no external fetch, no Anthropic call. Future stages (102+) replace the mock
+// draft with real per-type analysis.
+
+/** @type {import("./intake.d.mts").WorkspaceIntakeType[]} */
+export const WORKSPACE_INTAKE_TYPES = [
+  "idea",
+  "prd",
+  "product_url",
+  "github_repo",
+  "pull_request",
+  "ai_built_app",
+];
+
+/** @type {import("./intake.d.mts").WorkspaceIntakeOutput[]} */
+export const INTAKE_OUTPUTS = [
+  "product_understanding",
+  "acceptance_items",
+  "stage_plan",
+  "review_evidence",
+  "decision",
+  "release_readiness",
+];
+
+export const INTAKE_OUTPUT_LABELS = {
+  product_understanding: "Product understanding",
+  acceptance_items: "Acceptance items",
+  stage_plan: "Stage plan",
+  review_evidence: "Review evidence",
+  decision: "Accept / fix / rerun decisions",
+  release_readiness: "Release readiness",
+};
+
+export const INTAKE_META = {
+  idea: {
+    type: "idea",
+    label: "Idea",
+    description: "Start from a raw product idea.",
+    placeholder: "A tool that helps founders review AI-built apps before launch.",
+    inputHint: "Describe the product idea in a sentence or two.",
+  },
+  prd: {
+    type: "prd",
+    label: "PRD / spec",
+    description: "Turn an existing product document into acceptance items.",
+    placeholder: "Paste your PRD or requirements.",
+    inputHint: "Paste the PRD or spec text.",
+  },
+  product_url: {
+    type: "product_url",
+    label: "Product URL",
+    description: "Review an existing product surface.",
+    placeholder: "https://example.com",
+    inputHint: "Paste the product URL.",
+  },
+  github_repo: {
+    type: "github_repo",
+    label: "GitHub repo",
+    description: "Understand an existing codebase.",
+    placeholder: "owner/repo or GitHub URL",
+    inputHint: "Paste owner/repo or a GitHub URL.",
+  },
+  pull_request: {
+    type: "pull_request",
+    label: "Pull request",
+    description: "Review a proposed change.",
+    placeholder: "https://github.com/owner/repo/pull/123",
+    inputHint: "Paste a GitHub pull request URL.",
+  },
+  ai_built_app: {
+    type: "ai_built_app",
+    label: "AI-built app",
+    description: "Recover and structure a vibe-coded draft.",
+    placeholder: "Describe what the AI-built app currently does and what feels uncertain.",
+    inputHint: "Describe the current app and what feels uncertain.",
+  },
+};
+
+/** @returns {value is import("./intake.d.mts").WorkspaceIntakeType} */
+export function isWorkspaceIntakeType(value) {
+  return typeof value === "string" && WORKSPACE_INTAKE_TYPES.includes(value);
+}
+
+/**
+ * Deterministic local draft. No network, no model call. Every type yields the
+ * full set of expected outputs — the unified acceptance promise.
+ * @param {import("./intake.d.mts").WorkspaceIntakeType} type
+ * @param {string} rawInput
+ * @returns {import("./intake.d.mts").WorkspaceIntakeDraft}
+ */
+export function buildIntakeDraft(type, rawInput) {
+  if (!isWorkspaceIntakeType(type)) {
+    throw new Error(`unknown intake type: ${String(type)}`);
+  }
+  const meta = INTAKE_META[type];
+  const trimmed = typeof rawInput === "string" ? rawInput.trim() : "";
+  const firstLine = trimmed.split(/\r?\n/)[0] ?? "";
+  const snippet = firstLine.length > 80 ? `${firstLine.slice(0, 77)}…` : firstLine;
+  return {
+    type,
+    title: snippet ? `${meta.label}: ${snippet}` : `${meta.label} intake`,
+    sourceSummary: snippet
+      ? `${meta.label} — ${snippet}`
+      : `${meta.label} — no input provided yet`,
+    rawInput: trimmed,
+    expectedOutputs: [...INTAKE_OUTPUTS],
+  };
+}

--- a/apps/dashboard/test/intake-acceptance-map.test.mjs
+++ b/apps/dashboard/test/intake-acceptance-map.test.mjs
@@ -1,0 +1,105 @@
+// Stage 106 — shared Acceptance Map tests. Pure/deterministic; no backend.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildIntakeAcceptanceMap,
+  NEXT_STEP_LABELS,
+} from "../src/lib/intake-acceptance-map.mjs";
+import { WORKSPACE_INTAKE_TYPES } from "../src/lib/intake.mjs";
+
+const NEXT_STEPS = new Set(Object.keys(NEXT_STEP_LABELS));
+
+function assertShape(map) {
+  assert.ok(map.title.length > 0);
+  assert.ok(map.summary.length > 0);
+  assert.ok(map.areas.length >= 1);
+  assert.ok(map.items.length >= 5 && map.items.length <= 10, `items=${map.items.length}`);
+  for (const it of map.items) {
+    assert.ok(it.title.length > 0);
+    assert.ok(["candidate", "missing_detail", "needs_verification"].includes(it.status));
+    assert.ok(it.area.length > 0);
+  }
+  assert.ok(map.missingQuestions.length >= 1 && map.missingQuestions.length <= 6);
+  assert.ok(NEXT_STEPS.has(map.recommendedNextStep));
+  assert.ok(["low", "medium", "high"].includes(map.confidence));
+}
+
+test("builds a valid map for every intake type", () => {
+  for (const type of WORKSPACE_INTAKE_TYPES) {
+    const map = buildIntakeAcceptanceMap({ type, rawInput: "some pasted input here" });
+    assert.equal(map.intakeType, type);
+    assertShape(map);
+  }
+});
+
+test("idea → clarify_product_intent", () => {
+  const map = buildIntakeAcceptanceMap({ type: "idea", rawInput: "a small idea" });
+  assert.equal(map.recommendedNextStep, "clarify_product_intent");
+});
+
+test("prd map uses PRD acceptance items", () => {
+  const map = buildIntakeAcceptanceMap({
+    type: "prd",
+    rawInput: "Overview: a tool. Users: founder. User can submit a request.",
+  });
+  assert.ok(map.items.some((i) => /without errors|first use|recoverable|release/i.test(i.title)));
+  assert.ok(["draft_acceptance_items", "clarify_product_intent"].includes(map.recommendedNextStep));
+});
+
+test("product_url demo → verify_release_readiness", () => {
+  const map = buildIntakeAcceptanceMap({ type: "product_url", rawInput: "https://trysimsa.com/demo" });
+  assert.equal(map.recommendedNextStep, "verify_release_readiness");
+  assert.ok(map.areas.includes("trust_and_proof"));
+});
+
+test("github_repo app → review_core_flow; library → create_stage_plan", () => {
+  assert.equal(
+    buildIntakeAcceptanceMap({ type: "github_repo", rawInput: "acme/web-app" }).recommendedNextStep,
+    "review_core_flow",
+  );
+  assert.equal(
+    buildIntakeAcceptanceMap({ type: "github_repo", rawInput: "acme/js-sdk" }).recommendedNextStep,
+    "create_stage_plan",
+  );
+});
+
+test("ai_built_app maps recovery action to a next step", () => {
+  const broken = buildIntakeAcceptanceMap({
+    type: "ai_built_app",
+    rawInput: "It has bugs and broken flows with errors everywhere.",
+  });
+  assert.equal(broken.recommendedNextStep, "create_stage_plan");
+  const launch = buildIntakeAcceptanceMap({
+    type: "ai_built_app",
+    rawInput: "Looks usable, want to share with early users and launch.",
+  });
+  assert.equal(launch.recommendedNextStep, "verify_release_readiness");
+});
+
+test("pull_request generic fallback + PR question", () => {
+  const map = buildIntakeAcceptanceMap({
+    type: "pull_request",
+    rawInput: "https://github.com/acme/widget/pull/12",
+  });
+  assert.equal(map.recommendedNextStep, "review_core_flow");
+  assert.ok(map.missingQuestions.some((q) => /this PR prove/.test(q)));
+  assert.ok(map.areas.includes("decision_history"));
+});
+
+test("always 5–10 items even with empty input", () => {
+  for (const type of WORKSPACE_INTAKE_TYPES) {
+    const map = buildIntakeAcceptanceMap({ type, rawInput: "" });
+    assert.ok(map.items.length >= 5 && map.items.length <= 10);
+  }
+});
+
+test("does not throw for empty input; throws for unknown type", () => {
+  assert.doesNotThrow(() => buildIntakeAcceptanceMap({ type: "idea", rawInput: "" }));
+  assert.throws(() => buildIntakeAcceptanceMap({ type: "bogus", rawInput: "x" }));
+});
+
+test("deterministic", () => {
+  const a = buildIntakeAcceptanceMap({ type: "prd", rawInput: "Overview: x. User can create." });
+  const b = buildIntakeAcceptanceMap({ type: "prd", rawInput: "Overview: x. User can create." });
+  assert.deepEqual(a, b);
+});

--- a/apps/dashboard/test/intake-ai-built-app.test.mjs
+++ b/apps/dashboard/test/intake-ai-built-app.test.mjs
@@ -1,0 +1,98 @@
+// Stage 105 — Existing App Recovery Assessment tests. Pure/deterministic.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildAiBuiltAppRecoveryPreview,
+  SAMPLE_AI_BUILT_APP,
+} from "../src/lib/intake-ai-built-app.mjs";
+
+test("fallback for empty/minimal input", () => {
+  const p = buildAiBuiltAppRecoveryPreview("   ");
+  assert.match(p.currentStateSummary, /AI-built product draft/);
+  assert.equal(p.likelyProductSurface, "unknown");
+  assert.equal(p.recommendedNextAction, "create_acceptance_map");
+  assert.equal(p.confidence, "low");
+  assert.ok(p.recoveryFocusAreas.length >= 5);
+});
+
+test("detects surfaces", () => {
+  assert.equal(buildAiBuiltAppRecoveryPreview("a marketing landing page").likelyProductSurface, "landing");
+  assert.equal(buildAiBuiltAppRecoveryPreview("a task dashboard for teams").likelyProductSurface, "dashboard");
+  assert.equal(buildAiBuiltAppRecoveryPreview("an iOS mobile app").likelyProductSurface, "mobile");
+  assert.equal(buildAiBuiltAppRecoveryPreview("a backend api server").likelyProductSurface, "api");
+  assert.equal(buildAiBuiltAppRecoveryPreview("a quick MVP prototype").likelyProductSurface, "prototype");
+});
+
+test("adds auth focus when login mentioned", () => {
+  const p = buildAiBuiltAppRecoveryPreview("It has login and sessions.");
+  assert.ok(p.recoveryFocusAreas.includes("Account and session behavior"));
+  assert.ok(p.candidateAcceptanceItems.some((i) => /signed-out user/.test(i)));
+});
+
+test("adds payment focus when checkout mentioned", () => {
+  const p = buildAiBuiltAppRecoveryPreview("It has checkout and payment.");
+  assert.ok(p.recoveryFocusAreas.includes("Payment and billing flow"));
+  assert.ok(p.candidateAcceptanceItems.some((i) => /payment failure/.test(i)));
+});
+
+test("adds sharing focus when invite/link mentioned", () => {
+  const p = buildAiBuiltAppRecoveryPreview("Users can share invite links.");
+  assert.ok(p.recoveryFocusAreas.includes("Sharing and permission boundaries"));
+  assert.ok(p.candidateAcceptanceItems.some((i) => /Shared links/.test(i)));
+});
+
+test("adds AI fallback focus when AI/LLM mentioned", () => {
+  const p = buildAiBuiltAppRecoveryPreview("It uses an LLM to generate summaries.");
+  assert.ok(p.recoveryFocusAreas.includes("AI output quality and fallback behavior"));
+  assert.ok(p.candidateAcceptanceItems.some((i) => /AI-generated output/.test(i)));
+});
+
+test("adds deploy verification when repo/deploy/env mentioned", () => {
+  const p = buildAiBuiltAppRecoveryPreview("Deployed from a GitHub repo with env vars.");
+  assert.ok(p.recoveryFocusAreas.includes("Build, deploy, and environment verification"));
+});
+
+test("recommends create_fix_stage for broken/error input", () => {
+  const p = buildAiBuiltAppRecoveryPreview(
+    "The app has bugs and failed saves throw errors that are broken right now.",
+  );
+  assert.equal(p.recommendedNextAction, "create_fix_stage");
+});
+
+test("recommends verify_release_readiness for launch/share input", () => {
+  const p = buildAiBuiltAppRecoveryPreview(
+    "It looks usable and I want to share it with early users and launch soon.",
+  );
+  assert.equal(p.recommendedNextAction, "verify_release_readiness");
+});
+
+test("recommends review_core_flow when core flow mentioned", () => {
+  const p = buildAiBuiltAppRecoveryPreview(
+    "I want to make sure the main flow and user journey hold up before more work.",
+  );
+  assert.equal(p.recommendedNextAction, "review_core_flow");
+});
+
+test("includes fix vs rebuild signals", () => {
+  const p = buildAiBuiltAppRecoveryPreview(SAMPLE_AI_BUILT_APP);
+  assert.ok(p.fixVsRebuildSignals.likelyKeep.length >= 1);
+  assert.ok(p.fixVsRebuildSignals.likelyFix.length >= 1);
+  assert.ok(p.fixVsRebuildSignals.likelyRebuild.length >= 1);
+  assert.ok(p.fixVsRebuildSignals.needsVerification.length >= 1);
+});
+
+test("handles input without throwing + deterministic", () => {
+  for (const bad of ["", null, "x"]) {
+    assert.doesNotThrow(() => buildAiBuiltAppRecoveryPreview(bad));
+  }
+  assert.deepEqual(
+    buildAiBuiltAppRecoveryPreview(SAMPLE_AI_BUILT_APP),
+    buildAiBuiltAppRecoveryPreview(SAMPLE_AI_BUILT_APP),
+  );
+});
+
+test("sample reaches higher confidence and 3-6 questions", () => {
+  const p = buildAiBuiltAppRecoveryPreview(SAMPLE_AI_BUILT_APP);
+  assert.ok(["medium", "high"].includes(p.confidence));
+  assert.ok(p.missingQuestions.length >= 3 && p.missingQuestions.length <= 6);
+});

--- a/apps/dashboard/test/intake-github-repo.test.mjs
+++ b/apps/dashboard/test/intake-github-repo.test.mjs
@@ -1,0 +1,80 @@
+// Stage 104 — GitHub repo intake preview tests. Pure/deterministic; no fetch/API.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildGitHubRepoIntakePreview,
+  SAMPLE_GITHUB_REPO,
+} from "../src/lib/intake-github-repo.mjs";
+
+test("parses owner/repo", () => {
+  const p = buildGitHubRepoIntakePreview("acme/widget");
+  assert.equal(p.owner, "acme");
+  assert.equal(p.repo, "widget");
+  assert.equal(p.normalizedRepo, "acme/widget");
+  assert.equal(p.repoUrl, "https://github.com/acme/widget");
+});
+
+test("parses https github URL", () => {
+  const p = buildGitHubRepoIntakePreview("https://github.com/acme/widget");
+  assert.equal(p.normalizedRepo, "acme/widget");
+});
+
+test("parses github.com/owner/repo without scheme", () => {
+  const p = buildGitHubRepoIntakePreview("github.com/acme/widget");
+  assert.equal(p.normalizedRepo, "acme/widget");
+});
+
+test("parses PR URL and flags PR-vs-repo question", () => {
+  const p = buildGitHubRepoIntakePreview("https://github.com/acme/widget/pull/123");
+  assert.equal(p.normalizedRepo, "acme/widget");
+  assert.ok(p.missingQuestions.some((q) => /PR change or the whole repo/.test(q)));
+});
+
+test("parses tree URL and keeps repo", () => {
+  const p = buildGitHubRepoIntakePreview("https://github.com/acme/widget/tree/main");
+  assert.equal(p.normalizedRepo, "acme/widget");
+});
+
+test("strips .git suffix", () => {
+  const p = buildGitHubRepoIntakePreview("https://github.com/acme/widget.git");
+  assert.equal(p.repo, "widget");
+});
+
+test("detects repo types", () => {
+  assert.equal(buildGitHubRepoIntakePreview("acme/web-dashboard").likelyRepoType, "app");
+  assert.equal(buildGitHubRepoIntakePreview("acme/billing-api").likelyRepoType, "api");
+  assert.equal(buildGitHubRepoIntakePreview("acme/product-docs").likelyRepoType, "docs");
+  assert.equal(buildGitHubRepoIntakePreview("acme/js-sdk").likelyRepoType, "library");
+  assert.equal(buildGitHubRepoIntakePreview("acme/platform-monorepo").likelyRepoType, "monorepo");
+  assert.equal(buildGitHubRepoIntakePreview("acme/widget").likelyRepoType, "unknown");
+});
+
+test("type-specific question appears (app)", () => {
+  const p = buildGitHubRepoIntakePreview("acme/web-app");
+  assert.ok(p.missingQuestions.some((q) => /first user journey/.test(q)));
+});
+
+test("handles invalid input without throwing", () => {
+  for (const bad of ["", "   ", "justtext", "/", "owner", null]) {
+    const p = buildGitHubRepoIntakePreview(bad);
+    assert.equal(p.owner, "Unknown");
+    assert.equal(p.likelyRepoType, "unknown");
+    assert.equal(p.confidence, "low");
+  }
+});
+
+test("preview shape: focus areas, items, 3-6 questions", () => {
+  for (const r of [SAMPLE_GITHUB_REPO, "acme/billing-api", "bad"]) {
+    const p = buildGitHubRepoIntakePreview(r);
+    assert.ok(p.reviewFocusAreas.length >= 3);
+    assert.ok(p.candidateAcceptanceItems.length >= 4);
+    assert.ok(p.missingQuestions.length >= 3 && p.missingQuestions.length <= 6);
+  }
+});
+
+test("is deterministic", () => {
+  assert.deepEqual(
+    buildGitHubRepoIntakePreview(SAMPLE_GITHUB_REPO),
+    buildGitHubRepoIntakePreview(SAMPLE_GITHUB_REPO),
+  );
+});

--- a/apps/dashboard/test/intake-prd.test.mjs
+++ b/apps/dashboard/test/intake-prd.test.mjs
@@ -1,0 +1,75 @@
+// Stage 102 — PRD/spec intake preview tests. Pure/deterministic; no backend.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildPrdIntakePreview, SAMPLE_PRD } from "../src/lib/intake-prd.mjs";
+
+test("empty/minimal input returns a fallback preview", () => {
+  const p = buildPrdIntakePreview("   ");
+  assert.match(p.productIntent, /converted into acceptance items/);
+  assert.deepEqual(p.likelyUsers, ["User", "Operator"]);
+  assert.ok(p.candidateAcceptanceItems.length >= 4);
+  assert.ok(p.missingQuestions.length >= 3 && p.missingQuestions.length <= 6);
+  assert.equal(p.confidence, "low");
+});
+
+test("detects users from PRD text", () => {
+  const p = buildPrdIntakePreview("Users: Founder and admin manage the team.");
+  assert.ok(p.likelyUsers.includes("Founder"));
+  assert.ok(p.likelyUsers.includes("Admin"));
+  assert.ok(p.likelyUsers.includes("Team"));
+});
+
+test("detects action-oriented flows", () => {
+  const p = buildPrdIntakePreview(
+    "User can create a project and submit it. Operator can review and approve.",
+  );
+  const flows = p.candidateUserFlows.join(" ");
+  assert.match(flows, /create the main item/);
+  assert.match(flows, /submit a request/);
+  assert.match(flows, /review results/);
+  assert.match(flows, /approve work/);
+});
+
+test("creates acceptance-style items", () => {
+  const p = buildPrdIntakePreview("User can submit a form.");
+  assert.ok(
+    p.candidateAcceptanceItems.some((i) => /without errors/.test(i)),
+  );
+  assert.ok(
+    p.candidateAcceptanceItems.some((i) => /Release readiness/.test(i)),
+  );
+});
+
+test("always includes missing questions (3–6)", () => {
+  const p = buildPrdIntakePreview("A vague document with no signals.");
+  assert.ok(p.missingQuestions.length >= 3 && p.missingQuestions.length <= 6);
+  assert.ok(p.missingQuestions.some((q) => /successful outcome/.test(q)));
+});
+
+test("detects payment-specific question", () => {
+  const p = buildPrdIntakePreview("Users can pay at checkout for a subscription.");
+  assert.ok(
+    p.missingQuestions.some((q) => /payment failures and refunds/.test(q)),
+    "expected a payment question",
+  );
+});
+
+test("detects repo/PR-specific question", () => {
+  const p = buildPrdIntakePreview("A founder connects a GitHub repo to review.");
+  assert.ok(
+    p.missingQuestions.some((q) => /repository or branch/.test(q)),
+  );
+});
+
+test("is deterministic", () => {
+  assert.deepEqual(
+    buildPrdIntakePreview(SAMPLE_PRD),
+    buildPrdIntakePreview(SAMPLE_PRD),
+  );
+});
+
+test("sample PRD reaches higher confidence", () => {
+  const p = buildPrdIntakePreview(SAMPLE_PRD);
+  assert.ok(["medium", "high"].includes(p.confidence));
+  assert.ok(p.likelyUsers.includes("Founder"));
+});

--- a/apps/dashboard/test/intake-stage-plan.test.mjs
+++ b/apps/dashboard/test/intake-stage-plan.test.mjs
@@ -1,0 +1,95 @@
+// Stage 107 — Stage Plan tests. Pure/deterministic; no backend.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildIntakeStagePlan,
+  STAGE_STATUS_LABELS,
+  STAGE_KIND_LABELS,
+} from "../src/lib/intake-stage-plan.mjs";
+import { WORKSPACE_INTAKE_TYPES } from "../src/lib/intake.mjs";
+
+function assertPlan(plan) {
+  assert.ok(plan.title.length > 0);
+  assert.ok(plan.summary.length > 0);
+  assert.ok(plan.stages.length >= 4 && plan.stages.length <= 7, `stages=${plan.stages.length}`);
+  // sequential numbering
+  plan.stages.forEach((s, i) => assert.equal(s.number, i + 1));
+  // each stage well-formed
+  for (const s of plan.stages) {
+    assert.ok(s.title.length > 0);
+    assert.ok(STAGE_KIND_LABELS[s.kind], `bad kind ${s.kind}`);
+    assert.ok(STAGE_STATUS_LABELS[s.status], `bad status ${s.status}`);
+    assert.ok(s.goal.length > 0);
+    assert.ok(s.candidateChecks.length >= 2 && s.candidateChecks.length <= 4);
+    assert.ok(s.evidenceToCollect.length >= 1 && s.evidenceToCollect.length <= 3);
+    assert.ok(s.exitCriteria.length >= 1 && s.exitCriteria.length <= 3);
+  }
+  // ends with a release stage
+  assert.equal(plan.stages[plan.stages.length - 1].kind, "release");
+  // release gate
+  assert.ok(plan.releaseGate.checks.length >= 1);
+  // start stage in range
+  assert.ok(plan.recommendedStartStage >= 1 && plan.recommendedStartStage <= plan.stages.length);
+  assert.ok(["low", "medium", "high"].includes(plan.confidence));
+}
+
+test("builds a valid plan for every intake type", () => {
+  for (const type of WORKSPACE_INTAKE_TYPES) {
+    const plan = buildIntakeStagePlan({ type, rawInput: "some pasted input here" });
+    assert.equal(plan.intakeType, type);
+    assertPlan(plan);
+  }
+});
+
+test("4–7 stages even with empty input", () => {
+  for (const type of WORKSPACE_INTAKE_TYPES) {
+    assertPlan(buildIntakeStagePlan({ type, rawInput: "" }));
+  }
+});
+
+test("prd plan includes acceptance conversion + resolve questions", () => {
+  const plan = buildIntakeStagePlan({
+    type: "prd",
+    rawInput: "Overview: a tool. Users: founder. User can submit.",
+  });
+  assert.ok(plan.stages.some((s) => /acceptance items/i.test(s.title)));
+  assert.ok(plan.stages.some((s) => /missing product questions/i.test(s.title)));
+});
+
+test("github_repo plan includes build/test evidence stage", () => {
+  const plan = buildIntakeStagePlan({ type: "github_repo", rawInput: "acme/web-app" });
+  assert.ok(plan.stages.some((s) => /build\/test evidence/i.test(s.title)));
+});
+
+test("ai_built_app plan includes fix-or-rebuild stage", () => {
+  const plan = buildIntakeStagePlan({
+    type: "ai_built_app",
+    rawInput: "AI-built dashboard with login and sharing.",
+  });
+  assert.ok(plan.stages.some((s) => s.kind === "fix"));
+});
+
+test("pull_request plan maps PR to acceptance item", () => {
+  const plan = buildIntakeStagePlan({
+    type: "pull_request",
+    rawInput: "https://github.com/acme/widget/pull/9",
+  });
+  assert.ok(plan.stages.some((s) => /PR change to an acceptance item/i.test(s.title)));
+});
+
+test("low confidence (empty) starts at stage 1", () => {
+  const plan = buildIntakeStagePlan({ type: "idea", rawInput: "" });
+  assert.equal(plan.confidence, "low");
+  assert.equal(plan.recommendedStartStage, 1);
+});
+
+test("does not throw for empty; throws for unknown type", () => {
+  assert.doesNotThrow(() => buildIntakeStagePlan({ type: "idea", rawInput: "" }));
+  assert.throws(() => buildIntakeStagePlan({ type: "bogus", rawInput: "x" }));
+});
+
+test("deterministic", () => {
+  const a = buildIntakeStagePlan({ type: "ai_built_app", rawInput: "login + sharing app" });
+  const b = buildIntakeStagePlan({ type: "ai_built_app", rawInput: "login + sharing app" });
+  assert.deepEqual(a, b);
+});

--- a/apps/dashboard/test/intake-url.test.mjs
+++ b/apps/dashboard/test/intake-url.test.mjs
@@ -1,0 +1,67 @@
+// Stage 103 — Product URL intake preview tests. Pure/deterministic; no fetch.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildProductUrlIntakePreview,
+  SAMPLE_PRODUCT_URL,
+} from "../src/lib/intake-url.mjs";
+
+test("normalizes a bare domain", () => {
+  const p = buildProductUrlIntakePreview("example.com");
+  assert.equal(p.domain, "example.com");
+  assert.equal(p.normalizedUrl, "https://example.com");
+  assert.equal(p.pathType, "homepage");
+});
+
+test("detects homepage", () => {
+  assert.equal(buildProductUrlIntakePreview("https://example.com/").pathType, "homepage");
+  assert.equal(buildProductUrlIntakePreview("https://example.com").pathType, "homepage");
+});
+
+test("detects pricing path", () => {
+  const p = buildProductUrlIntakePreview("https://example.com/pricing");
+  assert.equal(p.pathType, "pricing");
+  assert.ok(p.missingQuestions.some((q) => /billing terms/.test(q)));
+});
+
+test("detects docs/developer path", () => {
+  assert.equal(buildProductUrlIntakePreview("https://example.com/docs").pathType, "docs");
+  assert.equal(buildProductUrlIntakePreview("https://example.com/developers").pathType, "docs");
+  const p = buildProductUrlIntakePreview("https://example.com/docs");
+  assert.ok(p.missingQuestions.some((q) => /developer action/.test(q)));
+});
+
+test("detects app subdomain", () => {
+  const p = buildProductUrlIntakePreview("https://app.example.com");
+  assert.equal(p.pathType, "app");
+  assert.ok(p.missingQuestions.some((q) => /new users with no data/.test(q)));
+});
+
+test("detects demo path", () => {
+  assert.equal(buildProductUrlIntakePreview(SAMPLE_PRODUCT_URL).pathType, "demo");
+});
+
+test("handles invalid input without throwing", () => {
+  for (const bad of ["", "   ", "not a url", "justtext", null]) {
+    const p = buildProductUrlIntakePreview(bad);
+    assert.equal(p.domain, "Unknown");
+    assert.equal(p.pathType, "unknown");
+    assert.equal(p.confidence, "low");
+  }
+});
+
+test("every preview has focus areas, acceptance items, and 3-6 questions", () => {
+  for (const u of [SAMPLE_PRODUCT_URL, "example.com/pricing", "bad input"]) {
+    const p = buildProductUrlIntakePreview(u);
+    assert.ok(p.reviewFocusAreas.length >= 3);
+    assert.ok(p.candidateAcceptanceItems.length >= 4);
+    assert.ok(p.missingQuestions.length >= 3 && p.missingQuestions.length <= 6);
+  }
+});
+
+test("is deterministic", () => {
+  assert.deepEqual(
+    buildProductUrlIntakePreview(SAMPLE_PRODUCT_URL),
+    buildProductUrlIntakePreview(SAMPLE_PRODUCT_URL),
+  );
+});

--- a/apps/dashboard/test/intake.test.mjs
+++ b/apps/dashboard/test/intake.test.mjs
@@ -1,0 +1,86 @@
+// Stage 101 — unified intake model tests. Pure/deterministic; no backend.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  WORKSPACE_INTAKE_TYPES,
+  INTAKE_OUTPUTS,
+  INTAKE_OUTPUT_LABELS,
+  INTAKE_META,
+  isWorkspaceIntakeType,
+  buildIntakeDraft,
+} from "../src/lib/intake.mjs";
+
+test("there are 6 unique intake types", () => {
+  assert.equal(WORKSPACE_INTAKE_TYPES.length, 6);
+  assert.equal(new Set(WORKSPACE_INTAKE_TYPES).size, 6);
+  assert.deepEqual(WORKSPACE_INTAKE_TYPES, [
+    "idea",
+    "prd",
+    "product_url",
+    "github_repo",
+    "pull_request",
+    "ai_built_app",
+  ]);
+});
+
+test("every type has complete, non-empty meta", () => {
+  for (const type of WORKSPACE_INTAKE_TYPES) {
+    const meta = INTAKE_META[type];
+    assert.ok(meta, `missing meta for ${type}`);
+    assert.equal(meta.type, type);
+    for (const field of ["label", "description", "placeholder", "inputHint"]) {
+      assert.ok(meta[field] && meta[field].length > 0, `${type}.${field} empty`);
+    }
+  }
+});
+
+test("all 6 outputs have labels", () => {
+  assert.equal(INTAKE_OUTPUTS.length, 6);
+  for (const out of INTAKE_OUTPUTS) {
+    assert.ok(INTAKE_OUTPUT_LABELS[out], `missing label for ${out}`);
+  }
+});
+
+test("isWorkspaceIntakeType validates", () => {
+  assert.ok(isWorkspaceIntakeType("idea"));
+  assert.ok(isWorkspaceIntakeType("ai_built_app"));
+  assert.ok(!isWorkspaceIntakeType("nope"));
+  assert.ok(!isWorkspaceIntakeType(""));
+  assert.ok(!isWorkspaceIntakeType(null));
+});
+
+test("buildIntakeDraft: every type yields the full set of expected outputs", () => {
+  for (const type of WORKSPACE_INTAKE_TYPES) {
+    const draft = buildIntakeDraft(type, "some input");
+    assert.equal(draft.type, type);
+    assert.deepEqual(draft.expectedOutputs, INTAKE_OUTPUTS);
+    assert.ok(draft.title.length > 0);
+    assert.ok(draft.sourceSummary.length > 0);
+    assert.equal(draft.rawInput, "some input");
+  }
+});
+
+test("buildIntakeDraft is deterministic", () => {
+  const a = buildIntakeDraft("idea", "An app that reviews AI-built drafts");
+  const b = buildIntakeDraft("idea", "An app that reviews AI-built drafts");
+  assert.deepEqual(a, b);
+  assert.equal(a.title, "Idea: An app that reviews AI-built drafts");
+});
+
+test("buildIntakeDraft handles empty input deterministically", () => {
+  const d = buildIntakeDraft("prd", "   ");
+  assert.equal(d.rawInput, "");
+  assert.equal(d.title, "PRD / spec intake");
+  assert.match(d.sourceSummary, /no input provided yet/);
+});
+
+test("buildIntakeDraft truncates a long first line", () => {
+  const long = "x".repeat(200);
+  const d = buildIntakeDraft("idea", long);
+  assert.ok(d.title.includes("…"));
+  assert.ok(d.title.length < 120);
+});
+
+test("buildIntakeDraft rejects unknown type", () => {
+  assert.throws(() => buildIntakeDraft("bogus", "x"), /unknown intake type/);
+});

--- a/conclave-builder-pack/out/stage-101-unified-intake-model.md
+++ b/conclave-builder-pack/out/stage-101-unified-intake-model.md
@@ -1,0 +1,49 @@
+# Stage 101 — Unified Intake Model
+
+**Date:** 2026-06-23
+**Branch:** `feat/stage-101-unified-intake` · base `main` `78f766f`
+**Train:** Stage 101~108 — Intake to Staged Acceptance Core (this is the foundation stage).
+
+## Goal
+Make the public promise real inside the product: *start from an idea, PRD, product URL, GitHub repo, pull request, or AI-built app — Simsa turns it into a staged acceptance workflow.* Stage 101 introduces the **shared intake model + a safe first UI path + deterministic local preview** — not the per-type analyzers (those are Stages 102+).
+
+## Product principle
+One intake system with multiple starting points — not six products. Every intake type maps to the **same** downstream outputs.
+
+## Intake types
+`idea` · `prd` · `product_url` · `github_repo` · `pull_request` · `ai_built_app`
+
+## Shared model — `apps/dashboard/src/lib/intake.mjs` (+ `.d.mts`)
+- `WORKSPACE_INTAKE_TYPES` (6) · `INTAKE_OUTPUTS` (6) · `INTAKE_OUTPUT_LABELS`
+- `INTAKE_META[type]` → `{ type, label, description, placeholder, inputHint }`
+- `isWorkspaceIntakeType(value)`
+- `buildIntakeDraft(type, rawInput)` → `WorkspaceIntakeDraft { type, title, sourceSummary, rawInput, expectedOutputs }`
+  - **deterministic**, pure; every type yields the full `INTAKE_OUTPUTS` set (the unified acceptance promise).
+- `WorkspaceIntakeDraft.expectedOutputs`: `product_understanding · acceptance_items · stage_plan · review_evidence · decision · release_readiness`.
+
+`.mjs` + `.d.mts` so it is both testable under `node --test` and importable from TSX (matches the dashboard convention; Node20 CI can't type-strip `.ts`).
+
+## UI path — `apps/dashboard/src/app/projects/new/intake/page.tsx` (route `/projects/new/intake`)
+- "What do you want Simsa to review?" → 6 selectable cards (label + one-line description).
+- On select → "Paste what you have." textarea with a per-type placeholder + input hint.
+- "Create intake draft" → deterministic local preview: draft title + source summary + "Simsa will turn this into:" list of the 6 expected outputs.
+- New route only — the **existing `/projects/new` idea→spec flow is untouched** (no rewrite, no risk to the working backend path).
+
+## What is intentionally mock / local
+- No backend ingestion, no Anthropic/central-plane call, no external fetch (URL/repo/PR not actually fetched), no file upload, no DB.
+- The preview is computed in-browser from the static model. Labeled "Preview only — staged analysis arrives in later stages."
+
+## Copy
+Uses the public positioning ("Start from anything. … staged acceptance workflow."). Avoids "AI will build this for you / instant production app / fully automated / guaranteed release readiness".
+- i18n: this foundation page uses English copy from the shared model; it does not yet route through the EN/KO dictionary (parity tests unaffected). Localizing the intake surface is a follow-up.
+
+## Verification
+- `apps/dashboard`: **200/200** tests pass (+9 new intake tests), typecheck clean, lint = pre-existing `export/page.tsx` warning only, build green (`/projects/new/intake` = 1.92 kB).
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Not changed (Stage 101 out of scope)
+DB / D1 migration · central-plane · production backend ingestion · URL crawler · GitHub deep scanner · file upload · billing · deploy · domains · existing `/projects/new` flow.
+
+## Next stages
+- **Stage 102 — PRD / Spec Intake** (first real per-type analyzer)
+- then product_url / github_repo / pull_request / ai_built_app intakes, converging on the shared acceptance pipeline.

--- a/conclave-builder-pack/out/stage-102-prd-spec-intake.md
+++ b/conclave-builder-pack/out/stage-102-prd-spec-intake.md
@@ -1,0 +1,36 @@
+# Stage 102 — PRD / Spec Intake
+
+**Date:** 2026-06-23
+**Train:** Core Intake Train (Stage 101~108) · branch `feat/stage-101-unified-intake` · PR #142 (do not merge until Stage 108).
+
+## Goal
+Make the `prd` intake type useful: paste a PRD/spec and get a **deterministic** preview of product intent, likely users, candidate flows, candidate acceptance items, and missing questions. Still local/mock — no backend, no AI.
+
+## Product principle
+A PRD is an artifact Simsa converts into acceptance work, not the final source of truth. Everything is "candidate / likely / preview" — no overclaiming.
+
+## Helper — `apps/dashboard/src/lib/intake-prd.mjs` (+ `.d.mts`)
+`buildPrdIntakePreview(rawInput): PrdIntakePreview` — pure, deterministic, heuristic:
+- **productIntent**: first line containing `goal/problem/overview/summary/purpose/objective/we need/we want` (label prefix stripped); else a neutral fallback.
+- **likelyUsers**: unique matches of `user/admin/owner/team/customer/mentor/founder/operator/manager/member/guest`; fallback `[User, Operator]`.
+- **candidateUserFlows**: detected action verbs (`create/submit/invite/login/sign up/upload/connect/review/approve/reject/pay/share/export/download/comment`) → `"<actor> can <flow>."`; fallback to a single main-action flow.
+- **candidateAcceptanceItems**: flow-derived items (if actions found) + generic product-quality items (clear first use, recoverable error states, no unintended data exposure, release readiness).
+- **missingQuestions**: 3–6 useful questions, adapted to missing signals; adds a payment question if `pay/payment/checkout/billing/subscription` present, and a repo question if `github/repo/pull request/pr` present.
+- **confidence**: `low/medium/high` from how many signal groups matched.
+- `SAMPLE_PRD` constant for the "Use example PRD" button.
+
+## UI — `/projects/new/intake` (prd type only)
+After "Create intake draft" with `PRD / spec` selected, an extra **"PRD / spec preview"** card shows product intent · likely users (chips) · candidate user flows · candidate acceptance items · missing questions · confidence. A "Use example PRD" button fills the sample. Labeled "Preview only — deterministic PRD parsing." **Non-PRD types keep Stage 101 behavior; existing `/projects/new` flow untouched.**
+
+## Deterministic limitations (intentional)
+Heuristic keyword matching, not semantic understanding. No AI, no backend, no fetch, no DB. It surfaces *candidates and questions*, not validated requirements.
+
+## Verification
+- `apps/dashboard`: **209/209** tests (+9 PRD), typecheck clean, lint = pre-existing `export/page.tsx` warning only, build green (`/projects/new/intake` 3.52 kB).
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Not changed
+central-plane / Anthropic / URL fetch / GitHub fetch / file upload / DB / migration / deploy / domain — none.
+
+## Next
+Stage 103 — Product URL Intake.

--- a/conclave-builder-pack/out/stage-103-product-url-intake.md
+++ b/conclave-builder-pack/out/stage-103-product-url-intake.md
@@ -1,0 +1,37 @@
+# Stage 103 — Product URL Intake
+
+**Date:** 2026-06-23
+**Train:** Core Intake Train (Stage 101~108) · branch `feat/stage-101-unified-intake` · PR #142 (do not merge until Stage 108).
+
+## Goal
+Make the `product_url` intake type useful: paste a product/service URL and get a deterministic **review plan** — what Simsa would check before the surface can be accepted, fixed, or released. **No live crawl/fetch** — Stage 103 reasons only from the URL shape.
+
+## Product principle
+A URL is a product artifact. Simsa turns it into "what to review", never claiming to know the real page content (it isn't fetched).
+
+## Helper — `apps/dashboard/src/lib/intake-url.mjs` (+ `.d.mts`)
+`buildProductUrlIntakePreview(rawInput): ProductUrlIntakePreview` — pure, deterministic, throw-free:
+- **URL normalization**: accepts bare domains, adds `https://`, validates via `URL`; bad input → fallback (`domain:"Unknown"`, `pathType:"unknown"`, `confidence:"low"`), never throws.
+- **pathType**: `homepage / pricing / docs / app / demo / blog / unknown` from path + `app.` subdomain.
+- **likelySurface**: human label per path type.
+- **reviewFocusAreas**: path-type-specific (homepage value-prop/CTA/trust; pricing plan/billing/refund; docs getting-started/keys; app onboarding/empty/error/privacy; demo fictional-labeling/limitations; …).
+- **candidateAcceptanceItems**: surface-quality checks (visitor understands audience, CTA clear, claims have evidence/limitations, error/empty states handled, no private/misleading exposure).
+- **missingQuestions**: 3–6, with pricing/app/docs-specific additions.
+- **confidence**: `high` for a recognized path type, `medium` for unknown-but-parsed, `low` for unparseable.
+- `SAMPLE_PRODUCT_URL = https://trysimsa.com/demo` (→ `demo`).
+
+## UI — `/projects/new/intake` (product_url type only)
+After "Create intake draft" with `Product URL` selected, a **"Product URL preview"** card shows normalized URL · domain · surface type · likely surface · review focus areas · candidate acceptance items · missing questions · confidence. "Use example URL" button. Labeled **"Preview only — no live crawl or external fetch."** Other types unchanged; existing `/projects/new` untouched.
+
+## Deterministic limitations (intentional)
+Reasons from URL shape only — no HTML, no rendered content, no screenshot, no API. Surfaces a *review plan + questions*, not findings about the actual page.
+
+## Verification
+- `apps/dashboard`: **218/218** tests (+9 URL), typecheck clean, lint = pre-existing `export/page.tsx` warning only, build green (`/projects/new/intake` 4.88 kB).
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Not changed
+live URL fetch / crawler / screenshot / HTML parse / external API / central-plane / Anthropic / browser automation / DB / migration / deploy / domain — none.
+
+## Next
+Stage 104 — GitHub Repo Intake v1.

--- a/conclave-builder-pack/out/stage-104-github-repo-intake.md
+++ b/conclave-builder-pack/out/stage-104-github-repo-intake.md
@@ -1,0 +1,37 @@
+# Stage 104 — GitHub Repo Intake v1
+
+**Date:** 2026-06-23
+**Train:** Core Intake Train (Stage 101~108) · branch `feat/stage-101-unified-intake` · PR #142 (do not merge until Stage 108).
+
+## Goal
+Make the `github_repo` intake type useful: paste a repo URL or `owner/repo` and get a deterministic **review plan** for the implementation. **No GitHub API, clone, or remote file fetch** — Stage 104 reasons only from the owner/repo (and path) shape.
+
+## Product principle
+A repo is an implementation artifact mapped back to product acceptance. Simsa turns a repo reference into "how to review it", never claiming to know the contents (not fetched).
+
+## Helper — `apps/dashboard/src/lib/intake-github-repo.mjs` (+ `.d.mts`)
+`buildGitHubRepoIntakePreview(rawInput): GitHubRepoIntakePreview` — pure, deterministic, throw-free:
+- **Parsing**: `owner/repo`, `github.com/owner/repo`, `https://github.com/owner/repo`, PR URLs (`/pull/123`), tree URLs (`/tree/main`); strips `.git`; validates owner/repo chars; bad input → fallback (`owner/repo:"Unknown"`, `unknown`, `low`), never throws.
+- **repoNameSignals**: name/path keyword hits (`dashboard/app/api/server/docs/sdk/monorepo/...`).
+- **likelyRepoType**: `app / docs / api / library / monorepo / unknown` (heuristic over owner/repo).
+- **reviewFocusAreas**: per repo type (app: flow/onboarding/errors/config/release; api: contract/errors/auth/limits/deploy; docs/library/monorepo/unknown variants).
+- **candidateAcceptanceItems**: purpose clarity, build/test discoverable, env vars documented without exposing secrets, main flows have checks, error/edge states, release readiness.
+- **missingQuestions**: 3–6, with type-specific additions; **PR URL** adds "review the PR change or the whole repo?" (prioritized so it survives the 6-cap).
+- **confidence**: `high` for recognized type, `medium` for parsed-but-unknown, `low` for unparseable.
+- `SAMPLE_GITHUB_REPO = example/ai-built-task-app` (fictional).
+
+## UI — `/projects/new/intake` (github_repo type only)
+After "Create intake draft" with `GitHub repo` selected, a **"GitHub repo preview"** card shows normalized repo · owner · repository · repo URL · likely repo type · review focus areas · candidate acceptance items · missing questions · confidence. "Use example repo" button (populates input + deterministic parse only — no fetch). Labeled **"Preview only — no GitHub API, clone, or remote file fetch."** Other types unchanged; existing `/projects/new` untouched.
+
+## Deterministic limitations (intentional)
+Reasons from the repo *reference* only — no API, no clone, no file/package.json read, no dependency/security scan. Surfaces a *review plan + questions*, not findings about actual code.
+
+## Verification
+- `apps/dashboard`: **229/229** tests (+11 repo), typecheck clean, lint = pre-existing `export/page.tsx` warning only, build green (`/projects/new/intake` 6.18 kB).
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Not changed
+GitHub API / clone / remote fetch / package.json fetch / dependency scan / security scan / central-plane / Anthropic / DB / migration / deploy / domain — none.
+
+## Next
+Stage 105 — Existing App Recovery Assessment.

--- a/conclave-builder-pack/out/stage-105-existing-app-recovery-assessment.md
+++ b/conclave-builder-pack/out/stage-105-existing-app-recovery-assessment.md
@@ -1,0 +1,38 @@
+# Stage 105 — Existing App Recovery Assessment
+
+**Date:** 2026-06-23
+**Train:** Core Intake Train (Stage 101~108) · branch `feat/stage-101-unified-intake` · PR #142 (do not merge until Stage 108).
+
+## Goal
+Make the `ai_built_app` intake type meaningfully useful for the key scenario: *"I built something with an AI coding agent, but I don't know if it's ready to share, fix, rebuild, or release."* Deterministic, preview-only — **no live app inspection, URL fetch, repo scan, or backend.**
+
+## Product principle
+Not "vibe-coding shaming." Framing: AI creates the first draft fast; Simsa helps decide what to accept, fix, rebuild, or verify next. Helpful, not judgmental — language stays "draft / unclear / not yet verified / recovery plan / next action".
+
+## Helper — `apps/dashboard/src/lib/intake-ai-built-app.mjs` (+ `.d.mts`)
+`buildAiBuiltAppRecoveryPreview(rawInput): AiBuiltAppRecoveryPreview` — pure, deterministic, throw-free:
+- **likelyProductSurface**: `landing / web_app / dashboard / mobile / api / prototype / unknown` from the user's words.
+- **currentStateSummary**: deterministic summary of the pasted text (fallback when empty).
+- **recoveryFocusAreas**: base readiness areas + context-specific (auth→session, payment→billing, sharing→permissions, AI→fallback, repo/deploy→build/env).
+- **candidateAcceptanceItems**: base + context-specific checks.
+- **likelyRisks**: base + context-specific.
+- **fixVsRebuildSignals**: `{ likelyKeep, likelyFix, likelyRebuild, needsVerification }` — rebuild wording softens unless the text signals "broken/messy/cannot build".
+- **recommendedNextAction**: `create_acceptance_map` (short) · `create_fix_stage` (broken/bugs) · `verify_release_readiness` (launch/share/users) · `review_core_flow` (core-flow mention).
+- **missingQuestions**: 3–6. **confidence** from recognized-signal count.
+- `SAMPLE_AI_BUILT_APP` for "Use example app".
+
+## UI — `/projects/new/intake` (ai_built_app type only)
+After "Create intake draft" with `AI-built app` selected, an **"Existing app recovery preview"** card: current state summary · likely product surface · recommended next action · recovery focus areas · candidate acceptance items · likely risks · fix-vs-rebuild signals (4 buckets) · missing questions · confidence. "Use example app" button. Labeled **"Preview only — no live inspection, repo scan, or external fetch."** Other types unchanged; existing `/projects/new` untouched.
+
+## Deterministic limitations (intentional)
+Heuristics over the user's own description only — never claims to know actual app behavior. Surfaces a *recovery plan + questions + signals*, not findings.
+
+## Verification
+- `apps/dashboard`: **242/242** tests (+13 recovery), typecheck clean, lint = pre-existing `export/page.tsx` warning only, build green (`/projects/new/intake` 8 kB).
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Not changed
+live app inspection / URL fetch / screenshot / browser automation / GitHub API / repo clone / upload / central-plane / Anthropic / DB / migration / deploy / domain — none.
+
+## Next
+Stage 106 — Intake to Acceptance Map (all 6 intake types now have deterministic previews; 106 begins converging them into a shared acceptance map).

--- a/conclave-builder-pack/out/stage-106-intake-to-acceptance-map.md
+++ b/conclave-builder-pack/out/stage-106-intake-to-acceptance-map.md
@@ -1,0 +1,40 @@
+# Stage 106 — Intake to Acceptance Map
+
+**Date:** 2026-06-23
+**Train:** Core Intake Train (Stage 101~108) · branch `feat/stage-101-unified-intake` · PR #142 (do not merge until Stage 108).
+
+## Goal
+Add a **shared, deterministic Acceptance Map** that all 6 intake types converge into — the bridge between "what the user pasted" and "the staged acceptance workflow Simsa will run". Local, preview-only, **not saved**.
+
+## Helper — `apps/dashboard/src/lib/intake-acceptance-map.mjs` (+ `.d.mts`)
+`buildIntakeAcceptanceMap({ type, rawInput }): IntakeAcceptanceMap` — pure, deterministic; **reuses** the Stage 102–105 helpers + `buildIntakeDraft`. No backend / AI / fetch / DB.
+
+`IntakeAcceptanceMap`: `{ intakeType, title, summary, areas[], items[], missingQuestions[], recommendedNextStep, confidence }`.
+- `AcceptanceMapArea`: product_intent · primary_user_flow · onboarding · error_recovery · data_privacy · implementation_readiness · release_readiness · trust_and_proof · decision_history.
+- `AcceptanceMapItem`: `{ area, title (acceptance-style sentence), status, rationale }`; status ∈ `candidate / missing_detail / needs_verification`.
+- **Items clamped to 5–10**, deduped, topped up from generic product-quality baseline items when a type yields too few.
+- `recommendedNextStep` ∈ `clarify_product_intent / draft_acceptance_items / create_stage_plan / review_core_flow / verify_release_readiness` (+ `NEXT_STEP_LABELS`).
+
+## Mapping by intake type
+- **prd** → PRD preview: productIntent→summary, acceptance items→items; next = `draft_acceptance_items` (or `clarify_product_intent` if ≥5 missing questions).
+- **product_url** → URL preview: likelySurface→summary, focus areas→`trust_and_proof` (needs_verification); next = `verify_release_readiness` for demo/pricing/app else `review_core_flow`.
+- **github_repo** → repo preview: focus→`implementation_readiness`; next = `review_core_flow` (app) else `create_stage_plan`.
+- **ai_built_app** → recovery preview: currentStateSummary→summary, risks→rationale; recommendedNextAction mapped (create_acceptance_map→draft_acceptance_items, create_fix_stage→create_stage_plan, …).
+- **idea** → generic draft + default areas (product_intent/primary_user_flow/onboarding/release_readiness); next = `clarify_product_intent`.
+- **pull_request** → generic fallback (no full PR parsing yet) + areas incl. `implementation_readiness`/`decision_history`; adds "What acceptance item should this PR prove?"; next = `review_core_flow`.
+
+## UI — `/projects/new/intake`
+After "Create intake draft", a common **"Acceptance Map"** card renders for **all** types (after the intake draft + any type-specific preview): summary · areas (chips) · acceptance items (with status) · missing questions · recommended next step · confidence. Labeled "Preview only — acceptance map is deterministic and not yet saved." Order: intake draft → type-specific preview → Acceptance Map.
+
+## Deterministic limitations (intentional)
+Composed from the same heuristic helpers — no semantic model, no fetch, no persistence. Items are candidates/questions, not validated requirements.
+
+## Verification
+- `apps/dashboard`: **252/252** tests (+10 map), typecheck clean, lint = pre-existing `export/page.tsx` warning only, build green (`/projects/new/intake` 9.26 kB).
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Not changed
+backend / central-plane / Anthropic / URL fetch / GitHub API / repo clone / live inspection / upload / DB / migration / deploy / domain — none.
+
+## Next
+Stage 107 — Intake to Stage Plan.

--- a/conclave-builder-pack/out/stage-107-intake-to-stage-plan.md
+++ b/conclave-builder-pack/out/stage-107-intake-to-stage-plan.md
@@ -1,0 +1,42 @@
+# Stage 107 — Intake to Stage Plan
+
+**Date:** 2026-06-23
+**Train:** Core Intake Train (Stage 101~108) · branch `feat/stage-101-unified-intake` · PR #142 (do not merge until Stage 108).
+
+## Goal
+Turn the Acceptance Map into an ordered, deterministic **Stage Plan** (Acceptance Map → ordered workflow). Compact (4–7 stages), local, preview-only, **not saved, not executed**.
+
+## Helper — `apps/dashboard/src/lib/intake-stage-plan.mjs` (+ `.d.mts`)
+`buildIntakeStagePlan({ type, rawInput }): IntakeStagePlan` — pure, deterministic; **reuses** `buildIntakeAcceptanceMap`. No backend / AI / fetch / DB.
+
+`IntakeStagePlan`: `{ intakeType, title, summary, stages[], recommendedStartStage, releaseGate{title,checks[]}, confidence }`.
+`IntakeStagePlanStage`: `{ number, title, kind, status, goal, acceptanceAreas[], candidateChecks[2–4], evidenceToCollect[1–3], exitCriteria[1–3] }`.
+- `kind` ∈ clarify / acceptance / review / fix / evidence / release. `status` ∈ planned / needs_clarification / needs_evidence / deferred.
+- Spine (always present): **Clarify → Acceptance → Review → Release**, plus a context stage by type, clamped to **4–7** stages, numbered sequentially, always ending in a `release` stage; plus a `releaseGate` with checks.
+- Tone: "planned / candidate / needs evidence / not yet saved" — never "completed/verified/passed".
+
+## Stage generation by type
+- **prd**: + "Resolve missing product questions" (clarify).
+- **product_url**: + "Check CTA and user-journey evidence" (evidence).
+- **github_repo**: + "Review build/test evidence" (evidence).
+- **ai_built_app**: + "Fix or rebuild decision" (fix).
+- **pull_request**: + "Map the PR change to an acceptance item" (evidence).
+- **idea**: spine only (Clarify product intent → …).
+
+`recommendedStartStage` from the map's `confidence`/`recommendedNextStep` (low confidence → stage 1; verify_release_readiness still routed to the preceding evidence/review stage). `STAGE_STATUS_LABELS` / `STAGE_KIND_LABELS` for UI.
+
+## UI — `/projects/new/intake`
+After "Create intake draft", a common **"Stage Plan"** card renders for all types (order: intake draft → type-specific preview → Acceptance Map → **Stage Plan**): summary · recommended start · ordered stage cards (number/title/kind/status/goal/checks/evidence/exit) · release gate · confidence. Recommended-start stage highlighted. Labeled "Preview only — not yet saved." Not persisted.
+
+## Deterministic limitations (intentional)
+Composed from the Acceptance Map heuristics — no semantic model, no fetch, no execution. Stages, checks, evidence are *planned/suggested*, not done.
+
+## Verification
+- `apps/dashboard`: **261/261** tests (+9 stage plan), typecheck clean, lint = pre-existing `export/page.tsx` warning only, build green (`/projects/new/intake` 11 kB).
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Not changed
+backend / central-plane / Anthropic / URL fetch / GitHub API / repo clone / live inspection / upload / DB / migration / deploy / domain — none.
+
+## Next
+Stage 108 — Core Intake Train Checkpoint.

--- a/conclave-builder-pack/out/stage-108-core-intake-train-checkpoint.md
+++ b/conclave-builder-pack/out/stage-108-core-intake-train-checkpoint.md
@@ -1,0 +1,54 @@
+# Stage 108 — Core Intake Train Checkpoint
+
+**Date:** 2026-06-23
+**Train branch:** `feat/stage-101-unified-intake` · **PR #142** (OPEN) · HEAD `119ce1a`
+**Base:** `origin/main` `78f766f`.
+
+## Summary
+A dashboard-only, **deterministic, preview-only** implementation of the unified intake → staged-acceptance flow. Six starting points (idea / PRD / product URL / GitHub repo / pull request / AI-built app) each produce a per-type preview and converge into a shared **Acceptance Map** and **Stage Plan**. Nothing is fetched, AI-generated, persisted, or sent to central-plane.
+
+## Included stages
+- **101 — Unified Intake Model** (`lib/intake.mjs`): 6 types → same 6 outputs; `buildIntakeDraft`; route `/projects/new/intake`. 9 tests.
+- **102 — PRD / Spec Intake** (`lib/intake-prd.mjs`): `buildPrdIntakePreview`. 9 tests.
+- **103 — Product URL Intake** (`lib/intake-url.mjs`): `buildProductUrlIntakePreview` (no crawl). 9 tests.
+- **104 — GitHub Repo Intake v1** (`lib/intake-github-repo.mjs`): `buildGitHubRepoIntakePreview` (no GitHub API/clone). 11 tests.
+- **105 — Existing App Recovery Assessment** (`lib/intake-ai-built-app.mjs`): `buildAiBuiltAppRecoveryPreview` (no live inspection). 13 tests.
+- **106 — Intake → Acceptance Map** (`lib/intake-acceptance-map.mjs`): shared map (areas, 5–10 acceptance items w/ status, next step). 10 tests.
+- **107 — Intake → Stage Plan** (`lib/intake-stage-plan.mjs`): Acceptance Map → ordered 4–7 stage plan + release gate + recommended start. 9 tests.
+- **108 — Checkpoint** (this doc).
+
+## User-facing flow (`/projects/new/intake`)
+Pick a starting point → "Paste what you have" → **Intake draft** → **type-specific preview** (PRD / URL / repo / app-recovery, where applicable; each with a "Use example …" button) → **Acceptance Map** → **Stage Plan**. First internal implementation of the public promise: *start from anything → staged acceptance workflow.*
+
+## Surfaces changed
+`apps/dashboard/src/lib/intake*.mjs` + `.d.mts` (7 helpers), `apps/dashboard/test/intake*.test.mjs` (7 suites), `apps/dashboard/src/app/projects/new/intake/page.tsx` (new route), `conclave-builder-pack/out/stage-101..108`. No `pnpm-lock.yaml` change (no new dependencies).
+
+## Surfaces intentionally unchanged
+`apps/central-plane`, `database/migrations`, `apps/simsa-landing`, `apps/simsa-dev`, `.github/workflows`, `packages/*` — **no diff** (audited). Existing `/projects/new` idea→spec flow untouched. Internal `@conclave-ai/*` / `CONCLAVE_*` namespace frozen.
+
+## Verification
+- `apps/dashboard`: **261/261** tests, typecheck clean, build green (`/projects/new/intake` ≈ 11 kB, static).
+- Monorepo `turbo run typecheck`: **56/56**.
+- Secret/token scan of `origin/main...HEAD`: none.
+
+## Known warnings
+- Dashboard lint: only the **pre-existing** `apps/dashboard/src/app/projects/[id]/export/page.tsx` (236:107) `react-hooks/exhaustive-deps` warning. **Not from this train; non-blocking.** No new warnings introduced.
+
+## No-go / out of scope (not yet implemented — later trains)
+live URL crawl · GitHub API fetch · repo clone · file upload · PR diff review from the intake route · DB persistence · project creation from intake · saved acceptance maps · saved stage plans · AI generation · central-plane connection.
+
+## Deploy plan (post-merge, gated)
+Dashboard UI only → deploy `apps/dashboard` to **app.trysimsa.com** (Vercel `conclave-dashboard` project, repo-root `vercel deploy --prod`). **No** central-plane deploy, **no** D1 migration, **no** landing/simsa.dev deploy, **no** domain change.
+
+## Smoke plan (after deploy)
+`app.trysimsa.com/projects/new/intake` → 6 intake cards; select each → input; "Create intake draft" → Intake draft + type-specific preview (PRD only for PRD, URL only for product_url, etc.) + Acceptance Map (all) + Stage Plan (all). `app.trysimsa.com/projects/new` idea→spec still works. `app.trysimsa.com` dashboard loads. `trysimsa.com` / `simsa.dev` / `conclave-dashboard.vercel.app` unchanged.
+
+## Rollback
+Dashboard breaks → redeploy previous `conclave-dashboard` production deployment (instant) or revert PR #142. `/projects/new/intake` is an isolated new route (preview-only, no persistence) — low blast radius. Landing/simsa.dev/central-plane unaffected. No DB rollback.
+
+## Recommendation
+**Ready to merge.** No blockers: dashboard-only, deterministic/preview-only, all checks green, no unintended changes, no secrets, no new deps, existing flows untouched.
+Suggested: **merge PR #142 (squash) → deploy dashboard to app.trysimsa.com** (one gated step), then smoke. Or merge now / deploy later if preferred.
+
+## Status
+Merge: NOT executed. Deploy: NOT executed. Awaiting Bae approval.


### PR DESCRIPTION
# Stage 101~108 — Core Intake Train

## Summary
Dashboard-only, **deterministic, preview-only** unified intake → staged-acceptance flow. Six starting points (idea / PRD / product URL / GitHub repo / pull request / AI-built app) each produce a per-type preview and converge into a shared **Acceptance Map** + **Stage Plan**. Nothing is fetched, AI-generated, persisted, or sent to central-plane.

## Included stages
- 101 — Unified Intake Model
- 102 — PRD / Spec Intake
- 103 — Product URL Intake
- 104 — GitHub Repo Intake v1
- 105 — Existing App Recovery Assessment
- 106 — Intake to Acceptance Map
- 107 — Intake to Stage Plan
- 108 — Checkpoint

## User-facing flow (`/projects/new/intake`)
Pick a starting point → paste → **Intake draft** → **type-specific preview** (where applicable, each with "Use example …") → **Acceptance Map** → **Stage Plan**.

## Surfaces changed
`apps/dashboard/src/lib/intake*.{mjs,d.mts}` (7 helpers), `apps/dashboard/test/intake*.test.mjs` (7 suites), `apps/dashboard/src/app/projects/new/intake/page.tsx` (new route), `conclave-builder-pack/out/stage-101..108`. **No `pnpm-lock.yaml` change** (no new deps).

## Surfaces intentionally unchanged
`apps/central-plane`, `database/migrations`, `apps/simsa-landing`, `apps/simsa-dev`, `.github/workflows`, `packages/*` — no diff. Existing `/projects/new` idea→spec flow untouched. Internal namespace frozen.

## Verification
`apps/dashboard` **261/261** tests, typecheck clean, build green. Monorepo `turbo run typecheck` **56/56**.

## Known warnings
Pre-existing only: `apps/dashboard/.../export/page.tsx` exhaustive-deps (not from this train; non-blocking). No new warnings.

## No-go / out of scope (later trains)
live URL crawl · GitHub API fetch · repo clone · file upload · PR diff review · DB persistence · project creation from intake · saved acceptance maps/stage plans · AI generation · central-plane connection.

## Deploy plan (post-merge, gated)
Dashboard UI only → deploy `apps/dashboard` to **app.trysimsa.com**. No central-plane deploy, no D1 migration, no landing/simsa.dev/domain change.

## Smoke plan
`app.trysimsa.com/projects/new/intake`: 6 cards → select → "Create intake draft" → intake draft + type-specific preview + Acceptance Map + Stage Plan. `/projects/new` idea→spec still works. Dashboard / trysimsa.com / simsa.dev / legacy fallback unchanged.

## Rollback
Redeploy previous `conclave-dashboard` production or revert PR #142. Isolated new route (preview-only, not persisted). No DB rollback.

## Recommendation
**Ready to merge.** Suggested: merge (squash) → deploy dashboard to app.trysimsa.com → smoke. Merge/deploy await approval.

Full detail: `conclave-builder-pack/out/stage-108-core-intake-train-checkpoint.md`.