### PR TITLE
Stage 192~194 — Better Auth Proof-read and Implementation Plan

### DIFF
--- a/conclave-builder-pack/out/stage-192-better-auth-proofread-implementation-readiness.md
+++ b/conclave-builder-pack/out/stage-192-better-auth-proofread-implementation-readiness.md
@@ -1,0 +1,201 @@
+# Stage 192 — Better Auth Proof-read / Implementation Readiness Check
+
+**Date:** 2026-06-25
+**Branch:** `docs/stage-192-better-auth-proofread` · **Base / main:** `d869560` · production deploy: `9b645af` (Plan Map) · live: https://app.trysimsa.com
+**Type:** research / proof-read / docs only. **No auth implementation, no Better Auth install, no package.json/lockfile change, no login routes, no session middleware, no OAuth, no migration, no deploy, no MCP/npm publish, no payment/billing, no domain/DNS, no server write, no DB persistence, no token/secret request-print-store, no env-var change, no live-dashboard change.**
+
+> Re-verified against **current Better Auth official docs + GitHub issues** (URLs in §Sources).
+> Facts not confirmable from a primary source are marked **[verify]** / **[unknown]**. No memory
+> reliance; no tokens/secrets.
+
+## 1. Executive summary
+**Better Auth remains viable as the primary candidate (Option A).** Primary docs confirm: a
+4-table identity schema, **Cloudflare D1 support** (Kysely built-in / Drizzle / community
+`better-auth-cloudflare`), a Hono mount pattern, DB-backed sessions, and a documented
+**organization plugin** (members/roles/invitations). **No hard blocker found.** Cautions: the
+**#4203 / #10021 cookieCache-with-secondary-storage logout bug** (avoid the `cookieCache` +
+KV-`secondaryStorage` combo — use DB-backed D1 sessions), the **exact Workers/D1 binding wiring**
+is in the Cloudflare integration/community guide rather than the Hono page **[verify]**, and
+Simsa's 5-role model needs **custom access control** (the org plugin defaults to
+owner/admin/member). **WorkOS fallback stays active.** **Confidence: medium-high. No
+implementation in this stage.**
+
+## 2. Current Simsa baseline
+`main` `d869560` carries **auth planning docs only**. Production (`9b645af`) has **Plan Map live,
+no auth**. `/account` = local stub · `userKey` insufficient · real collaboration **blocked**.
+
+## 3. Better Auth runtime fit
+- **Hono:** official mount — `app.on(["POST","GET"], "/api/auth/*", (c) => auth.handler(c.req.raw))`
+  (verified). CORS via `hono/cors` with `credentials: true`; middleware injects `user`/`session`.
+- **Cloudflare Workers / D1:** **D1 is a supported database** (Kysely built-in adapter covers
+  SQLite/D1; Drizzle also; community `better-auth-cloudflare` + a `hono.dev` example exist). The
+  **Hono docs page itself does not detail Workers/D1 binding wiring** — that lives in the
+  Cloudflare integration guide / community package **[verify exact D1-binding + edge wiring before
+  implementation]**.
+- **Vercel ⇄ Workers split:** Better Auth can run **either** in the **central-plane (Hono on
+  Workers + D1)** — recommended, co-located with the data it authorizes — **or** as a Next.js
+  route on Vercel. **Recommendation: host the auth handler in central-plane (Workers/D1)**, with
+  the dashboard calling it; this keeps identity next to `workspace_*`/D1 and the existing
+  encrypted-token store. **[verify cookie domain works across `app.trysimsa.com` ⇄ the
+  central-plane host]** (§5).
+- **Edge caveats:** DB-backed sessions on D1 = a D1 read per request (acceptable at the edge);
+  `cookieCache` would reduce reads **but** triggers the #4203 caution (§8). Stateless/encrypted
+  sessions are an option but reduce revocation control.
+
+## 4. Better Auth schema expectations (verified)
+**Better Auth-owned core tables** *(do not hand-edit without understanding Better Auth)*:
+| Table | Key fields (verified) |
+|---|---|
+| `user` | id(PK), name, email, emailVerified(bool), image, createdAt, updatedAt |
+| `session` | id(PK), userId(FK), token, expiresAt, ipAddress?, userAgent?, createdAt, updatedAt |
+| `account` | id(PK), userId(FK), accountId, providerId, accessToken?, refreshToken?, accessTokenExpiresAt?, scope, idToken?, password?(credential), timestamps |
+| `verification` | id(PK), identifier, value, expiresAt, timestamps |
+**Adapters:** Kysely (built-in: SQLite/**D1**, Postgres, MySQL, MSSQL), Drizzle, Prisma, MongoDB;
+can run **without a DB** (stateless). → **`user`/`session`/`account`/`verification` are Better
+Auth-owned** (created/migrated via Better Auth's CLI/schema generator **[verify generator on
+D1]**). **Simsa-owned** tables (§9) reference `user.id`.
+
+## 5. Session & cookie model (verified)
+- **Default = DB-backed sessions** (queried each request); also **stateless/encrypted-cookie** and
+  **secondary storage** (Redis/KV) modes.
+- **`cookieCache`** = short-lived signed cookie (`compact` default / `jwt` / `jwe`), `maxAge` —
+  reduces DB hits but see §8.
+- **Expiration:** `expiresIn` default **7 days**; auto-refresh at `updateAge` (default 1 day);
+  `freshAge` (default 1 day).
+- **Cookie attributes:** `crossSubDomainCookies`, `defaultCookieAttributes`, per-cookie
+  `sameSite`/`secure` are configurable (Hono integration). **Exact httpOnly/secure/SameSite
+  defaults [verify]**; must set **secure + appropriate SameSite + domain** for
+  `app.trysimsa.com` and confirm CORS (`credentials: true` / client `credentials: "include"`).
+- **Cross-subdomain:** if dashboard and auth host differ, use `crossSubDomainCookies` **[verify
+  domain layout]**.
+- **Logout/invalidation:** `revokeSession()` / `revokeOtherSessions()` / `revokeSessions()`;
+  stateless invalidation via a `version` bump.
+
+## 6. Organization plugin proof-read (verified)
+- **Exists, documented, no stated maturity/stability warning.** Tables: `organization`
+  (id,name,slug,logo,metadata,createdAt), `member` (id,userId,organizationId,role,createdAt),
+  `invitation` (id,email,inviterId,organizationId,role,status,createdAt,expiresAt); `session`
+  extended with `activeOrganizationId`/`activeTeamId`. Optional: `organizationRole`, `team`,
+  `teamMember`.
+- **Roles:** defaults **owner/admin/member**; **custom roles via `createAccessControl()`** and
+  **`dynamicAccessControl`** (runtime, DB-stored). → **Simsa's Owner/Admin/Editor/Reviewer/Viewer
+  is achievable but requires custom access-control config** (not out-of-the-box).
+- **Invitations:** `sendInvitationEmail` callback → `inviteMember` → `acceptInvitation`/
+  `rejectInvitation`/`cancelInvitation`; default expiry **48h**, member limit **100** (configurable).
+- **Fit / risk:** functionally covers members/roles/invites. **Decision point:** use the plugin's
+  `organization`/`member`/`invitation` **or** keep **Simsa-owned `workspace`/`workspace_member`/
+  `invitation`** (Stage 189). The plugin is faster; Simsa-owned is more portable (WorkOS) + gives
+  direct audit control. **No maturity blocker**, but custom-roles + plugin-shaped tables are an
+  implementation consideration (caution, not blocker).
+
+## 7. Kakao / Naver / social provider note (verified)
+- **Kakao and Naver are documented first-class social providers** (dedicated docs pages;
+  `socialProviders` with clientId/clientSecret) — lowest-effort path for Korea social later.
+- **Recommendation unchanged: email-first MVP**; Kakao/Naver **post-MVP** (low effort to add via
+  Better Auth when the market need is concrete).
+
+## 8. Known issue / risk review
+| Risk | Source | Status | Classification | Mitigation |
+|---|---|---|---|---|
+| **#4203** `secondaryStorage` TTL forces re-login (cookieCache + KV after cache expiry → logout instead of falling back to storage) | github #4203 | **OPEN, reopened Jan 2026** | **Caution** (combo-specific) | **Avoid `cookieCache` + KV-`secondaryStorage` combo; use DB-backed D1 sessions** |
+| **#10021** expired `session_data` cookie cache logs out instead of DB fallback | github #10021 | open (same family) | **Caution** | same — don't rely on cookieCache for fallback |
+| Exact Workers/D1 binding + edge wiring | Hono docs page silent | **[verify]** | **Watch** | confirm via Cloudflare integration guide / community pkg before impl |
+| 5-role model needs `createAccessControl` | org-plugin docs | n/a | **Caution** | plan custom access control |
+| Maintenance/release status | docs/changelog | active (Better Auth 1.5 referenced) | **Watch** | pin a reviewed version at impl |
+**Net:** no **blocker**; cautions are configuration-avoidable. Do not over-index on #4203 — it
+only bites the cookieCache+secondary-storage combination Simsa need not use.
+
+## 9. Simsa-owned collaboration layer check
+The Stage 189 portability principle **still holds**:
+- **Better Auth owns:** `user` · `session` · `account` · `verification`.
+- **Simsa owns:** `Workspace` · `WorkspaceMember` · `Invitation` (unless the org plugin is
+  adopted — open question §14) · `ProjectAccess` · `IntegrationAccount` · `GateDecision` ·
+  `ActivityEvent` · `PlanMap/Roadmap` events.
+**Why portability matters:** keeping the collaboration layer Simsa-owned means a later swap
+(Better Auth ⇄ WorkOS) touches mainly the identity layer + a mapping column, and keeps the
+Plan-Map approval **audit** fully queryable/controlled by Simsa rather than a vendor.
+
+## 10. Migration-readiness impact (for Stage 193+)
+A future migration stage must plan: **exact tables** (Better Auth `user`/`session`/`account`/
+`verification` via its generator **[verify on D1]** + Simsa collaboration tables) · **additive
+migrations** (`0047+`) · **feature flag** · **`userKey` backfill** → default workspace · **dual-
+read** fallback · **rollback** (keep `userKey` columns) · **local/dev verification** (wrangler D1
+local) · **production migration approval** · **no destructive migration** (never auto-merge
+`userKey` tenants).
+
+## 11. Security review checklist (refined)
+Cookie attributes (**httpOnly + secure + SameSite + domain** on `app.trysimsa.com`) **[verify
+defaults]** · CSRF/CORS for the Vercel↔Workers split (`credentials` both ends) · session
+expiration/refresh (`expiresIn`/`updateAge`/`freshAge`) · **encrypted token storage** for
+`account`/`integration_account` · provider account linking · **OAuth callback handling** (redirect
+allowlist) · webhook signatures **[if any used]** · invite-token design (hash-at-rest, 48h default
+**[confirm]**) · audit-log attribution · account deletion/export (secret-free) · rate limiting /
+abuse prevention. Each = a **security-review gate**.
+
+## 12. Implementation-readiness checklist (future stage — do NOT implement now)
+- [ ] **Architecture choice confirmed by Bae** (Better Auth vs WorkOS; org-plugin vs Simsa-owned).
+- [ ] **Better Auth exact version selected** (pin + review changelog; confirm #4203/#10021 status
+      at that version).
+- [ ] **Auth runtime location decided** (recommended central-plane Workers/D1).
+- [ ] **Migration plan approved** (additive `0047+`, feature flag, `userKey` backfill, rollback).
+- [ ] **Env-var handling plan approved** (auth secrets server-side only, never printed).
+- [ ] **Local dev auth flow plan** (wrangler D1 local; `/api/auth/*` mount).
+- [ ] **Test plan** (session E2E, cookie/CORS, role checks, dual-read parity).
+- [ ] **Rollback plan** (flag back to `userKey` read path).
+- [ ] **Deploy plan** (separate Bae approval; auth routes + cookies in production).
+- [ ] **Security review completed** (§11).
+
+## 13. Decision update — **Option A: Better Auth remains the primary candidate**
+Current primary-source proof-read **supports** the Stage 188/189 recommendation: D1/Hono fit
+confirmed, schema known, org plugin real, Kakao/Naver first-class. **No blocker**; the risks are
+**cautions** that are configuration-avoidable (DB-backed sessions; avoid cookieCache+KV; plan
+custom roles; verify edge/D1 wiring). **WorkOS fallback stays active.** (Not Option B/C/D — no
+uncertainty rising to a spike-blocker or downgrade.)
+
+## 14. Bae decision questions (updated)
+1. Confirm **Better Auth primary**? (proof-read says yes)
+2. Keep **WorkOS fallback**? (recommended yes)
+3. **Email-first MVP**? (recommended yes)
+4. **Kakao/Naver later**? (recommended yes — first-class when needed)
+5. **Simsa-owned `workspace`/`workspace_member`** — or **adopt Better Auth org plugin**? (lean
+   Simsa-owned for portability/audit; plugin is the faster alternative)
+6. **Where does auth runtime live** — central-plane (Workers/D1, recommended) or dashboard?
+7. **First approved implementation slice** — e.g. identity-only (`user`/`session`/`account`/
+   `verification` + sign-in) behind a flag, before any workspace migration?
+8. **Acceptable migration gate** — additive + flag + dual-read + rollback (recommended)?
+9. **Audit-log retention** period?
+
+## 15. Recommended next stage
+**Stage 193 — Auth Architecture Decision Gate** (Bae answers §14 → freeze: provider, org-plugin
+vs Simsa-owned, runtime location, first slice). Then **Stage 194 — Better Auth Minimal
+Implementation Plan** (identity-only slice, still planning until Bae approves install + migration
++ deploy). A **WorkOS Fallback Deep Review** is only needed if Bae leans managed.
+
+## 16. Now-safe vs gated
+- **Now-safe:** this proof-read · source verification · decision questions · implementation-
+  readiness checklist · migration-planning notes.
+- **Requires Bae auth approval:** installing Better Auth · auth routes · session middleware ·
+  OAuth/social providers · account linking.
+- **Requires migration approval:** Better Auth tables · Simsa `User`/`Workspace`/`WorkspaceMember`
+  tables · `userKey` backfill · `IntegrationAccount` ownership · `GateDecision`/`ActivityEvent`.
+- **Requires deploy approval:** auth routes in production · session cookies in production ·
+  workspace-aware project reads · env-var changes.
+- **Requires security review:** cookies/sessions · OAuth callbacks · token storage · invite/share
+  tokens · audit trail · account deletion/export.
+
+## 17. Stage 192 decision — **Option A (Better Auth primary, no blocker; cautions documented)**
+Proof-read against current primary sources confirms Better Auth fits Simsa's D1/Hono/Workers
+direction; identity schema + org plugin + Kakao/Naver verified; the #4203/#10021 logout risk is a
+configuration-avoidable **caution**, not a blocker; edge/D1 binding wiring + cookie defaults are
+flagged **[verify]** for the implementation stage. The portable Simsa-owned collaboration layer
+(Stage 189) holds. **No code, no install, no migration.** Decisions return to Bae (§14).
+
+## Sources (current)
+- Better Auth database/schema: https://www.better-auth.com/docs/concepts/database
+- Session management / cookies: https://www.better-auth.com/docs/concepts/session-management
+- Hono integration: https://www.better-auth.com/docs/integrations/hono
+- Organization plugin: https://www.better-auth.com/docs/plugins/organization
+- Kakao provider: https://www.better-auth.com/docs/authentication/kakao · Naver: https://www.better-auth.com/docs/authentication/naver
+- Issue #4203 (secondaryStorage TTL re-login): https://github.com/better-auth/better-auth/issues/4203
+- Issue #10021 (expired cookie cache logout vs DB fallback): https://github.com/better-auth/better-auth/issues/10021
+- Cloudflare D1/Workers integration (community): https://hono.dev/examples/better-auth-on-cloudflare · https://github.com/zpg6/better-auth-cloudflare

--- a/conclave-builder-pack/out/stage-193-auth-architecture-decision-gate.md
+++ b/conclave-builder-pack/out/stage-193-auth-architecture-decision-gate.md
@@ -1,0 +1,176 @@
+# Stage 193 — Auth Architecture Decision Gate
+
+**Date:** 2026-06-25
+**Branch:** `docs/stage-192-better-auth-proofread` (auth train, continues 192) · **Base / main:** `d869560` · production deploy: `9b645af` (Plan Map) · live: https://app.trysimsa.com
+**Type:** decision record / docs only. **No auth implementation, no Better Auth install, no package.json/lockfile change, no login routes, no session middleware, no OAuth, no migration, no deploy, no MCP/npm publish, no payment/billing, no domain/DNS, no server write, no DB persistence, no token/secret request-print-store, no env-var change, no live-dashboard change. Stale dogfood PRs #121~130 not touched.**
+
+> This is a **decision-gate** that freezes the architecture *direction*. It does **not** approve
+> implementation, install, migration, env-vars, token handling, or deploy. No blocker was found
+> while writing this record, so the recommended architecture below is **adopted for planning**.
+
+## 1. Executive decision
+- **Primary auth architecture: Better Auth** (selected for planning).
+- **Fallback: WorkOS AuthKit** (managed; remains active).
+- **Collaboration layer: Simsa-owned** (`workspace`/`workspace_member`/`invitation`/
+  `project_access`/`integration_account`/`gate_decision`/`activity_event` are Simsa's source of
+  truth).
+- **Better Auth organization plugin: NOT the MVP source of workspace truth** (deferred; later
+  optional reference only).
+- **Auth runtime: planned for central-plane / Cloudflare Workers / D1** (not browser-local).
+- **Implementation remains BLOCKED** until separate Bae approvals (auth install → migration →
+  deploy), each with security review.
+
+## 2. Decision basis (Stage 187~192 evidence)
+- **Stage 187 (brief):** `userKey` is a client-supplied tenant surrogate, **not** authentication;
+  MVP identity floor = User(verified email)+Workspace+WorkspaceMember+session.
+- **Stage 188 (matrix):** current-doc-grounded — **Better Auth primary** (native D1+Hono+Workers,
+  org plugin, native Kakao/Naver, flat self-host cost, low lock-in); **WorkOS fallback** (org-
+  native, free to 1M MAU); Auth0/Supabase deferred; Clerk third; custom rejected.
+- **Stage 189 (schema):** portable schema — identity provider-backed, **collaboration Simsa-owned**.
+- **Stage 192 (proof-read):** primary-source-verified — 4-table identity schema; **D1 viable**;
+  **DB-backed sessions** viable at the edge; org plugin real (owner/admin/member + custom roles
+  via `createAccessControl`); **Kakao/Naver first-class** (later benefit); **#4203/#10021
+  cookieCache+secondary-storage logout = caution, avoidable** (use DB-backed D1 sessions, no
+  cookieCache+KV combo); **no blocker**. WorkOS fallback retains value (offloads security).
+
+## 3. Explicit architecture choices
+| Dimension | Decision |
+|---|---|
+| Provider | **Better Auth** |
+| Fallback | **WorkOS AuthKit** |
+| Identity runtime | **central-plane / Cloudflare Workers / D1** |
+| Dashboard role | **consumes** session/auth state — **not** source of truth |
+| Workspace source of truth | **Simsa-owned tables** |
+| Membership source of truth | **Simsa-owned tables** |
+| GateDecision source of truth | **Simsa-owned tables** |
+| ActivityEvent source of truth | **Simsa-owned tables** |
+| IntegrationAccount source of truth | **Simsa-owned tables** |
+| Better Auth org plugin | **defer / not MVP** |
+| Kakao / Naver | **later, not an MVP blocker** |
+| Email-first MVP | **acceptable** |
+| Payment provider | **TBD, no Stripe assumption** |
+
+## 4. What is approved by this decision
+- The **architecture planning direction** (Better Auth primary, Simsa-owned collaboration,
+  central-plane/Workers/D1 runtime target).
+- Future **implementation planning** may assume **Better Auth primary**.
+- Future **schema planning** may assume **Simsa-owned collaboration tables**.
+- Future **proof-of-concept planning** may target **D1 / Hono / Workers**.
+**This decision does NOT approve** implementation, migration, deployment, env-var changes, or
+token handling.
+
+## 5. What is NOT approved
+Installing Better Auth · adding auth routes · adding session middleware · adding OAuth providers ·
+creating migrations · creating `User`/`Workspace` tables · changing project-access behavior ·
+turning on workspace-aware reads · adding invitation flow · adding role enforcement · adding Plan
+Map approval audit · connecting GitHub/Vercel ownership · changing production env vars · deploying
+auth. **All remain separately Bae-approval-gated.**
+
+## 6. Architecture diagram (text)
+```
+Browser / Dashboard (Vercel, app.trysimsa.com)
+  → calls dashboard pages + central-plane auth/session endpoints (/api/auth/*)
+      → central-plane (Hono on Cloudflare Workers + D1) verifies the session
+          → Better Auth-owned identity:  user · session · account · verification   (D1)
+          → Simsa-owned collaboration:   workspace · workspace_member · project(+workspaceId)
+                                          · project_access · invitation · gate_decision
+                                          · activity_event · (roadmap_event)         (D1)
+          → integration tokens:          integration_account, server-side ENCRYPTED  (later)
+Dashboard consumes session/auth state; it is NOT the source of truth.
+userKey persists as legacy tenant-scoping fallback during transition (never authentication).
+```
+
+## 7. First future implementation slice (plan only — Stage 194+)
+The smallest safe future slice (still **planning**, not execution):
+- **Better Auth minimal identity setup plan** (`user`/`session`/`account`/`verification` + sign-in)
+  **behind a feature flag**.
+- **Simsa `User` mapping** only if needed (open question §16).
+- **No** team invite · **no** workspace role enforcement · **no** Plan-Map gate approval · **no**
+  integration-ownership migration.
+- **Local-only proof plan** (wrangler D1 local), **exact table list**, **exact env-var plan
+  without values**, **test plan**, **rollback plan**.
+**First real implementation still requires explicit Bae auth approval + migration approval.**
+
+## 8. Migration gate implications (approve later)
+Better Auth identity tables (via its generator **[verify on D1]**) · Simsa `User` mapping (if
+used) · `Workspace` table · `WorkspaceMember` table · `userKey` backfill plan → default workspace ·
+**additive migration number (`0047+`)** · **local D1 verification** · **production migration
+approval** · **rollback plan** (preserve `userKey` columns; no destructive merge).
+
+## 9. Runtime gate implications (approve later)
+Central-plane auth runtime location (Workers/D1) · dashboard→auth **domain/cookie strategy**
+(`crossSubDomainCookies` if hosts differ) · **CORS/CSRF** (credentials both ends) · **session
+verification strategy** (DB-backed D1) · **local dev auth flow** · **production deploy plan**.
+
+## 10. Security gate implications (review later)
+Cookie **httpOnly/secure/SameSite/domain** **[verify defaults]** · session expiration/`updateAge`/
+`freshAge` · **OAuth callback allowlist** · provider-account **token encryption** · invite/share
+**token hash/expiry** · **audit retention** · **account deletion/export** (secret-free) · **rate
+limiting** · **abuse prevention**.
+
+## 11. WorkOS fallback trigger
+Switch to WorkOS if: Better Auth **D1/Hono integration proves unstable**; Better Auth
+**session/cookie behavior creates unacceptable risk** (e.g. #4203-class issue cannot be configured
+around); **organization/member requirements exceed manageable custom work**; **security
+responsibility is too high** for the early team; or an **implementation spike reveals a blocker**.
+
+## 12. Plan Map relationship
+Current Plan Map stays **read-only**. `GateDecision` (attributable approvals) is **future**. **No
+Plan-Map approval audit before real identity.** This decision **unblocks future planning only —
+not approval features**. The blocker copy can later evolve **"Blocked by identity decision" →
+"Auth architecture selected"** — but **not** "implemented" until implementation ships.
+
+## 13. Collaboration feature relationship
+Team/invite/share/roles remain **blocked until implementation**. Stage 193 **only decides
+architecture**. Workspace-aware project access requires **migration + auth implementation + deploy
+approval**. `userKey` **cannot enforce any collaboration rights.**
+
+## 14. Integration ownership relationship
+GitHub/Vercel connected accounts stay **separate from login identity**. `IntegrationAccount`
+remains a **future Simsa-owned** table; tokens stay **server-side encrypted** later. **No
+integration-ownership migration yet; no write actions without explicit gates.**
+
+## 15. Decision questions CLOSED (for planning)
+- Better Auth primary? **yes** · WorkOS fallback? **yes** · email-first MVP? **yes** ·
+  Kakao/Naver MVP? **no, later** · Simsa-owned workspace/member? **yes** · Better Auth org plugin
+  MVP? **no** · auth runtime? **central-plane / Workers / D1 target** · first slice? **identity-only
+  behind a flag**.
+
+## 16. Decision questions STILL OPEN
+- Exact Better Auth **version** · exact **migration number** · whether **Simsa `User` is separate
+  from Better Auth `user` or unified** · exact **cookie domain strategy** · **local dev auth
+  callback URL** strategy · **production env-var names** · **audit retention** period · **first
+  social login provider** · whether to run a **local-only spike before migration**.
+
+## 17. Recommended next stage
+**Stage 194 — Better Auth Minimal Implementation Plan (docs-only)** — plan: exact package/version
+proposal · exact table/migration proposal · central-plane runtime plan · env-var plan **without
+values** · local-only test plan · rollback plan · implementation-approval checklist. **No
+implementation recommended yet.**
+
+## 18. Now-safe vs gated
+- **Now-safe:** architecture decision record · implementation plan · migration plan · security
+  checklist · local-only proof plan.
+- **Requires Bae auth approval:** installing Better Auth · auth route handlers · session
+  middleware · OAuth/social providers · account linking.
+- **Requires migration approval:** Better Auth tables · `User`/`Workspace`/`WorkspaceMember`
+  tables · `userKey` backfill · `IntegrationAccount` ownership · `GateDecision`/`ActivityEvent`.
+- **Requires deploy approval:** auth routes in production · session cookies in production ·
+  workspace-aware project reads · env-var changes.
+- **Requires security review:** cookies/sessions · OAuth callbacks · token encryption ·
+  invite/share tokens · audit trail · account deletion/export.
+
+## 19. Stage 193 decision — **Gate frozen: Better Auth primary, Simsa-owned collaboration,
+central-plane runtime, identity-only first slice**
+No blocker was found while writing this record. The architecture **direction is frozen** for
+planning: **Better Auth** primary (WorkOS fallback), **Simsa-owned** collaboration layer, **org
+plugin deferred**, **central-plane/Workers/D1** runtime target, **identity-only behind a flag** as
+the first future slice, **`userKey` legacy fallback** (never authentication). **No code, no
+install, no migration, no deploy.** Closed/open questions recorded (§15/§16); implementation stays
+gated.
+
+## 20. Out-of-scope confirmation
+No deploy · no payment/Stripe/billing · no hosted execution · no central-plane deploy · no
+migration · no MCP publish · no npm publish · no auth/OAuth · no Better Auth install · no
+token/secret · no domain/DNS · no server write · no DB persistence · no live-dashboard change ·
+dogfood PRs #121~130 untouched.

--- a/conclave-builder-pack/out/stage-194-better-auth-minimal-implementation-plan.md
+++ b/conclave-builder-pack/out/stage-194-better-auth-minimal-implementation-plan.md
@@ -1,0 +1,204 @@
+# Stage 194 — Better Auth Minimal Implementation Plan
+
+**Date:** 2026-06-25
+**Branch:** `docs/stage-192-better-auth-proofread` (auth train, continues 192/193) · **Base / main:** `d869560` · production deploy: `9b645af` (Plan Map) · live: https://app.trysimsa.com
+**Type:** implementation **planning** / docs only. **No auth implementation, no Better Auth install, no package.json/lockfile change, no login routes, no session middleware, no OAuth, no migration, no deploy, no MCP/npm publish, no payment/billing, no domain/DNS, no server write, no DB persistence, no token/secret request-print-store, no env-var change, no live-dashboard change. Stale dogfood PRs #121~130 not touched.**
+
+> **Better Auth implementation is NOT approved.** This is a blueprint for the **first identity-only
+> slice**. Workspaces-as-truth, roles, invitations, Plan-Map approvals, integration ownership, and
+> the audit ledger remain **future phases**. **Migration, auth implementation, and deploy each
+> require separate Bae approval.** Package versions / D1 wiring are flagged **[verify]** —
+> re-confirm at implementation time; nothing is installed here.
+
+## 1. Executive summary
+Plans only the **minimal future first slice**: **identity-only behind a feature flag**, oriented
+to **central-plane / Hono / Workers / D1**. No workspace role enforcement, no team invite, no
+Plan-Map approval audit, no IntegrationAccount migration, no production rollout, no production
+migration execution. Architecture frozen in Stage 193 (Better Auth primary, WorkOS fallback,
+Simsa-owned collaboration).
+
+## 2. Implementation scope
+**Included in this plan (not execution):** Better Auth package/version proposal · central-plane
+auth runtime plan · D1-backed identity tables · local-only auth route plan · session-verification
+plan · feature-flag plan · local test plan · rollback plan · env-var plan (no values).
+**Explicitly excluded:** production deploy · workspace role enforcement · invitations · share links
+· Plan-Map gate approval · `ActivityEvent` audit ledger · `IntegrationAccount` ownership migration
+· GitHub/Vercel connected-account ownership · payment/billing · Kakao/Naver social in MVP · Better
+Auth **organization plugin as workspace source of truth**.
+
+## 3. Package / version proposal
+- **Core:** **`better-auth`** (current major line **1.5.x**; **[verify exact version + changelog +
+  #4203/#10021 status at install time]**, pin exactly).
+- **DB adapter:** **native Cloudflare D1** (first-class) or the **built-in Kysely adapter** (SQLite/
+  D1) — **no Drizzle required** for MVP. The community **`better-auth-cloudflare`** (npm, ~v0.3.0)
+  + `@better-auth-cloudflare/cli` are **optional** provisioning/scaffolding helpers — **evaluate,
+  not required**; prefer minimal first-party deps. **[verify which D1 path is least-dep at impl]**.
+- **Hono integration:** **no separate package** — mount `auth.handler(c.req.raw)` on a Hono route
+  (Stage 192 verified).
+- **Package-manager constraints:** repo is **pnpm + Turbo, ESM-only, Node ≥20**; add `better-auth`
+  to **`apps/central-plane`** only (not the dashboard) for the first slice. **Do not install now.**
+
+## 4. Runtime location plan
+- **Primary:** auth runs in **central-plane (Hono on Workers + D1)** — co-located with `workspace_*`
+  data + the existing encrypted-token store (`crypto.ts`).
+- **Dashboard** consumes auth/session state; **not** the identity source of truth. **`userKey`**
+  remains the **legacy fallback** during transition.
+- **Route shape (planning only):** central-plane `**/api/auth/***` (Better Auth handler). Local dev:
+  central-plane local URL; dashboard local URL calls it with **`credentials: "include"`**.
+- **CORS/CSRF:** dashboard↔central-plane is **cross-origin** → needs `hono/cors` with
+  `credentials: true` + an **explicit trusted-origin allowlist**; CSRF per Better Auth defaults.
+- **Cross-domain/cookie strategy** (e.g. `crossSubDomainCookies`, cookie domain for
+  `app.trysimsa.com` ⇄ the central-plane host) **needs approval + [verify]** — gated.
+
+## 5. D1 / schema plan (conceptual — no migration files)
+**Better Auth-owned identity (first slice):**
+| Table | Key columns | Indexes | Owner | First slice? |
+|---|---|---|---|---|
+| `user` | id, name, email, emailVerified, image, createdAt, updatedAt | unique(email) | Better Auth | **Yes** |
+| `session` | id, userId, token, expiresAt, ipAddress?, userAgent?, timestamps | index(userId), unique(token) | Better Auth | **Yes** |
+| `account` | id, userId, accountId, providerId, accessToken?(enc), refreshToken?(enc), scope, idToken?, password?, timestamps | index(userId), unique(providerId,accountId) | Better Auth | **Yes** (email/password first) |
+| `verification` | id, identifier, value, expiresAt, timestamps | index(identifier) | Better Auth | **Yes** |
+
+**Simsa-owned minimal:**
+| Table | Key columns | Indexes | Owner | First slice? |
+|---|---|---|---|---|
+| `workspace` | id, name, slug, ownerUserId, defaultLocale, timestamps, archivedAt? | unique(slug) | Simsa | **Optional in slice / next** |
+| `workspace_member` | workspaceId, userId, role, status, joinedAt, invitedByUserId | PK(workspaceId,userId), index(userId) | Simsa | **Optional in slice / next** |
+| `simsa_user` *(only if separate)* | id, betterAuthUserId, … | unique(betterAuthUserId) | Simsa | only if **not unified** (§16 open) |
+| `project.workspace_id` backfill | — | index(workspace_id) | Simsa | **Later** (not first identity-only route unless explicitly approved) |
+
+**Later tables:** `invitation` · `project_access` · `share_link` · `integration_account` ·
+`gate_decision` · `activity_event` · `roadmap_event`. **No migration files created here.** Each
+group: purpose/columns/indexes/owner/phase/rollback per Stage 189.
+
+## 6. Migration plan draft (additive — do NOT create files now)
+- **Next available number = `0047`** (verified: latest on main is `0046_workspace_agent_workflow_records.sql`).
+- **`0047_auth_identity_tables.sql`** *(or as emitted by Better Auth's schema generator —
+  **[verify D1 output]**)*: `user` / `session` / `account` / `verification`.
+- **`0048_workspace_min.sql`** *(optional/next)*: `workspace` / `workspace_member`.
+- **No destructive changes** · **keep `userKey` columns** · **no project-access behavior change** in
+  the first migration · **feature flag disabled by default** · **local D1 migration test (wrangler
+  local) before any production migration** · **production migration requires explicit Bae approval**.
+- **Rollback:** no destructive change; keep the old `userKey` read path; disable the auth flag;
+  **never auto-delete identity rows**.
+
+## 7. Feature flag plan
+- Flags (names TBD, **no values set**): e.g. **`AUTH_ENABLED`** (master), **`AUTH_PROVIDER`**
+  (`better-auth`), optionally **`AUTH_MODE`**.
+- **Local-only default** (enabled in dev for testing); **production disabled until deploy approval**.
+- The dashboard UI **must not imply auth** until the flag is on; **`/account` stays the local stub**
+  until the auth UI is explicitly rolled out.
+
+## 8. Environment variable plan (categories only — NO values, NO .env change)
+- **Better Auth secret** category (server-side signing/encryption secret).
+- **Base URL / trusted origin** category (central-plane base URL; dashboard origin allowlist).
+- **OAuth provider client id/secret** category — **later** (GitHub-login / Kakao / Naver).
+- **Cookie domain / SameSite** related settings.
+- **Integration-token encryption key** — **later** (reuse/extend `crypto.ts` approach).
+- **Feature-flag** variables (§7).
+**Do not print/request actual values; do not modify any `.env` or production env.**
+
+## 9. Local development plan
+- **Local D1** via wrangler (central-plane already uses D1). Commands (**[verify exact]**):
+  `wrangler d1 migrations apply <db> --local`, `wrangler dev` for central-plane.
+- **Dashboard local URL** (Next dev) calls **central-plane local URL** `/api/auth/*` with
+  `credentials: "include"`.
+- **Flow to test locally:** account creation (email/password first) → login → session persistence →
+  logout. **Email verification:** MVP can use **email/password**; email-link/passwordless is
+  **[verify which Better Auth flow]** and may defer real email sending (log link in dev).
+- **No production credentials**; dev secrets are local-only and never printed.
+
+## 10. Test plan (for the future implementation)
+Unit tests for auth **config helpers** (pure) · session-verification tests · **D1 schema migration
+smoke test (local)** · login/logout local-flow test · **disabled-flag behavior** test (auth off →
+no auth surface) · **`userKey` fallback** test (legacy path still works) · `/account` copy test ·
+**no-token-output** test · **no production auth when disabled** · `pnpm typecheck` + `pnpm build`.
+Mock at the seam (inject D1/fetch) per repo convention; `node --test`, no Jest/Vitest.
+
+## 11. Security plan
+Cookie **httpOnly + secure + SameSite + domain** **[verify defaults]** · session
+**expiration/`updateAge`/`freshAge`** · **CSRF/CORS** (trusted-origin allowlist, credentials both
+ends) · **callback URL allowlist** · provider-account **token storage encrypted** (extend
+`crypto.ts`) · **no token output** · **rate limiting** · **abuse prevention** · account
+deletion/export **later** · audit log **later**. Avoid the **#4203/#10021** logout class: **DB-
+backed D1 sessions, no `cookieCache` + KV combo**.
+
+## 12. Dashboard UX plan (future — do NOT implement)
+- `/account` can show a **"sign-in required"** state **when the auth flag is enabled**; the **local
+  preference stub remains the fallback** until then.
+- Plan Map may later show **"Auth architecture selected"** — **not** "approval audit enabled" until
+  `gate_decision` ships.
+- **No team/invite/share UI** until workspace/member implementation; **no connected-account
+  management UI** until `integration_account` ownership exists. **Honest copy only.**
+
+## 13. First implementation approval checklist (Bae must approve before Stage 195+ impl)
+- [ ] Better Auth **package/version** approved (pinned).
+- [ ] **Migration file plan** approved (`0047+`, additive, flag-off).
+- [ ] **Env-var names** approved (no values in chat).
+- [ ] **Feature-flag plan** approved.
+- [ ] **Runtime location** approved (central-plane/Workers/D1).
+- [ ] **Local dev plan** approved.
+- [ ] **Rollback plan** approved.
+- [ ] **Security checklist** accepted.
+- [ ] **No production deploy** until a separate deploy approval.
+
+## 14. Risk register
+| Risk | Classification | Mitigation |
+|---|---|---|
+| D1/Hono integration mismatch | **Caution** | verify native-D1 vs Kysely vs community pkg in a local spike |
+| Cookie domain / cross-host issues (Vercel ⇄ Workers) | **Caution** | `crossSubDomainCookies`/domain plan + [verify]; approval-gated |
+| CORS/CSRF issues | **Caution** | trusted-origin allowlist, credentials both ends |
+| Better Auth version drift (#4203/#10021) | **Watch** | pin version; DB-backed sessions; recheck issue status |
+| Migration numbering conflict | **Mitigated** | next number verified = `0047` |
+| `userKey` backfill ambiguity | **Caution** | dual-read, audit unmatched, no destructive merge |
+| Local vs production origin mismatch | **Watch** | explicit origin allowlists per env |
+| Accidental auth-UI claims before enabled | **Caution** | flag-gated UI; honest copy; tests |
+| Token leakage | **Caution** (no blocker) | server-side encrypted, never printed; no-token-output test |
+| Premature workspace role enforcement | **Mitigated** | excluded from first slice |
+No **blocker** in the register; all caution/watch/mitigated.
+
+## 15. WorkOS fallback preservation
+- **Keep the Simsa-owned collaboration layer** (don't make a provider the workspace source of truth).
+- **Avoid provider-specific workspace truth in MVP** (org plugin deferred).
+- Later switch path: **map provider user IDs → Simsa `user`/`workspace`**.
+- **Keep `gate_decision`/`activity_event` Simsa-owned.**
+- **Do not hardwire** the Better Auth org plugin into core project ownership.
+
+## 16. Recommended next stage
+**Default: Stage 195 — Auth Proof-read PR Prep / Push / Review Gate** (bundle Stage 192+193+194
+docs into one PR against `main`; no implementation). Alternatively, **Stage 195 — Better Auth Local
+Spike Approval Gate** only if Bae wants to move toward a **local-only** implementation spike. **No
+implementation recommended yet.**
+
+## 17. Now-safe vs gated
+- **Now-safe:** implementation plan doc · migration plan draft · env-var categories (no values) ·
+  test plan · rollback plan · PR prep.
+- **Requires Bae auth-implementation approval:** installing Better Auth · route handlers · session
+  middleware · auth config · login/logout logic.
+- **Requires Bae migration approval:** adding SQL migration files · running local D1 migrations ·
+  running production D1 migrations · backfilling `userKey` projects.
+- **Requires Bae deploy approval:** production auth routes · production session cookies · production
+  env vars · workspace-aware reads.
+- **Requires security review:** cookies · sessions · OAuth callbacks · env-var handling · token
+  storage · CORS/CSRF · rate limits.
+
+## 18. Stage 194 decision — **Implementation blueprint ready (not approved for execution)**
+The minimal identity-only first slice is fully planned: package/version proposal (`better-auth`
+1.5.x **[verify]**, native-D1/Kysely, no Drizzle), central-plane/Workers/D1 runtime, D1 identity
+schema, additive `0047+` migration draft, feature-flag + env-var (no values) + local-dev + test +
+security + rollback plans, an approval checklist, a risk register (no blocker), and WorkOS-fallback
+preservation. **No code, no install, no migration, no deploy.** Execution stays gated on Bae's
+auth → migration → deploy approvals.
+
+## 19. Out-of-scope confirmation
+No deploy · no payment/Stripe/billing · no hosted execution · no central-plane deploy · no migration
+· no MCP publish · no npm publish · no auth/OAuth · no Better Auth install · no token/secret · no
+domain/DNS · no server write · no DB persistence · no live-dashboard change · dogfood PRs #121~130
+untouched.
+
+## Sources (current)
+- Better Auth (core, 1.5): https://better-auth.com/ · https://better-auth.com/blog/1-5
+- Better Auth DB/schema: https://www.better-auth.com/docs/concepts/database
+- Hono integration: https://www.better-auth.com/docs/integrations/hono
+- Cloudflare D1 (community pkg + example): https://www.npmjs.com/package/better-auth-cloudflare · https://hono.dev/examples/better-auth-on-cloudflare
+- Issue #4203 / #10021: https://github.com/better-auth/better-auth/issues/4203 · https://github.com/better-auth/better-auth/issues/10021


### PR DESCRIPTION
## Stage 192~194 — Better Auth Proof-read and Implementation Plan

Planning-only auth train (continues Stage 187~189 already on main). **No auth implementation, no Better Auth install, no package changes, no migration, no deploy, no env-var changes, no token/secret handling.** Implementation, migration, and deploy each remain separately Bae-approval-gated.

### What's in this PR (3 docs-only commits)
- **Stage 192 — Better Auth Proof-read / Implementation Readiness:** current-doc-grounded re-verification. Confirmed: 4-table identity schema (`user`/`session`/`account`/`verification`), Cloudflare **D1** support, **Hono** mount, DB-backed sessions, organization plugin (members/roles/invitations + custom roles via `createAccessControl`), **Kakao/Naver** first-class. The **#4203/#10021** cookieCache+secondary-storage logout issue is a **configuration-avoidable caution** (use DB-backed D1 sessions), **not a blocker**.
- **Stage 193 — Auth Architecture Decision Gate (frozen):** **Better Auth primary**, **WorkOS fallback**, **Simsa-owned collaboration layer**, Better Auth **organization plugin deferred** for MVP workspace truth, **auth runtime = central-plane / Workers / D1**, **first slice = identity-only behind a feature flag**, **`userKey` legacy fallback** (never authentication).
- **Stage 194 — Better Auth Minimal Implementation Plan (blueprint, not approved):** package proposal (`better-auth` 1.5.x `[verify]`, native-D1/Kysely, no Drizzle for MVP, add to `apps/central-plane` only); central-plane runtime; D1 identity schema; additive migration draft (next number **`0047`**, verified; flag-off, keep `userKey`, non-destructive rollback); feature-flag + env-var (no values) + local-dev + test + security + dashboard-UX plans; approval checklist; risk register (no blocker); WorkOS-fallback preservation.

### Key decision state
- **Better Auth primary**; **WorkOS fallback**; **Simsa-owned collaboration layer**; **org plugin deferred for MVP**; **central-plane/Workers/D1** runtime target; **identity-only first slice behind a flag**; **`userKey`** remains legacy fallback, not authentication.
- Payment remains **TBD** (Korea-compatible later; **no Stripe assumption**).
- No token/secret values printed or requested; **exact Better Auth version + migration plan must still be verified before implementation** (`[verify]` items flagged).

### Out of scope (not in this PR)
No auth/OAuth/session impl · no Better Auth install · no package/lockfile change · no migration · no deploy · no MCP/npm publish · no payment/billing · no domain/DNS · no central-plane change · no DB persistence · no server write · no token/secret · no live-dashboard change.

### Implementation stays blocked until (each separately, in order)
1. Bae approves the Better Auth implementation slice, 2. package/version, 3. migration plan, 4. env-var names (no values), 5. local-spike boundaries, 6. a separate production deploy approval.

### Verification
`pnpm typecheck` — **57/57**. Docs-only; no code/migration/config/package change; secret scan clean.

### Recommended next (after review)
A **merge approval gate** (Stage 196, only with explicit Bae merge approval), then **Stage 197 — Better Auth Local Spike Approval Gate** only if Bae wants to move toward local-only implementation planning. **Not merged, not implemented.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
