### PR TITLE
Stage 154~159 — MCP Private Dogfood Evidence / Claude Desktop App QA

### DIFF
--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -5,6 +5,7 @@
 // only — no backend, no model call, no external fetch. Future stages wire real
 // per-type analysis behind the same model.
 import { useMemo, useState } from "react";
+import { useI18n } from "@/i18n/I18nProvider";
 import {
   WORKSPACE_INTAKE_TYPES,
   INTAKE_META,
@@ -94,6 +95,8 @@ import { buildAgentToolRecommendationMemoryView } from "@/lib/agent-tool-recomme
 import { buildTemplateEffectivenessSignalsView } from "@/lib/template-effectiveness-signals.mjs";
 
 export default function IntakePage() {
+  // Stage 159 — dictionary-first i18n for the MCP handoff/intake destination.
+  const { t: tr } = useI18n();
   const [type, setType] = useState<WorkspaceIntakeType | null>(null);
   const [rawInput, setRawInput] = useState("");
   const [draft, setDraft] = useState<WorkspaceIntakeDraft | null>(null);
@@ -387,14 +390,14 @@ export default function IntakePage() {
     <div className="flex flex-1 justify-center px-4 py-12">
       <div className="w-full max-w-2xl">
         <h1 className="text-2xl font-semibold tracking-tight text-gray-900">
-          What do you want Simsa to review?
+          {tr.intake.handoff.title}
         </h1>
         <p className="mt-2 text-sm text-gray-500">
-          Start from anything. Simsa turns it into a staged acceptance workflow.
+          {tr.intake.handoff.subtitle}
         </p>
         {/* Stage 119 — page-level beta feedback CTA */}
         <p className="mt-2 text-xs text-gray-400">
-          <FeedbackLink label="Share beta feedback" context={{ section: "Intake workflow" }} />{" "}
+          <FeedbackLink label={tr.intake.handoff.feedbackLabel} context={{ section: "Intake workflow" }} />{" "}
           — {BETA_SAFETY_NOTES.feedback}
         </p>
 
@@ -415,7 +418,7 @@ export default function IntakePage() {
           </p>
 
           {/* Stage 120 — preview language legend */}
-          <p className="mt-4 text-xs font-medium text-gray-500">Preview language</p>
+          <p className="mt-4 text-xs font-medium text-gray-500">{tr.intake.handoff.previewLanguageLabel}</p>
           <dl className="mt-1 space-y-1">
             {PREVIEW_LANGUAGE_ITEMS.map((item) => (
               <div key={item.term} className="text-xs text-gray-600">
@@ -458,10 +461,10 @@ export default function IntakePage() {
                 }`}
               >
                 <span className="block text-sm font-medium text-gray-900">
-                  {m.label}
+                  {tr.intake.startPoints[t]?.label ?? m.label}
                 </span>
                 <span className="mt-0.5 block text-xs text-gray-500">
-                  {m.description}
+                  {tr.intake.startPoints[t]?.description ?? m.description}
                 </span>
               </button>
             );
@@ -477,7 +480,7 @@ export default function IntakePage() {
         {meta && (
           <div className="mt-8">
             <label className="mb-2 block text-sm font-medium text-gray-900">
-              Paste what you have.
+              {tr.intake.handoff.pasteLabel}
             </label>
             <p className="text-xs text-gray-400">{meta.inputHint}</p>
             {/* Stage 120 — before-input beta safety note */}

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -1226,6 +1226,44 @@ export type Dictionary = {
     timelineTruncated: string;
   };
   errors: { generic: string; loadFailed: string };
+  intake: {
+    handoff: {
+      eyebrow: string;
+      title: string;
+      subtitle: string;
+      pasteLabel: string;
+      previewLanguageLabel: string;
+      feedbackLabel: string;
+      previewOnly: string;
+      notSaved: string;
+      safetyNote: string;
+    };
+    startPoints: {
+      idea: { label: string; description: string };
+      prd: { label: string; description: string };
+      product_url: { label: string; description: string };
+      github_repo: { label: string; description: string };
+      pull_request: { label: string; description: string };
+      ai_built_app: { label: string; description: string };
+    };
+    previewKinds: {
+      acceptance_map: string;
+      stage_plan: string;
+      evidence_plan: string;
+      agent_run_plan: string;
+      acceptance_graph_summary: string;
+      recurring_blockers: string;
+      agent_tool_memory: string;
+      template_signals: string;
+    };
+    boundaries: {
+      requiresPaymentFalse: string;
+      mutatesStateFalse: string;
+      usesHostedExecutionFalse: string;
+      createsPersistenceFalse: string;
+      containsSecretsFalse: string;
+    };
+  };
 };
 
 export const LOCALES: Locale[];

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -1284,6 +1284,45 @@ const EN = {
     generic: "Something went wrong. Please try again.",
     loadFailed: "Could not load. Please try again.",
   },
+  // Stage 159 — MCP handoff/intake destination (the page the MCP handoff link opens).
+  intake: {
+    handoff: {
+      eyebrow: "MCP Basic",
+      title: "What do you want Simsa to review?",
+      subtitle: "Start from anything. Simsa turns it into a staged acceptance workflow.",
+      pasteLabel: "Paste what you have.",
+      previewLanguageLabel: "Preview language",
+      feedbackLabel: "Share beta feedback",
+      previewOnly: "Preview only",
+      notSaved: "Not saved",
+      safetyNote: "Deterministic local preview only — nothing is saved, no payment, no code is run.",
+    },
+    startPoints: {
+      idea: { label: "Idea", description: "Start from a raw product idea." },
+      prd: { label: "PRD / spec", description: "Turn an existing product document into acceptance items." },
+      product_url: { label: "Product URL", description: "Review an existing product surface." },
+      github_repo: { label: "GitHub repo", description: "Understand an existing codebase." },
+      pull_request: { label: "Pull request", description: "Review a proposed change." },
+      ai_built_app: { label: "AI-built app", description: "Recover and structure a vibe-coded draft." },
+    },
+    previewKinds: {
+      acceptance_map: "Acceptance map",
+      stage_plan: "Stage plan",
+      evidence_plan: "Evidence plan",
+      agent_run_plan: "Agent run plan",
+      acceptance_graph_summary: "Acceptance graph summary",
+      recurring_blockers: "Recurring blockers",
+      agent_tool_memory: "Agent/tool memory",
+      template_signals: "Template signals",
+    },
+    boundaries: {
+      requiresPaymentFalse: "No payment",
+      mutatesStateFalse: "Nothing is saved",
+      usesHostedExecutionFalse: "No hosted execution",
+      createsPersistenceFalse: "No data persisted",
+      containsSecretsFalse: "No secrets",
+    },
+  },
 };
 
 const KO = {
@@ -2546,6 +2585,45 @@ const KO = {
   errors: {
     generic: "문제가 발생했어요. 다시 시도해주세요.",
     loadFailed: "불러오지 못했어요. 다시 시도해주세요.",
+  },
+  // Stage 159 — MCP 핸드오프/인테이크 도착 화면. Product term은 영어 유지 + 한국어 보조.
+  intake: {
+    handoff: {
+      eyebrow: "MCP Basic",
+      title: "Simsa로 무엇을 검토하시겠어요?",
+      subtitle: "무엇이든 시작하세요. Simsa가 단계별 수용 기준 워크플로로 만들어 드립니다.",
+      pasteLabel: "가지고 있는 내용을 붙여넣으세요.",
+      previewLanguageLabel: "미리보기 용어",
+      feedbackLabel: "베타 피드백 보내기",
+      previewOnly: "미리보기 전용 (Preview only)",
+      notSaved: "저장되지 않음 (Not saved)",
+      safetyNote: "결정론적 로컬 미리보기 전용입니다 — 저장·결제·코드 실행이 없습니다.",
+    },
+    startPoints: {
+      idea: { label: "Idea (아이디어)", description: "원시 제품 아이디어에서 시작합니다." },
+      prd: { label: "PRD / spec (기획서)", description: "기존 제품 문서를 수용 기준 항목으로 변환합니다." },
+      product_url: { label: "Product URL (제품 URL)", description: "기존 제품 화면을 검토합니다." },
+      github_repo: { label: "GitHub repo (깃허브 저장소)", description: "기존 코드베이스를 파악합니다." },
+      pull_request: { label: "Pull request (PR)", description: "제안된 변경을 검토합니다." },
+      ai_built_app: { label: "AI-built app (AI로 만든 앱)", description: "바이브 코딩 초안을 복구·구조화합니다." },
+    },
+    previewKinds: {
+      acceptance_map: "Acceptance map (수용 기준 지도)",
+      stage_plan: "Stage plan (단계 계획)",
+      evidence_plan: "Evidence plan (검증 증거 계획)",
+      agent_run_plan: "Agent run plan (에이전트 실행 계획)",
+      acceptance_graph_summary: "Acceptance graph summary (수용 그래프 요약)",
+      recurring_blockers: "Recurring blockers (반복 블로커)",
+      agent_tool_memory: "Agent/tool memory (에이전트·도구 메모리)",
+      template_signals: "Template signals (템플릿 신호)",
+    },
+    boundaries: {
+      requiresPaymentFalse: "결제 없음",
+      mutatesStateFalse: "저장되지 않음",
+      usesHostedExecutionFalse: "호스티드 실행 없음",
+      createsPersistenceFalse: "데이터 영속 없음",
+      containsSecretsFalse: "비밀정보 없음",
+    },
   },
 };
 

--- a/conclave-builder-pack/out/stage-154-claude-desktop-dogfood-evidence-intake.md
+++ b/conclave-builder-pack/out/stage-154-claude-desktop-dogfood-evidence-intake.md
@@ -1,0 +1,180 @@
+# Stage 154 — Claude Desktop App-side Dogfood Evidence Intake
+
+**Date:** 2026-06-24
+**Branch:** `docs/stage-154-claude-desktop-dogfood-evidence` (Stage 154~159 train) · **Base:** `main` @ `de6f7e6`
+**Type:** evidence intake (docs-only). **No publish, no version bump, no payment/Stripe, no hosted execution, no central-plane, no migration, no deploy, no auth.**
+
+This stage adds **no product functionality**. It packages an evidence-intake kit so Bae
+can run the **actual Claude Desktop app-side** dogfood of Simsa MCP Basic and record
+the result. Until Bae runs it, app-side status stays **Status B (pending)** — success
+is **not** claimed.
+
+## 1. Goal
+Prepare and capture Claude Desktop app-side dogfood evidence: a step-by-step operator
+checklist, safe test prompts, a reusable evidence template, pass/fail criteria,
+classification statuses, and redaction/safety rules.
+
+## 2. Current MCP Basic state
+- MCP Basic **9 tools** registered in the server runtime; Basic-only mode works without
+  credentials (merged Stage 141~147, main `de6f7e6`).
+- Terminal `smoke:basic`, real-process `smoke:basic:stdio`, and `qa:basic-tools` all
+  pass (Stage 150~151).
+- Troubleshooting/operator docs ready (Stage 152).
+- **Claude Desktop app-side evidence: pending.** MCP package remains **unpublished**.
+
+## 3. Local pre-check results (this checkout, terminal)
+- `build` ✓
+- `smoke:basic` → exit 0 (mode basic_only, 9 tools, network/credentials not required)
+- `smoke:basic:stdio` → exit 0 (initialize ok, 9 tools, 3 tool calls)
+- `qa:basic-tools` → exit 0 (9 tools + chaining + malformed + sensitive omission)
+- `print:claude-desktop-basic-config` → prints a valid Basic-only config with
+  `command:"node"`, the absolute path to `dist/index.js`, and **`env: {}`** — **no
+  credentials printed**.
+
+## 4. Claude Desktop operator checklist (for Bae)
+1. Pull the latest `main` (or this Stage 154 branch).
+2. Run `pnpm install` if dependencies changed.
+3. `pnpm --filter @conclave-ai/mcp-workspace build`.
+4. `pnpm --filter @conclave-ai/mcp-workspace smoke:basic` (expect exit 0, 9 tools).
+5. `pnpm --filter @conclave-ai/mcp-workspace smoke:basic:stdio` (expect exit 0).
+6. `pnpm --filter @conclave-ai/mcp-workspace qa:basic-tools` (expect exit 0).
+7. `pnpm --filter @conclave-ai/mcp-workspace print:claude-desktop-basic-config`.
+8. Copy the generated `simsa-basic` config.
+9. Add it to Claude Desktop's MCP/server configuration.
+10. Keep `env` **empty** for Basic-only mode.
+11. **Restart** Claude Desktop.
+12. Open a **new** chat.
+13. Confirm the Simsa Basic tools are visible or callable.
+14. Confirm **no credential prompt** appears.
+15. Confirm **connected tools do not appear** in Basic-only mode.
+16. Run the safe prompts (§6).
+17. Capture evidence using the template (§7).
+18. Redact paths or local usernames if sharing screenshots.
+19. Do **not** paste real tokens / private code.
+
+## 5. Local config guidance
+Generate the per-machine config (resolves the absolute path automatically; never
+writes the host file):
+```bash
+pnpm --filter @conclave-ai/mcp-workspace print:claude-desktop-basic-config
+```
+It prints (path shown here as a placeholder; the helper inserts your real absolute path):
+```json
+{
+  "mcpServers": {
+    "simsa-basic": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/TO/conclave-ai/packages/mcp-workspace/dist/index.js"],
+      "env": {}
+    }
+  }
+}
+```
+> The exact Claude Desktop settings location or config file path may vary by OS and
+> Claude Desktop version. Add a server entry equivalent to the JSON above in that
+> host's MCP configuration file.
+
+## 6. Safe test prompts (no private data)
+Scenario:
+> Build a small landing page for an AI software review tool. It should explain the
+> product, show three use cases, and include a request-access form.
+
+1. `Use Simsa Basic to create an acceptance map for this product idea: "<scenario>"`
+2. `Use Simsa Basic to create a stage plan from the same idea.`
+3. `Use Simsa Basic to create an agent run plan from the same idea.`
+4. `Use Simsa Basic to create an evidence plan from the same idea.`
+5. `Use Simsa Basic to create a Simsa Web App handoff link for this preview.`
+
+Expected: preview responses appear; boundary metadata appears or is inferable;
+`requiresPayment:false`, `mutatesState:false`, `usesHostedExecution:false`; handoff URL
+starts with `https://app.trysimsa.com/projects/new/intake`; no credentials requested;
+no connected/risky tools exposed.
+
+## 7. Evidence template
+```text
+# Claude Desktop App-side Dogfood Evidence
+
+Date/time:
+Tester:
+OS:
+Claude Desktop version:
+Node version:
+Repo commit:
+Branch:
+Build result:
+smoke:basic result:
+smoke:basic:stdio result:
+qa:basic-tools result:
+Config helper result:
+Config method:
+Server path redacted: yes/no
+Claude Desktop restarted: yes/no
+
+Tool discovery:
+- Simsa Basic tools visible/callable: yes/no
+- Number of Simsa Basic tools observed:
+- Connected tools observed in Basic-only mode: yes/no
+- run_pr_review observed: yes/no
+- post_pr_comment observed: yes/no
+- Credential prompt shown: yes/no
+
+Prompt results:
+1. acceptance map:
+2. stage plan:
+3. agent run plan:
+4. evidence plan:
+5. handoff link:
+
+Boundary checks:
+- requiresPayment false observed: yes/no/unclear
+- mutatesState false observed: yes/no/unclear
+- usesHostedExecution false observed: yes/no/unclear
+- handoff createsPersistence false observed: yes/no/unclear
+- handoff containsSecrets false observed: yes/no/unclear
+
+Errors/warnings:
+Screenshots or text snippets captured:
+Redactions applied:
+Pass/fail:
+Notes:
+```
+
+## 8. Pass/fail criteria
+**Pass:** Claude Desktop recognizes the local `simsa-basic` server; Simsa Basic tools
+are visible/callable; at least acceptance map, stage plan, evidence plan, and handoff
+link work; no credentials required; no connected/risky tools visible in Basic-only
+mode; no secret/private input captured.
+
+**Fail / blocker:** Claude Desktop can't start the local server; tools don't appear;
+tool calls fail consistently; Basic-only asks for `CONCLAVE_USER_KEY`; `run_pr_review`
+or `post_pr_comment` appears in Basic-only mode; handoff leaks sensitive data;
+payment/Stripe/hosted execution appears.
+
+## 9. Evidence classification
+- **Status A — passed:** Bae's evidence shows simsa-basic recognized, ≥4 preview tools
+  callable, handoff works, no credential prompt, no connected/risky tools, no
+  secrets/private code captured.
+- **Status B — intake prepared, manual run pending:** this stage's state (checklist +
+  template ready; Bae has not yet run the app-side test).
+- **Status C — blocked:** app-side config cannot start or tools cannot be discovered.
+
+**Current status: B — evidence intake prepared, manual app-side run pending.**
+
+## 10. Redaction and safety rules
+- Do not paste real tokens into prompts.
+- Do not paste private customer code; do not capture private repo contents.
+- Redact local usernames / absolute paths if sharing screenshots.
+- Keep Basic-only `env` empty.
+- Do not add `CONCLAVE_USER_KEY` unless intentionally testing connected mode in a later stage.
+- Do not enable `post_pr_comment`.
+- Do not publish the package.
+
+## 11. Stage 154 decision
+**Option A — Evidence intake ready.** The Claude Desktop evidence-intake package
+(checklist + config helper + prompts + template + criteria + redaction rules) is ready;
+Bae can run the manual app-side dogfood. App-side evidence remains **Status B (pending)**.
+
+## 12. Recommended next stage
+**Stage 155 — Record Bae Claude Desktop App-side Evidence** (paste Bae's completed
+evidence template into a recorded artifact, classify Status A/C, and note any
+follow-ups). **Do not merge** the train PR until the Stage 159 checkpoint + Bae approval.

--- a/conclave-builder-pack/out/stage-155-claude-desktop-app-evidence-record.md
+++ b/conclave-builder-pack/out/stage-155-claude-desktop-app-evidence-record.md
@@ -1,0 +1,135 @@
+# Stage 155 — Claude Desktop App-side Evidence Record
+
+**Date:** 2026-06-24
+**Branch:** `docs/stage-154-claude-desktop-dogfood-evidence` (Stage 154~159 train, PR #153) · **Base:** `main` @ `de6f7e6`
+**Type:** evidence record (docs-only). **No publish, no version bump, no payment/Stripe, no hosted execution, no central-plane, no migration, no deploy, no auth.**
+
+This is the durable record where Bae's actual Claude Desktop app-side evidence is
+captured. Until that evidence is supplied, the record is honestly marked **Pending** —
+Claude Desktop success is **not** claimed.
+
+## 1. Goal
+Provide a reusable, durable evidence record for the Claude Desktop app-side dogfood,
+define the bar to move from Pending → Passed (Status A) or → Blocked (Status C), and
+record the current status honestly.
+
+## 2. Current evidence status
+**Status B — Evidence intake prepared, manual app-side run pending.**
+
+Terminal-side evidence is complete; Claude Desktop **app-side** evidence has not been
+recorded yet. This will only change to Status A or C when Bae supplies actual app-side
+evidence in §9.
+
+## 3. What has been verified by terminal
+On `main`/this branch (HEAD of the train), re-verified this stage:
+- `build` ✓
+- `smoke:basic` → exit 0 (mode basic_only, 9 tools, network/credentials not required)
+- `smoke:basic:stdio` → exit 0 (real process: initialize, tools/list = 9, 3 tool calls)
+- `qa:basic-tools` → exit 0 (9 tools + snapshot chaining + malformed + sensitive omission)
+- `print:claude-desktop-basic-config` → valid Basic-only config (empty `env`, no credentials)
+- mcp-workspace tests **74/74**, monorepo typecheck **57/57**
+
+## 4. What remains manual
+Only Bae can record these (GUI, not driveable from this terminal):
+- actual Claude Desktop app **restart** after adding the `simsa-basic` entry
+- actual app-side **tool discovery** (the Simsa Basic tools appearing in the app)
+- actual app-side **tool call output** (preview + handoff responses in the app)
+- absence of a **credential prompt** and of **connected/risky tools** in the app UI
+
+## 5. Evidence required for Status A (passed)
+Recorded evidence that:
+- Claude Desktop recognizes the local `simsa-basic` server.
+- Simsa Basic tools are visible or callable.
+- At least **4** Basic tools are successfully invoked: `preview_acceptance_map`,
+  `preview_stage_plan`, `preview_evidence_plan`, `create_web_app_handoff_link`.
+- **No credential prompt** appears in Basic-only mode.
+- Connected/risky tools are **not** visible; `run_pr_review` **not** visible;
+  `post_pr_comment` **not** visible.
+- Handoff link starts with `https://app.trysimsa.com/projects/new/intake`.
+- No real token / private code / customer-confidential data is captured.
+
+## 6. Evidence that triggers Status C (blocked)
+- Claude Desktop cannot start the local MCP server.
+- `simsa-basic` does not appear after restart.
+- Tool discovery fails, or tool calls consistently fail.
+- Basic-only mode asks for `CONCLAVE_USER_KEY`.
+- Connected/risky tools appear in Basic-only mode (`run_pr_review` / `post_pr_comment`).
+- Handoff leaks sensitive data.
+- Payment / Stripe / hosted execution appears.
+
+## 7. Evidence template
+(Use the "Evidence template for Bae" in §8; mirrors the Stage 154 intake template.)
+
+## 8. Redaction checklist
+Before sharing evidence, redact:
+- local usernames in absolute paths
+- private repo names if needed
+- screenshots containing unrelated private chats
+- tokens · keys · private customer code · confidential customer data · real
+  authorization headers
+
+Do not share secrets of any kind.
+
+## 9. Current recorded evidence
+
+**Status: Pending**
+
+No Bae app-side evidence has been supplied in this stage yet.
+
+### Evidence template for Bae
+```text
+Date/time:
+Tester:
+OS:
+Claude Desktop version:
+Node version:
+Repo commit:
+Branch:
+Build result:
+smoke:basic result:
+smoke:basic:stdio result:
+qa:basic-tools result:
+Config helper result:
+Config method:
+Server path redacted: yes/no
+Claude Desktop restarted: yes/no
+
+Tool discovery:
+- Simsa Basic tools visible/callable: yes/no
+- Number of Simsa Basic tools observed:
+- Connected tools observed in Basic-only mode: yes/no
+- run_pr_review observed: yes/no
+- post_pr_comment observed: yes/no
+- Credential prompt shown: yes/no
+
+Prompt results:
+1. acceptance map:
+2. stage plan:
+3. agent run plan:
+4. evidence plan:
+5. handoff link:
+
+Boundary checks:
+- requiresPayment false observed: yes/no/unclear
+- mutatesState false observed: yes/no/unclear
+- usesHostedExecution false observed: yes/no/unclear
+- handoff createsPersistence false observed: yes/no/unclear
+- handoff containsSecrets false observed: yes/no/unclear
+
+Errors/warnings:
+Screenshots or text snippets captured:
+Redactions applied:
+Pass/fail:
+Notes:
+```
+
+## 10. Stage 155 decision
+**Option A — Evidence record created, app-side evidence pending.** The record is ready;
+Claude Desktop app-side status remains **Status B — prepared, pending Bae manual run**.
+Publish stays held.
+
+## 11. Recommended next stage
+**Stage 156 — Claude Desktop Evidence Review / Gap Analysis** (once Bae fills §9: review
+the evidence against the Status A bar, flag any gaps/blockers, and decide whether the
+dogfood is complete enough to inform a publish-readiness decision at Stage 159).
+**Do not merge** the train PR until the Stage 159 checkpoint + Bae approval.

--- a/conclave-builder-pack/out/stage-155-claude-desktop-app-evidence-record.md
+++ b/conclave-builder-pack/out/stage-155-claude-desktop-app-evidence-record.md
@@ -72,7 +72,14 @@ Do not share secrets of any kind.
 
 ## 9. Current recorded evidence
 
-**Status: Pending**
+> **Superseded by Stage 157 (2026-06-24):** Bae subsequently supplied actual Claude
+> Desktop app-side evidence (acceptance map / stage plan / evidence plan / handoff link
+> succeeded; no credential prompt; no `run_pr_review` / `post_pr_comment` exposure). The
+> app-side status is now **Status A (with caveats)** — see
+> `stage-157-claude-desktop-evidence-update-mcp-branding-gap.md`. The Pending slot below
+> reflects the original state of this stage.
+
+**Status: Pending** *(original; see supersede note above)*
 
 No Bae app-side evidence has been supplied in this stage yet.
 

--- a/conclave-builder-pack/out/stage-156-claude-desktop-evidence-review-gap-analysis.md
+++ b/conclave-builder-pack/out/stage-156-claude-desktop-evidence-review-gap-analysis.md
@@ -1,0 +1,106 @@
+# Stage 156 — Claude Desktop Evidence Review / Gap Analysis
+
+**Date:** 2026-06-24
+**Branch:** `docs/stage-154-claude-desktop-dogfood-evidence` (Stage 154~159 train, PR #153) · **Base:** `main` @ `de6f7e6`
+**Type:** evidence review / gap analysis (docs-only). **No publish, no version bump, no payment/Stripe, no hosted execution, no central-plane, no migration, no deploy, no auth.**
+
+This stage provides the structure to **review** Bae's Claude Desktop app-side evidence
+against the Status A bar and to **enumerate the exact gaps** while it is pending. No
+app-side success is claimed.
+
+## 1. Goal
+Define how to review Bae's Claude Desktop evidence, score each requirement
+(PASS/PENDING/BLOCKED/NOT_APPLICABLE), map current evidence to the Status A
+requirements, identify missing gaps, and attach a remediation playbook — keeping MCP
+publish held.
+
+## 2. Current evidence status
+**Status B — Evidence intake prepared, manual app-side run pending.** No Bae app-side
+evidence has been supplied; terminal evidence is complete but **does not** replace
+actual Claude Desktop app-side evidence.
+
+## 3. Review method
+When Bae fills the Stage 155 §9 template, score each row of the §4 matrix:
+- **PASS** — evidence supplied and meets the requirement.
+- **PENDING** — evidence not yet supplied.
+- **BLOCKED** — evidence supplied and shows failure.
+- **NOT_APPLICABLE** — not required for Basic-only dogfood.
+
+Any **BLOCKED** row → classify the run Status C and route to the matching gap
+category (§6) + remediation (§7). All app-side rows PASS (and no BLOCKED) → Status A.
+No numeric scores.
+
+## 4. Evidence requirements matrix
+| # | Requirement | Evidence needed | Current evidence | Status | Gap | Remediation |
+|---|-------------|-----------------|------------------|--------|-----|-------------|
+| 1 | Claude Desktop recognizes local `simsa-basic` | server appears in host MCP list after restart | none supplied | **PENDING** | G1 | Bae runs Stage 154 template |
+| 2 | Basic tools visible/callable | tool list or successful call in app | none | **PENDING** | G1 | Bae runs template |
+| 3 | 9 Basic tools observed (or equivalent call access) | tool count / callable set | none | **PENDING** | G1 | Bae runs template |
+| 4 | `preview_acceptance_map` app-side call succeeds | app response (kind acceptance_map) | none | **PENDING** | G1 | Bae runs template |
+| 5 | `preview_stage_plan` app-side call succeeds | app response (kind stage_plan) | none | **PENDING** | G1 | Bae runs template |
+| 6 | `preview_evidence_plan` app-side call succeeds | app response (kind evidence_plan) | none | **PENDING** | G1 | Bae runs template |
+| 7 | `create_web_app_handoff_link` app-side call succeeds | app response (kind web_app_handoff_link) | none | **PENDING** | G1 | Bae runs template |
+| 8 | Handoff URL starts with `https://app.trysimsa.com/projects/new/intake` | URL in app output | none | **PENDING** | G1 | Bae runs template |
+| 9 | No credential prompt in Basic-only mode | observation/screenshot | none | **PENDING** | G1/G4 | Bae runs template; if prompted → G4 |
+| 10 | Connected tools not visible in Basic-only | tool list observation | none | **PENDING** | G1/G5 | Bae runs template; if visible → G5 |
+| 11 | `run_pr_review` not visible | tool list observation | none | **PENDING** | G1/G5 | as above |
+| 12 | `post_pr_comment` not visible | tool list observation | none | **PENDING** | G1/G5 | as above |
+| 13 | No token/private code/confidential data captured | redaction confirmation | none | **PENDING** | G1 | Bae runs template + redaction checklist |
+| 14 | Boundary metadata visible or inferable | app output / inferred from tool kind | none | **PENDING** | G1 | Bae runs template |
+| 15 | Errors/warnings recorded | template fields | none | **PENDING** | G1/G8 | Bae records OS/Node/CD version + non-secret errors |
+
+Terminal cross-reference (already PASS, for comparison, **not** a substitute for
+app-side rows): `smoke:basic`, `smoke:basic:stdio` (initialize + tools/list = 9 +
+3 calls), `qa:basic-tools` (9 tools + chaining + malformed + sensitive omission), all
+exit 0; `print:claude-desktop-basic-config` emits a valid Basic-only config (empty
+`env`, no credentials).
+
+## 5. Current gap analysis
+App-side evidence status remains **Status B — prepared, pending Bae manual run**.
+Terminal evidence is complete, but it does not replace actual Claude Desktop app-side
+evidence. Open gaps (all **G1 — missing app-side evidence**):
+- Pending: app **restart** evidence
+- Pending: app-side **tool discovery** evidence
+- Pending: app-side **tool-call** evidence (items 4–8)
+- Pending: **credential prompt absence** evidence
+- Pending: **connected/risky tool absence** evidence (items 10–12)
+
+## 6. Gap categories
+- **G1** — Missing app-side evidence
+- **G2** — Tool discovery issue
+- **G3** — Tool call issue
+- **G4** — Credential/env leak
+- **G5** — Connected/risky tool exposure
+- **G6** — Handoff/sensitive-data issue
+- **G7** — Documentation/operator confusion
+- **G8** — Host/version/environment issue
+
+## 7. Remediation playbook
+- **G1:** Bae runs the Claude Desktop dogfood checklist and fills the evidence template.
+- **G2:** verify build, absolute path, config JSON, Claude Desktop restart, new chat/session.
+- **G3:** compare terminal stdio QA output with the app-side error, capture the exact
+  (non-secret) error text, test one tool at a time.
+- **G4:** remove `env` from the Basic-only config, restart the host, rerun.
+- **G5:** stop dogfood, inspect `env` and the registration plan — **publish blocker**.
+- **G6:** test with a safe synthetic prompt, verify `omittedFields`/`warnings` behavior,
+  do not force secret-like content into the URL.
+- **G7:** update README / troubleshooting docs before the checkpoint.
+- **G8:** record OS, Node version, Claude Desktop version, config method, exact
+  non-secret error.
+
+## 8. Publish readiness implication
+**MCP publish remains held.** Reasons: terminal stdio and tool-by-tool QA passed;
+private dogfood docs are ready; **Claude Desktop app-side evidence remains pending**.
+Public publish should not proceed until app-side evidence is **Status A**, or an
+explicit Bae override is recorded.
+
+## 9. Stage 156 decision
+**Option A — Gap analysis ready, app-side evidence pending.** The evidence review matrix
+is ready; Claude Desktop app-side status remains **Status B** with **G1
+missing-app-side-evidence** gaps. Publish held.
+
+## 10. Recommended next stage
+**Stage 157 — Claude Desktop Manual Evidence Pack / Operator Submission** (a clean,
+copy-ready submission pack Bae fills once and returns, which Stage 158 folds into the
+record and Stage 159 checkpoints). **Do not merge** the train PR until the Stage 159
+checkpoint + Bae approval.

--- a/conclave-builder-pack/out/stage-156-claude-desktop-evidence-review-gap-analysis.md
+++ b/conclave-builder-pack/out/stage-156-claude-desktop-evidence-review-gap-analysis.md
@@ -15,9 +15,16 @@ requirements, identify missing gaps, and attach a remediation playbook — keepi
 publish held.
 
 ## 2. Current evidence status
-**Status B — Evidence intake prepared, manual app-side run pending.** No Bae app-side
-evidence has been supplied; terminal evidence is complete but **does not** replace
-actual Claude Desktop app-side evidence.
+> **Superseded by Stage 157 (2026-06-24):** Bae then supplied actual app-side evidence;
+> the core flow is now **Status A (with caveats)** — see
+> `stage-157-claude-desktop-evidence-update-mcp-branding-gap.md`. The matrix below was
+> written while evidence was still pending; the review method, gap categories (G1–G8),
+> and remediation playbook remain valid for any future re-runs.
+
+**Status B — Evidence intake prepared, manual app-side run pending.** *(original state
+of this stage; see supersede note above.)* No Bae app-side evidence had been supplied;
+terminal evidence is complete but **does not** replace actual Claude Desktop app-side
+evidence.
 
 ## 3. Review method
 When Bae fills the Stage 155 §9 template, score each row of the §4 matrix:

--- a/conclave-builder-pack/out/stage-157-claude-desktop-evidence-update-mcp-branding-gap.md
+++ b/conclave-builder-pack/out/stage-157-claude-desktop-evidence-update-mcp-branding-gap.md
@@ -1,0 +1,99 @@
+# Stage 157 — Claude Desktop Evidence Update / MCP Display Branding Gap
+
+**Date:** 2026-06-24
+**Branch:** `docs/stage-154-claude-desktop-dogfood-evidence` (Stage 154~159 train, PR #153) · **Base:** `main` @ `de6f7e6`
+**Type:** evidence update + local config branding. **No publish, no version bump, no payment/Stripe, no hosted execution, no central-plane, no migration, no deploy, no auth.**
+
+## 1. Goal
+Record Bae's **actual** Claude Desktop app-side dogfood evidence as **passed** for the
+core MCP Basic flow, supersede the Stage 156 pending-only status, fix the local MCP
+display name (`simsa-basic` → `Simsa-Basic`), investigate custom-icon support, and
+record the Web App handoff English-hardcoding gap. Publish stays held.
+
+## 2. Correction to Stage 156 evidence status
+Stage 156 was written under the assumption that **no** Bae app-side evidence existed
+(Status B). That assumption is now **superseded**: Bae ran the Claude Desktop app-side
+dogfood and reported success for the core flow. This stage updates the classification.
+
+## 3. Bae app-side evidence summary
+Claude Desktop app-side Simsa Basic flow worked:
+- acceptance map generated successfully
+- stage plan generated successfully
+- evidence plan generated successfully
+- Simsa Web App handoff link generated successfully (URL starts with
+  `https://app.trysimsa.com/projects/new/intake`)
+- Basic-only preview behavior was shown
+- **no** credential / user-key prompt reported
+- **no** `run_pr_review` / `post_pr_comment` exposure reported
+
+New UX gaps reported by Bae:
+1. MCP server/display name appears as `simsa-basic`; desired display is **`Simsa-Basic`**.
+2. Icon appears as a generic "S"; desired branding improved **if** Claude Desktop supports it.
+3. Handoff destination in the Simsa Web App shows hardcoded **English** copy.
+
+## 4. Updated evidence classification
+**Status A — Claude Desktop app-side dogfood passed for the core MCP Basic flow, with
+branding and handoff UX gaps recorded.** This is **not** full public-publish readiness:
+core invocation worked inside Claude Desktop, but product-facing polish gaps remain
+(display name correction; icon capability unconfirmed; handoff English-hardcoded copy).
+
+## 5. MCP display name gap
+The generated local config used server key `simsa-basic`. The user-facing entry should
+read `Simsa-Basic`. This is **local MCP server display/config branding only** — the npm
+package, internal package, internal namespace, and `@conclave-ai/mcp-workspace` are
+**not** renamed.
+
+## 6. Config helper update
+`packages/mcp-workspace/scripts/print-claude-desktop-basic-config.mjs` now emits server
+key **`Simsa-Basic`** (command `node`, args → local `dist/index.js`, `env: {}`, no
+credentials, no config-file mutation). Tests
+(`test/print-claude-desktop-basic-config.test.mjs`) updated to assert the `Simsa-Basic`
+entry **and** that the old lowercase `simsa-basic` key is gone. README examples + the
+"Private Claude Desktop dogfood" and Troubleshooting references updated to `Simsa-Basic`
+with a note that internal package names are unchanged. Verified: generated config
+contains `"Simsa-Basic"` and no `"simsa-basic"` server key.
+
+## 7. Icon support investigation — **Icon Outcome B (not confirmed)**
+The local Claude Desktop config (`claude_desktop_config.json`) `mcpServers` entries are
+documented for `command` / `args` / `env` (stdio servers). A custom **icon** field for
+a local stdio MCP server entry is **not confirmed** in the config schema available here.
+Therefore **no icon configuration is implemented in this stage** — to avoid fabricating
+unsupported config. The **display name `Simsa-Basic`** is the branding lever used now;
+custom icon is tracked as a host-capability follow-up (revisit if/when a documented,
+supported field is confirmed).
+
+## 8. Web App handoff English hardcoding gap
+The MCP handoff link itself is valid and safe (correct URL prefix, sensitive fields
+omitted, persists nothing). However, the **receiving Simsa Web App** intake/handoff
+surface displays **hardcoded English copy** — a dashboard localization gap (the
+dashboard has an i18n system; this destination should honor it). This is a
+**dashboard** issue, not an MCP runtime issue.
+
+## 9. Impact classification
+- MCP runtime: **PASS**
+- Claude Desktop app-side core flow: **PASS**
+- Handoff URL safety: **PASS**
+- MCP display branding: **FIXED** (`Simsa-Basic`)
+- Custom icon: **follow-up** (host capability not confirmed)
+- Dashboard handoff localization: **GAP**
+- Korean beta/public readiness: **BLOCKED until the handoff copy is localized or
+  explicitly accepted**
+- MCP publish: **still held**
+
+## 10. Publish readiness implication
+**MCP publish remains held.** Core app-side flow passing is necessary but not
+sufficient: the dashboard handoff English-hardcoding gap blocks Korean beta/public
+readiness until fixed or explicitly accepted, and custom-icon branding is an open
+follow-up. No publish is recommended.
+
+## 11. Stage 157 decision
+**Option A — Evidence status updated and display branding fixed.** Claude Desktop core
+MCP app-side evidence is **Status A with caveats**; the `Simsa-Basic` display config is
+updated and verified; icon support is documented as **not confirmed** (Outcome B); the
+handoff English copy remains a dashboard UX gap routed to Stage 158.
+
+## 12. Recommended next stage
+**Stage 158 — Web App Handoff Localization / Korean UX Gap Inventory** (inventory the
+hardcoded English copy on the handoff/intake destination and plan the i18n fix, reusing
+the dashboard's existing dictionary-first i18n). **Do not merge** the train PR until the
+Stage 159 checkpoint + Bae approval.

--- a/conclave-builder-pack/out/stage-158-web-app-handoff-global-localization-gap-inventory.md
+++ b/conclave-builder-pack/out/stage-158-web-app-handoff-global-localization-gap-inventory.md
@@ -1,0 +1,133 @@
+# Stage 158 — Web App Handoff Global Localization / i18n Gap Inventory
+
+**Date:** 2026-06-24
+**Branch:** `docs/stage-154-claude-desktop-dogfood-evidence` (Stage 154~159 train, PR #153) · **Base:** `main` @ `de6f7e6`
+**Type:** inventory / planning (docs-only). **No publish, no version bump, no payment/Stripe, no hosted execution, no central-plane, no migration, no deploy, no auth.**
+
+## 1. Goal
+Inventory the hardcoded English copy on the Simsa Web App handoff/intake destination
+(the page the MCP handoff link opens) and plan a **global, dictionary-first** i18n fix
+that reuses the dashboard's existing i18n system. Publish stays held.
+
+## 2. Bae-reported gap
+The MCP handoff link works, but the receiving Simsa Web App intake/handoff page displays
+**hardcoded English** text.
+
+## 3. Why this is global i18n, not Korean-only
+Simsa targets global users. The fix is **not** to swap English for Korean — it is to
+remove hardcoded copy from the user-facing surface and route it through the existing
+dictionary system, with **English as the safe fallback**, **Korean as a required early
+locale**, and future languages added by **dictionary entries only** (no component
+rewrites). No machine translation / no translation API / no AI translation in this train.
+
+## 4. Handoff destination route
+- Handoff URL: `https://app.trysimsa.com/projects/new/intake` (built by
+  `@conclave-ai/workspace-preview` `buildWebAppHandoffLink`; `source=mcp_basic`).
+- Route file: **`apps/dashboard/src/app/projects/new/intake/page.tsx`** (`"use client"`,
+  **1899 lines**), plus its imported label modules `@/lib/intake.mjs`
+  (`INTAKE_META`, `INTAKE_OUTPUT_LABELS`) and the per-type/preview `lib/intake-*.mjs`
+  helpers it renders.
+
+## 5. Existing i18n/dictionary pattern (reusable — do NOT invent a second system)
+- `apps/dashboard/src/i18n/dictionary.mjs` — `LOCALES = ["en","ko"]`,
+  `DEFAULT_LOCALE = "en"`, `normalizeLocale`, `getDictionary(locale)` (falls back to en),
+  `readStoredLocale`/`writeStoredLocale` (localStorage key `conclave:locale`). Large
+  nested `EN`/`KO` dictionaries.
+- `apps/dashboard/src/i18n/I18nProvider.tsx` — client provider; `useI18n()` →
+  `{ locale, setLocale, t }`; SSR falls back to `DEFAULT_LOCALE`.
+- This is the same dictionary-first system that localized the rest of the dashboard
+  (Stage 59/60/63). **The architecture is sufficient.**
+
+## 6. Locale detection and propagation inventory
+- **Detection today:** `I18nProvider` reads locale from **localStorage only**. No
+  browser-language detection, **no route locale segment, no `?locale`/`?lang` query**,
+  no account locale setting. Fallback = en.
+- **Handoff link builder:** allowlists `source/intent/type/preview/previewId/title/
+  summary/utm_*` — **no `locale`/`lang` param**.
+- **Implication:** an MCP user's host language can't yet propagate to the Web App.
+  Recommend a **follow-up** (not this train): (1) intake page consumes `useI18n`;
+  (2) `I18nProvider` reads a safe `?locale=` query (normalized via `normalizeLocale`,
+  en fallback); (3) handoff builder allowlists a `locale` param (values `en`/`ko`…).
+  Do **not** add `locale` to the handoff builder until the Web App consumes it.
+
+## 7. Hardcoded copy inventory
+**Root finding:** `projects/new/intake/page.tsx` **does not import `useI18n` at all** —
+it is **100% hardcoded English**, and the dictionary has **no `intake:` namespace**.
+This is the one major dashboard surface that bypasses the i18n system (it was added in
+the Stage 101~108 Intake Train, after the Stage 63 full-i18n pass). Magnitude:
+**hundreds** of strings across the page + sub-sections.
+
+| File | UI surface | Hardcoded copy (examples) | Current behavior | i18n key proposal | en | ko | Priority | Fix stage |
+|------|-----------|---------------------------|------------------|-------------------|----|----|----------|-----------|
+| `intake/page.tsx` | page header / front door | "Intake workflow", start-point labels (`INTAKE_META`) | hardcoded | `intake.header.*`, `intake.startPoints.*` | keep | "인테이크 워크플로" | **P0** | Stage 159 |
+| `intake/page.tsx` | preview output headings | "Candidate user flows", "Candidate acceptance items", "Missing questions", "Review focus areas" | hardcoded | `intake.preview.*` | keep | 번역 | **P0** | Stage 159 |
+| `intake/page.tsx` | evidence plan section | "Candidate checks", "Evidence to collect", "Exit criteria" | hardcoded | `intake.evidence.*` | keep | 번역 | **P0** | Stage 159 |
+| `intake/page.tsx` | ai-built-app section | "Likely keep", "Likely fix", "Likely rebuild", "Needs verification", "Likely risks" | hardcoded | `intake.aiApp.*` | keep | 번역 | P1 | Stage 159 |
+| `intake/page.tsx` | graph/blocker/memory/template sections | "Inputs", "Acceptance items", section headers | hardcoded | `intake.graph.* / blockers.* / memory.* / template.*` | keep | 번역 | P1 | Stage 159 |
+| `intake/page.tsx` | beta feedback | "Share beta feedback" | hardcoded (FeedbackLink may already be i18n) | `intake.feedback.*` | keep | 번역 | P1 | Stage 159 |
+| `@/lib/intake.mjs` | `INTAKE_META`, `INTAKE_OUTPUT_LABELS` | type/output display labels | hardcoded constants (shared) | label-map via `t` (Stage 63 `(t,value)` helper pattern) | keep | 번역 | **P0** | Stage 159 |
+| `lib/intake-*.mjs` | per-type preview field labels | derived field titles | hardcoded in helpers | render-time map through `t`, keep helper data deterministic | keep | 번역 | P1 | Stage 159 |
+
+Priority key: **P0** = visible on the MCP handoff first screen; **P1** = visible after
+interaction/expansion; P2 = dev-only (none material here).
+
+## 8. Global copy policy recommendation — **Option G (global dictionary-first)**
+- Do **not** replace English hardcoding with Korean hardcoding.
+- Convert visible copy to dictionary keys (new `intake.*` namespace under `EN`/`KO`).
+- Maintain the English baseline; add Korean early-locale coverage for this surface.
+- Keep technical product terms consistent globally.
+- **Product terms kept in English** (optionally with a Korean gloss): Simsa, MCP Basic,
+  Acceptance map (수용 기준 지도), Stage plan (단계 계획), Evidence plan (검증 증거 계획),
+  Handoff (웹앱으로 넘기기), Preview only (미리보기 전용), Not saved (저장되지 않음).
+- Follow the established Stage 63 convention: keep `.mjs` helper **data** deterministic
+  and map enums/labels to copy at render time via a `(t, value)` helper, so label
+  modules stay testable under Node 20 CI.
+
+## 9. Initial locale recommendation
+- **Phase 1 (Stage 159):** `en` complete baseline + `ko` complete for the handoff/intake
+  surface; fallback `en`. (Matches current `LOCALES = ["en","ko"]`.)
+- **Phase 2 (future, dictionary-only):** add `ja, zh-CN, zh-TW, es, fr, de, pt, id, vi,
+  th, ar, hi` by adding dictionary entries (and `LOCALES`) — no component rewrites. Do
+  **not** add Phase 2 translations in this train; the Stage 158 output is the structure
+  + inventory, not full translation coverage.
+
+## 10. Fix plan (for Stage 159)
+1. Add an `intake.*` namespace to `EN` and `KO` in `dictionary.mjs` (+ `.d.mts` types),
+   covering P0 first, then P1.
+2. Make `intake/page.tsx` consume `useI18n()` and replace hardcoded strings with `t.intake.*`.
+3. Localize `INTAKE_META` / `INTAKE_OUTPUT_LABELS` / per-type labels via render-time `t`
+   maps (keep helper data deterministic).
+4. Add/extend i18n parity tests (en/ko key parity) and the dashboard i18n test.
+5. Verify with `pnpm --filter @conclave-ai/dashboard test/typecheck/build`; **no deploy**.
+6. (Deferred follow-up, not Stage 159 unless trivial) locale propagation: `?locale=`
+   consumption in `I18nProvider` + `locale` param in the handoff builder.
+
+## 11. Risk assessment
+- **Large surface (1899 lines):** convert in P0→P1 order; keep each change copy-only (no
+  route/data/API behavior change) to stay low-risk and reviewable.
+- **Shared label modules:** `intake.mjs` is shared (also re-exported via
+  `@conclave-ai/workspace-preview`); localize at the dashboard render layer, **not** by
+  hardcoding Korean into the shared deterministic helpers (would break MCP determinism +
+  Node-CI tests).
+- **KO parity drift:** enforce with en/ko key-parity tests (existing pattern).
+- **No new system:** reuse `useI18n`/dictionary — do not add a second i18n mechanism.
+
+## 12. Publish readiness implication
+**MCP publish remains held.** Claude Desktop core MCP flow passed; `Simsa-Basic` display
+name fixed; the handoff link itself is valid and safe — **but** the receiving Web App
+handoff/intake surface still has a global i18n readiness gap (100% hardcoded English).
+No public publish recommended until this surface is dictionary-first (Stage 159) or the
+gap is explicitly accepted for private dogfood only.
+
+## 13. Stage 158 decision
+**Option A — Inventory ready, global i18n fix deferred to Stage 159.** The existing
+dictionary-first i18n system is sufficient and reusable; this is a **coverage** gap (the
+intake page was never wired to `useI18n`), not an architecture gap. Stage 159 implements
+the dictionary-first `intake.*` localization (en baseline + ko), P0 first. Docs-only this
+stage; no dashboard code changed.
+
+## 14. Recommended next stage
+**Stage 159 — Web App Handoff Dictionary-first i18n Fix / Private Dogfood Checkpoint**
+(implement the `intake.*` localization for the handoff/intake surface, add en/ko parity
+tests, verify dashboard build; then the train checkpoint + merge/publish decision pending
+Bae approval). **Do not merge** the train PR until then.

--- a/conclave-builder-pack/out/stage-159-web-app-handoff-dictionary-i18n-fix-checkpoint.md
+++ b/conclave-builder-pack/out/stage-159-web-app-handoff-dictionary-i18n-fix-checkpoint.md
@@ -1,0 +1,107 @@
+# Stage 159 — Web App Handoff Dictionary-first i18n Fix / Private Dogfood Checkpoint
+
+**Date:** 2026-06-24
+**Branch:** `docs/stage-154-claude-desktop-dogfood-evidence` (PR #153) · **Base:** `main` @ `de6f7e6`
+**Type:** dashboard i18n fix + train checkpoint. **No publish, no version bump, no payment/Stripe, no hosted execution, no central-plane, no migration, no deploy, no auth.**
+
+## 1. Goal
+Implement a **dictionary-first** global i18n fix for the Simsa Web App handoff/intake
+destination (the page the MCP handoff link opens), then produce the private dogfood
+checkpoint for PR #153. Publish stays held.
+
+## 2. Stage 158 findings addressed
+Stage 158 found `apps/dashboard/src/app/projects/new/intake/page.tsx` (the handoff
+destination) did **not** use `useI18n` and the dictionary had **no `intake.*`
+namespace** → 100% hardcoded English (a coverage gap). Stage 159 wires the page to the
+existing dictionary-first system and adds `intake.*` (en + ko), reusing
+`src/i18n/dictionary.mjs` + `I18nProvider` (`LOCALES = ["en","ko"]`, en fallback). No
+second i18n system introduced.
+
+## 3. Implementation summary
+- `apps/dashboard/src/app/projects/new/intake/page.tsx`: import + `const { t: tr } =
+  useI18n();` (named `tr` to avoid shadowing the `WORKSPACE_INTAKE_TYPES.map((t) => …)`
+  callback param). Replaced the **P0 first-screen** copy with dictionary lookups:
+  page title (`tr.intake.handoff.title`), subtitle, the "Paste what you have." label,
+  the "Preview language" label, the beta-feedback CTA label, and the **start-point
+  buttons** (`tr.intake.startPoints[t]?.label ?? m.label`, `?? m.description`).
+- `apps/dashboard/src/i18n/dictionary.mjs`: added the `intake` namespace to **both** EN
+  and KO.
+- `apps/dashboard/src/i18n/dictionary.d.mts`: added the `intake` shape to the
+  `Dictionary` type.
+
+### Start-point labels — safe render-layer override
+`INTAKE_META` lives in the shared, deterministic `@conclave-ai/workspace-preview`
+package (re-exported as `@/lib/intake.mjs`) and is also consumed by MCP. To avoid
+breaking MCP determinism / Node-CI, **no Korean was hardcoded into the shared helper**.
+The page localizes at the **render layer** via the dictionary, falling back to the
+existing English constant (`?? m.label`) when a key is absent.
+
+## 4. Dictionary keys added (`intake.*`)
+- `intake.handoff.*` — `eyebrow, title, subtitle, pasteLabel, previewLanguageLabel,
+  feedbackLabel, previewOnly, notSaved, safetyNote`
+- `intake.startPoints.{idea|prd|product_url|github_repo|pull_request|ai_built_app}` —
+  `{ label, description }`
+- `intake.previewKinds.{acceptance_map|stage_plan|evidence_plan|agent_run_plan|
+  acceptance_graph_summary|recurring_blockers|agent_tool_memory|template_signals}`
+- `intake.boundaries.{requiresPaymentFalse|mutatesStateFalse|usesHostedExecutionFalse|
+  createsPersistenceFalse|containsSecretsFalse}`
+
+## 5. English baseline copy
+Unchanged wording from the current page (e.g. "What do you want Simsa to review?",
+"Start from anything…", the start-point labels/descriptions), now sourced from `EN`.
+English remains the fallback locale.
+
+## 6. Korean early-locale copy
+Korean added for the whole `intake.*` namespace. **Product terms kept in English with a
+Korean gloss** per the Stage 158 policy: Acceptance map (수용 기준 지도), Stage plan
+(단계 계획), Evidence plan (검증 증거 계획), Handoff, Preview only (미리보기 전용),
+Not saved (저장되지 않음); start points e.g. "AI-built app (AI로 만든 앱)".
+
+## 7. Deferred localization items (P1 / follow-up — recorded, not done here to keep the diff isolated)
+Still rendered from shared **constant** modules (would need a render-layer label map or
+threading `t`, a larger change): the onboarding panel (`ONBOARDING_*`), the beta usage
+boundary panel (`BETA_USAGE_*`), the preview-language legend items
+(`PREVIEW_LANGUAGE_ITEMS`), empty states (`EMPTY_STATES`), beta safety notes
+(`BETA_SAFETY_NOTES`), and the deep per-section preview copy (acceptance map / stage
+plan / agent run plan / evidence plan / graph / blocker / memory / template section
+headings + field labels), plus per-type preview field labels in `lib/intake-*.mjs`.
+Also deferred: **locale propagation** (`I18nProvider` reading `?locale=`, and a `locale`
+param in the handoff link builder) — only add once the Web App consumes it.
+
+## 8. Test / build / typecheck results
+- `@conclave-ai/dashboard` tests **218/218** ✓ — including the existing **en/ko key
+  parity** test, which confirms the new `intake.*` keys match exactly across locales.
+- `@conclave-ai/dashboard` typecheck ✓ · build ✓ (`/projects/new/intake` compiled,
+  30.1 kB).
+- `@conclave-ai/mcp-workspace` **74/74** ✓ (incl. `smoke-basic-stdio` real-spawn);
+  `smoke:basic` + `qa:basic-tools` exit 0.
+- monorepo typecheck **57/57** ✓.
+
+## 9. MCP private dogfood status
+- Claude Desktop core MCP flow: **PASS** (Stage 157, Bae evidence).
+- `Simsa-Basic` display name: **applied** (Stage 157).
+- Handoff link safety: **PASS**.
+- Handoff/intake **i18n**: **improved** — first-screen (P0) copy is now dictionary-first
+  with en + ko; deeper P1 copy deferred (§7).
+
+## 10. Publish readiness implication
+**MCP publish remains held.** Core app-side flow passed and the handoff/intake
+first-screen localization is in place, but public publish still requires a separate
+publish-readiness/release decision (and the P1 i18n + locale-propagation follow-ups are
+open). No publish in this stage.
+
+## 11. Merge readiness
+PR #153 contains the Stage 154~159 evidence/docs plus this **isolated, copy/dictionary
++ useI18n** dashboard change (no route/data/API/persistence change). All checks pass; CI
+green expected. Ready to merge after Bae approval. **No dashboard deploy** is performed
+here (a separate Bae-approved dashboard deploy would publish the localized page).
+
+## 12. Stage 159 decision — **Option A: Ready to merge PR #153 after Bae approval**
+- No deploy required (unless Bae separately approves a dashboard deploy to ship the
+  localized intake page).
+- No MCP publish · no npm publish · no central-plane deploy · no migration.
+
+## 13. Recommended next stage
+**Stage 160 — Simsa Wax Seal Thinking Animation / Motion System** (per the train plan),
+or a focused **Intake i18n P1 follow-up** to localize the deferred §7 surfaces. **Do not
+merge** PR #153 until Bae approves after this report.

--- a/packages/mcp-workspace/README.md
+++ b/packages/mcp-workspace/README.md
@@ -163,6 +163,11 @@ and an evidence template live in
 `conclave-builder-pack/out/stage-154-claude-desktop-dogfood-evidence-intake.md`. Keep
 `env` empty, don't paste real tokens or private code, and don't publish the package.
 
+Claude Desktop app-side evidence is tracked separately in
+`conclave-builder-pack/out/stage-155-claude-desktop-app-evidence-record.md`. Until that
+record shows app-side tool discovery and calls, treat Claude Desktop status as
+**prepared/pending, not passed**.
+
 ---
 
 ## Config examples (connected mode)

--- a/packages/mcp-workspace/README.md
+++ b/packages/mcp-workspace/README.md
@@ -143,6 +143,26 @@ Notes:
   another MCP host, add a server entry equivalent to the example above in that host's
   MCP configuration file.
 
+## Private Claude Desktop dogfood
+
+Before any publish, MCP Basic is dogfooded privately in real hosts. To run the
+Claude Desktop app-side check yourself:
+
+```bash
+pnpm --filter @conclave-ai/mcp-workspace build
+pnpm --filter @conclave-ai/mcp-workspace smoke:basic
+pnpm --filter @conclave-ai/mcp-workspace smoke:basic:stdio
+pnpm --filter @conclave-ai/mcp-workspace qa:basic-tools
+pnpm --filter @conclave-ai/mcp-workspace print:claude-desktop-basic-config
+```
+
+Then add the generated `simsa-basic` config (empty `env`) to Claude Desktop, restart,
+open a new chat, and confirm the 9 Basic tools are callable with **no credential
+prompt** and **no connected/risky tools**. The full operator checklist, safe prompts,
+and an evidence template live in
+`conclave-builder-pack/out/stage-154-claude-desktop-dogfood-evidence-intake.md`. Keep
+`env` empty, don't paste real tokens or private code, and don't publish the package.
+
 ---
 
 ## Config examples (connected mode)

--- a/packages/mcp-workspace/README.md
+++ b/packages/mcp-workspace/README.md
@@ -122,7 +122,7 @@ entry point. Build first, then point your MCP host at `dist/index.js`:
 ```json
 {
   "mcpServers": {
-    "simsa-basic": {
+    "Simsa-Basic": {
       "command": "node",
       "args": [
         "/ABSOLUTE/PATH/TO/conclave-ai/packages/mcp-workspace/dist/index.js"
@@ -132,6 +132,10 @@ entry point. Build first, then point your MCP host at `dist/index.js`:
   }
 }
 ```
+
+The local MCP server display/config entry uses **`Simsa-Basic`** for user-facing
+private dogfood. (Internal package names — `@conclave-ai/mcp-workspace`,
+`@conclave-ai/workspace-preview` — are unchanged.)
 
 Notes:
 
@@ -156,7 +160,7 @@ pnpm --filter @conclave-ai/mcp-workspace qa:basic-tools
 pnpm --filter @conclave-ai/mcp-workspace print:claude-desktop-basic-config
 ```
 
-Then add the generated `simsa-basic` config (empty `env`) to Claude Desktop, restart,
+Then add the generated `Simsa-Basic` config (empty `env`) to Claude Desktop, restart,
 open a new chat, and confirm the 9 Basic tools are callable with **no credential
 prompt** and **no connected/risky tools**. The full operator checklist, safe prompts,
 and an evidence template live in
@@ -331,7 +335,7 @@ also confirm your Node version and the local absolute path. **Do not** attempt h
 config (or GUI dogfood) until the smokes pass. **Safety:** don't add credentials to
 "make it work" — Basic-only needs none.
 
-### Host (e.g. Claude Desktop) cannot see `simsa-basic`
+### Host (e.g. Claude Desktop) cannot see `Simsa-Basic`
 **Likely cause:** wrong absolute path · build not run · app not restarted · config
 saved in the wrong/inactive file · invalid JSON. **Fix:** regenerate with
 `print:claude-desktop-basic-config`, rebuild, **restart** the host, open a **new**

--- a/packages/mcp-workspace/scripts/print-claude-desktop-basic-config.mjs
+++ b/packages/mcp-workspace/scripts/print-claude-desktop-basic-config.mjs
@@ -34,7 +34,9 @@ export function buildClaudeDesktopBasicConfig({ requireBuilt = true } = {}) {
   }
   return {
     mcpServers: {
-      "simsa-basic": {
+      // User-facing display/config entry name (Claude Desktop shows this). Only the
+      // local server entry name is branded; internal package names are unchanged.
+      "Simsa-Basic": {
         command: "node",
         args: [entry],
         env: {},

--- a/packages/mcp-workspace/test/print-claude-desktop-basic-config.test.mjs
+++ b/packages/mcp-workspace/test/print-claude-desktop-basic-config.test.mjs
@@ -14,15 +14,17 @@ describe("Claude Desktop Basic config helper", () => {
     assert.ok(entry.replace(/\\/g, "/").endsWith("packages/mcp-workspace/dist/index.js"));
   });
 
-  it("builds a Basic-only config: simsa-basic, node, absolute path, empty env", () => {
+  it("builds a Basic-only config: Simsa-Basic, node, absolute path, empty env", () => {
     // requireBuilt:false so the test does not depend on a prior build.
     const cfg = buildClaudeDesktopBasicConfig({ requireBuilt: false });
-    const s = cfg.mcpServers["simsa-basic"];
-    assert.ok(s, "simsa-basic entry present");
+    const s = cfg.mcpServers["Simsa-Basic"];
+    assert.ok(s, "Simsa-Basic entry present");
     assert.equal(s.command, "node");
     assert.equal(s.args.length, 1);
     assert.ok(isAbsolute(s.args[0]));
     assert.deepEqual(s.env, {});
+    // Display branding: the user-facing entry uses Simsa-Basic, not the old lowercase.
+    assert.equal(cfg.mcpServers["simsa-basic"], undefined, "old lowercase key must be gone");
   });
 
   it("includes no credentials / tokens anywhere in the config", () => {
@@ -41,7 +43,7 @@ describe("Claude Desktop Basic config helper", () => {
       // requireBuilt:true; if dist exists this won't throw — so we assert either it
       // returns a valid config OR throws the documented message.
       const cfg = buildClaudeDesktopBasicConfig({ requireBuilt: true });
-      assert.ok(cfg.mcpServers["simsa-basic"]); // build present → valid config
+      assert.ok(cfg.mcpServers["Simsa-Basic"]); // build present → valid config
     } catch (err) {
       assert.match(String(err.message), /dist\/index\.js not found/);
       assert.match(String(err.message), /pnpm --filter @conclave-ai\/mcp-workspace build/);


### PR DESCRIPTION
# Stage 154~159 — MCP Private Dogfood Evidence / Claude Desktop App QA (✅ checkpoint — ready to merge after Bae approval)

Train branch `docs/stage-154-claude-desktop-dogfood-evidence`. **Recommendation: Option A — ready to merge after Bae approval. No deploy / MCP publish / central-plane / migration. Publish still held.**

## App-side status: **Status A (with caveats)** — Bae confirmed the core flow in Claude Desktop. `Simsa-Basic` display fixed; handoff/intake first-screen i18n now dictionary-first (en+ko).

## Included stages

### Stage 154 — App-side Dogfood Evidence Intake (docs-only)
Operator checklist, config guidance, safe prompts, evidence template, pass/fail, Status A/B/C, redaction rules.

### Stage 155 — Record Bae App-side Evidence (docs-only)
Durable evidence record (originally Pending; **superseded by Stage 157**).

### Stage 156 — Evidence Review / Gap Analysis (docs-only)
Review method + 15-row matrix + gap categories **G1–G8** + remediation (originally all-PENDING; **superseded by Stage 157**; method stays valid for re-runs).

### Stage 157 — Evidence Update / MCP Display Branding Gap
Bae supplied **actual** app-side evidence → core flow **Status A (with caveats)**. Config helper now emits **`Simsa-Basic`** (display only; internal package names unchanged; tests assert lowercase gone). Icon: **Outcome B (not confirmed)** → not implemented. Web App handoff **English-hardcoded copy** recorded as a dashboard GAP.

### Stage 158 — Web App Handoff Global Localization / i18n Gap Inventory (docs-only)
Root finding: `projects/new/intake/page.tsx` (1899 lines) didn't use `useI18n`, no `intake.*` namespace → 100% hardcoded English; a **coverage** gap, not architecture. Global dictionary-first plan (Option G), en+ko Phase 1 / dictionary-only Phase 2, locale-propagation follow-up.

### Stage 159 — Web App Handoff Dictionary-first i18n Fix / Private Dogfood Checkpoint
Implements the **dictionary-first** fix for the handoff/intake destination, reusing the existing i18n system.
- `page.tsx`: `useI18n` (named `tr` to avoid shadowing the `map((t)=>)` param); P0 first-screen copy localized — title, subtitle, paste label, "Preview language", feedback CTA, and start-point buttons via `tr.intake.startPoints[t]?.label ?? m.label` (**render-layer override**; shared deterministic `INTAKE_META` in workspace-preview untouched).
- `dictionary.mjs`: `intake.*` namespace in **EN + KO** (`handoff` / `startPoints` / `previewKinds` / `boundaries`). Product terms kept in English with a Korean gloss (e.g. Acceptance map (수용 기준 지도)).
- `dictionary.d.mts`: `intake` shape added to the `Dictionary` type.
- **Deferred (recorded):** onboarding/beta-usage/empty-state constant copy, deep per-section preview copy, `lib/intake-*.mjs` field labels, and locale propagation (`?locale=` + handoff `locale` param).
- **Decision: Option A.** `conclave-builder-pack/out/stage-159-web-app-handoff-dictionary-i18n-fix-checkpoint.md`.

## Verification
- **dashboard 218/218** (incl. the en/ko key-parity test — confirms `intake.*` matches across locales) · typecheck ✓ · **build ✓** (`/projects/new/intake` compiled, 30.1 kB).
- **mcp-workspace 74/74** (incl. real-spawn stdio smoke); `smoke:basic` + `smoke:basic:stdio` + `qa:basic-tools` exit 0.
- **monorepo typecheck 57/57.** Pre-push verify green. (CI running on push.)

## Conclusions
- PR #153 **ready to merge** (after Bae approval).
- MCP **not** published (held). Dashboard deploy **not** performed (separate Bae-approved deploy would ship the localized page).
- Central-plane deploy **not** required · migration **not** required.

## Recommended next stage
**Stage 160 — Simsa Wax Seal Thinking Animation / Motion System** (or a focused Intake i18n P1 follow-up for the deferred surfaces).

## Not in this train
No MCP publish/version bump/npm, no registry install, no central-plane, no migration, no payment/Stripe (provider TBD, Korea-compatible first), no hosted execution, no auth/login/session, no PR comments, no deploy, no domain/DNS, no token/secret output. No npm/internal package rename. No route/data/API/persistence change in the i18n fix.