### PR TITLE
Stage 118~124 — Beta Readiness / Team Usage Train

### DIFF
--- a/apps/central-plane/src/routes/workspace-agent-workflow.ts
+++ b/apps/central-plane/src/routes/workspace-agent-workflow.ts
@@ -30,6 +30,7 @@ import {
   getOwnedWorkflowRecordById,
   updateWorkflowRecordStatus,
   deleteWorkflowRecordById,
+  adminListWorkflowRecords,
   WORKFLOW_RECORD_STATUSES,
   type WorkflowRecordStatus,
 } from "../workspace/agent-workflow-record-db.js";
@@ -278,6 +279,105 @@ export function createWorkspaceAgentWorkflowRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ ok: true, deleted: true, id });
     } catch (err) {
       console.error("[workspace/agent-workflows DELETE] failed:", err);
+      return c.json({ ok: false, error: "delete_failed" }, 500);
+    }
+  });
+
+  // ── Stage 121 — admin beta console (x-admin-key gated, across userKeys) ───────
+  // Beta operations only. Records are scoped by client-supplied userKey, NOT full
+  // account auth. Admin list returns summaries (no snapshot JSON) to limit
+  // sensitive exposure. Reuses the existing ADMIN_USAGE_STATS_KEY convention.
+  function adminGuard(c: { env: Env; req: { header: (k: string) => string | undefined } }):
+    | { ok: true }
+    | { ok: false; status: 503 | 401; body: { ok: false; error: string } } {
+    if (!c.env.ADMIN_USAGE_STATS_KEY) {
+      return { ok: false, status: 503, body: { ok: false, error: "disabled" } };
+    }
+    if ((c.req.header("x-admin-key") ?? "") !== c.env.ADMIN_USAGE_STATS_KEY) {
+      return { ok: false, status: 401, body: { ok: false, error: "unauthorized" } };
+    }
+    return { ok: true };
+  }
+
+  app.get("/workspace/admin/agent-workflows", async (c) => {
+    const guard = adminGuard(c);
+    if (!guard.ok) return c.json(guard.body, guard.status);
+
+    const userKey = c.req.query("userKey") || undefined;
+    const rawStatus = c.req.query("status") || undefined;
+    const status = rawStatus && WORKFLOW_RECORD_STATUSES.includes(rawStatus as WorkflowRecordStatus)
+      ? rawStatus
+      : undefined;
+    const includeArchived = c.req.query("includeArchived") === "true";
+    const rawLimit = Number(c.req.query("limit"));
+    const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : undefined;
+
+    try {
+      const { records, summary } = await adminListWorkflowRecords(c.env, {
+        userKey,
+        status,
+        includeArchived,
+        limit,
+      });
+      return c.json({ ok: true, records, summary });
+    } catch (err) {
+      console.error("[workspace/admin/agent-workflows GET] failed:", err);
+      return c.json({ ok: false, error: "query_failed" }, 500);
+    }
+  });
+
+  app.patch("/workspace/admin/agent-workflows/:id", async (c) => {
+    const guard = adminGuard(c);
+    if (!guard.ok) return c.json(guard.body, guard.status);
+    const id = c.req.param("id");
+
+    let body: { status?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ ok: false, error: "invalid_json" }, 400);
+    }
+    const status = typeof body.status === "string" ? body.status : "";
+    if (!PATCHABLE_STATUSES.includes(status)) {
+      return c.json({ ok: false, error: "invalid_status" }, 400);
+    }
+
+    try {
+      const owned = await getOwnedWorkflowRecordById(c.env, id);
+      if (!owned) return c.json({ ok: false, error: "not_found" }, 404);
+      const updatedAt = await updateWorkflowRecordStatus(c.env, id, status as WorkflowRecordStatus);
+      return c.json({
+        ok: true,
+        record: {
+          id: owned.id,
+          userKey: owned.userKey,
+          projectId: owned.projectId,
+          intakeType: owned.intakeType,
+          title: owned.title,
+          sourceSummary: owned.sourceSummary,
+          status,
+          createdAt: owned.createdAt,
+          updatedAt,
+        },
+      });
+    } catch (err) {
+      console.error("[workspace/admin/agent-workflows PATCH] failed:", err);
+      return c.json({ ok: false, error: "update_failed" }, 500);
+    }
+  });
+
+  app.delete("/workspace/admin/agent-workflows/:id", async (c) => {
+    const guard = adminGuard(c);
+    if (!guard.ok) return c.json(guard.body, guard.status);
+    const id = c.req.param("id");
+
+    try {
+      const owned = await getOwnedWorkflowRecordById(c.env, id);
+      if (!owned) return c.json({ ok: false, error: "not_found" }, 404);
+      await deleteWorkflowRecordById(c.env, id);
+      return c.json({ ok: true, deleted: true, id });
+    } catch (err) {
+      console.error("[workspace/admin/agent-workflows DELETE] failed:", err);
       return c.json({ ok: false, error: "delete_failed" }, 500);
     }
   });

--- a/apps/central-plane/src/routes/workspace-agent-workflow.ts
+++ b/apps/central-plane/src/routes/workspace-agent-workflow.ts
@@ -15,9 +15,11 @@
  * under that key and only ever read back under the same key, so a record made by
  * one userKey is invisible to another (list excludes it; detail returns 404).
  *
- * POST /workspace/agent-workflows
- * GET  /workspace/agent-workflows
- * GET  /workspace/agent-workflows/:id
+ * POST   /workspace/agent-workflows
+ * GET    /workspace/agent-workflows           (?includeArchived=true to include archived)
+ * GET    /workspace/agent-workflows/:id
+ * PATCH  /workspace/agent-workflows/:id        (Stage 118 — archive/restore via status)
+ * DELETE /workspace/agent-workflows/:id        (Stage 118 — explicit removal)
  */
 import { Hono } from "hono";
 import { corsMiddleware } from "./cors.js";
@@ -26,9 +28,15 @@ import {
   insertWorkflowRecord,
   listWorkflowRecords,
   getOwnedWorkflowRecordById,
+  updateWorkflowRecordStatus,
+  deleteWorkflowRecordById,
   WORKFLOW_RECORD_STATUSES,
   type WorkflowRecordStatus,
 } from "../workspace/agent-workflow-record-db.js";
+
+// Stage 118 — statuses a user may set via PATCH (archive/restore/relabel).
+// 'draft' is creation-only; PATCH allows planned/needs_evidence/archived.
+const PATCHABLE_STATUSES = ["planned", "needs_evidence", "archived"];
 
 // Mirror the dashboard's WORKSPACE_INTAKE_TYPES (Stage 101).
 const INTAKE_TYPES = ["idea", "prd", "product_url", "github_repo", "pull_request", "ai_built_app"];
@@ -153,8 +161,14 @@ export function createWorkspaceAgentWorkflowRoutes(): Hono<{ Bindings: Env }> {
     const userKey = c.req.query("userKey") ?? "";
     if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
     const projectId = c.req.query("projectId") || undefined;
+    const includeArchived = c.req.query("includeArchived") === "true";
     try {
-      const records = await listWorkflowRecords(c.env, { userKey, projectId, limit: 50 });
+      const records = await listWorkflowRecords(c.env, {
+        userKey,
+        projectId,
+        includeArchived,
+        limit: 50,
+      });
       return c.json({ ok: true, records });
     } catch (err) {
       console.error("[workspace/agent-workflows GET] failed:", err);
@@ -194,6 +208,77 @@ export function createWorkspaceAgentWorkflowRoutes(): Hono<{ Bindings: Env }> {
     } catch (err) {
       console.error("[workspace/agent-workflows detail GET] failed:", err);
       return c.json({ ok: false, error: "query_failed" }, 500);
+    }
+  });
+
+  // ── PATCH status (Stage 118 — archive / restore / relabel; own record only) ──
+  app.patch("/workspace/agent-workflows/:id", async (c) => {
+    const id = c.req.param("id");
+    let body: { userKey?: unknown; status?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ ok: false, error: "invalid_json" }, 400);
+    }
+    const userKey = typeof body.userKey === "string" ? body.userKey : "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    const status = typeof body.status === "string" ? body.status : "";
+    if (!PATCHABLE_STATUSES.includes(status)) {
+      return c.json({ ok: false, error: "invalid_status" }, 400);
+    }
+
+    try {
+      const owned = await getOwnedWorkflowRecordById(c.env, id);
+      // 404 (not 403) for missing OR cross-tenant — do not reveal existence.
+      if (!owned || owned.userKey !== userKey) {
+        return c.json({ ok: false, error: "not_found" }, 404);
+      }
+      const updatedAt = await updateWorkflowRecordStatus(
+        c.env,
+        id,
+        status as WorkflowRecordStatus,
+      );
+      return c.json({
+        ok: true,
+        record: {
+          id: owned.id,
+          projectId: owned.projectId,
+          intakeType: owned.intakeType,
+          title: owned.title,
+          sourceSummary: owned.sourceSummary,
+          rawInputExcerpt: owned.rawInputExcerpt,
+          acceptanceMap: owned.acceptanceMap,
+          stagePlan: owned.stagePlan,
+          agentRunPlan: owned.agentRunPlan,
+          evidencePlan: owned.evidencePlan,
+          status,
+          createdAt: owned.createdAt,
+          updatedAt,
+        },
+      });
+    } catch (err) {
+      console.error("[workspace/agent-workflows PATCH] failed:", err);
+      return c.json({ ok: false, error: "update_failed" }, 500);
+    }
+  });
+
+  // ── DELETE (Stage 118 — explicit removal; own record only) ───────────────────
+  app.delete("/workspace/agent-workflows/:id", async (c) => {
+    const id = c.req.param("id");
+    const userKey = c.req.query("userKey") ?? "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+    try {
+      const owned = await getOwnedWorkflowRecordById(c.env, id);
+      // 404 (not 403) for missing OR cross-tenant. A repeated delete also 404s.
+      if (!owned || owned.userKey !== userKey) {
+        return c.json({ ok: false, error: "not_found" }, 404);
+      }
+      await deleteWorkflowRecordById(c.env, id);
+      return c.json({ ok: true, deleted: true, id });
+    } catch (err) {
+      console.error("[workspace/agent-workflows DELETE] failed:", err);
+      return c.json({ ok: false, error: "delete_failed" }, 500);
     }
   });
 

