### PR TITLE
Stage 187~189 — Auth / Identity Foundation Planning

### DIFF
--- a/conclave-builder-pack/out/stage-187-auth-identity-foundation-decision-brief.md
+++ b/conclave-builder-pack/out/stage-187-auth-identity-foundation-decision-brief.md
@@ -1,0 +1,220 @@
+# Stage 187 — Auth / Identity Foundation Decision Brief
+
+**Date:** 2026-06-25
+**Branch:** `docs/stage-187-auth-identity-brief` · **Base / deployed main:** `9b645af` · live: https://app.trysimsa.com
+**Type:** decision brief / docs only. **No auth implementation, no auth packages, no login/session middleware, no OAuth, no migration, no deploy, no MCP/npm publish, no payment/billing, no domain/DNS, no server write, no token/secret request-print-store, no env-var change, no live-dashboard change.**
+
+> **Core product principle: Simsa must not fake collaboration.** Until auth/workspace exists,
+> `/account` stays local/browser-scoped, Plan Map gates stay read-only, team/invite/share stay
+> planned/disabled, GitHub/Vercel connected-account management stays placeholder/read-first, and
+> `userKey` is never treated as real identity.
+
+## 0. Stack baseline (verified, shapes every option below)
+- **Dashboard:** Next.js (App Router) on **Vercel** (`app.trysimsa.com`).
+- **Backend:** `apps/central-plane` = **Hono on Cloudflare Workers + D1** (SQLite-at-edge);
+  sequential SQL migrations.
+- **Existing GitHub OAuth** (`workspace/github-oauth.ts` + encrypted tokens via `crypto.ts`)
+  is **repo-access** auth, **not** login identity.
+- **Implication:** any auth choice must issue an identity proof that **both** the Vercel
+  Next.js app **and** the Cloudflare Workers API can verify (a signed JWT verifiable via JWKS,
+  or a shared-secret/session the edge can check). This split is the central constraint.
+
+## 1. Current state inventory
+- `/account` = **local preference stub** (Stage 170): local **display name** (`localStorage
+  conclave:account:displayName`), local **locale** preference, **avatar initial** derived
+  locally; **GitHub** = read-only placeholder; **Vercel** = "Planned" placeholder.
+- **`userKey`** = client-supplied tenant-scoping surrogate on every `workspace_*` table.
+- **Absent:** real login · real session · verified email · workspace-member model · invite
+  acceptance · role enforcement · approval audit trail · workspace-owned integrations.
+- Plan Map (Stage 182~183) surfaces a permanent **"Blocked by identity decision"** blocker —
+  this brief is what unblocks it.
+
+## 2. Why `userKey` is insufficient
+- It is **client-supplied** (generated in the browser) → anyone can present any key.
+- It is **not authentication** — it proves nothing about who the user is.
+- It cannot support **team membership** (a key is one anonymous tenant, not many identified
+  users).
+- It cannot support **role-aware approval** (no identity to attach a role to).
+- It cannot support an **audit trail** (no verifiable actor for "who did X when").
+- It cannot **safely own integrations** (a leaked key would expose connected accounts).
+- It cannot **authorize account/workspace export** (no identity to scope "my data" to).
+
+## 3. Product requirements for identity
+Stable **user id** · **verified email** · **session** model · **workspace selection** ·
+**default-workspace creation** on first auth · **workspace membership** · **invitation
+acceptance** · **role assignment** · **integration-account ownership** · **approval-gate
+attribution** · **audit-event attribution** · **data-export ownership** · **project-access
+enforcement**.
+
+## 4. Proposed domain model (conceptual — no migration)
+Refines Stage 171:
+| Entity | Purpose | Key fields | Notes |
+|---|---|---|---|
+| **User** | real identity | id, email(verified), name, avatar, locale | created on first auth |
+| **Workspace** | team container | id, name, slug, ownerUserId, defaultLocale, archivedAt? | one owner |
+| **WorkspaceMember** | membership+role | workspaceId, userId, role, status, joinedAt, invitedBy | composite key |
+| **Invitation** | pending invite | id, workspaceId, email, role, tokenHash, expiresAt, accepted/revokedAt | **tokenHash only** |
+| **Project** | existing + scope | + workspaceId | migrate from `userKey` |
+| **ProjectAccess** | per-project override | projectId, userId/role | defaults to workspace role |
+| **ShareLink** | external/link share | id, projectId, scope, tokenHash, expiresAt, revokedAt | **tokenHash only**, least scope |
+| **IntegrationAccount** | GitHub/Vercel conn | id, workspaceId, provider, externalId, scopes, status | tokens **server-side encrypted** |
+| **ActivityEvent** | audit log | id, workspaceId, actorUserId, type, target, at | append-only, no secrets |
+| **GateDecision** | approval ledger | id, workspaceId, gateKey, targetRef, decidedByUserId, decision, at | attributes Plan-Map gates |
+| **RoadmapEvent** *(optional)* | Plan-Map history | id, projectId, kind, actorUserId, at | persists the now-generated map |
+
+## 5. Role model
+**Owner · Admin · Editor · Reviewer · Viewer** (Stage 171). Eventual capabilities:
+| Capability | Owner | Admin | Editor | Reviewer | Viewer |
+|---|:--:|:--:|:--:|:--:|:--:|
+| Manage workspace / transfer ownership | ✓ (transfer Owner-only) | | | | |
+| Invite / remove members, change roles | ✓ | ✓ | | | |
+| Connect / disconnect integrations | ✓ | ✓ | | | |
+| Approve merge/deploy/publish/migration gates | ✓ | ✓ (scope TBD) | | | |
+| Edit acceptance items | ✓ | ✓ | ✓ | | |
+| View evidence / Plan Map | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Review / comment | ✓ | ✓ | ✓ | ✓ | |
+| Export project | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Export workspace data | ✓ | ✓ | | | |
+Role **enforcement** is future implementation (auth + WorkspaceMember required first).
+
+## 6. Auth architecture options (category-level; verify vendor specifics before implementing)
+| Category | Examples | Complexity | Security responsibility | Workspace/team | OAuth linking | Email verify | Session | Migration impact | Cost / lock-in | Fit for early Simsa | Risk |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| **Managed auth (orgs-native)** | provider-with-organizations | Low–Med | **Mostly offloaded** | **Built-in orgs** | Built-in | Built-in | Built-in (JWT) | Map provider org→Workspace; store `workspace_id` | $ per MAU; medium lock-in | **Strong** — offloads the riskiest parts | Low–Med |
+| **Managed auth (identity-only)** | provider-without-orgs | Low–Med | Mostly offloaded | **Build ourselves** | Built-in | Built-in | Built-in (JWT) | Build Workspace/Member tables ourselves | $ per MAU; medium lock-in | Good if we want to own the workspace model | Med |
+| **Framework-native** | Next.js-native auth library | Med | **On us** (sessions, tokens) | Build ourselves | Library adapters | Build/extend | Self-managed (JWT or DB session) | Full User/Session/Account tables in D1 | **Free**, low lock-in | Good if cost-sensitive + team can own security | Med–High |
+| **Enterprise SSO** | SAML/OIDC broker | Med–High | Offloaded | Orgs/SSO-centric | SSO + OAuth | Built-in | Built-in | Heavier | $$; B2B-oriented | **Later** (enterprise buyers) | Med |
+| **Custom on D1** | hand-rolled | **High** | **Entirely on us** | Build all | Build all | Build all | Build all | Full | Free; no lock-in | **Not recommended** | **High** |
+- **Do not** treat any vendor row as final — provider-specific claims (JWT/JWKS verification at
+  the Workers edge, org primitives, pricing, Korea data-residency, social providers incl.
+  Kakao/Naver) must be **verified against current provider docs before implementation** (a
+  Stage 188 selection matrix). **Note:** avoid any auth library known to be in
+  sunset/maintenance — confirm maintenance status at selection time.
+
+## 7. GitHub / Vercel distinction
+- The existing **GitHub OAuth is repo-evidence access, NOT login identity** — keep them
+  **separate concerns**. A "Sign in with GitHub" login (if chosen) is a *different* OAuth
+  purpose and should be modeled distinctly from repo-access tokens.
+- **Vercel** should also be a **connected integration**, **not** the identity source by default.
+- **Login identity** ⟂ **connected provider accounts**: model `User`/session separately from
+  `IntegrationAccount`. Integration ownership should eventually belong to the **workspace (or
+  user+workspace)** context, never browser-local state.
+
+## 8. Plan Map relationship
+- Today's Plan Map is a **read-only generated preview** (no attribution).
+- Post-auth it should show **who approved which gate and when** (via `GateDecision`/
+  `ActivityEvent`), with **role-aware** gate visibility.
+- The Plan-Map blocker **"Blocked by identity decision"** should resolve **only after** an auth
+  architecture is **selected and implemented** — not before.
+- Audit trails and role-aware gates **require real identity + WorkspaceMember**.
+
+## 9. Share / invite / permission relationship
+- **Private project links** require **auth + ProjectAccess**.
+- **Public share links** require a **ShareLink token model** (hash-at-rest, expiry, revoke,
+  access log, least scope).
+- **Teammate invitations** require **verified email + session + invite tokens** (hash-at-rest,
+  rate-limited, expiring; invited role ≤ inviter authority).
+- **Remove member / change role** requires the **Owner/Admin** model (Owner protected; transfer
+  before removal).
+- **Member-aware delete/archive** requires **project/workspace ownership**.
+
+## 10. Export / import relationship
+- **Project export** can stay **now-safe** if **secret-free**.
+- **Account/workspace export** requires **identity + workspace scope**.
+- Export must **never** include tokens/secrets/credentials.
+- An **imported** Simsa artifact does **not** prove live access or identity (re-import ≠ auth).
+- **Audit-linked export** (who exported what) requires auth/workspace later.
+
+## 11. Integration ownership relationship
+- Connected accounts need a **visible identity**.
+- Tokens **server-side only and encrypted** (as GitHub does via `crypto.ts`) — **never** output.
+- **Least-privilege scopes**; explicit **connect/disconnect**.
+- **Workspace-owned** integration accounts (not browser-local) — later.
+- **Write actions remain explicit approval-gated.**
+
+## 12. Migration strategy (phases only — do not implement)
+- **Phase 0** — current `userKey` / browser scope (today).
+- **Phase 1** — **select auth architecture** (decision; no code).
+- **Phase 2** — `User` + `Workspace` schema **behind a feature flag** *(migration approval +
+  security review)*.
+- **Phase 3** — **backfill** existing `userKey` projects → a default workspace per key
+  *(migration approval; verify before switching read paths to avoid cross-tenant leak)*.
+- **Phase 4** — **session middleware + workspace context** *(auth approval + deploy approval +
+  env-var handling + security review)*.
+- **Phase 5** — `WorkspaceMember` + roles *(migration + deploy approval)*.
+- **Phase 6** — **invitations** *(migration + security review for invite tokens/email)*.
+- **Phase 7** — **share links + project access** *(migration + security review for public
+  tokens)*.
+- **Phase 8** — **integration-ownership migration** *(migration + security review for token
+  storage)*.
+- **Phase 9** — **approval / audit ledger** (`GateDecision`/`ActivityEvent`) *(migration;
+  unblocks Plan-Map approvals)*.
+Each additive-first; read paths switch only after a verified backfill.
+
+## 13. Safety gates (hard rules)
+- **Auth/session/OAuth implementation → separate Bae approval.**
+- **DB migration → separate Bae approval.**
+- **Production deploy → separate Bae approval.**
+- **Payment/billing remains TBD** — evaluate a **Korea-compatible** provider later; **no Stripe
+  assumption**.
+- **Tokens/secrets must never be printed or requested.**
+- **Vercel token** revoke/rotate status should remain confirmed if relevant — **never print
+  token values**.
+
+## 14. Recommendation
+- **Category:** lead with a **managed auth provider**, preferring one with **native
+  organization/team primitives** and a **JWT verifiable at the Cloudflare Workers edge** — it
+  **offloads the riskiest parts** (session, email verification, OAuth, token storage) that a
+  small team should not hand-roll, and it fits the Vercel↔Workers split. Keep **framework-native
+  auth** as the serious cost-sensitive alternative (free, low lock-in, but security
+  responsibility and org modeling land on us). **Reject custom-on-D1** (high risk).
+  *This is a category recommendation; the specific vendor must be verified in Stage 188.*
+- **Minimum viable identity model for collaboration:** `User` (id + **verified email**) +
+  `Workspace` (owner) + `WorkspaceMember` (role) + **session** + default-workspace-on-first-auth.
+  Nothing team-facing should ship before this floor exists.
+- **Before invite/share/roles:** the MVP floor above + `Invitation`/`ShareLink` token models
+  (hash-at-rest, expiry, revoke).
+- **Before GitHub/Vercel connected-account management:** `User`+`Workspace`+session +
+  `IntegrationAccount` ownership (workspace-scoped, server-side encrypted tokens).
+- **Before Plan-Map approval audit:** real identity + `WorkspaceMember` + `GateDecision`/
+  `ActivityEvent` ledger.
+- **Answers:** hosted vs native vs custom → **hosted (managed) recommended, native as fallback,
+  custom rejected**. Until then, **everything multi-user stays blocked**; only the read-only
+  generated Plan Map, the local `/account` stub, and secret-free export/handoff exist.
+
+## 15. Now-safe vs gated
+- **Now-safe:** this decision brief · auth-requirements doc · conceptual schema · migration
+  plan · UI copy clarifying "requires sign-in" · Plan-Map blocker copy.
+- **Requires separate auth approval:** login/session impl · OAuth provider impl · verified-email
+  flow · session middleware · account linking.
+- **Requires migration approval:** `User` · `Workspace` · `WorkspaceMember` · `Invitation` ·
+  `ProjectAccess` · `IntegrationAccount` ownership changes · `ActivityEvent`/approval-ledger
+  tables.
+- **Requires deploy approval:** any production rollout · any auth/session route going live · any
+  workspace-gated project-access change.
+- **Requires security review:** token storage · OAuth scopes · session cookies · invite tokens ·
+  public share links · audit-log retention · account deletion/export.
+
+## 16. Suggested next stages
+- **Option A — Stage 188: Auth Provider / Architecture Selection Matrix** *(recommended)*.
+- **Option B — Stage 188: User + Workspace Schema Planning.**
+- **Option C — Stage 188: Stale Dogfood PR Cleanup Review** (#121~130).
+**Recommendation: Option A.** The architecture **category choice shapes the schema** (a managed
+orgs-native provider owns User/Org and we store a `workspace_id` mapping; framework-native means
+we own full `User`/`Session`/`Account` tables in D1). Picking the provider/architecture **first**
+(with vendor specifics verified against current docs — JWKS-at-edge, org primitives, Korea
+residency, social/Kakao/Naver, pricing, maintenance status) prevents reworking the schema later.
+Option B should follow once the category is chosen; Option C is independent housekeeping.
+
+## 17. Stage 187 decision — **Option A: Auth/Identity decision brief ready**
+The current-state inventory, why-`userKey`-is-insufficient analysis, identity requirements,
+conceptual domain + role model, category-level architecture comparison, GitHub/Vercel
+distinction, Plan-Map / share-invite / export / integration relationships, phased migration,
+safety gates, and a category recommendation (**managed auth, native fallback, custom rejected**)
+are defined. **No implementation occurred.** Real collaboration stays blocked until Bae selects
+an architecture; the next step is **Stage 188 — Auth Provider / Architecture Selection Matrix**.
+
+## 18. Recommended next stage
+**Stage 188 — Auth Provider / Architecture Selection Matrix** (verify vendor specifics against
+current docs before any implementation), then **User + Workspace Schema Planning**. Auth/OAuth
+implementation, migrations, and deploy each remain **separately Bae-approval-gated**.

--- a/conclave-builder-pack/out/stage-188-auth-provider-architecture-selection-matrix.md
+++ b/conclave-builder-pack/out/stage-188-auth-provider-architecture-selection-matrix.md
@@ -1,0 +1,192 @@
+# Stage 188 — Auth Provider / Architecture Selection Matrix
+
+**Date:** 2026-06-25
+**Branch:** `docs/stage-187-188-auth-identity-selection` (renamed from `docs/stage-187-auth-identity-brief`) · **Base / deployed main:** `9b645af` · live: https://app.trysimsa.com
+**Type:** research / decision matrix only. **No auth implementation, no SDK install, no login routes, no session middleware, no OAuth, no migration, no deploy, no MCP/npm publish, no payment/billing, no domain/DNS, no server write, no token/secret request-print-store, no env-var change, no live-dashboard change.**
+
+> Research was done against **current (June 2026) official/provider sources** (URLs in §4/§Sources). Where a fact could not be confirmed from a primary source, it is marked **[verify]** and must be re-checked against the provider's current docs **before** any implementation. No tokens/secrets were requested, printed, or stored.
+
+## 1. Executive recommendation
+**Two finalists; final pick is Bae's. Confidence: medium (stack-fit facts are strong; a few provider specifics need re-verification before coding).**
+- **Primary (best fit for Simsa's specific stack): Better Auth (framework-native).** It natively
+  targets **Cloudflare D1 + Hono + Workers** — *exactly* the central-plane stack — has an
+  **organization plugin** (members/roles/invitations), and ships **native Kakao + Naver**
+  providers, free/self-host, low lock-in, full data control.
+- **Fallback (managed, offloads security responsibility): WorkOS AuthKit.** First-class
+  **organizations** (workspaces/roles/invitations/domain verification), **free up to 1M MAU**,
+  edge-verifiable JWT, B2B-oriented. Best if the team would rather not own session/email/token
+  security.
+- **Reject / defer now:** **Auth0** (Organizations is Professional-only → ~$150/mo+ at 500 MAU,
+  "growth-penalty" for early B2B); **Supabase Auth** (would introduce Postgres/Supabase
+  alongside the existing **D1** backend — a stack divergence — and has **no built-in orgs**);
+  **Clerk** is strong but its **per-organization B2B pricing** ($1/MAO after 100 free orgs) can
+  scale unfavorably for a workspace-heavy product — keep as a third option, not primary.
+- **Reject: custom-on-D1** (Stage 187, high security risk).
+- **Open questions for Bae (see §13):** managed-vs-native (offload security vs own the stack);
+  is email-only acceptable for MVP; is Kakao/Naver MVP or later; Simsa-owned vs provider-org
+  workspace model; acceptable lock-in/cost tradeoff.
+
+## 2. Decision context (from Stage 187)
+`userKey` is a client-supplied tenant surrogate, **not** identity. The **MVP identity floor**
+before any collaboration is **User (verified email) + Workspace + WorkspaceMember + session**.
+Real collaboration (team/invite/share/roles/approval-audit) stays **blocked** until an auth
+architecture is selected **and** Bae-approved. **No implementation in this stage.**
+
+## 3. Candidate shortlist (why included)
+1. **WorkOS AuthKit** — managed, **org-native**, B2B-first, very generous free tier.
+2. **Better Auth** — framework-native, **D1/Hono/Workers-native**, org plugin, Kakao/Naver.
+3. **Clerk** — managed, excellent DX + edge verification, generous user free tier (per-org cost
+   caution).
+4. **Auth0 by Okta** — mature, but Organizations is paid-tier; included as the enterprise-grade
+   baseline.
+5. **Supabase Auth** — JWT + RLS; included because it's common, but diverges from the D1 stack.
+6. **Custom** — negative baseline (rejected in Stage 187).
+
+## 4. Provider / architecture matrix (current-doc grounded)
+| Criterion | **Better Auth** (native) | **WorkOS AuthKit** (managed) | **Clerk** (managed) | **Auth0** (managed) | **Supabase Auth** | **Custom** |
+|---|---|---|---|---|---|---|
+| Category | Framework-native / self-host | Managed org-native | Managed org-native | Managed (B2C + B2B tier) | Managed (JWT+RLS) | Internal |
+| Core identity (user id, email verify, session, social) | Yes, code-config | Yes (email/pw, social, MFA) | Yes (rich, social, MFA) | Yes (mature) | Yes (JWT) | Build all |
+| **Orgs / workspace primitives** | **Organization plugin** (members, roles, invites) | **First-class orgs** (members, roles, invites, domain verify) | Orgs (B2B add-on) | **Organizations = Professional-only** | **None built-in** (model yourself) | Build all |
+| GitHub login linking / connected-acct separation | Yes (account linking; keep IntegrationAccount separate) | Yes | Yes | Yes | Yes (OAuth providers) | Build |
+| **Edge / Workers JWT verify** | Runs **on Workers/Hono natively** | JWT verifiable at edge **[verify JWKS/cookie model]** | **Networkless JWT verify** via `jwtKey` (edge-proven) | JWT/JWKS verifiable **[verify edge]** | JWT verifiable (JWKS) | Build |
+| **D1 fit** | **Native D1** (first-class, no custom adapter) | Provider-hosted (we store mapping in D1) | Provider-hosted (mapping in D1) | Provider-hosted | **Postgres/Supabase** (diverges from D1) | D1 |
+| Security responsibility | **On us** (self-host) | **Offloaded** | Offloaded | Offloaded | Mostly offloaded | **Entirely on us** |
+| Data/model control & lock-in | **Full control, low lock-in** | Medium lock-in | Medium lock-in | Medium–high | Medium (ties to Supabase) | Full |
+| **Korea social (Kakao/Naver)** | **Native providers** (docs exist) | **[verify]** (custom OAuth likely) | **[verify]** (custom OAuth likely) | **[verify]** | **[verify]** | Build |
+| Cost (early stage) | **~$10–40/mo infra, user-count-independent** | **Free ≤ 1M MAU** | Free ≤ 50K MAU; **B2B $1/MAO after 100 orgs** | Free 25K MAU B2C; **B2B ~$150/mo+ at 500 MAU** | Free tier + usage | Infra only |
+| Implementation complexity | Medium (we wire it) | Low–Med | Low–Med | Med | Med (new DB) | High |
+| **Simsa fit (stack + Korea + collab)** | **Highest** (exact stack + Korea + control) | **High** (managed orgs, cheap) | High (per-org cost caution) | Medium (org pricing) | Low–Med (stack divergence) | Low |
+| Notable risk | Open bug **#4203** (5-min session edge case, reopened Jan 2026) **[verify fixed]**; younger org plugin | Some lock-in; Kakao **[verify]** | Per-org cost scaling | "Growth penalty" cost | Adds Postgres dependency | High risk |
+
+Pricing/feature cells reflect June-2026 sources (§Sources) and **must be re-verified at sign-up
+time** — provider plans change.
+
+## 5. Runtime compatibility notes
+- **Vercel dashboard:** all managed options + Better Auth integrate with Next.js on Vercel.
+- **Cloudflare Workers / edge (central-plane = Hono on Workers + D1):** **Better Auth runs
+  directly on Workers/Hono with native D1** (best fit). Managed providers (Clerk/WorkOS/Auth0/
+  Supabase) require the Worker to **verify the provider's JWT at the edge** — feasible with a
+  JOSE library + **JWKS caching** (per-isolate LRU or KV; cold JWKS ~15–25 ms, cached
+  sub-ms; cap refresh at 5–10 min). **Clerk** documents **networkless JWT verification**
+  (supply the PEM `jwtKey`) which removes the per-request JWKS round-trip — strong edge story.
+- **Session cookies:** managed providers set their own session cookies (domain/SameSite/secure
+  to verify for `app.trysimsa.com`); Better Auth's cookie/session is self-managed (and is where
+  bug #4203 lives — **verify resolved**).
+- **Must re-verify before implementation:** exact edge JWT/JWKS verification path per provider,
+  cookie domain behavior on the custom domain, and Worker-side authorization wiring.
+
+## 6. Workspace / organization model fit
+- **WorkOS / Clerk:** provide org primitives → map **Provider Org → Simsa Workspace**, provider
+  membership/roles → `WorkspaceMember`; least custom code, but the workspace model partly lives
+  in the vendor.
+- **Better Auth:** organization **plugin** gives members/roles/invites while the data stays in
+  **our D1** → **Simsa-owned Workspace model** with the most control.
+- **Auth0:** Organizations only on Professional → costly early.
+- **Supabase:** no orgs → we model `account` + membership + `has_role_on_account` ourselves
+  (plus a Postgres dependency).
+- The **Owner/Admin/Editor/Reviewer/Viewer** model (Stage 171/187) maps onto either a provider's
+  role system (WorkOS/Clerk/Better-Auth org plugin) or our own `WorkspaceMember.role`.
+
+## 7. GitHub / Vercel connected-account distinction
+Whatever is chosen, **login identity must stay separate** from:
+- **GitHub repo access** (the existing repo-evidence OAuth + encrypted tokens) — a "Sign in with
+  GitHub" *login* is a distinct OAuth purpose;
+- **Vercel deployment access** — a connected integration, never the identity source.
+`IntegrationAccount` ownership ties to **user/workspace context**, with tokens **server-side
+encrypted** (as `crypto.ts` does today) and **never** browser-local or printed.
+
+## 8. Data model mapping
+- **ProviderUser → Simsa `User`** (stable id + verified email + profile).
+- **Provider Org (WorkOS/Clerk) or Simsa-created `Workspace` (Better Auth/Supabase) → `Workspace`.**
+- **Provider membership or `WorkspaceMember` table → `WorkspaceMember`** (role, status).
+- **Provider invitation or `Invitation` table → `Invitation`** (tokenHash, expiry, revoke).
+- **`GateDecision` attribution → `User` + `WorkspaceMember`** (who approved which Plan-Map gate,
+  when) — needed for the Plan-Map audit trail.
+
+## 9. Migration implications
+- Current **`userKey` projects** must be **backfilled to a default Workspace per key** (Phase 3,
+  Stage 187) — additive, behind a **feature flag**, with **dual-read** until the backfill is
+  verified, then switch read paths; **rollback** = keep `userKey` columns until cutover is
+  proven.
+- **Default workspace** created on first auth; project **ownership** assigned during backfill.
+- Better Auth/Supabase add their tables **into D1/Postgres we control**; WorkOS/Clerk keep
+  identity vendor-side and we store a **`workspace_id`/`external_id` mapping** in D1.
+- All migrations are **separate-Bae-approval-gated** (Stage 187 §13).
+
+## 10. Security & compliance review needs (before implementation)
+Session cookie settings (domain/SameSite/secure on `app.trysimsa.com`) · CSRF/CORS for the
+Vercel↔Workers split · **JWKS/edge JWT verification** · token **encryption at rest** · **invite
+token** lifetime/hash · **public share-link** tokens · **account deletion/export** · **audit-log
+retention** · **provider webhooks** (signature verification) · **environment variables** (auth
+secrets handling). Each is a **security-review gate**.
+
+## 11. Pricing / cost caution (verified June-2026, re-verify at sign-up)
+- **WorkOS AuthKit:** free **up to 1M MAU**, then ~$2,500/1M; enterprise SSO/SCIM $125/conn/mo
+  (only when needed).
+- **Clerk:** free up to **50K MAU** (2026 raise); **B2B add-on** free for 100 MAO (5 members
+  each), then **$1/MAO**; Pro $25/mo base + per-MAU over tier.
+- **Auth0:** free **25K MAU** B2C; **Organizations = Professional**, ~$150/mo+ starting 500 MAU.
+- **Better Auth:** open-source/self-host → roughly **$10–40/mo infra, user-count-independent**.
+- **Do not** pick on price alone — but for a workspace-heavy early product, **per-organization**
+  pricing (Clerk) and **org-gated tiers** (Auth0) are the cost risks; WorkOS (free-to-1M) and
+  Better Auth (flat infra) are the most early-stage-friendly.
+
+## 12. Korea / global login note
+- **Email-first (+ generic social) is sufficient for MVP.** Do **not** block MVP on Kakao/Naver.
+- **Kakao/Naver later:** **Better Auth ships native Kakao + Naver providers** (lowest effort);
+  managed providers (WorkOS/Clerk/Auth0) would add them via **custom OAuth connections** **[verify
+  each provider's custom-OAuth support]**.
+- **Data residency / localization:** **[verify per provider]** if Korean data-residency becomes a
+  requirement. Global product direction favors an **email/social-neutral MVP** first, adding
+  Korea social when the market need is concrete.
+
+## 13. Decision questions for Bae
+1. **Managed vs framework-native** — offload security (WorkOS/Clerk) **or** own the stack
+   (Better Auth)?
+2. **Provider shortlist** — confirm finalists: **Better Auth** and **WorkOS** (drop Auth0/
+   Supabase/Clerk, or keep Clerk as third)?
+3. **Org-native from day one?** — provider-backed orgs (WorkOS/Clerk) vs Simsa-owned workspace
+   tables (Better Auth)?
+4. **Email-only MVP acceptable?** (recommended yes).
+5. **Kakao/Naver — MVP or later?** (recommended later).
+6. **Workspace model — Simsa-owned or provider-org-backed?**
+7. **Acceptable lock-in / cost tradeoff** (flat self-host infra vs managed per-MAU/per-MAO)?
+
+## 14. Recommended next stage
+**Stage 189 — User + Workspace Schema Planning Based on the Selected Auth Category** — but
+**only after Bae answers §13** (especially managed-vs-native, since that determines whether we
+own full `User`/`Session`/`Workspace` tables in D1 or store a vendor-id mapping). If Bae wants
+more provider depth first, a short **provider proof-read** (re-verify the **[verify]** cells —
+Kakao on the managed providers, Better Auth #4203 status, current pricing) precedes schema
+planning. **No implementation until Bae selects an architecture.**
+
+## 15. Now-safe vs gated
+- **Now-safe:** this provider matrix · architecture research · decision questions · schema
+  planning · auth copy updates ("requires sign-in" / Plan-Map blocker).
+- **Requires Bae auth approval:** installing a provider SDK · login/session routes · OAuth
+  provider setup · account linking · verified-email flow.
+- **Requires migration approval:** `User`/`Workspace`/`WorkspaceMember` tables · backfill
+  `userKey` projects · `Invitation`/`ProjectAccess` tables · `GateDecision`/`ActivityEvent`
+  tables.
+- **Requires deploy approval:** auth rollout · session middleware in production · workspace-gated
+  access · environment-variable changes.
+- **Requires security review:** token/cookie/session handling · JWKS verification · webhook
+  signature verification · provider metadata · invite/share tokens · audit logs.
+
+## 16. Stage 188 decision — **Option A: selection matrix ready (two finalists)**
+Current-doc-grounded comparison done. **Primary: Better Auth** (exact D1/Hono/Workers stack fit
++ native Kakao/Naver + low cost/lock-in). **Fallback: WorkOS AuthKit** (managed org-native, free
+to 1M MAU). **Defer Auth0/Supabase; Clerk third (per-org cost caution); custom rejected.** A
+handful of provider specifics are flagged **[verify]** for a pre-implementation check. **No code,
+no provider account, no token work.** Decision now sits with Bae (§13).
+
+## Sources (current, June 2026)
+- WorkOS pricing / orgs: https://workos.com/pricing
+- Clerk pricing: https://clerk.com/pricing · B2B/per-org: https://workos.com/blog/clerk-pricing · https://supertokens.com/blog/clerk-pricing-the-complete-guide
+- Clerk edge / networkless JWT: https://clerk.com/docs/guides/sessions/manual-jwt-verification · https://clerk.com/articles/authentication-for-serverless-and-edge-deployments
+- Auth0 pricing / B2B Organizations: https://auth0.com/pricing
+- Supabase Auth + RLS multi-tenancy: https://supabase.com/docs/guides/auth · https://github.com/supabase/auth
+- Better Auth: https://better-auth.com/ · Kakao: https://www.better-auth.com/docs/authentication/kakao · Naver: https://www.better-auth.com/docs/authentication/naver
+- Better Auth on Cloudflare D1/Hono: https://hono.dev/examples/better-auth-on-cloudflare · https://github.com/zpg6/better-auth-cloudflare
+- Edge JWT/JWKS verification practice: https://securityboulevard.com/2025/11/how-to-validate-jwts-efficiently-at-the-edge-with-cloudflare-workers-and-vercel/

--- a/conclave-builder-pack/out/stage-189-user-workspace-schema-planning.md
+++ b/conclave-builder-pack/out/stage-189-user-workspace-schema-planning.md
@@ -1,0 +1,213 @@
+# Stage 189 — User + Workspace Schema Planning (Better Auth primary)
+
+**Date:** 2026-06-25
+**Branch:** `docs/stage-187-188-auth-identity-selection` (auth train, continues 187/188) · **Base / deployed main:** `9b645af` · live: https://app.trysimsa.com
+**Type:** schema planning / docs only. **No auth implementation, no Better Auth/SDK install, no login routes, no session middleware, no OAuth, no migration, no deploy, no MCP/npm publish, no payment/billing, no domain/DNS, no server write, no token/secret request-print-store, no env-var change, no live-dashboard change.**
+
+> Backend = **Hono on Cloudflare Workers + D1 (SQLite-at-edge)**; migrations are sequential SQL
+> (latest ~0046). All new tables below are **conceptual** and **additive** (`0047+`). Better
+> Auth-specific column/table shapes are marked **[verify before implementation]** against current
+> Better Auth docs.
+
+## 1. Executive summary
+**Better Auth is the primary planning assumption** (native D1 + Hono + Workers, organization
+plugin, native Kakao/Naver — Stage 188). **WorkOS AuthKit stays a fallback** comparison. **No
+implementation, no install, no migration in this stage.** Real collaboration stays **blocked**
+until auth + migration + deploy approvals (separate Bae gates). The schema is designed
+**portable**: Simsa **owns** Workspace / WorkspaceMember / Invitation / GateDecision /
+ActivityEvent so a later swap (Better Auth ⇄ WorkOS) touches mostly the identity layer.
+
+## 2. Current state
+`userKey` = client-supplied tenant surrogate on every `workspace_*` table · `/account` =
+local/browser stub · Plan Map gates = read-only · **no** real user identity / workspace
+ownership / member roles / approval audit · GitHub/Vercel = integrations, **not** login identity.
+
+## 3. Schema design goals
+Stable identity mapping · workspace ownership · member roles · project ownership · project-access
+enforcement · invite lifecycle · integration ownership · approval-gate attribution · activity/
+audit trail · export scoping · **Better Auth compatibility** · **WorkOS-fallback portability**
+where feasible.
+
+## 4. Proposed tables / entities (conceptual — SQLite/D1, additive)
+> Convention: `id` = text UUID; timestamps = ISO text or epoch int; FKs reference the identity
+> `user.id`. "Owner" = who controls the row.
+
+### Identity layer — **Better Auth-owned in our D1** *(exact shapes [verify])*
+| Table | Purpose | Key fields | Owner | Indexes | Lifecycle | Security | MVP? |
+|---|---|---|---|---|---|---|---|
+| `user` | real identity | id, email, emailVerified, name, image, locale?, createdAt | self | unique(email) | created on first auth | email verified; no secrets | **MVP** |
+| `session` | login session | id, userId, token, expiresAt, ipAddress, userAgent | user | index(userId), unique(token) | create→expire/revoke | httpOnly/secure cookie; rotate | **MVP** |
+| `account` | provider/credential acct | id, userId, providerId, accountId, accessToken**(enc)**, refreshToken**(enc)**, scope, idToken | user | index(userId), unique(providerId,accountId) | link/unlink | **tokens encrypted server-side**, never exported | **MVP** |
+| `verification` | email/OTP tokens | id, identifier, value(hash), expiresAt | system | index(identifier) | create→consume/expire | hash-at-rest, short TTL | **MVP** |
+
+### Collaboration layer — **Simsa-owned** (portable across providers)
+| Table | Purpose | Key fields | Owner | Indexes | Lifecycle | Security | MVP? |
+|---|---|---|---|---|---|---|---|
+| `workspace` | team container | id, name, slug, ownerUserId, defaultLocale, createdAt, updatedAt, archivedAt? | owner | unique(slug) | create/rename/archive | owner-gated destructive | **MVP** |
+| `workspace_member` | membership+role | workspaceId, userId, role, status, joinedAt, invitedByUserId | workspace | **PK(workspaceId,userId)**, index(userId) | invite→active→removed | role change Owner/Admin only; Owner protected | **MVP** |
+| `invitation` | pending invite | id, workspaceId, email, role, tokenHash, status, expiresAt, acceptedAt, revokedAt, invitedByUserId | workspace | index(workspaceId), index(email) | create→accept/revoke/expire | **tokenHash only**, rate-limit, role ≤ inviter | Later |
+| `project` | existing + scope | …existing… **+ workspaceId**, ownerUserId? | workspace | index(workspaceId) | backfill from userKey | dual-read during cutover | **MVP (backfill)** |
+| `project_access` | per-project override | projectId, userId, role | workspace+project | **PK(projectId,userId)** | optional | defaults to workspace role | Later |
+| `share_link` | external link share | id, projectId, scope, tokenHash, expiresAt, revokedAt, createdByUserId, lastAccessedAt | project | index(projectId) | create→revoke/expire | **tokenHash only**, least scope, access log | Later |
+| `integration_account` | GitHub/Vercel conn | id, workspaceId, provider, externalId, scopes, status, **encryptedToken**, connectedByUserId, createdAt | workspace | index(workspaceId,provider) | connect/disconnect | **server-side encrypted**, never exported/printed | Later (migrate existing GitHub tokens) |
+| `gate_decision` | approval ledger | id, workspaceId, projectId?, gateType, targetRef, state, decidedByUserId, reason, createdAt, expiresAt? | workspace | index(workspaceId), index(projectId) | pending→approved/rejected/expired/superseded | attributes Plan-Map gates | Later |
+| `activity_event` | audit log | id, workspaceId, actorUserId, type, target, metadata(**no secrets**), createdAt | workspace | index(workspaceId,createdAt) | append-only | retention policy; no secrets in payload | Later |
+| `roadmap_event` *(opt)* | Plan-Map history | id, projectId, kind, actorUserId, createdAt | project | index(projectId,createdAt) | append-only | persists the now-generated map | Later |
+
+## 5. Better Auth mapping
+- **Better Auth `user` → Simsa `User`** (Better Auth owns the table in our D1; Simsa may add a
+  `locale` column). **[verify Better Auth user columns]**
+- **Better Auth `session` → Simsa session context** (request → userId; workspace context resolved
+  by Simsa from `workspace_member`). **[verify session/cookie model on `app.trysimsa.com`]**
+- **Better Auth `account` → provider/credential accounts** (GitHub-login, Kakao/Naver later,
+  email/password) — **distinct from** `integration_account` (repo/deploy access). **[verify]**
+- **Better Auth organization plugin** *(optional)* → could supply `organization`/`member`/
+  `invitation`. **Recommendation: do NOT outsource these — keep Simsa-owned `workspace`/
+  `workspace_member`/`invitation`** for (a) WorkOS portability and (b) full audit/control. Using
+  the org plugin is an **open question (§14)**; if adopted, treat its tables as Simsa-controlled
+  (they live in our D1). **[verify org-plugin schema + access-control model]**
+- **Kakao/Naver** = future social option via Better Auth providers — **not MVP** (email-first).
+- **Simsa must own** (never outsource): `gate_decision`, `activity_event`, `workspace`/roles —
+  these back the Plan-Map approval audit and must be queryable/portable.
+
+## 6. WorkOS fallback mapping
+If WorkOS is chosen instead: **WorkOS user → `User`** (vendor-side; store an `external_id`
+mapping in our `user`), **WorkOS organization → `workspace`** (or mirror into our `workspace`),
+**WorkOS membership → `workspace_member`**, **WorkOS invitation → `invitation`** (or an external
+invitation reference). **`gate_decision`, `activity_event`, `integration_account` stay
+Simsa-owned.** Because the collaboration layer is Simsa-owned in both cases, the swap touches
+mainly the **identity layer + a mapping column** — the portability goal.
+
+## 7. Role & permission model
+Roles: **Owner · Admin · Editor · Reviewer · Viewer.**
+| Action | Owner | Admin | Editor | Reviewer | Viewer |
+|---|:--:|:--:|:--:|:--:|:--:|
+| View project / Plan Map | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Edit brief / acceptance items | ✓ | ✓ | ✓ | | |
+| Create stage plan | ✓ | ✓ | ✓ | | |
+| Run evidence collection | ✓ | ✓ | ✓ | | |
+| Approve **merge** gate | ✓ | ✓ | | | |
+| Approve **deploy** gate | ✓ | ✓ (scope TBD §14) | | | |
+| Approve **migration/publish** gate | ✓ | | | | |
+| Manage integrations | ✓ | ✓ | | | |
+| Invite members | ✓ | ✓ | | | |
+| Remove members | ✓ | ✓ | | | |
+| Change roles | ✓ | ✓ | | | |
+| Export project data | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Export workspace data | ✓ | ✓ | | | |
+| Delete/archive project | ✓ | ✓ | | | |
+**Role enforcement is future implementation;** today's `userKey` cannot enforce any of this.
+
+## 8. Migration / rollout phases (additive only — do not implement)
+| Phase | What | Approval gate | Rollback | Verification | Prod risk |
+|---|---|---|---|---|---|
+| **0** | current `userKey`/browser | — | — | — | none |
+| **1** | freeze schema assumptions (this doc + Bae §14) | decision | n/a | review | none |
+| **2** | add `user`+`workspace`+`workspace_member` behind **feature flag** | **migration** + security review | drop new tables (unused) | tables created, no read-path change | low |
+| **3** | **backfill** `userKey` projects → default workspace | **migration** | keep `userKey`; revert mapping | row counts match; no cross-tenant | med |
+| **4** | session middleware + workspace context | **auth + deploy** + env + security review | disable middleware (flag) | auth E2E; cookie/CORS | med |
+| **5** | switch project reads to workspace-aware | **deploy** | flag back to `userKey` read | dual-read parity | **high** |
+| **6** | invitations + project access | **migration** + security review (tokens) | drop tables | invite E2E; token hash/expiry | med |
+| **7** | integration-ownership migration (existing GitHub tokens → `integration_account`) | **migration** + security review | keep old storage | tokens decrypt; no leak | med |
+| **8** | `gate_decision`/`activity_event`/Plan-Map approval audit | **migration** | drop tables | attribution correct | med |
+| **9** | account/workspace export + deletion flows | **deploy** + security review | disable flows | export secret-free; deletion complete | med |
+
+## 9. userKey transition strategy
+- **Preserve the `userKey` column** through cutover (no drop until proven).
+- Create a **default workspace per authenticated user** (map `userKey`→ owner's first workspace
+  on first sign-in; or per-`userKey` default workspace during backfill).
+- **Never delete old records**; **no automatic destructive merge** of `userKey` tenants
+  (a wrong merge = cross-tenant leak).
+- **Dual-read period:** read by `workspace_id` with `userKey` fallback until parity verified.
+- **Audit unmatched records** (userKey with no mapped user/workspace) before switching read paths.
+- **Rollback** = flip the read path back to `userKey`.
+
+## 10. GateDecision / Plan Map approval model
+- **Gate types:** `merge · deploy · migration · publish · auth · payment · dns · production_write`.
+- **States:** `pending · approved · rejected · expired · superseded`.
+- **Fields:** id, **userId** (decider), **workspaceId**, projectId?, stageId/trainId/targetRef?,
+  decision, reason, createdAt, expiresAt?.
+- **Why:** the Plan Map's read-only gate cards become **attributable approvals** — who approved
+  which gate, when, why — the audit the live read-only preview cannot provide today.
+- **Evolution:** read-only Plan Map (Stage 182~186) → + `gate_decision` attribution + role-aware
+  visibility → an **approval map** with history (`roadmap_event`). Requires real identity +
+  `workspace_member`.
+
+## 11. IntegrationAccount ownership
+- **Providers:** GitHub, Vercel, future. **Owner context = user + workspace.**
+- **Token storage: encrypted server-side only** (as `crypto.ts` does) — **never exported, never
+  printed, never browser-local.**
+- **Visible connected identity** (which provider account is linked) + **least-privilege scopes**.
+- **connect/disconnect → `activity_event`** audit entries.
+- **Write actions** (PR comment beyond confirm, deploy/promote) stay **explicit approval-gated**.
+
+## 12. Share / invite / export implications
+- **Private links → `project_access`** (auth required).
+- **Public links → `share_link`** (tokenHash, expiry, revoke, access log, least scope).
+- **Invitations → verified email + session + invite token** (hash-at-rest, rate-limited,
+  expiring; role ≤ inviter).
+- **Project export** uses project/workspace authorization; **secret-free**.
+- **Workspace export** requires **Owner/Admin**; **tokens/secrets excluded** always.
+- **Imported artifact ≠ live access/identity** (re-import is not auth).
+
+## 13. Security review checklist (before implementation)
+Session cookies (domain/SameSite/secure on `app.trysimsa.com`) · CSRF/CORS (Vercel↔Workers
+split) · JWKS/auth verification at the edge · webhook signatures · invite-token hash/expiry ·
+share-link token hash/expiry · **encrypted provider-token storage** · account deletion · data
+export (secret-free) · audit-log retention · rate limiting · abuse prevention. Each = a
+**security-review gate**.
+
+## 14. Open questions for Bae
+1. Confirm **Better Auth as primary**? (this doc assumes yes)
+2. Keep **WorkOS** as fallback? (recommended yes)
+3. **Email-only MVP** or social day-one? (recommended email-only)
+4. **Kakao/Naver** MVP or later? (recommended later)
+5. **Better Auth organization plugin** vs **Simsa-owned workspace tables**? (recommended
+   Simsa-owned for portability + audit)
+6. **Unify** provider `user` and Simsa `User`, or **map** via `external_id`? (recommended unify
+   on Better Auth `user`; map for WorkOS)
+7. **Who approves deploy gates in MVP** — Owner only, or Owner+Admin?
+8. Is a **Reviewer-only role** needed in MVP, or defer?
+9. **Audit-log retention** period?
+
+## 15. Recommendation
+- **Adopt a portable schema:** Simsa **owns** `workspace` / `workspace_member` / `invitation` /
+  `gate_decision` / `activity_event` / `integration_account` even though Better Auth (or WorkOS)
+  supplies identity/orgs — so a provider swap is mostly an identity-layer change.
+- **Better Auth primary planning can continue;** use Better Auth for `user`/`session`/`account`/
+  `verification`, **Simsa-owned** for the collaboration layer.
+- **Do not implement auth until Bae approves provider + migration plan** (and the §13 security
+  review is scheduled).
+- **MVP table set:** `user`, `session`, `account`, `verification` (Better Auth) + `workspace`,
+  `workspace_member`, `project(+workspaceId backfill)`. Everything else (invitations, share,
+  integration ownership, gate/audit) is **Phase 6+**.
+
+## 16. Now-safe vs gated
+- **Now-safe:** schema planning · permission matrix · migration phases · security checklist ·
+  auth-related UI copy planning.
+- **Requires Bae auth approval:** installing Better Auth · login/session routes · social provider
+  setup · organization-plugin setup · OAuth account linking.
+- **Requires migration approval:** `user`/`workspace`/`workspace_member` tables · backfill
+  `userKey` projects · `project_access`/`invitation`/`share_link` · `gate_decision`/
+  `activity_event` · token-storage schema.
+- **Requires deploy approval:** session-middleware rollout · workspace-aware project reads ·
+  production auth UI · environment-variable changes.
+- **Requires security review:** cookie/JWKS/session · invite/share tokens · encrypted provider
+  tokens · webhooks · account deletion/export · audit retention.
+
+## 17. Stage 189 decision — **Option A: schema plan ready (Better Auth primary, portable)**
+A conceptual, migration-ready, **portable** schema is defined: Better Auth-owned identity
+(`user`/`session`/`account`/`verification`) + **Simsa-owned** collaboration (`workspace`/
+`workspace_member`/`invitation`/`project+workspaceId`/`project_access`/`share_link`/
+`integration_account`/`gate_decision`/`activity_event`/`roadmap_event`), with a role/permission
+matrix, 0→9 additive rollout (per-phase approval + rollback + verification), a safe `userKey`
+transition, the Plan-Map approval model, and a security checklist. **No code, no install, no
+migration.** Open questions (§14) return to Bae.
+
+## 18. Recommended next stage
+**Stage 190 — Auth Train PR Prep / Push / Review Gate** (bundle the Stage 187 brief + Stage 188
+matrix + Stage 189 schema plan into one docs PR against `main`; no implementation) — **or**, if
+Bae prefers, a short **Better Auth proof-read** (re-verify the §4/§5 **[verify]** items — exact
+Better Auth `user`/`session`/`account`/org-plugin schema on D1, session/cookie model, #4203
+status) before opening the PR. Auth install / migration / deploy each remain **separately
+Bae-approval-gated**.


### PR DESCRIPTION
## Stage 187~189 — Auth / Identity Foundation Planning

Planning-only auth train. **No auth implementation, no package install, no migration, no deploy, no token/secret handling.** Real collaboration stays blocked until Bae approves a provider, a migration plan, and a deploy plan.

### What's in this PR (3 docs-only commits)
- **Stage 187 — Auth / Identity Foundation Decision Brief:** why `userKey` (client-supplied tenant surrogate) is **not** identity; what identity must provide (stable user id, verified email, session, workspace/membership/roles, gate/audit attribution); conceptual domain + role model; phased migration; safety gates.
- **Stage 188 — Auth Provider / Architecture Selection Matrix:** current-doc-grounded (June 2026) comparison. **Better Auth = primary** (native Cloudflare D1 + Hono + Workers, organization plugin, native Kakao/Naver, flat self-host cost, low lock-in); **WorkOS AuthKit = managed fallback** (org-native, free to 1M MAU). Auth0/Supabase deferred; Clerk third (per-org cost caution); **custom rejected**. Provider specifics that need re-checking are marked `[verify]`.
- **Stage 189 — User + Workspace Schema Planning:** conceptual, migration-ready, **portable** schema — identity layer (`user`/`session`/`account`/`verification`) may be provider-backed; **collaboration layer (`workspace`/`workspace_member`/`invitation`/`project+workspaceId`/`project_access`/`share_link`/`integration_account`/`gate_decision`/`activity_event`/`roadmap_event`) stays Simsa-owned** for portability + audit. Includes role/permission matrix, additive rollout phases 0–9 (per-phase approval + rollback + verification), `userKey` transition (preserve column, default workspace, dual-read, no destructive merge), the GateDecision / Plan-Map approval model, IntegrationAccount ownership, and a security-review checklist.

### Key decisions captured
- `userKey` is insufficient for real identity.
- **Better Auth = primary** planning assumption; **WorkOS = fallback**; **custom auth rejected**.
- **Portable schema principle:** the identity provider can change; the collaboration layer remains Simsa-owned.
- **MVP identity floor:** `User` + session + provider `account` + `verification` + `Workspace` + `WorkspaceMember` + project→workspace backfill.
- Payment remains **TBD** (Korea-compatible provider evaluated later; **no Stripe assumption**).
- Tokens/secrets are never printed or requested; `[verify]` items must be re-checked before implementation.

### Out of scope (not in this PR)
No auth/OAuth/session impl · no Better Auth/SDK install · no migration · no deploy · no MCP/npm publish · no payment/billing · no domain/DNS · no central-plane change · no DB persistence · no server write · no token/secret · no live-dashboard change.

### Implementation remains blocked until (in order)
1. Bae selects the architecture, 2. Better Auth (or fallback) `[verify]` specifics are re-verified, 3. the migration plan is approved, 4. auth implementation is separately approved, 5. the deployment plan is separately approved.

### Verification
`pnpm typecheck` — **57/57**. Docs-only; no code/migration/config/package change; secret scan clean.

### Recommended next (after review)
A **merge approval gate** (Stage 191, only with explicit Bae merge approval), then **Stage 192 — Better Auth Proof-read / Implementation Readiness Check** (docs/research only). **Not merged, not implemented.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