--- a/apps/central-plane/src/workspace/agent-workflow-record-db.ts
+++ b/apps/central-plane/src/workspace/agent-workflow-record-db.ts
@@ -264,3 +264,95 @@ export async function updateWorkflowRecordStatus(
 export async function deleteWorkflowRecordById(env: Env, id: string): Promise<void> {
   await env.DB.prepare(`DELETE FROM workspace_agent_workflow_records WHERE id = ?`).bind(id).run();
 }
+
+/** Admin list item — includes the owning user_key (operator-only view). */
+export type AdminWorkflowRecordListItem = WorkflowRecordListItem & { userKey: string };
+
+export type AdminWorkflowRecordSummary = {
+  total: number;
+  byStatus: Record<string, number>;
+  byIntakeType: Record<string, number>;
+  uniqueUserKeys: number;
+};
+
+/**
+ * Stage 121 — admin/beta-operations list ACROSS userKey scopes. Returns summary
+ * fields only (NO snapshot JSON) to limit sensitive exposure. Authorization is
+ * the caller's responsibility (admin-key gated at the route). A FETCH_CAP bounds
+ * the scan; `summary` is computed over the fetched set and `records` is the first
+ * `limit` of it.
+ */
+export async function adminListWorkflowRecords(
+  env: Env,
+  opts: { userKey?: string; status?: string; includeArchived?: boolean; limit?: number } = {},
+): Promise<{ records: AdminWorkflowRecordListItem[]; summary: AdminWorkflowRecordSummary }> {
+  const FETCH_CAP = 1000;
+  const limit = opts.limit && opts.limit > 0 ? Math.min(opts.limit, 200) : 50;
+
+  const where: string[] = [];
+  const binds: Array<string | number> = [];
+  if (opts.userKey) {
+    where.push("user_key = ?");
+    binds.push(opts.userKey);
+  }
+  if (opts.status) {
+    where.push("status = ?");
+    binds.push(opts.status);
+  } else if (!opts.includeArchived) {
+    where.push("status != 'archived'");
+  }
+  binds.push(FETCH_CAP);
+
+  const res = await env.DB.prepare(
+    `SELECT id, user_key, project_id, intake_type, title, source_summary, status, created_at, updated_at
+       FROM workspace_agent_workflow_records
+      ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+      ORDER BY created_at DESC
+      LIMIT ?`,
+  )
+    .bind(...binds)
+    .all();
+
+  const rows = (res?.results ?? []) as Array<{
+    id: string;
+    user_key: string;
+    project_id: string | null;
+    intake_type: string;
+    title: string;
+    source_summary: string;
+    status: string;
+    created_at: string;
+    updated_at: string;
+  }>;
+
+  const byStatus: Record<string, number> = {};
+  const byIntakeType: Record<string, number> = {};
+  const userKeys = new Set<string>();
+  for (const r of rows) {
+    byStatus[r.status] = (byStatus[r.status] ?? 0) + 1;
+    byIntakeType[r.intake_type] = (byIntakeType[r.intake_type] ?? 0) + 1;
+    userKeys.add(r.user_key);
+  }
+
+  const records = rows.slice(0, limit).map((r) => ({
+    id: r.id,
+    userKey: r.user_key,
+    projectId: r.project_id ?? null,
+    intakeType: r.intake_type,
+    title: r.title,
+    sourceSummary: r.source_summary,
+    status: r.status,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  }));
+
+  return {
+    records,
+    summary: {
+      total: rows.length,
+      byStatus,
+      byIntakeType,
+      uniqueUserKeys: userKeys.size,
+    },
+  };
+}

--- a/apps/central-plane/src/workspace/agent-workflow-record-db.ts
+++ b/apps/central-plane/src/workspace/agent-workflow-record-db.ts
@@ -153,28 +153,32 @@ export async function insertWorkflowRecord(
 
 export async function listWorkflowRecords(
   env: Env,
-  opts: { userKey: string; projectId?: string; limit?: number },
+  opts: { userKey: string; projectId?: string; includeArchived?: boolean; limit?: number },
 ): Promise<WorkflowRecordListItem[]> {
   const limit = opts.limit && opts.limit > 0 ? Math.min(opts.limit, 100) : 50;
   // Always scoped to the caller's user_key. The optional project_id filter
-  // applies WITHIN that scope (records may exist without a project).
-  const stmt = opts.projectId
-    ? env.DB.prepare(
-        `SELECT id, project_id, intake_type, title, source_summary, status, created_at, updated_at
-           FROM workspace_agent_workflow_records
-          WHERE user_key = ? AND project_id = ?
-          ORDER BY created_at DESC
-          LIMIT ?`,
-      ).bind(opts.userKey, opts.projectId, limit)
-    : env.DB.prepare(
-        `SELECT id, project_id, intake_type, title, source_summary, status, created_at, updated_at
-           FROM workspace_agent_workflow_records
-          WHERE user_key = ?
-          ORDER BY created_at DESC
-          LIMIT ?`,
-      ).bind(opts.userKey, limit);
+  // applies WITHIN that scope. Archived records are excluded by default
+  // (Stage 118) unless includeArchived is set.
+  const where = ["user_key = ?"];
+  const binds: Array<string | number> = [opts.userKey];
+  if (opts.projectId) {
+    where.push("project_id = ?");
+    binds.push(opts.projectId);
+  }
+  if (!opts.includeArchived) {
+    where.push("status != 'archived'");
+  }
+  binds.push(limit);
 
-  const res = await stmt.all();
+  const res = await env.DB.prepare(
+    `SELECT id, project_id, intake_type, title, source_summary, status, created_at, updated_at
+       FROM workspace_agent_workflow_records
+      WHERE ${where.join(" AND ")}
+      ORDER BY created_at DESC
+      LIMIT ?`,
+  )
+    .bind(...binds)
+    .all();
   const rows = (res?.results ?? []) as Array<{
     id: string;
     project_id: string | null;
@@ -231,4 +235,32 @@ export async function getOwnedWorkflowRecordById(
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+/**
+ * Update a record's status (Stage 118 — archive/restore). The caller MUST have
+ * already verified ownership (`record.userKey === currentUserKey`); this updates
+ * by id only. Returns the new updatedAt.
+ */
+export async function updateWorkflowRecordStatus(
+  env: Env,
+  id: string,
+  status: WorkflowRecordStatus,
+  now?: string,
+): Promise<string> {
+  const updatedAt = now ?? new Date().toISOString();
+  await env.DB.prepare(
+    `UPDATE workspace_agent_workflow_records SET status = ?, updated_at = ? WHERE id = ?`,
+  )
+    .bind(status, updatedAt, id)
+    .run();
+  return updatedAt;
+}
+
+/**
+ * Hard-delete a record by id (Stage 118 — explicit removal). The caller MUST
+ * have already verified ownership before calling this.
+ */
+export async function deleteWorkflowRecordById(env: Env, id: string): Promise<void> {
+  await env.DB.prepare(`DELETE FROM workspace_agent_workflow_records WHERE id = ?`).bind(id).run();
 }

--- a/apps/central-plane/test/workspace-agent-workflow.test.mjs
+++ b/apps/central-plane/test/workspace-agent-workflow.test.mjs
@@ -34,6 +34,20 @@ function makeDb({ records = [] } = {}) {
               });
               return { meta: { changes: 1 } };
             }
+            if (sql.includes("UPDATE workspace_agent_workflow_records SET status")) {
+              const [status, updated_at, id] = args;
+              const rec = records.find((r) => r.id === id);
+              if (rec) {
+                rec.status = status;
+                rec.updated_at = updated_at;
+              }
+              return { meta: { changes: rec ? 1 : 0 } };
+            }
+            if (sql.includes("DELETE FROM workspace_agent_workflow_records")) {
+              const idx = records.findIndex((r) => r.id === args[0]);
+              if (idx >= 0) records.splice(idx, 1);
+              return { meta: { changes: idx >= 0 ? 1 : 0 } };
+            }
             return { meta: { changes: 0 } };
           },
           async first() {
@@ -44,11 +58,18 @@ function makeDb({ records = [] } = {}) {
           },
           async all() {
             if (sql.includes("FROM workspace_agent_workflow_records")) {
-              let rows = records;
-              if (sql.includes("WHERE user_key = ? AND project_id = ?")) {
-                rows = records.filter((r) => r.user_key === args[0] && r.project_id === args[1]);
-              } else if (sql.includes("WHERE user_key = ?")) {
-                rows = records.filter((r) => r.user_key === args[0]);
+              // Positional binds: user_key, [project_id], limit. Archived filter
+              // ("status != 'archived'") is a SQL literal, not a bound param.
+              let i = 0;
+              let rows = records.filter((r) => r.user_key === args[i]);
+              i += 1;
+              if (sql.includes("project_id = ?")) {
+                const pid = args[i];
+                i += 1;
+                rows = rows.filter((r) => r.project_id === pid);
+              }
+              if (sql.includes("status != 'archived'")) {
+                rows = rows.filter((r) => r.status !== "archived");
               }
               const sorted = [...rows].sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
               return { results: sorted };
@@ -310,4 +331,120 @@ test("isolation: a record created by one user is invisible to another by id", as
   assert.equal(detail.status, 404);
   const list = await req(env, "GET", `/workspace/agent-workflows?userKey=${OTHER}`);
   assert.equal(list.json.records.length, 0);
+});
+
+// ─── Stage 118 — archive / restore / delete + includeArchived ──────────────────
+
+async function createRecord(env, over) {
+  const r = await req(env, "POST", "/workspace/agent-workflows", validBody(over));
+  return r.json.record.id;
+}
+
+test("PATCH archive: own record → status archived, user_key not exposed", async () => {
+  const env = makeEnv();
+  const id = await createRecord(env);
+  const { status, json } = await req(env, "PATCH", `/workspace/agent-workflows/${id}`, {
+    userKey: USER,
+    status: "archived",
+  });
+  assert.equal(status, 200);
+  assert.equal(json.ok, true);
+  assert.equal(json.record.status, "archived");
+  assert.equal(json.record.userKey, undefined);
+});
+
+test("PATCH restore: archived → planned", async () => {
+  const env = makeEnv();
+  const id = await createRecord(env);
+  await req(env, "PATCH", `/workspace/agent-workflows/${id}`, { userKey: USER, status: "archived" });
+  const { json } = await req(env, "PATCH", `/workspace/agent-workflows/${id}`, {
+    userKey: USER,
+    status: "planned",
+  });
+  assert.equal(json.record.status, "planned");
+});
+
+test("PATCH: invalid status returns 400", async () => {
+  const env = makeEnv();
+  const id = await createRecord(env);
+  for (const bad of ["draft", "verified", "deleted", ""]) {
+    const { status, json } = await req(env, "PATCH", `/workspace/agent-workflows/${id}`, {
+      userKey: USER,
+      status: bad,
+    });
+    assert.equal(status, 400, `status ${bad}`);
+    assert.equal(json.error, "invalid_status");
+  }
+});
+
+test("PATCH: missing userKey returns 400", async () => {
+  const env = makeEnv();
+  const id = await createRecord(env);
+  const { status, json } = await req(env, "PATCH", `/workspace/agent-workflows/${id}`, {
+    status: "archived",
+  });
+  assert.equal(status, 400);
+  assert.equal(json.error, "userKey_required");
+});
+
+test("PATCH: cross-tenant record returns 404", async () => {
+  const env = makeEnv();
+  const id = await createRecord(env, { userKey: USER });
+  const { status, json } = await req(env, "PATCH", `/workspace/agent-workflows/${id}`, {
+    userKey: OTHER,
+    status: "archived",
+  });
+  assert.equal(status, 404);
+  assert.equal(json.error, "not_found");
+});
+
+test("DELETE: own record succeeds, repeated delete returns 404", async () => {
+  const env = makeEnv();
+  const id = await createRecord(env);
+  const first = await req(env, "DELETE", `/workspace/agent-workflows/${id}?userKey=${USER}`);
+  assert.equal(first.status, 200);
+  assert.equal(first.json.deleted, true);
+  const second = await req(env, "DELETE", `/workspace/agent-workflows/${id}?userKey=${USER}`);
+  assert.equal(second.status, 404);
+});
+
+test("DELETE: cross-tenant record returns 404 and does not delete", async () => {
+  const env = makeEnv();
+  const id = await createRecord(env, { userKey: USER });
+  const cross = await req(env, "DELETE", `/workspace/agent-workflows/${id}?userKey=${OTHER}`);
+  assert.equal(cross.status, 404);
+  // Owner can still read it.
+  const detail = await req(env, "GET", `/workspace/agent-workflows/${id}?userKey=${USER}`);
+  assert.equal(detail.status, 200);
+});
+
+test("DELETE: missing userKey returns 400", async () => {
+  const env = makeEnv();
+  const id = await createRecord(env);
+  const { status, json } = await req(env, "DELETE", `/workspace/agent-workflows/${id}`);
+  assert.equal(status, 400);
+  assert.equal(json.error, "userKey_required");
+});
+
+test("GET list: excludes archived by default, includeArchived=true includes them", async () => {
+  const env = makeEnv();
+  const keep = await createRecord(env, { title: "Active" });
+  const arch = await createRecord(env, { title: "ToArchive" });
+  await req(env, "PATCH", `/workspace/agent-workflows/${arch}`, { userKey: USER, status: "archived" });
+
+  const def = await req(env, "GET", `/workspace/agent-workflows?userKey=${USER}`);
+  assert.equal(def.json.records.length, 1);
+  assert.equal(def.json.records[0].id, keep);
+
+  const all = await req(env, "GET", `/workspace/agent-workflows?userKey=${USER}&includeArchived=true`);
+  assert.equal(all.json.records.length, 2);
+});
+
+test("GET detail: still returns an own archived record", async () => {
+  const env = makeEnv();
+  const id = await createRecord(env);
+  await req(env, "PATCH", `/workspace/agent-workflows/${id}`, { userKey: USER, status: "archived" });
+  const { status, json } = await req(env, "GET", `/workspace/agent-workflows/${id}?userKey=${USER}`);
+  assert.equal(status, 200);
+  assert.equal(json.record.status, "archived");
 });

--- a/apps/central-plane/test/workspace-agent-workflow.test.mjs
+++ b/apps/central-plane/test/workspace-agent-workflow.test.mjs
@@ -57,9 +57,29 @@ function makeDb({ records = [] } = {}) {
             return null;
           },
           async all() {
+            // Admin list (Stage 121): SELECT begins "id, user_key, project_id";
+            // optional WHERE user_key=? / status=? / status!='archived'; LIMIT cap.
+            if (sql.includes("id, user_key, project_id") && sql.includes("FROM workspace_agent_workflow_records")) {
+              let i = 0;
+              let rows = records;
+              if (sql.includes("user_key = ?")) {
+                const uk = args[i];
+                i += 1;
+                rows = rows.filter((r) => r.user_key === uk);
+              }
+              if (sql.includes("status = ?")) {
+                const st = args[i];
+                i += 1;
+                rows = rows.filter((r) => r.status === st);
+              } else if (sql.includes("status != 'archived'")) {
+                rows = rows.filter((r) => r.status !== "archived");
+              }
+              const sorted = [...rows].sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+              return { results: sorted };
+            }
             if (sql.includes("FROM workspace_agent_workflow_records")) {
-              // Positional binds: user_key, [project_id], limit. Archived filter
-              // ("status != 'archived'") is a SQL literal, not a bound param.
+              // User list. Positional binds: user_key, [project_id], limit.
+              // Archived filter ("status != 'archived'") is a SQL literal.
               let i = 0;
               let rows = records.filter((r) => r.user_key === args[i]);
               i += 1;
@@ -89,12 +109,14 @@ function makeDb({ records = [] } = {}) {
 }
 
 function makeEnv(opts = {}) {
-  return { ENVIRONMENT: "test", DB: makeDb(opts) };
+  const env = { ENVIRONMENT: "test", DB: makeDb(opts) };
+  if (opts.adminKey) env.ADMIN_USAGE_STATS_KEY = opts.adminKey;
+  return env;
 }
 
-async function req(env, method, path, body) {
+async function req(env, method, path, body, headers = {}) {
   const app = createApp();
-  const init = { method, headers: { "content-type": "application/json" } };
+  const init = { method, headers: { "content-type": "application/json", ...headers } };
   if (body !== undefined) init.body = JSON.stringify(body);
   const res = await app.fetch(new Request(`http://localhost${path}`, init), env);
   let json = null;
@@ -105,6 +127,9 @@ async function req(env, method, path, body) {
   }
   return { status: res.status, json };
 }
+
+const ADMIN_KEY = "admin_secret_test";
+const adminHdr = { "x-admin-key": ADMIN_KEY };
 
 const validBody = (over = {}) => ({
   userKey: USER,
@@ -447,4 +472,96 @@ test("GET detail: still returns an own archived record", async () => {
   const { status, json } = await req(env, "GET", `/workspace/agent-workflows/${id}?userKey=${USER}`);
   assert.equal(status, 200);
   assert.equal(json.record.status, "archived");
+});
+
+// ─── Stage 121 — admin beta console (x-admin-key gated, across userKeys) ────────
+
+async function seedTwoUsers(env) {
+  // USER: one planned + one archived; OTHER: one planned (different intake type)
+  const a = await createRecord(env, { userKey: USER, title: "A planned" });
+  const b = await createRecord(env, { userKey: USER, title: "B toArchive" });
+  await req(env, "PATCH", `/workspace/agent-workflows/${b}`, { userKey: USER, status: "archived" });
+  const c = await req(env, "POST", "/workspace/agent-workflows", validBody({ userKey: OTHER, intakeType: "prd", title: "C other" }));
+  return { a, b, cId: c.json.record.id };
+}
+
+test("admin list: requires admin key (503 when unset, 401 on mismatch)", async () => {
+  const noKey = makeEnv();
+  const disabled = await req(noKey, "GET", "/workspace/admin/agent-workflows");
+  assert.equal(disabled.status, 503);
+
+  const env = makeEnv({ adminKey: ADMIN_KEY });
+  const unauth = await req(env, "GET", "/workspace/admin/agent-workflows");
+  assert.equal(unauth.status, 401);
+  const wrong = await req(env, "GET", "/workspace/admin/agent-workflows", undefined, { "x-admin-key": "nope" });
+  assert.equal(wrong.status, 401);
+});
+
+test("admin list: returns summaries across userKeys + summary counts (no snapshots)", async () => {
+  const env = makeEnv({ adminKey: ADMIN_KEY });
+  await seedTwoUsers(env);
+  const { status, json } = await req(env, "GET", "/workspace/admin/agent-workflows?includeArchived=true", undefined, adminHdr);
+  assert.equal(status, 200);
+  assert.equal(json.records.length, 3);
+  // user_key is visible to admin; snapshot JSON is not.
+  assert.ok(json.records.every((r) => typeof r.userKey === "string"));
+  assert.ok(json.records.every((r) => r.acceptanceMap === undefined && r.stagePlan === undefined));
+  assert.equal(json.summary.total, 3);
+  assert.equal(json.summary.uniqueUserKeys, 2);
+  assert.equal(json.summary.byStatus.archived, 1);
+  assert.equal(json.summary.byStatus.planned, 2);
+  assert.ok(json.summary.byIntakeType.github_repo >= 1);
+  assert.ok(json.summary.byIntakeType.prd >= 1);
+});
+
+test("admin list: excludes archived by default; includeArchived=true includes", async () => {
+  const env = makeEnv({ adminKey: ADMIN_KEY });
+  await seedTwoUsers(env);
+  const def = await req(env, "GET", "/workspace/admin/agent-workflows", undefined, adminHdr);
+  assert.equal(def.json.records.length, 2); // archived excluded
+  const all = await req(env, "GET", "/workspace/admin/agent-workflows?includeArchived=true", undefined, adminHdr);
+  assert.equal(all.json.records.length, 3);
+});
+
+test("admin list: userKey + status filters", async () => {
+  const env = makeEnv({ adminKey: ADMIN_KEY });
+  await seedTwoUsers(env);
+  const byUser = await req(env, "GET", `/workspace/admin/agent-workflows?userKey=${OTHER}`, undefined, adminHdr);
+  assert.equal(byUser.json.records.length, 1);
+  assert.equal(byUser.json.records[0].userKey, OTHER);
+  const byStatus = await req(env, "GET", "/workspace/admin/agent-workflows?status=archived", undefined, adminHdr);
+  assert.equal(byStatus.json.records.length, 1);
+  assert.equal(byStatus.json.records[0].status, "archived");
+});
+
+test("admin PATCH: archives/restores any record regardless of userKey", async () => {
+  const env = makeEnv({ adminKey: ADMIN_KEY });
+  const id = await createRecord(env, { userKey: OTHER });
+  const arch = await req(env, "PATCH", `/workspace/admin/agent-workflows/${id}`, { status: "archived" }, adminHdr);
+  assert.equal(arch.status, 200);
+  assert.equal(arch.json.record.status, "archived");
+  assert.equal(arch.json.record.userKey, OTHER);
+});
+
+test("admin PATCH: invalid status 400; missing record 404; non-admin 401", async () => {
+  const env = makeEnv({ adminKey: ADMIN_KEY });
+  const id = await createRecord(env, { userKey: USER });
+  const bad = await req(env, "PATCH", `/workspace/admin/agent-workflows/${id}`, { status: "verified" }, adminHdr);
+  assert.equal(bad.status, 400);
+  const missing = await req(env, "PATCH", "/workspace/admin/agent-workflows/wawr_nope", { status: "archived" }, adminHdr);
+  assert.equal(missing.status, 404);
+  const noauth = await req(env, "PATCH", `/workspace/admin/agent-workflows/${id}`, { status: "archived" });
+  assert.equal(noauth.status, 401);
+});
+
+test("admin DELETE: removes any record; missing 404; non-admin 401", async () => {
+  const env = makeEnv({ adminKey: ADMIN_KEY });
+  const id = await createRecord(env, { userKey: OTHER });
+  const noauth = await req(env, "DELETE", `/workspace/admin/agent-workflows/${id}`);
+  assert.equal(noauth.status, 401);
+  const del = await req(env, "DELETE", `/workspace/admin/agent-workflows/${id}`, undefined, adminHdr);
+  assert.equal(del.status, 200);
+  assert.equal(del.json.deleted, true);
+  const again = await req(env, "DELETE", `/workspace/admin/agent-workflows/${id}`, undefined, adminHdr);
+  assert.equal(again.status, 404);
 });

--- a/apps/dashboard/src/app/admin/workflows/page.tsx
+++ b/apps/dashboard/src/app/admin/workflows/page.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+// Stage 121 — minimal beta admin console for saved agent workflow records.
+// Operator-only. Records are scoped by client-supplied userKey, NOT full account
+// authentication. Summaries only (no snapshot JSON). Admin key is entered at
+// query time and never stored.
+import { useState } from "react";
+import {
+  listAdminAgentWorkflows,
+  updateAdminAgentWorkflowStatus,
+  deleteAdminAgentWorkflow,
+} from "@/lib/admin-agent-workflows-api";
+import type {
+  AdminWorkflowRecord,
+  AdminWorkflowSummary,
+} from "@/lib/admin-agent-workflows-api";
+
+const STATUS_OPTIONS = ["", "planned", "needs_evidence", "archived"];
+
+export default function AdminWorkflowsPage() {
+  const [adminKey, setAdminKey] = useState("");
+  const [userKey, setUserKey] = useState("");
+  const [status, setStatus] = useState("");
+  const [includeArchived, setIncludeArchived] = useState(false);
+  const [records, setRecords] = useState<AdminWorkflowRecord[] | null>(null);
+  const [summary, setSummary] = useState<AdminWorkflowSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  async function load() {
+    if (!adminKey.trim()) {
+      setError("Enter the admin key.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    const res = await listAdminAgentWorkflows(adminKey.trim(), {
+      userKey: userKey.trim() || undefined,
+      status: status || undefined,
+      includeArchived,
+    });
+    if (res.ok) {
+      setRecords(res.records);
+      setSummary(res.summary);
+    } else {
+      setError(res.error);
+      setRecords(null);
+      setSummary(null);
+    }
+    setLoading(false);
+  }
+
+  async function setRecordStatus(id: string, next: "planned" | "archived") {
+    setBusyId(id);
+    const res = await updateAdminAgentWorkflowStatus(adminKey.trim(), id, next);
+    if (!res.ok) setError(res.error);
+    await load();
+    setBusyId(null);
+  }
+
+  async function remove(id: string) {
+    if (typeof window !== "undefined" && !window.confirm(`Delete record ${id}? This cannot be undone.`)) {
+      return;
+    }
+    setBusyId(id);
+    const res = await deleteAdminAgentWorkflow(adminKey.trim(), id);
+    if (!res.ok) setError(res.error);
+    await load();
+    setBusyId(null);
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-4 py-12">
+      <h1 className="text-2xl font-semibold tracking-tight text-gray-900">
+        Beta admin · Saved workflow records
+      </h1>
+      <p className="mt-2 text-sm text-gray-500">
+        Beta admin console. Records are scoped by client-supplied userKey, not full
+        account authentication. Avoid exposing or copying sensitive workflow content.
+      </p>
+
+      {/* Controls */}
+      <div className="card mt-6 p-5">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Admin key</label>
+            <input
+              type="password"
+              value={adminKey}
+              onChange={(e) => setAdminKey(e.target.value)}
+              placeholder="x-admin-key"
+              className="input w-full rounded-lg"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">User key filter</label>
+            <input
+              type="text"
+              value={userKey}
+              onChange={(e) => setUserKey(e.target.value)}
+              placeholder="uk_… (optional)"
+              className="input w-full rounded-lg"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Status filter</label>
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+              className="input w-full rounded-lg"
+            >
+              {STATUS_OPTIONS.map((s) => (
+                <option key={s || "any"} value={s}>
+                  {s || "Any"}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-end gap-3">
+            <label className="flex items-center gap-1.5 text-xs text-gray-600">
+              <input
+                type="checkbox"
+                checked={includeArchived}
+                onChange={(e) => setIncludeArchived(e.target.checked)}
+              />
+              Include archived
+            </label>
+            <button
+              type="button"
+              onClick={load}
+              disabled={loading}
+              className="btn btn-primary btn-md"
+            >
+              {loading ? "Loading…" : "Refresh"}
+            </button>
+          </div>
+        </div>
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+      </div>
+
+      {/* Summary cards */}
+      {summary && (
+        <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-5">
+          <SummaryCard label="Total" value={summary.total} />
+          <SummaryCard label="Planned" value={summary.byStatus.planned ?? 0} />
+          <SummaryCard label="Needs evidence" value={summary.byStatus.needs_evidence ?? 0} />
+          <SummaryCard label="Archived" value={summary.byStatus.archived ?? 0} />
+          <SummaryCard label="Unique user keys" value={summary.uniqueUserKeys} />
+        </div>
+      )}
+
+      {/* Records table */}
+      {records !== null && (
+        <div className="card mt-6 p-5">
+          {records.length === 0 ? (
+            <p className="text-sm text-gray-500">No records for this filter.</p>
+          ) : (
+            <ul className="space-y-2">
+              {records.map((r) => (
+                <li key={r.id} className="rounded-lg border border-gray-200 bg-white p-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-semibold text-gray-900">{r.title}</span>
+                    <span className="rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-500">
+                      {r.intakeType.replace(/_/g, " ")}
+                    </span>
+                    <span className="rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-500">
+                      {r.status}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500">{r.sourceSummary}</p>
+                  <p className="mt-1 text-xs text-gray-400">
+                    {r.id} · userKey {r.userKey} · created {r.createdAt} · updated {r.updatedAt}
+                  </p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {r.status === "archived" ? (
+                      <button
+                        type="button"
+                        onClick={() => setRecordStatus(r.id, "planned")}
+                        disabled={busyId === r.id}
+                        className="btn btn-secondary btn-sm"
+                      >
+                        {busyId === r.id ? "…" : "Restore"}
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => setRecordStatus(r.id, "archived")}
+                        disabled={busyId === r.id}
+                        className="btn btn-secondary btn-sm"
+                      >
+                        {busyId === r.id ? "…" : "Archive"}
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => remove(r.id)}
+                      disabled={busyId === r.id}
+                      className="btn btn-secondary btn-sm text-red-600"
+                    >
+                      {busyId === r.id ? "…" : "Delete"}
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 text-center">
+      <p className="text-xl font-semibold text-gray-900">{value}</p>
+      <p className="mt-0.5 text-xs text-gray-500">{label}</p>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/admin/workflows/page.tsx
+++ b/apps/dashboard/src/app/admin/workflows/page.tsx
@@ -14,6 +14,10 @@ import type {
   AdminWorkflowRecord,
   AdminWorkflowSummary,
 } from "@/lib/admin-agent-workflows-api";
+import {
+  ADMIN_USAGE_BOUNDARY_NOTE,
+  ADMIN_COUNTS_SIGNAL_NOTE,
+} from "@/lib/beta-usage-boundary.mjs";
 
 const STATUS_OPTIONS = ["", "planned", "needs_evidence", "archived"];
 
@@ -78,6 +82,10 @@ export default function AdminWorkflowsPage() {
       <p className="mt-2 text-sm text-gray-500">
         Beta admin console. Records are scoped by client-supplied userKey, not full
         account authentication. Avoid exposing or copying sensitive workflow content.
+      </p>
+      {/* Stage 122 — usage boundary note */}
+      <p className="mt-1 text-xs text-gray-400">
+        {ADMIN_USAGE_BOUNDARY_NOTE} {ADMIN_COUNTS_SIGNAL_NOTE}
       </p>
 
       {/* Controls */}

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -79,6 +79,12 @@ import {
   BETA_SAFETY_NOTES,
   EMPTY_STATES,
 } from "@/lib/beta-onboarding.mjs";
+import {
+  BETA_USAGE_BOUNDARY_HEADING,
+  BETA_USAGE_BOUNDARY_ITEMS,
+  BETA_USAGE_NOT_ACTIVE_COPY,
+  SAVED_WORKFLOW_USAGE_NOTE,
+} from "@/lib/beta-usage-boundary.mjs";
 import { buildBenchmarkHandoffPreview } from "@/lib/intake-benchmark-handoff.mjs";
 import { buildDecisionOutcomeLinkPreview } from "@/lib/intake-decision-outcome-link.mjs";
 import { buildEvolutionActionPackPreview } from "@/lib/intake-evolution-action-preview.mjs";
@@ -335,6 +341,21 @@ export default function IntakePage() {
               </div>
             ))}
           </dl>
+        </div>
+
+        {/* Stage 122 — beta usage / cost boundary panel */}
+        <div className="card mt-6 p-5">
+          <p className="text-sm font-semibold text-gray-900">
+            {BETA_USAGE_BOUNDARY_HEADING}
+          </p>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-gray-600">
+            {BETA_USAGE_BOUNDARY_ITEMS.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+          <p className="mt-3 rounded-md border border-gray-100 bg-gray-50 px-3 py-2 text-xs text-gray-500">
+            {BETA_USAGE_NOT_ACTIVE_COPY}
+          </p>
         </div>
 
         {/* Step 1 — pick a starting point */}
@@ -980,8 +1001,9 @@ export default function IntakePage() {
             </div>
           </div>
 
-          {/* Stage 120 — beta tenant-scope + retention notes */}
-          <p className="mt-2 text-xs text-gray-400">{BETA_SAFETY_NOTES.savedScope}</p>
+          {/* Stage 120/122 — beta tenant-scope + retention + usage-boundary notes */}
+          <p className="mt-2 text-xs text-gray-400">{SAVED_WORKFLOW_USAGE_NOTE}</p>
+          <p className="mt-1 text-xs text-gray-400">{BETA_SAFETY_NOTES.savedScope}</p>
           <p className="mt-1 text-xs text-gray-400">{BETA_SAFETY_NOTES.savedRetention}</p>
 
           {manageMsg && (

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -70,6 +70,15 @@ import type {
 } from "@/lib/workspace-agent-workflow-api";
 import { getUserKey } from "@/lib/workflow-store";
 import { buildBetaFeedbackMailto } from "@/lib/beta-feedback.mjs";
+import {
+  ONBOARDING_HEADING,
+  ONBOARDING_INTRO,
+  ONBOARDING_STEPS,
+  ONBOARDING_SAFETY_LINE,
+  PREVIEW_LANGUAGE_ITEMS,
+  BETA_SAFETY_NOTES,
+  EMPTY_STATES,
+} from "@/lib/beta-onboarding.mjs";
 import { buildBenchmarkHandoffPreview } from "@/lib/intake-benchmark-handoff.mjs";
 import { buildDecisionOutcomeLinkPreview } from "@/lib/intake-decision-outcome-link.mjs";
 import { buildEvolutionActionPackPreview } from "@/lib/intake-evolution-action-preview.mjs";
@@ -295,14 +304,41 @@ export default function IntakePage() {
           Start from anything. Simsa turns it into a staged acceptance workflow.
         </p>
         {/* Stage 119 — page-level beta feedback CTA */}
-        <p className="mb-8 mt-2 text-xs text-gray-400">
+        <p className="mt-2 text-xs text-gray-400">
           <FeedbackLink label="Share beta feedback" context={{ section: "Intake workflow" }} />{" "}
-          — opens an email with safe context only (no pasted content or workflow
-          snapshots are included).
+          — {BETA_SAFETY_NOTES.feedback}
         </p>
 
+        {/* Stage 120 — preview-only onboarding panel */}
+        <div className="card mt-6 p-5">
+          <p className="text-sm font-semibold text-gray-900">{ONBOARDING_HEADING}</p>
+          <p className="mt-1 text-sm text-gray-500">{ONBOARDING_INTRO}</p>
+          <ol className="mt-3 space-y-1">
+            {ONBOARDING_STEPS.map((step, i) => (
+              <li key={step} className="flex gap-2 text-sm text-gray-700">
+                <span className="text-gray-400">{i + 1}.</span>
+                <span>{step}</span>
+              </li>
+            ))}
+          </ol>
+          <p className="mt-3 rounded-md border border-gray-100 bg-gray-50 px-3 py-2 text-xs text-gray-500">
+            {ONBOARDING_SAFETY_LINE}
+          </p>
+
+          {/* Stage 120 — preview language legend */}
+          <p className="mt-4 text-xs font-medium text-gray-500">Preview language</p>
+          <dl className="mt-1 space-y-1">
+            {PREVIEW_LANGUAGE_ITEMS.map((item) => (
+              <div key={item.term} className="text-xs text-gray-600">
+                <dt className="inline font-medium text-gray-700">{item.term}</dt>
+                <dd className="inline"> — {item.meaning}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
         {/* Step 1 — pick a starting point */}
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <div className="mt-8 grid grid-cols-1 gap-2 sm:grid-cols-2">
           {WORKSPACE_INTAKE_TYPES.map((t) => {
             const m = INTAKE_META[t];
             const selected = t === type;
@@ -328,13 +364,22 @@ export default function IntakePage() {
           })}
         </div>
 
+        {/* Stage 120 — empty state before a starting point is picked */}
+        {!meta && (
+          <p className="mt-4 text-sm text-gray-500">{EMPTY_STATES.beforeInput}</p>
+        )}
+
         {/* Step 2 — paste what you have */}
         {meta && (
           <div className="mt-8">
             <label className="mb-2 block text-sm font-medium text-gray-900">
               Paste what you have.
             </label>
-            <p className="mb-2 text-xs text-gray-400">{meta.inputHint}</p>
+            <p className="text-xs text-gray-400">{meta.inputHint}</p>
+            {/* Stage 120 — before-input beta safety note */}
+            <p className="mb-2 mt-1 text-xs text-amber-600">
+              {BETA_SAFETY_NOTES.beforeInput}
+            </p>
             <textarea
               value={rawInput}
               onChange={(e) => {
@@ -935,6 +980,10 @@ export default function IntakePage() {
             </div>
           </div>
 
+          {/* Stage 120 — beta tenant-scope + retention notes */}
+          <p className="mt-2 text-xs text-gray-400">{BETA_SAFETY_NOTES.savedScope}</p>
+          <p className="mt-1 text-xs text-gray-400">{BETA_SAFETY_NOTES.savedRetention}</p>
+
           {manageMsg && (
             <p className="mt-2 text-xs text-gray-500">{manageMsg}</p>
           )}
@@ -945,9 +994,10 @@ export default function IntakePage() {
             </p>
           )}
           {savedList !== null && savedList.length === 0 && (
-            <p className="mt-3 text-sm text-gray-500">
-              No saved workflow plans yet.
-            </p>
+            <p className="mt-3 text-sm text-gray-500">{EMPTY_STATES.noSavedRecords}</p>
+          )}
+          {savedList !== null && savedList.length > 0 && !openRecord && !detailLoading && (
+            <p className="mt-3 text-xs text-gray-400">{EMPTY_STATES.noOpenedRecord}</p>
           )}
           {savedList !== null && savedList.length > 0 && (
             <ul className="mt-3 space-y-2">

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -69,6 +69,7 @@ import type {
   WorkflowRecordListItem,
 } from "@/lib/workspace-agent-workflow-api";
 import { getUserKey } from "@/lib/workflow-store";
+import { buildBetaFeedbackMailto } from "@/lib/beta-feedback.mjs";
 import { buildBenchmarkHandoffPreview } from "@/lib/intake-benchmark-handoff.mjs";
 import { buildDecisionOutcomeLinkPreview } from "@/lib/intake-decision-outcome-link.mjs";
 import { buildEvolutionActionPackPreview } from "@/lib/intake-evolution-action-preview.mjs";
@@ -290,8 +291,14 @@ export default function IntakePage() {
         <h1 className="text-2xl font-semibold tracking-tight text-gray-900">
           What do you want Simsa to review?
         </h1>
-        <p className="mb-8 mt-2 text-sm text-gray-500">
+        <p className="mt-2 text-sm text-gray-500">
           Start from anything. Simsa turns it into a staged acceptance workflow.
+        </p>
+        {/* Stage 119 — page-level beta feedback CTA */}
+        <p className="mb-8 mt-2 text-xs text-gray-400">
+          <FeedbackLink label="Share beta feedback" context={{ section: "Intake workflow" }} />{" "}
+          — opens an email with safe context only (no pasted content or workflow
+          snapshots are included).
         </p>
 
         {/* Step 1 — pick a starting point */}
@@ -839,6 +846,13 @@ export default function IntakePage() {
             <p className="mt-4 text-xs text-gray-400">
               Preview only — evidence is expected, not collected or verified.
             </p>
+            {/* Stage 119 — preview-section feedback CTA */}
+            <p className="mt-2">
+              <FeedbackLink
+                label="Feedback on this preview"
+                context={{ intakeType: type ?? undefined, section: "Evidence Plan" }}
+              />
+            </p>
           </div>
         )}
 
@@ -1041,6 +1055,17 @@ export default function IntakePage() {
               <p className="mt-2 text-xs text-gray-400">
                 Read-only snapshot of a saved plan. No agent execution or evidence
                 collection happened.
+              </p>
+              {/* Stage 119 — saved-workflow feedback CTA */}
+              <p className="mt-2">
+                <FeedbackLink
+                  label="Send feedback on this saved workflow"
+                  context={{
+                    intakeType: openRecord.intakeType,
+                    workflowRecordId: openRecord.id,
+                    section: "Saved workflow detail",
+                  }}
+                />
               </p>
 
               {/* Stage 113 — benchmark handoff preview from the saved record */}
@@ -1318,6 +1343,32 @@ export default function IntakePage() {
         </div>
       </div>
     </div>
+  );
+}
+
+// Stage 119 — beta feedback CTA. Opens a mailto with SAFE context only (no
+// pasted content, workflow snapshots, or userKey are ever included).
+function FeedbackLink({
+  label,
+  context,
+  className,
+}: {
+  label: string;
+  context?: {
+    route?: string;
+    intakeType?: string;
+    workflowRecordId?: string;
+    section?: string;
+  };
+  className?: string;
+}) {
+  return (
+    <a
+      href={buildBetaFeedbackMailto({ route: "/projects/new/intake", ...context })}
+      className={className ?? "text-xs font-medium text-brand-600 hover:underline"}
+    >
+      {label}
+    </a>
   );
 }
 

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -61,6 +61,8 @@ import {
   saveWorkflowRecord,
   listWorkflowRecords,
   getWorkflowRecord,
+  patchWorkflowRecordStatus,
+  deleteWorkflowRecord,
 } from "@/lib/workspace-agent-workflow-api";
 import type {
   WorkflowRecord,
@@ -92,6 +94,10 @@ export default function IntakePage() {
   const [listLoading, setListLoading] = useState(false);
   const [openRecord, setOpenRecord] = useState<WorkflowRecord | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
+  // Stage 118 — saved workflow management (archive / restore / delete).
+  const [showArchived, setShowArchived] = useState(false);
+  const [manageBusyId, setManageBusyId] = useState<string | null>(null);
+  const [manageMsg, setManageMsg] = useState<string | null>(null);
 
   const meta = type ? INTAKE_META[type] : null;
 
@@ -197,11 +203,17 @@ export default function IntakePage() {
     setSaving(false);
   }
 
-  async function refreshSavedList() {
+  async function refreshSavedList(includeArchived = showArchived) {
     setListLoading(true);
-    const res = await listWorkflowRecords(getUserKey());
+    const res = await listWorkflowRecords(getUserKey(), { includeArchived });
     setSavedList(res.ok ? res.records : []);
     setListLoading(false);
+  }
+
+  function toggleShowArchived() {
+    const next = !showArchived;
+    setShowArchived(next);
+    void refreshSavedList(next);
   }
 
   async function openSavedRecord(id: string) {
@@ -210,6 +222,39 @@ export default function IntakePage() {
     const res = await getWorkflowRecord(id, getUserKey());
     if (res.ok) setOpenRecord(res.record);
     setDetailLoading(false);
+  }
+
+  // Stage 118 — archive / restore a saved record, then refresh the list.
+  async function setRecordStatus(id: string, status: "planned" | "archived") {
+    setManageBusyId(id);
+    setManageMsg(null);
+    const res = await patchWorkflowRecordStatus(id, getUserKey(), status);
+    if (res.ok) {
+      setManageMsg(status === "archived" ? "Workflow archived." : "Workflow restored.");
+      if (openRecord?.id === id) setOpenRecord(res.record);
+      await refreshSavedList();
+    } else {
+      setManageMsg(`Could not update: ${res.error}`);
+    }
+    setManageBusyId(null);
+  }
+
+  // Stage 118 — explicit delete (with confirmation), then refresh the list.
+  async function removeRecord(id: string) {
+    if (typeof window !== "undefined" && !window.confirm("Delete this saved workflow plan? This cannot be undone.")) {
+      return;
+    }
+    setManageBusyId(id);
+    setManageMsg(null);
+    const res = await deleteWorkflowRecord(id, getUserKey());
+    if (res.ok) {
+      setManageMsg("Workflow deleted.");
+      if (openRecord?.id === id) setOpenRecord(null);
+      await refreshSavedList();
+    } else {
+      setManageMsg(`Could not delete: ${res.error}`);
+    }
+    setManageBusyId(null);
   }
 
   function selectType(next: WorkspaceIntakeType) {
@@ -856,15 +901,29 @@ export default function IntakePage() {
             <p className="text-xs uppercase tracking-wide text-gray-400">
               Saved workflow plans
             </p>
-            <button
-              type="button"
-              onClick={refreshSavedList}
-              disabled={listLoading}
-              className="btn btn-secondary btn-sm"
-            >
-              {listLoading ? "Loading…" : "Refresh"}
-            </button>
+            <div className="flex items-center gap-2">
+              <label className="flex items-center gap-1.5 text-xs text-gray-500">
+                <input
+                  type="checkbox"
+                  checked={showArchived}
+                  onChange={toggleShowArchived}
+                />
+                Show archived
+              </label>
+              <button
+                type="button"
+                onClick={() => refreshSavedList()}
+                disabled={listLoading}
+                className="btn btn-secondary btn-sm"
+              >
+                {listLoading ? "Loading…" : "Refresh"}
+              </button>
+            </div>
           </div>
+
+          {manageMsg && (
+            <p className="mt-2 text-xs text-gray-500">{manageMsg}</p>
+          )}
 
           {savedList === null && (
             <p className="mt-3 text-sm text-gray-500">
@@ -896,15 +955,44 @@ export default function IntakePage() {
                   </div>
                   <p className="mt-1 text-xs text-gray-500">{r.sourceSummary}</p>
                   <p className="mt-1 text-xs text-gray-400">
-                    {r.id} · {r.createdAt}
+                    {r.id} · created {r.createdAt} · updated {r.updatedAt}
                   </p>
-                  <button
-                    type="button"
-                    onClick={() => openSavedRecord(r.id)}
-                    className="btn btn-secondary btn-sm mt-2"
-                  >
-                    Open
-                  </button>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => openSavedRecord(r.id)}
+                      className="btn btn-secondary btn-sm"
+                    >
+                      Open
+                    </button>
+                    {r.status === "archived" ? (
+                      <button
+                        type="button"
+                        onClick={() => setRecordStatus(r.id, "planned")}
+                        disabled={manageBusyId === r.id}
+                        className="btn btn-secondary btn-sm"
+                      >
+                        {manageBusyId === r.id ? "…" : "Restore"}
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => setRecordStatus(r.id, "archived")}
+                        disabled={manageBusyId === r.id}
+                        className="btn btn-secondary btn-sm"
+                      >
+                        {manageBusyId === r.id ? "…" : "Archive"}
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => removeRecord(r.id)}
+                      disabled={manageBusyId === r.id}
+                      className="btn btn-secondary btn-sm text-red-600"
+                    >
+                      {manageBusyId === r.id ? "…" : "Delete"}
+                    </button>
+                  </div>
                 </li>
               ))}
             </ul>

--- a/apps/dashboard/src/lib/admin-agent-workflows-api.ts
+++ b/apps/dashboard/src/lib/admin-agent-workflows-api.ts
@@ -1,0 +1,96 @@
+"use client";
+
+/**
+ * admin-agent-workflows-api.ts — Stage 121
+ *
+ * Client for the beta admin console over saved agent workflow records. The admin
+ * key is entered by the operator at query time and sent as `x-admin-key` — never
+ * stored (matches workspace-admin-api.ts). Admin list returns summaries only (no
+ * snapshot JSON). Records are scoped by client-supplied userKey, NOT full auth.
+ */
+const BASE_URL =
+  process.env.NEXT_PUBLIC_CENTRAL_PLANE_URL ?? "https://conclave-ai.seunghunbae.workers.dev";
+
+const base = `${BASE_URL}/workspace/admin/agent-workflows`;
+
+export type AdminWorkflowRecord = {
+  id: string;
+  userKey: string;
+  projectId: string | null;
+  intakeType: string;
+  title: string;
+  sourceSummary: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AdminWorkflowSummary = {
+  total: number;
+  byStatus: Record<string, number>;
+  byIntakeType: Record<string, number>;
+  uniqueUserKeys: number;
+};
+
+export type AdminListResponse =
+  | { ok: true; records: AdminWorkflowRecord[]; summary: AdminWorkflowSummary }
+  | { ok: false; error: string };
+
+export type AdminMutateResponse =
+  | { ok: true; record?: AdminWorkflowRecord; deleted?: boolean; id?: string }
+  | { ok: false; error: string };
+
+export async function listAdminAgentWorkflows(
+  adminKey: string,
+  filters: { userKey?: string; status?: string; includeArchived?: boolean; limit?: number } = {},
+): Promise<AdminListResponse> {
+  try {
+    const params = new URLSearchParams();
+    if (filters.userKey) params.set("userKey", filters.userKey);
+    if (filters.status) params.set("status", filters.status);
+    if (filters.includeArchived) params.set("includeArchived", "true");
+    if (filters.limit) params.set("limit", String(filters.limit));
+    const qs = params.toString();
+    const resp = await fetch(qs ? `${base}?${qs}` : base, {
+      headers: { "x-admin-key": adminKey },
+      signal: AbortSignal.timeout(8000),
+    });
+    return (await resp.json()) as AdminListResponse;
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
+export async function updateAdminAgentWorkflowStatus(
+  adminKey: string,
+  id: string,
+  status: "planned" | "needs_evidence" | "archived",
+): Promise<AdminMutateResponse> {
+  try {
+    const resp = await fetch(`${base}/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", "x-admin-key": adminKey },
+      body: JSON.stringify({ status }),
+      signal: AbortSignal.timeout(8000),
+    });
+    return (await resp.json()) as AdminMutateResponse;
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
+export async function deleteAdminAgentWorkflow(
+  adminKey: string,
+  id: string,
+): Promise<AdminMutateResponse> {
+  try {
+    const resp = await fetch(`${base}/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+      headers: { "x-admin-key": adminKey },
+      signal: AbortSignal.timeout(8000),
+    });
+    return (await resp.json()) as AdminMutateResponse;
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}

--- a/apps/dashboard/src/lib/beta-feedback.d.mts
+++ b/apps/dashboard/src/lib/beta-feedback.d.mts
@@ -1,0 +1,11 @@
+// Type declarations for beta-feedback.mjs (Stage 119).
+
+export function buildBetaFeedbackMailto(input?: {
+  route?: string;
+  intakeType?: string;
+  workflowRecordId?: string;
+  section?: string;
+  subjectPrefix?: string;
+}): string;
+
+export const FEEDBACK_EMAIL: string;

--- a/apps/dashboard/src/lib/beta-feedback.mjs
+++ b/apps/dashboard/src/lib/beta-feedback.mjs
@@ -1,0 +1,69 @@
+// Stage 119 — lightweight, beta-safe feedback capture.
+//
+// Builds a `mailto:` URL with SAFE context only. By design it cannot transmit
+// raw pasted input, workflow snapshots, repo details, userKey, or any
+// secret/token — the function signature only accepts a small allowlist of
+// non-sensitive context fields, and the body is a fixed template. No backend, no
+// DB, no email/analytics provider. Pure + deterministic + URL-encoded.
+
+// Existing public contact email used across the product surfaces. Do NOT invent
+// hi@/support@/feedback@ addresses without explicit approval.
+const FEEDBACK_EMAIL = "seunghunbae@b2w.kr";
+const DEFAULT_SUBJECT_PREFIX = "[Simsa beta feedback]";
+
+function str(x) {
+  return typeof x === "string" ? x.trim() : "";
+}
+
+/**
+ * @param {{
+ *   route?: string,
+ *   intakeType?: string,
+ *   workflowRecordId?: string,
+ *   section?: string,
+ *   subjectPrefix?: string,
+ * }} [input]
+ * @returns {string} a mailto: URL with safe context only
+ */
+export function buildBetaFeedbackMailto(input = {}) {
+  const route = str(input.route);
+  const intakeType = str(input.intakeType);
+  const workflowRecordId = str(input.workflowRecordId);
+  const section = str(input.section);
+  const subjectPrefix = str(input.subjectPrefix) || DEFAULT_SUBJECT_PREFIX;
+
+  const subjectTopic = section || "Intake workflow";
+  const subject = `${subjectPrefix} ${subjectTopic}`;
+
+  // Only safe, non-sensitive context lines are included.
+  const contextLines = [];
+  if (route) contextLines.push(`- Route: ${route}`);
+  if (intakeType) contextLines.push(`- Intake type: ${intakeType}`);
+  if (workflowRecordId) contextLines.push(`- Saved workflow record: ${workflowRecordId}`);
+  if (section) contextLines.push(`- Section: ${section}`);
+  if (contextLines.length === 0) contextLines.push("- (no extra context)");
+
+  const body = [
+    "Hi Simsa team,",
+    "",
+    "I have feedback about the beta workflow.",
+    "",
+    "Context:",
+    ...contextLines,
+    "",
+    "Feedback:",
+    "- What was confusing?",
+    "- What felt useful?",
+    "- What did you expect next?",
+    "- Any bug or issue?",
+    "",
+    "Please do not include sensitive product details unless you are comfortable sharing them.",
+  ].join("\n");
+
+  const params = new URLSearchParams({ subject, body });
+  // URLSearchParams encodes spaces as "+"; mailto clients expect %20 in
+  // subject/body, so normalize.
+  return `mailto:${FEEDBACK_EMAIL}?${params.toString().replace(/\+/g, "%20")}`;
+}
+
+export { FEEDBACK_EMAIL };

--- a/apps/dashboard/src/lib/beta-onboarding.d.mts
+++ b/apps/dashboard/src/lib/beta-onboarding.d.mts
@@ -1,0 +1,22 @@
+// Type declarations for beta-onboarding.mjs (Stage 120).
+
+export const ONBOARDING_HEADING: string;
+export const ONBOARDING_INTRO: string;
+export const ONBOARDING_STEPS: string[];
+export const ONBOARDING_SAFETY_LINE: string;
+
+export type PreviewLanguageItem = { term: string; meaning: string };
+export const PREVIEW_LANGUAGE_ITEMS: PreviewLanguageItem[];
+
+export const BETA_SAFETY_NOTES: {
+  beforeInput: string;
+  savedScope: string;
+  savedRetention: string;
+  feedback: string;
+};
+
+export const EMPTY_STATES: {
+  beforeInput: string;
+  noSavedRecords: string;
+  noOpenedRecord: string;
+};

--- a/apps/dashboard/src/lib/beta-onboarding.mjs
+++ b/apps/dashboard/src/lib/beta-onboarding.mjs
@@ -1,0 +1,53 @@
+// Stage 120 — preview-only onboarding copy + constants.
+//
+// Centralizes the beta onboarding / "preview language" / safety copy so it stays
+// consistent across the intake route and is unit-testable (no completion claims,
+// safety notes present). Pure data — no component, no backend.
+
+export const ONBOARDING_HEADING = "How this beta preview works";
+
+export const ONBOARDING_INTRO =
+  "Paste an idea, PRD, product URL, repo, PR, or AI-built app description. Simsa turns it into a staged acceptance workflow preview.";
+
+/** The 4-step explanation of the intake preview chain. */
+export const ONBOARDING_STEPS = [
+  "Understand the artifact",
+  "Map acceptance items",
+  "Plan role-based review work",
+  "Save the workflow plan for later review",
+];
+
+/** Top-level safety line — what this flow does NOT do. */
+export const ONBOARDING_SAFETY_LINE =
+  "This beta flow creates plans and previews. It does not execute agents, collect evidence, run benchmarks, or make final decisions.";
+
+/** Legend explaining repeated preview terms across the chain. */
+export const PREVIEW_LANGUAGE_ITEMS = [
+  { term: "Candidate", meaning: "a suggested item that still needs review" },
+  { term: "Expected evidence", meaning: "proof that should be collected later" },
+  { term: "Not verified", meaning: "no evidence has been collected yet" },
+  { term: "Recommended tool", meaning: "a suggested tool, not an executed action" },
+  { term: "Action preview", meaning: "a suggested next action, not a created action pack" },
+];
+
+/** Beta data-safety notes shown around input + saved records. */
+export const BETA_SAFETY_NOTES = {
+  beforeInput:
+    "Avoid pasting confidential secrets, tokens, or sensitive customer data.",
+  savedScope:
+    "Saved workflow plans are scoped to this browser/user key. This is beta tenant scoping, not full team authentication.",
+  savedRetention:
+    "Saved workflow plans may include excerpts and generated workflow snapshots. Archive or delete records you no longer need.",
+  feedback:
+    "Feedback email opens with safe context only. No pasted content or workflow snapshots are included.",
+};
+
+/** Empty-state copy. */
+export const EMPTY_STATES = {
+  beforeInput:
+    "Start with what you already have. You can paste a rough idea, a product spec, a URL, a repo, a PR, or a description of an AI-built app. Simsa will create a deterministic acceptance workflow preview from it.",
+  noSavedRecords:
+    "No saved workflow plans yet. Create a preview above, then save it to reopen the benchmark, decision, and action previews later.",
+  noOpenedRecord:
+    "Open a saved workflow plan to see benchmark handoff, decision/outcome, and evolution action previews.",
+};

--- a/apps/dashboard/src/lib/beta-usage-boundary.d.mts
+++ b/apps/dashboard/src/lib/beta-usage-boundary.d.mts
@@ -1,0 +1,8 @@
+// Type declarations for beta-usage-boundary.mjs (Stage 122).
+
+export const BETA_USAGE_BOUNDARY_HEADING: string;
+export const BETA_USAGE_BOUNDARY_ITEMS: string[];
+export const BETA_USAGE_NOT_ACTIVE_COPY: string;
+export const SAVED_WORKFLOW_USAGE_NOTE: string;
+export const ADMIN_USAGE_BOUNDARY_NOTE: string;
+export const ADMIN_COUNTS_SIGNAL_NOTE: string;

--- a/apps/dashboard/src/lib/beta-usage-boundary.mjs
+++ b/apps/dashboard/src/lib/beta-usage-boundary.mjs
@@ -1,0 +1,32 @@
+// Stage 122 — beta usage / cost boundary copy.
+//
+// Honest, conservative copy that makes the beta usage boundary clear: the intake
+// preview chain is deterministic and low-cost, saving stores a lightweight
+// snapshot, and NO agent/benchmark/LLM execution (and no billing) happens. Pure
+// data — no enforcement, no billing, no backend.
+
+export const BETA_USAGE_BOUNDARY_HEADING = "Beta usage boundary";
+
+/** What is happening now + the boundary, as bullet copy. */
+export const BETA_USAGE_BOUNDARY_ITEMS = [
+  "This flow generates deterministic previews in your browser/app experience.",
+  "Saving a workflow stores a lightweight workflow snapshot.",
+  "This beta flow does not execute agents, run benchmarks, upload evidence, or make final decisions.",
+  "Future AI/agent execution features will need explicit usage limits before beta expansion.",
+];
+
+/** Explicit "no billing" line. */
+export const BETA_USAGE_NOT_ACTIVE_COPY =
+  "No billing or paid usage is active for this beta preview.";
+
+/** Saved workflow section boundary note. */
+export const SAVED_WORKFLOW_USAGE_NOTE =
+  "Saved workflow plans are stored snapshots for reopening the preview chain. They are not completed agent runs or benchmark results.";
+
+/** Admin console boundary note. */
+export const ADMIN_USAGE_BOUNDARY_NOTE =
+  "This admin view shows saved workflow record summaries only. It does not show usage charges, billing, agent execution, or benchmark execution.";
+
+/** Admin counts framing. */
+export const ADMIN_COUNTS_SIGNAL_NOTE =
+  "Use record counts as beta activity signals, not billing metrics.";

--- a/apps/dashboard/src/lib/workspace-agent-workflow-api.ts
+++ b/apps/dashboard/src/lib/workspace-agent-workflow-api.ts
@@ -63,6 +63,8 @@ export type WorkflowRecordListItem = {
 type SaveResponse = { ok: true; record: WorkflowRecord } | { ok: false; error: string };
 type ListResponse = { ok: true; records: WorkflowRecordListItem[] } | { ok: false; error: string };
 type DetailResponse = { ok: true; record: WorkflowRecord } | { ok: false; error: string };
+type PatchResponse = { ok: true; record: WorkflowRecord } | { ok: false; error: string };
+type DeleteResponse = { ok: true; deleted: true; id: string } | { ok: false; error: string };
 
 const base = `${CENTRAL_PLANE_URL}/workspace/agent-workflows`;
 
@@ -82,13 +84,47 @@ export async function saveWorkflowRecord(input: SaveWorkflowRecordInput): Promis
 
 export async function listWorkflowRecords(
   userKey: string,
-  projectId?: string,
+  opts: { projectId?: string; includeArchived?: boolean } = {},
 ): Promise<ListResponse> {
   try {
     const params = new URLSearchParams({ userKey });
-    if (projectId) params.set("projectId", projectId);
+    if (opts.projectId) params.set("projectId", opts.projectId);
+    if (opts.includeArchived) params.set("includeArchived", "true");
     const resp = await fetch(`${base}?${params}`, { signal: AbortSignal.timeout(8000) });
     return (await resp.json()) as ListResponse;
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
+/** Stage 118 — archive / restore / relabel a saved record (tenant-scoped). */
+export async function patchWorkflowRecordStatus(
+  id: string,
+  userKey: string,
+  status: WorkflowRecordStatus,
+): Promise<PatchResponse> {
+  try {
+    const resp = await fetch(`${base}/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ userKey, status }),
+      signal: AbortSignal.timeout(8000),
+    });
+    return (await resp.json()) as PatchResponse;
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
+/** Stage 118 — explicit removal of a saved record (tenant-scoped). */
+export async function deleteWorkflowRecord(id: string, userKey: string): Promise<DeleteResponse> {
+  try {
+    const params = new URLSearchParams({ userKey });
+    const resp = await fetch(`${base}/${encodeURIComponent(id)}?${params}`, {
+      method: "DELETE",
+      signal: AbortSignal.timeout(8000),
+    });
+    return (await resp.json()) as DeleteResponse;
   } catch (err) {
     return { ok: false, error: String(err) };
   }

--- a/apps/dashboard/test/beta-feedback.test.mjs
+++ b/apps/dashboard/test/beta-feedback.test.mjs
@@ -1,0 +1,81 @@
+// Stage 119 — beta feedback mailto helper tests. Pure/deterministic; safe context
+// only (no raw input / snapshot / userKey / secrets).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildBetaFeedbackMailto, FEEDBACK_EMAIL } from "../src/lib/beta-feedback.mjs";
+
+function decoded(url) {
+  // Return the full decoded mailto string for content assertions.
+  return decodeURIComponent(url);
+}
+
+test("builds a mailto to the existing public contact email", () => {
+  const url = buildBetaFeedbackMailto({});
+  assert.ok(url.startsWith(`mailto:${FEEDBACK_EMAIL}?`));
+  assert.equal(FEEDBACK_EMAIL, "seunghunbae@b2w.kr");
+});
+
+test("subject carries the Simsa beta feedback prefix", () => {
+  const url = buildBetaFeedbackMailto({});
+  assert.match(decoded(url), /\[Simsa beta feedback\]/);
+});
+
+test("includes route / intake type / record id / section context", () => {
+  const url = buildBetaFeedbackMailto({
+    route: "/projects/new/intake",
+    intakeType: "product_url",
+    workflowRecordId: "wawr_abc123",
+    section: "Evidence Plan",
+  });
+  const d = decoded(url);
+  assert.match(d, /Route: \/projects\/new\/intake/);
+  assert.match(d, /Intake type: product_url/);
+  assert.match(d, /Saved workflow record: wawr_abc123/);
+  assert.match(d, /Section: Evidence Plan/);
+  // section drives the subject topic
+  assert.match(d, /\[Simsa beta feedback\] Evidence Plan/);
+});
+
+test("default subject topic is Intake workflow when no section", () => {
+  assert.match(decoded(buildBetaFeedbackMailto({})), /\[Simsa beta feedback\] Intake workflow/);
+});
+
+test("custom subjectPrefix is honored", () => {
+  const url = buildBetaFeedbackMailto({ subjectPrefix: "[Simsa internal]" });
+  assert.match(decoded(url), /\[Simsa internal\] Intake workflow/);
+});
+
+test("does NOT include raw input or userKey even if accidentally passed", () => {
+  // The helper signature ignores unknown keys; the body is a fixed template.
+  const url = buildBetaFeedbackMailto({
+    route: "/projects/new/intake",
+    // @ts-expect-error — these are not part of the input type, must be ignored
+    rawInput: "SECRET pasted product spec",
+    // @ts-expect-error
+    userKey: "uk_should_not_leak",
+    // @ts-expect-error
+    acceptanceMap: { items: ["secret"] },
+  });
+  const d = decoded(url);
+  assert.ok(!d.includes("SECRET pasted product spec"), "raw input must not leak");
+  assert.ok(!d.includes("uk_should_not_leak"), "userKey must not leak");
+  assert.ok(!d.toLowerCase().includes("acceptancemap"), "snapshot must not leak");
+});
+
+test("output is URL-encoded (no raw spaces or newlines in query)", () => {
+  const url = buildBetaFeedbackMailto({ section: "Stage Plan" });
+  const query = url.split("?")[1];
+  assert.ok(!/ /.test(query), "no raw spaces in query");
+  assert.ok(!/\n/.test(query), "no raw newlines in query");
+  assert.match(query, /%20/, "spaces encoded as %20");
+});
+
+test("carries a safety note discouraging sensitive content", () => {
+  assert.match(decoded(buildBetaFeedbackMailto({})), /do not include sensitive product details/i);
+});
+
+test("deterministic output for identical input", () => {
+  const a = buildBetaFeedbackMailto({ route: "/x", section: "Agent Run Plan" });
+  const b = buildBetaFeedbackMailto({ route: "/x", section: "Agent Run Plan" });
+  assert.equal(a, b);
+});

--- a/apps/dashboard/test/beta-onboarding.test.mjs
+++ b/apps/dashboard/test/beta-onboarding.test.mjs
@@ -1,0 +1,87 @@
+// Stage 120 — onboarding/legend/safety copy tests. Ensures preview-only language
+// never claims completion, and safety notes carry the right warnings.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ONBOARDING_HEADING,
+  ONBOARDING_INTRO,
+  ONBOARDING_STEPS,
+  ONBOARDING_SAFETY_LINE,
+  PREVIEW_LANGUAGE_ITEMS,
+  BETA_SAFETY_NOTES,
+  EMPTY_STATES,
+} from "../src/lib/beta-onboarding.mjs";
+
+// Positive completion claims that must not appear in onboarding/legend copy.
+// (Disclaimers phrase these negatively, e.g. "does not execute agents", so we
+// check the legend + step copy, not the negative safety lines.)
+const FORBIDDEN = ["passed", "verified", "completed", "production ready", "winner selected"];
+
+test("onboarding heading + intro + 4 steps present", () => {
+  assert.ok(ONBOARDING_HEADING.length > 0);
+  assert.match(ONBOARDING_INTRO, /Simsa/);
+  assert.equal(ONBOARDING_STEPS.length, 4);
+  for (const s of ONBOARDING_STEPS) assert.ok(s.length > 0);
+});
+
+test("safety line says it does NOT execute agents / collect evidence / run benchmarks / make decisions", () => {
+  const s = ONBOARDING_SAFETY_LINE.toLowerCase();
+  assert.match(s, /does not execute agents/);
+  assert.match(s, /collect evidence/);
+  assert.match(s, /run benchmarks/);
+  assert.match(s, /final decisions/);
+});
+
+test("preview language legend has the 5 terms and no completion claims", () => {
+  assert.equal(PREVIEW_LANGUAGE_ITEMS.length, 5);
+  const blob = PREVIEW_LANGUAGE_ITEMS.map((i) => `${i.term} ${i.meaning}`).join(" ").toLowerCase();
+  // "not verified" is allowed; strip it before scanning for "verified".
+  const scan = blob.replace(/not verified/g, "");
+  for (const w of FORBIDDEN) {
+    assert.ok(!scan.includes(w), `legend must not claim "${w}"`);
+  }
+  for (const i of PREVIEW_LANGUAGE_ITEMS) {
+    assert.ok(i.term.length > 0 && i.meaning.length > 0);
+  }
+});
+
+test("safety notes: before-input discourages secrets/tokens/sensitive data", () => {
+  const s = BETA_SAFETY_NOTES.beforeInput.toLowerCase();
+  assert.match(s, /secret|token|sensitive/);
+});
+
+test("safety notes: saved scope is honest about tenant-scoping-not-auth", () => {
+  const s = BETA_SAFETY_NOTES.savedScope.toLowerCase();
+  assert.match(s, /not full team authentication/);
+});
+
+test("safety notes: retention note mentions archive/delete", () => {
+  const s = BETA_SAFETY_NOTES.savedRetention.toLowerCase();
+  assert.match(s, /archive or delete/);
+});
+
+test("safety notes: feedback note says safe context only", () => {
+  assert.match(BETA_SAFETY_NOTES.feedback.toLowerCase(), /safe context only/);
+});
+
+test("empty states present and non-empty", () => {
+  assert.ok(EMPTY_STATES.beforeInput.length > 0);
+  assert.match(EMPTY_STATES.noSavedRecords.toLowerCase(), /no saved workflow plans yet/);
+  assert.match(EMPTY_STATES.noOpenedRecord.toLowerCase(), /open a saved workflow plan/);
+});
+
+test("no copy encourages sharing secrets/tokens", () => {
+  const all = [
+    ONBOARDING_INTRO,
+    ONBOARDING_SAFETY_LINE,
+    ...ONBOARDING_STEPS,
+    ...PREVIEW_LANGUAGE_ITEMS.map((i) => i.meaning),
+    ...Object.values(BETA_SAFETY_NOTES),
+    ...Object.values(EMPTY_STATES),
+  ]
+    .join(" ")
+    .toLowerCase();
+  // Must not invite including secrets/tokens (only the discourage note mentions them).
+  assert.ok(!/include (your )?(secret|token)/.test(all));
+  assert.ok(!/paste (your )?(secret|token)/.test(all));
+});

--- a/apps/dashboard/test/beta-usage-boundary.test.mjs
+++ b/apps/dashboard/test/beta-usage-boundary.test.mjs
@@ -1,0 +1,67 @@
+// Stage 122 — beta usage/cost boundary copy tests. Honest + conservative: no
+// agent/benchmark execution, no active billing, no paid-plan language.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  BETA_USAGE_BOUNDARY_HEADING,
+  BETA_USAGE_BOUNDARY_ITEMS,
+  BETA_USAGE_NOT_ACTIVE_COPY,
+  SAVED_WORKFLOW_USAGE_NOTE,
+  ADMIN_USAGE_BOUNDARY_NOTE,
+  ADMIN_COUNTS_SIGNAL_NOTE,
+} from "../src/lib/beta-usage-boundary.mjs";
+
+// Active-billing language that must NOT appear as a current claim.
+const ACTIVE_BILLING = ["charged", "invoice", "paid plan", "metered usage", "subscription", "payment required"];
+
+const allCopy = [
+  BETA_USAGE_BOUNDARY_HEADING,
+  ...BETA_USAGE_BOUNDARY_ITEMS,
+  BETA_USAGE_NOT_ACTIVE_COPY,
+  SAVED_WORKFLOW_USAGE_NOTE,
+  ADMIN_USAGE_BOUNDARY_NOTE,
+  ADMIN_COUNTS_SIGNAL_NOTE,
+]
+  .join(" ")
+  .toLowerCase();
+
+test("usage boundary mentions deterministic preview", () => {
+  assert.match(BETA_USAGE_BOUNDARY_ITEMS.join(" ").toLowerCase(), /deterministic preview/);
+});
+
+test("usage boundary says no agent execution", () => {
+  assert.match(BETA_USAGE_BOUNDARY_ITEMS.join(" ").toLowerCase(), /does not execute agents/);
+});
+
+test("usage boundary says no benchmark execution", () => {
+  assert.match(BETA_USAGE_BOUNDARY_ITEMS.join(" ").toLowerCase(), /run benchmarks/);
+});
+
+test("usage boundary says no billing active", () => {
+  assert.match(BETA_USAGE_NOT_ACTIVE_COPY.toLowerCase(), /no billing or paid usage is active/);
+});
+
+test("copy avoids active-billing language", () => {
+  for (const w of ACTIVE_BILLING) {
+    assert.ok(!allCopy.includes(w), `copy must not imply active billing ("${w}")`);
+  }
+});
+
+test("saved workflow note clarifies snapshots are not completed runs/benchmarks", () => {
+  const s = SAVED_WORKFLOW_USAGE_NOTE.toLowerCase();
+  assert.match(s, /not completed agent runs or benchmark results/);
+});
+
+test("admin note says summaries only, no billing/execution", () => {
+  const s = ADMIN_USAGE_BOUNDARY_NOTE.toLowerCase();
+  assert.match(s, /summaries only/);
+  assert.match(s, /does not show usage charges, billing/);
+});
+
+test("admin counts note frames counts as activity signals, not billing metrics", () => {
+  assert.match(ADMIN_COUNTS_SIGNAL_NOTE.toLowerCase(), /activity signals, not billing metrics/);
+});
+
+test("future limits are framed as future, not active", () => {
+  assert.match(BETA_USAGE_BOUNDARY_ITEMS.join(" ").toLowerCase(), /future ai\/agent execution features will need explicit usage limits/);
+});

--- a/conclave-builder-pack/out/stage-118-saved-workflow-management-hardening.md
+++ b/conclave-builder-pack/out/stage-118-saved-workflow-management-hardening.md
@@ -1,0 +1,88 @@
+# Stage 118 — Saved Workflow Management Hardening
+
+**Date:** 2026-06-23
+**Train:** Beta Readiness / Team Usage (Stage 118~124) · branch `feat/stage-118-saved-workflow-management` · PR (do not merge until Stage 124 checkpoint).
+
+## Goal
+Give users and operators safe, tenant-scoped controls to **archive, restore, and
+delete** saved agent workflow records. Stage 112 added save; Stage 116 left a safe
+smoke record in production precisely because there was no removal path. This is the
+first data-control prerequisite before inviting any beta user to save records.
+
+## Migration decision
+**No new migration.** The existing `workspace_agent_workflow_records` table already
+has `status TEXT NOT NULL DEFAULT 'planned'` and `updated_at`. Archive = set
+`status='archived'`; restore = set it back to `planned`; explicit removal = hard
+`DELETE`. No `archived_at`/`deleted_at` column was needed.
+
+## Central-plane behavior
+Existing routes unchanged; two added (browser-facing, CORS, tenant-scoped):
+
+| Method | Path | Behavior |
+| --- | --- | --- |
+| PATCH | `/workspace/agent-workflows/:id` | `{ userKey, status }` → set status; **404** if missing/cross-tenant; updates `updated_at`; `user_key` not exposed |
+| DELETE | `/workspace/agent-workflows/:id` | `?userKey=` → hard delete; **404** if missing/cross-tenant; returns `{ok:true,deleted:true,id}`; repeated delete → 404 |
+
+Rules:
+- `userKey` required (existing repo convention) → 400 if absent.
+- **PATCH status allowlist** = `planned | needs_evidence | archived` (`draft` is
+  creation-only; unknown/invalid → 400 `invalid_status`).
+- Ownership is verified via `getOwnedWorkflowRecordById` before any write; a
+  record owned by another `userKey` returns **404** (not 403) — does not reveal
+  existence.
+- DB helpers added: `updateWorkflowRecordStatus(id, status)` and
+  `deleteWorkflowRecordById(id)` (callers verify ownership first).
+
+## List / includeArchived behavior
+`GET /workspace/agent-workflows?userKey=…`:
+- **Default excludes archived** (`status != 'archived'`).
+- `&includeArchived=true` includes all statuses.
+- `projectId` filter still applies within the caller's scope.
+Implemented by building the `WHERE` clause dynamically (`status != 'archived'` is a
+SQL literal; binds remain user_key, [project_id], limit). `GET detail` still
+returns an own **archived** record (archive hides it from the default list, not
+from direct access).
+
+## Dashboard behavior (`/projects/new/intake` → Saved workflow plans)
+- **Show archived** checkbox (re-lists with `includeArchived`).
+- Each record shows title, intake type, **status**, created + updated time, id.
+- Per-record actions: **Open**; **Archive** (when not archived) / **Restore**
+  (when archived); **Delete** (with `window.confirm`).
+- After archive/restore/delete: the list refreshes; if the opened record was
+  archived it updates the open detail, if deleted it closes; a small
+  success/error message is shown.
+- API client (`workspace-agent-workflow-api.ts`): `listWorkflowRecords(userKey,
+  {includeArchived})`, `patchWorkflowRecordStatus(id, userKey, status)`,
+  `deleteWorkflowRecord(id, userKey)`.
+
+## No auth overhaul
+Tenant scoping is unchanged — still the existing client-supplied `userKey`
+convention (dashboard `getUserKey()`), the same as the rest of the workspace API.
+Archive/restore/delete are all `userKey`-scoped; they cannot touch another
+tenant's record. This is **tenant scoping, not full session/auth security** — the
+auth/workspace boundary decision is deferred to Stage 123.
+
+## No production deploy / migration in this stage
+No D1 migration added; no production deploy; no remote migration apply. (Routes
+work against the already-applied 0046 table — the new columns were never needed.)
+Merge/deploy is the Stage 124 checkpoint decision.
+
+## Smoke record cleanup (after rollout)
+Production has a known safe smoke record from Stage 116:
+`userKey: uk_stage116_smoke_a`, `id: wawr_qbxvly98wa`. **Not touched during Stage
+118 development.** After this train's production rollout, it can be removed with
+the new endpoint: `DELETE /workspace/agent-workflows/wawr_qbxvly98wa?userKey=uk_stage116_smoke_a`.
+
+## Verification
+- `apps/central-plane`: **1174/1174** tests (+10: PATCH archive/restore, invalid
+  status 400, missing userKey 400, cross-tenant 404; DELETE own/repeated/cross-
+  tenant/missing-userKey; list default-excludes-archived + includeArchived;
+  detail returns own archived). typecheck clean.
+- `apps/dashboard`: **306/306** (unchanged — `.ts` API client has no node --test,
+  per convention; exercised via build/typecheck), typecheck clean, build green
+  (`/projects/new/intake` 20.6 kB). Lint = pre-existing `export/page.tsx`
+  exhaustive-deps warning only.
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Next stage
+Stage 119 — Beta Feedback Capture.

--- a/conclave-builder-pack/out/stage-119-beta-feedback-capture.md
+++ b/conclave-builder-pack/out/stage-119-beta-feedback-capture.md
@@ -1,0 +1,75 @@
+# Stage 119 — Beta Feedback Capture
+
+**Date:** 2026-06-23
+**Train:** Beta Readiness / Team Usage (Stage 118~124) · branch `feat/stage-118-saved-workflow-management` · PR #146 (do not merge until Stage 124 checkpoint).
+
+## Goal
+Give beta users / internal testers an easy way to send feedback about the intake
+workflow **without accidentally transmitting sensitive pasted content.** Stage 118
+made saved records manageable; Stage 119 adds a low-risk feedback path.
+
+## Feedback capture approach — `mailto` first
+A deterministic helper builds a `mailto:` URL with **safe context only**. No
+backend, no DB, no central-plane route, no email/analytics provider. The user's
+own mail client opens pre-filled; they choose what to send.
+
+### Why mailto first
+- Zero backend/infra risk and zero new data at rest.
+- Cannot auto-transmit raw input or snapshots — the helper only accepts a small
+  allowlist of non-sensitive fields and uses a **fixed body template**.
+- Fastest safe path to real beta feedback; a backend route can come later only
+  with explicit approval.
+
+## Helper — `apps/dashboard/src/lib/beta-feedback.mjs` (+ `.d.mts`)
+`buildBetaFeedbackMailto({ route?, intakeType?, workflowRecordId?, section?,
+subjectPrefix? }): string` — pure, deterministic, URL-encoded (spaces as `%20`).
+
+- Recipient: **`seunghunbae@b2w.kr`** (existing public contact — no new mailbox
+  invented).
+- Subject: `[Simsa beta feedback] <section | "Intake workflow">`.
+- Body: greeting + **Context** (only the safe fields that were provided) +
+  **Feedback** prompts (what was confusing / useful / expected next / any bug) +
+  a safety note: *"Please do not include sensitive product details unless you are
+  comfortable sharing them."*
+
+### Safe context fields (included)
+`route`, `intakeType`, `workflowRecordId`, `section`, `subjectPrefix`.
+
+### Excluded sensitive fields (never included)
+Raw pasted input, full workflow snapshots (acceptance map / stage plan / agent run
+plan / evidence plan), private repo details, `userKey`, any secret/token. The
+function signature does not accept these, and the body is a fixed template — extra
+keys passed by accident are ignored (covered by a test).
+
+## UI behavior — `/projects/new/intake`
+A small `FeedbackLink` component (renders an `<a href={mailto}>`) at three minimal
+entry points:
+1. **Page-level** — "Share beta feedback" under the subtitle, with the note
+   *"opens an email with safe context only (no pasted content or workflow
+   snapshots are included)."* Context: `section: "Intake workflow"`.
+2. **Preview-section** — "Feedback on this preview" on the Evidence Plan card
+   (the deterministic chain endpoint). Context: `intakeType`, `section: "Evidence
+   Plan"`.
+3. **Saved workflow detail** — "Send feedback on this saved workflow" in the
+   opened record. Context: `intakeType`, `workflowRecordId`, `section: "Saved
+   workflow detail"`.
+
+Kept intentionally minimal to avoid clutter. `mailto` is an external link, so
+`<a>` is correct (no Next `no-html-link-for-pages` concern).
+
+## No backend / DB / provider
+No D1 migration, no central-plane feedback route, no email provider, no analytics
+provider, no automatic raw-content or snapshot submission. If a backend feedback
+route is ever wanted, scope it separately with approval — not in Stage 119.
+
+## Verification
+- `apps/dashboard`: **315/315** tests (+9 beta-feedback: recipient, subject
+  prefix, context fields, default topic, custom prefix, accidental-leak guard,
+  URL-encoding, safety note, deterministic), typecheck clean, build green
+  (`/projects/new/intake` 21.3 kB). Lint = pre-existing `export/page.tsx`
+  exhaustive-deps warning only.
+- `apps/central-plane`: **1174/1174** (unchanged), typecheck clean.
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Next stage
+Stage 120 — Preview-only Onboarding / Empty States.

--- a/conclave-builder-pack/out/stage-120-preview-only-onboarding-empty-states.md
+++ b/conclave-builder-pack/out/stage-120-preview-only-onboarding-empty-states.md
@@ -1,0 +1,69 @@
+# Stage 120 — Preview-only Onboarding / Empty States
+
+**Date:** 2026-06-23
+**Train:** Beta Readiness / Team Usage (Stage 118~124) · branch `feat/stage-118-saved-workflow-management` · PR #146 (do not merge until Stage 124 checkpoint).
+
+## Goal
+Make the long intake preview chain understandable and safe for beta users — so a
+**preview is never confused with an executed result.** Reinforces that the flow is
+deterministic, preview-only, and does **not** execute agents, run benchmarks,
+collect evidence, or make final decisions.
+
+## Onboarding copy added (`apps/dashboard/src/lib/beta-onboarding.mjs` + `.d.mts`)
+Centralized, testable copy constants (pure data, no component):
+- `ONBOARDING_HEADING` / `ONBOARDING_INTRO`
+- `ONBOARDING_STEPS` (4: Understand the artifact → Map acceptance items → Plan
+  role-based review work → Save the workflow plan for later review)
+- `ONBOARDING_SAFETY_LINE` ("…does not execute agents, collect evidence, run
+  benchmarks, or make final decisions.")
+- `PREVIEW_LANGUAGE_ITEMS` (5-term legend)
+- `BETA_SAFETY_NOTES` (`beforeInput`, `savedScope`, `savedRetention`, `feedback`)
+- `EMPTY_STATES` (`beforeInput`, `noSavedRecords`, `noOpenedRecord`)
+
+## Preview-only language (legend)
+A "Preview language" legend on the onboarding panel defines the repeated terms:
+- **Candidate** — a suggested item that still needs review
+- **Expected evidence** — proof that should be collected later
+- **Not verified** — no evidence has been collected yet
+- **Recommended tool** — a suggested tool, not an executed action
+- **Action preview** — a suggested next action, not a created action pack
+
+## UI placement (`/projects/new/intake`)
+1. **Top onboarding panel** — heading + intro + numbered 4 steps + safety line +
+   the preview-language legend (compact card under the page subtitle).
+2. **Before-input empty state** — when no starting point is picked, shows
+   `EMPTY_STATES.beforeInput`.
+3. **Before-input safety note** — under the textarea hint, an amber note:
+   *"Avoid pasting confidential secrets, tokens, or sensitive customer data."*
+4. **Saved workflow plans** — tenant-scope honesty note
+   (`savedScope`: "beta tenant scoping, not full team authentication") +
+   retention note (`savedRetention`: "Archive or delete records you no longer
+   need", linking Stage 118 controls to data safety).
+5. **No saved records empty state** — `EMPTY_STATES.noSavedRecords`.
+6. **Records exist but none opened** — `EMPTY_STATES.noOpenedRecord`
+   ("Open a saved workflow plan to see benchmark handoff, decision/outcome, and
+   evolution action previews.").
+7. **Feedback CTA** (Stage 119) reuses `BETA_SAFETY_NOTES.feedback` copy; no extra
+   feedback buttons added.
+
+## Data safety notes
+- Discourages pasting secrets/tokens/sensitive customer data before input.
+- Honest about scoping: client-supplied `userKey`, **not** full team auth.
+- Connects archive/delete (Stage 118) to retention hygiene.
+
+## No backend / DB / auth changes
+No D1 migration, central-plane route, auth change, billing, email/analytics
+provider, deploy, or domain change. Pure dashboard copy + a constants module.
+
+## Verification
+- `apps/dashboard`: **324/324** tests (+9 beta-onboarding: heading/steps,
+  safety-line claims, 5-term legend with no completion claims, secrets-discourage
+  note, tenant-scoping honesty, retention archive/delete, feedback safe-context,
+  empty states, no secret-encouragement), typecheck clean, build green
+  (`/projects/new/intake` 22.1 kB). Lint = pre-existing `export/page.tsx`
+  exhaustive-deps warning only.
+- `apps/central-plane`: **1174/1174** (unchanged), typecheck clean.
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Next stage
+Stage 121 — Admin Beta Console for Saved Workflows.

--- a/conclave-builder-pack/out/stage-121-admin-beta-console-saved-workflows.md
+++ b/conclave-builder-pack/out/stage-121-admin-beta-console-saved-workflows.md
@@ -1,0 +1,83 @@
+# Stage 121 — Admin Beta Console for Saved Workflows
+
+**Date:** 2026-06-23
+**Train:** Beta Readiness / Team Usage (Stage 118~124) · branch `feat/stage-118-saved-workflow-management` · PR #146 (do not merge until Stage 124 checkpoint).
+
+## Goal
+Give the operator a minimal **beta admin console** to understand beta usage and
+safely manage saved workflow records across `userKey` scopes. This is for beta
+operations — **not** full account administration.
+
+## Admin protection model (existing convention reused)
+Reuses the existing admin-key convention (`workspace-admin-stats.ts`):
+`x-admin-key` header must equal `c.env.ADMIN_USAGE_STATS_KEY`. **503** when the
+key is unset, **401** on mismatch. **No new secret, no new auth model, no RBAC.**
+The dashboard enters the admin key at query time and never stores it (matches
+`workspace-admin-api.ts`).
+
+## Central-plane endpoints (added to the CORS-enabled workflow route)
+| Method | Path | Behavior |
+| --- | --- | --- |
+| GET | `/workspace/admin/agent-workflows` | List across userKeys + summary; **summaries only (no snapshot JSON)** |
+| PATCH | `/workspace/admin/agent-workflows/:id` | Admin archive/restore (`{status}`, allowlist `planned|needs_evidence|archived`) |
+| DELETE | `/workspace/admin/agent-workflows/:id` | Admin hard delete (smoke/test/problematic records) |
+
+GET query options: `userKey?`, `status?` (validated against the status enum),
+`includeArchived?` (default **excludes** archived), `limit?`. Response:
+```ts
+{ records: [{ id, userKey, projectId, intakeType, title, sourceSummary, status, createdAt, updatedAt }],
+  summary: { total, byStatus, byIntakeType, uniqueUserKeys } }
+```
+PATCH returns the updated record summary (incl. `userKey`); DELETE returns
+`{ok,deleted:true,id}` and a repeated delete → **404**. PATCH/DELETE require the
+admin key (non-admin → 401) and update by id **regardless of userKey** (admin
+scope), 404 when the id does not exist. No bulk delete.
+
+DB: `adminListWorkflowRecords` (new) selects summary columns incl. `user_key`
+(no snapshot JSON), applies the filters, bounds the scan at FETCH_CAP=1000, and
+computes the summary in JS; PATCH/DELETE reuse Stage 118's
+`updateWorkflowRecordStatus` / `deleteWorkflowRecordById`.
+
+## Dashboard admin UI — `/admin/workflows`
+`"use client"` page (operator-only), self-contained copy:
+- Admin key input (password, not stored), userKey filter, status filter, include-
+  archived toggle, Refresh.
+- **Summary cards**: total · planned · needs evidence · archived · unique user keys.
+- **Records list**: id, userKey, intake type, title, status, created/updated +
+  per-record **Archive / Restore** and **Delete** (confirmed).
+- Disclaimer: *"Beta admin console. Records are scoped by client-supplied userKey,
+  not full account authentication. Avoid exposing or copying sensitive workflow
+  content."*
+- API client `lib/admin-agent-workflows-api.ts`:
+  `listAdminAgentWorkflows`, `updateAdminAgentWorkflowStatus`,
+  `deleteAdminAgentWorkflow` (all send `x-admin-key`).
+
+## Summary-only / privacy principle
+The admin list **never returns snapshot JSON** (acceptance map / stage plan /
+agent run plan / evidence plan) — only summary metadata. This limits sensitive
+exposure in the operator view. (No admin detail endpoint exposing full snapshots
+was added; summaries are sufficient for Stage 121.)
+
+## Tenant / userKey caveat (no overclaim)
+Records are scoped by the existing **client-supplied `userKey`** convention —
+this is **tenant scoping, not full account authentication or RBAC**. The admin
+console is gated by the shared admin key only. A real auth/workspace boundary is
+the Stage 123 decision.
+
+## No production deploy / migration
+No D1 migration (reuses the Stage 118 `status` column + 0046 table); no production
+deploy; no remote migration apply. Merge/deploy is the Stage 124 checkpoint.
+
+## Verification
+- `apps/central-plane`: **1181/1181** tests (+7 admin: key required 503/401,
+  list across userKeys + summary counts, no snapshot JSON, default-excludes-
+  archived + includeArchived, userKey/status filters, PATCH archive/restore any
+  record, PATCH invalid status 400 / missing 404 / non-admin 401, DELETE any /
+  missing 404 / non-admin 401). typecheck clean.
+- `apps/dashboard`: **324/324** (`.ts` admin client + page have no node --test,
+  per convention; exercised via build/typecheck), typecheck clean, build green
+  (`/admin/workflows` 2.15 kB). Lint = pre-existing `export/page.tsx` warning only.
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Next stage
+Stage 122 — Usage Limits / Cost Boundary UI.

--- a/conclave-builder-pack/out/stage-122-usage-limits-cost-boundary-ui.md
+++ b/conclave-builder-pack/out/stage-122-usage-limits-cost-boundary-ui.md
@@ -1,0 +1,71 @@
+# Stage 122 — Usage Limits / Cost Boundary UI
+
+**Date:** 2026-06-23
+**Train:** Beta Readiness / Team Usage (Stage 118~124) · branch `feat/stage-118-saved-workflow-management` · PR #146 (do not merge until Stage 124 checkpoint).
+
+## Goal
+Make the beta **usage/cost boundary** clear and honest — **not** implement billing
+or enforcement. Beta users and operators should understand that the intake preview
+chain is deterministic and low-cost, saved records are lightweight snapshots, and
+**no agent/benchmark/LLM execution (and no billing) happens**; future AI/agent
+execution will need explicit usage limits.
+
+## Beta usage boundary copy (`apps/dashboard/src/lib/beta-usage-boundary.mjs` + `.d.mts`)
+Testable copy constants (pure data, no enforcement/billing/backend):
+- `BETA_USAGE_BOUNDARY_HEADING` ("Beta usage boundary")
+- `BETA_USAGE_BOUNDARY_ITEMS` (4 bullets: deterministic previews · saving stores a
+  lightweight snapshot · does not execute agents / run benchmarks / upload
+  evidence / make final decisions · future AI/agent execution will need explicit
+  usage limits before beta expansion)
+- `BETA_USAGE_NOT_ACTIVE_COPY` ("No billing or paid usage is active for this beta
+  preview.")
+- `SAVED_WORKFLOW_USAGE_NOTE` ("…stored snapshots for reopening the preview chain.
+  They are not completed agent runs or benchmark results.")
+- `ADMIN_USAGE_BOUNDARY_NOTE` + `ADMIN_COUNTS_SIGNAL_NOTE` (admin view shows
+  summaries only, no charges/billing/execution; counts are activity signals, not
+  billing metrics)
+
+## What is active now
+- Deterministic, in-app preview chain (Intake → … → Evolution Action Pack Preview).
+- Lightweight saved workflow snapshots (tenant-scoped by `userKey`).
+
+## What is NOT active
+- No agent execution, no benchmark execution, no evidence upload, no final
+  decision, no LLM call from the beta workflow chain.
+- **No billing / paid usage / credit deduction / enforcement.** Copy deliberately
+  avoids active-billing language (charged / invoice / paid plan / metered usage /
+  subscription / payment required) — verified by tests.
+
+## UI placement
+1. **Intake page** (`/projects/new/intake`) — "Beta usage boundary" panel right
+   after the onboarding/preview-only panel: 4 boundary bullets + the "no billing
+   active" note.
+2. **Saved workflow plans section** — `SAVED_WORKFLOW_USAGE_NOTE` added alongside
+   the existing Stage 120 tenant-scope + retention notes (no conflicting copy).
+3. **Admin console** (`/admin/workflows`) — `ADMIN_USAGE_BOUNDARY_NOTE` +
+   `ADMIN_COUNTS_SIGNAL_NOTE` under the existing disclaimer. No billing metrics
+   added.
+
+## Data / privacy copy
+Reuses Stage 120 copy ("Saved workflow plans may include excerpts and generated
+snapshots. Archive or delete records you no longer need.") — no duplicate/
+conflicting copy introduced.
+
+## No billing / enforcement / backend changes
+No billing/payment implementation, credit deduction, usage enforcement, new D1
+migration, new central-plane route, AI/LLM call, agent/benchmark execution,
+analytics provider, deploy, or domain change. Pure dashboard copy + a constants
+module.
+
+## Verification
+- `apps/dashboard`: **333/333** tests (+9 beta-usage-boundary: deterministic
+  preview, no agent execution, no benchmark execution, no billing active, avoids
+  active-billing language, saved-snapshot framing, admin summaries-only, counts-
+  as-activity-signals, future-limits-framed-as-future), typecheck clean, build
+  green (`/projects/new/intake` 22.5 kB, `/admin/workflows` 2.59 kB). Lint =
+  pre-existing `export/page.tsx` warning only.
+- `apps/central-plane`: **1181/1181** (unchanged), typecheck clean.
+- Monorepo `turbo run typecheck`: **56/56**.
+
+## Next stage
+Stage 123 — Auth / Workspace Boundary Decision.

--- a/conclave-builder-pack/out/stage-123-auth-workspace-boundary-decision.md
+++ b/conclave-builder-pack/out/stage-123-auth-workspace-boundary-decision.md
@@ -1,0 +1,99 @@
+# Stage 123 — Auth / Workspace Boundary Decision
+
+**Date:** 2026-06-23
+**Train:** Beta Readiness / Team Usage (Stage 118~124) · branch `feat/stage-118-saved-workflow-management` · PR #146 (do not merge until Stage 124 checkpoint).
+**Type:** decision documentation (docs-only). **No real auth, no code change.**
+
+## 1. Decision
+**For the Stage 117~124 private beta, Simsa will NOT add real authentication or a
+team/workspace model.** The product keeps **private / invite-only** beta using the
+existing **client-supplied `userKey` tenant scoping** for saved workflow records.
+Real auth / workspace / RBAC is **deferred to a later dedicated train** after beta
+validation. This is recorded as the explicit auth boundary decision for this train.
+
+## 2. Current auth / tenant model (honest)
+- Dashboard `getUserKey()` creates/uses an anonymous client-side `userKey`
+  (localStorage), sent in the POST body / GET query — the same model as the
+  existing workspace benchmark/experiment/credit APIs.
+- Central-plane saved-workflow routes scope every read/write by `userKey`:
+  cross-`userKey` list / detail / PATCH / DELETE is blocked (detail of another
+  tenant returns **404**; verified live in the Stage 116 rollout smoke and by
+  central-plane tests).
+- The admin beta console (`/admin/workflows`, `GET/PATCH/DELETE
+  /workspace/admin/agent-workflows`) is protected by the existing `x-admin-key` /
+  `ADMIN_USAGE_STATS_KEY` convention.
+- **This is tenant scoping, not full account authentication.** Clearing
+  localStorage loses access; there is no cross-device identity, no recovery, and
+  it is not a security boundary against a determined actor — only against
+  accidental cross-tenant access.
+
+## 3. Why not real auth yet
+- The product loop still needs **beta validation** (understanding, feedback,
+  workflow management) — not scaled multi-user collaboration.
+- Real auth + team workspace is a **large scope increase** (provider choice,
+  sessions, account tables, invites, ownership migration, RBAC).
+- Saved records are **already tenant-scoped by `userKey`** for current beta ops.
+- The **admin console** gives operator-level oversight + cleanup.
+- A **private / invite-only** beta can run safely today with clear limitations.
+- Adding auth now would delay the actual learning goal of the beta.
+
+## 4. Private beta operating policy
+- **Private / invite-only** beta; **no open signup** yet.
+- **No marketing claim** of secure team workspace / authenticated accounts.
+- Ask beta users to **avoid pasting confidential secrets/tokens/sensitive customer
+  data** (already surfaced in the UI before input).
+- Use **archive / delete** (Stage 118) for data control; **admin console**
+  (Stage 121) for operator cleanup (incl. the Stage 116 smoke record).
+- Collect feedback via the **safe mailto flow** (Stage 119).
+- **Revisit real auth after** private-beta learning.
+
+## 5. What is safe to claim
+tenant-scoped beta records · private beta · invite-only beta · saved workflow
+plans · admin beta console · archive/delete controls.
+
+## 6. What NOT to claim
+secure team workspace · authenticated organization · enterprise-grade permissions
+· production auth · user accounts — unless explicitly marked as future work.
+
+## 7. UI copy status (already in place — no new copy needed)
+Option A (docs-only) applies because the required honesty copy already exists from
+Stages 120~122:
+- *"Saved workflow plans are scoped to this browser/user key. This is beta tenant
+  scoping, not full team authentication."* (`beta-onboarding.mjs` → intake)
+- *"Avoid pasting confidential secrets, tokens, or sensitive customer data."*
+  (intake, before input)
+- *"Beta admin console. Records are scoped by client-supplied userKey, not full
+  account authentication. Avoid exposing or copying sensitive workflow content."*
+  (`/admin/workflows`)
+- Stage 122 usage-boundary panel reinforces no execution / no billing.
+
+No UI copy change is made in Stage 123 — adding "invite-only" wording is an
+**operating policy** (above), not a UI claim required now; it can be added at beta
+launch if desired without reopening this decision.
+
+## 8. Future auth / workspace train (after beta learning — not now)
+A later dedicated train, roughly:
+- Auth 1 — Auth provider decision (e.g. Supabase/OAuth)
+- Auth 2 — User account / session model
+- Auth 3 — Workspace / team model
+- Auth 4 — Invite flow
+- Auth 5 — Record ownership migration (migrate `userKey`-scoped records → real
+  account/workspace ownership)
+- Auth 6 — Admin / RBAC model
+- Auth 7 — Auth beta checkpoint
+
+This will **require D1 migrations and careful data migration** from the current
+`userKey`-scoped `workspace_agent_workflow_records` to real ownership. Out of
+scope for the Beta Readiness train.
+
+## 9. Impact on Stage 124 checkpoint
+Stage 124 should evaluate, with this decision as input:
+- whether private beta can proceed **without** real auth (this decision: yes),
+- whether UI copy sufficiently warns users (Stages 120~122: yes),
+- whether archive/delete (118) + admin console (121) controls are enough for beta
+  data hygiene,
+- whether saved workflow records should be opened broadly or **kept limited /
+  invite-only** (this decision: invite-only).
+
+## 10. Recommended next stage
+Stage 124 — Private Beta Checkpoint.

--- a/conclave-builder-pack/out/stage-124-private-beta-checkpoint.md
+++ b/conclave-builder-pack/out/stage-124-private-beta-checkpoint.md
@@ -1,0 +1,147 @@
+# Stage 124 — Private Beta Checkpoint
+
+**Date:** 2026-06-23
+**PR:** #146 · **Branch:** `feat/stage-118-saved-workflow-management` · **HEAD:** `d804dcf`
+**Status:** checkpoint — decision-ready. **Not merged, not deployed, no migration (none in this train).**
+
+Decision-ready handoff for the Stage 118~124 Beta Readiness / Team Usage train.
+Evaluate this as a **beta safety / operations train**, not a core product feature
+train. Mirrors the PR #146 description.
+
+## Summary
+This train wraps beta-readiness layers around the (already-live) saved agent
+workflow feature so Simsa can run a **controlled private beta** without
+overclaiming auth, execution, billing, or team-workspace readiness.
+
+## Included stages
+- **118** Saved Workflow Management Hardening — tenant-scoped archive/restore/delete
+- **119** Beta Feedback Capture — safe `mailto` feedback
+- **120** Preview-only Onboarding / Empty States — comprehension + empty states
+- **121** Admin Beta Console — operator view/manage saved-workflow summaries
+- **122** Usage Limits / Cost Boundary UI — honest "no billing/execution" copy
+- **123** Auth / Workspace Boundary Decision — private/invite-only, no real auth yet
+- **124** Private Beta Checkpoint (this document)
+
+## Beta readiness improvements
+Users/operators can now archive/delete records; send safe feedback (no raw
+content); understand preview-only behavior; an operator can oversee/clean records;
+users see no-billing/no-execution boundaries; the private-beta auth boundary is
+documented.
+
+## User-facing changes (`/projects/new/intake`)
+Onboarding panel + preview-language legend; before-input empty state + secrets
+warning; "Beta usage boundary" panel + "no billing active" note; Saved workflow
+plans: Show-archived toggle, per-record Open/Archive/Restore/Delete (delete
+confirmed), tenant-scope + retention + usage notes; feedback links (page /
+Evidence Plan / saved detail) that open `mailto` with **safe context only**.
+
+## Admin/operator changes (`/admin/workflows`)
+New page: admin-key input (not stored), userKey/status filters + include-archived,
+summary cards (total/planned/needs-evidence/archived/unique userKeys), per-record
+archive/restore/delete. Summaries only (no snapshot JSON). Disclaimers: userKey is
+tenant scoping not full auth; counts are activity signals not billing metrics.
+
+## Auth / tenant boundary (honest)
+Saved workflow records stay scoped by the existing **client-supplied `userKey`**;
+cross-`userKey` list/detail/PATCH/DELETE is blocked (cross-tenant detail → 404,
+verified). Admin console gated by `x-admin-key` (existing `ADMIN_USAGE_STATS_KEY`).
+This is **tenant scoping, not full account authentication**; private beta stays
+**invite/manual, not open signup**. Real auth/workspace deferred to a future train
+(Stage 123).
+
+## Usage / cost boundary
+Deterministic, low-cost previews; lightweight snapshots; **no agent/benchmark/LLM
+execution and no billing/enforcement**. Copy avoids active-billing language
+(verified). Future AI/agent execution will need explicit usage limits.
+
+## Surfaces changed (vs `origin/main`, 22 files, +2107/-57)
+central-plane: `routes/workspace-agent-workflow.ts`,
+`workspace/agent-workflow-record-db.ts`, `test/workspace-agent-workflow.test.mjs`.
+dashboard libs (+`.d.mts`/tests): `workspace-agent-workflow-api.ts`,
+`admin-agent-workflows-api.ts`, `beta-feedback`, `beta-onboarding`,
+`beta-usage-boundary`. dashboard pages: `app/projects/new/intake/page.tsx`,
+`app/admin/workflows/page.tsx`. Docs: stage-118…123.
+
+## Surfaces intentionally unchanged
+`apps/simsa-landing`, `apps/simsa-dev`, `.github/workflows/**`, `packages/**`,
+billing/payment, domain/DNS, **migrations (none added)**, auth provider/session,
+the internal `@conclave-ai/*` namespace, and the existing `/projects/new` flow.
+Audited — none changed.
+
+## Verification (HEAD d804dcf)
+- central-plane: **1181/1181** · dashboard: **333/333** · both typecheck clean.
+- monorepo `turbo run typecheck`: **56/56**.
+- dashboard build: **green** (`/projects/new/intake` 22.5 kB, `/admin/workflows`
+  2.59 kB).
+- **Migration audit: no migration files changed** in this train (archive reuses
+  the `status` column; admin reuses the table + admin-key convention; Stage 123
+  docs-only).
+- **Secret scan** over the 22 changed files: **no sensitive literals found**
+  (no token values output; previously exposed Vercel token remains
+  operator-revoked/rotated).
+
+## Known warnings
+Only the pre-existing `apps/dashboard/src/app/projects/[id]/export/page.tsx`
+`react-hooks/exhaustive-deps` warning. Not introduced by this train; non-blocking.
+
+## Production deploy implications
+This train **changes central-plane code** (`PATCH`/`DELETE
+/workspace/agent-workflows/:id`, `GET` `includeArchived`, admin endpoints), so
+**dashboard-only deploy is not sufficient** — the dashboard archive/delete/admin
+UI calls these routes. **No D1 migration is needed.** A full rollout = central-
+plane deploy → dashboard deploy.
+
+## Rollout options
+- **A — Merge only, no deploy:** code on main; improvements not live.
+- **B — Merge + dashboard deploy only:** not recommended (archive/delete/admin UI
+  calls central-plane routes that wouldn't be live).
+- **C — Merge + central-plane deploy + dashboard deploy + smoke:** recommended
+  (no migration). Order: merge → central-plane → dashboard → smoke.
+- **D — Hold PR open:** only if blockers found.
+
+## Recommendation
+**READY TO MERGE + CONTROLLED ROLLOUT** (Option C), pending Bae approval:
+1. squash merge PR #146
+2. deploy central-plane (Actions → deploy-central-plane → `confirm=deploy`;
+   **apply-migrations can be false** — no migration in this train)
+3. deploy dashboard (repo root; project `conclave-dashboard`; alias
+   app.trysimsa.com)
+4. smoke (below)
+
+**Merge / deploy are NOT executed in this stage.** If any blocker is found →
+*READY TO MERGE BUT HOLD DEPLOY* or *NOT READY*.
+
+## Smoke plan (after approval)
+**Saved workflow management** (`app.trysimsa.com/projects/new/intake`): list loads;
+archive own record; archived hidden by default; Show-archived reveals it; restore;
+delete (confirm) removes it; cross-userKey archive/delete/detail stays blocked.
+**Feedback/onboarding:** onboarding panel + preview-language legend + usage-boundary
+panel appear; feedback links open `mailto` with safe context only (no raw
+input/snapshot/userKey).
+**Admin** (`app.trysimsa.com/admin/workflows`): admin key required; summaries load
+with valid key; no snapshot JSON; filters work; archive/restore/delete work;
+disclaimer present.
+**Regression (unchanged):** `app.trysimsa.com`, `/projects/new`, `trysimsa.com`,
+`trysimsa.com/demo`, `simsa.dev`, `conclave-dashboard.vercel.app`.
+
+## Rollback plan
+- central-plane deploy fails → roll back Worker; do not deploy dashboard.
+- dashboard deploy fails → roll back dashboard (central-plane may remain; unused).
+- admin endpoint issue → roll back central-plane; do not expose `/admin/workflows`.
+- archive/delete issue → roll back central-plane + dashboard save-management UI.
+- **No migration rollback needed** (no migration introduced).
+
+## Risks → mitigations
+- Admin console exposes cross-userKey **summaries** → no snapshot JSON in admin
+  list; admin-key gated (existing convention).
+- Admin key is a shared secret, not RBAC → matches existing admin routes;
+  documented; RBAC deferred (Stage 123).
+- Delete is a hard delete → UI confirmation + archive offers non-destructive hide.
+- `userKey` is tenant scoping, not full auth → documented; invite-only beta.
+- Dashboard management depends on central-plane → Option C deploys backend first.
+- Beta copy must not overclaim → tests assert no completion/active-billing/secure-
+  workspace claims; no agent/benchmark/billing execution added.
+
+## Recommendation (final)
+**READY TO MERGE + CONTROLLED ROLLOUT** (Option C) pending Bae review. No merge,
+deploy, or migration executed in this stage.


### PR DESCRIPTION
# Stage 118~124 — Beta Readiness / Team Usage Train

**Branch** `feat/stage-118-saved-workflow-management` · **HEAD** `f82491c` · **Checkpoint:** decision-ready. **Do not merge / deploy until Bae approves. No migration in this train.** Full checkpoint: `conclave-builder-pack/out/stage-124-private-beta-checkpoint.md`.

## Summary
Beta-readiness layers around the (already-live) saved agent workflow feature so Simsa can run a **controlled private beta** without overclaiming auth, execution, billing, or team-workspace readiness. Evaluate as a beta safety/operations train.

## Included stages
- Stage 118 — Saved Workflow Management Hardening
- Stage 119 — Beta Feedback Capture
- Stage 120 — Preview-only Onboarding / Empty States
- Stage 121 — Admin Beta Console for Saved Workflows
- Stage 122 — Usage Limits / Cost Boundary UI
- Stage 123 — Auth / Workspace Boundary Decision
- Stage 124 — Private Beta Checkpoint

## Beta readiness improvements
Archive/delete saved records (118); safe mailto feedback (119); preview-only onboarding + empty states (120); operator admin console (121); no-billing/no-execution boundary copy (122); documented private/invite-only auth boundary (123).

## User-facing changes (`/projects/new/intake`)
Onboarding panel + preview-language legend; before-input empty state + secrets warning; "Beta usage boundary" panel + "no billing active" note; Saved workflow plans with Show-archived toggle + per-record Open/Archive/Restore/Delete (delete confirmed) + tenant-scope/retention/usage notes; feedback links opening `mailto` with safe context only.

## Admin/operator changes (`/admin/workflows`)
Admin-key input (not stored), userKey/status filters + include-archived, summary cards, per-record archive/restore/delete. Summaries only (no snapshot JSON). Disclaimers: userKey = tenant scoping not full auth; counts = activity signals not billing metrics.

## Auth / tenant boundary
Records scoped by existing client-supplied `userKey`; cross-userKey list/detail/PATCH/DELETE blocked (cross-tenant detail → 404). Admin gated by `x-admin-key` (`ADMIN_USAGE_STATS_KEY`). **Tenant scoping, not full account auth.** Private beta stays invite/manual. Real auth deferred (Stage 123).

## Usage / cost boundary
Deterministic low-cost previews; lightweight snapshots; **no agent/benchmark/LLM execution, no billing/enforcement**. Copy avoids active-billing language (verified).

## Surfaces changed (22 files, +2107/-57)
central-plane workflow route/db/test; dashboard libs (workspace-agent-workflow-api, admin-agent-workflows-api, beta-feedback, beta-onboarding, beta-usage-boundary) + tests; intake page; admin/workflows page; docs 118–123.

## Surfaces intentionally unchanged
apps/simsa-landing, apps/simsa-dev, .github/workflows, packages/**, billing/payment, domain/DNS, **migrations (none added)**, auth provider/session, internal `@conclave-ai/*` namespace, existing `/projects/new` flow. Audited — none changed.

## Verification (HEAD d804dcf code; doc-only commit on top)
central-plane **1181/1181** · dashboard **333/333** · monorepo `turbo run typecheck` **56/56** · dashboard build green (`/projects/new/intake` 22.5 kB, `/admin/workflows` 2.59 kB). Migration audit: **none**. Secret scan over changed files: **no sensitive literals**.

## Known warnings
Only the pre-existing `export/page.tsx` exhaustive-deps warning. Non-blocking.

## Production deploy implications
Changes central-plane code (`PATCH`/`DELETE /workspace/agent-workflows/:id`, `GET includeArchived`, admin endpoints) → dashboard-only deploy is **not** sufficient. **No D1 migration needed.** Full rollout = central-plane deploy → dashboard deploy.

## Rollout options
- **A** Merge only (improvements not live).
- **B** Merge + dashboard only — not recommended (UI calls non-live routes).
- **C** Merge + central-plane deploy + dashboard deploy + smoke — **recommended** (no migration).
- **D** Hold PR open (if blockers).

## Smoke plan
Saved workflow management (list/archive/hide/restore/delete + cross-userKey blocked); onboarding/usage panels + feedback mailto safe context; admin `/admin/workflows` (key required, summaries only, filters, archive/restore/delete); regression (app.trysimsa.com, /projects/new, trysimsa.com, /demo, simsa.dev, conclave-dashboard.vercel.app unchanged).

## Rollback plan
central-plane fail → roll back Worker, don't deploy dashboard. dashboard fail → roll back dashboard (central-plane may remain). admin/archive issue → roll back central-plane (+ save-mgmt UI). **No migration rollback** (none introduced).

## Risks
Admin shows cross-userKey **summaries** (no snapshot JSON; admin-key gated) · admin key = shared secret not RBAC (documented) · hard delete (confirm + archive alternative) · userKey = tenant scoping not auth (invite-only beta) · dashboard depends on central-plane (Option C deploys backend first) · copy must not overclaim (tests enforce).

## Recommendation
**READY TO MERGE + CONTROLLED ROLLOUT** (Option C: merge → central-plane → dashboard → smoke; apply-migrations can be false) pending Bae review. Merge / deploy **not executed**.