### PR TITLE
Stage 197~198 — Better Auth Local Spike Gate and Cookie/CORS Strategy

### DIFF
--- a/conclave-builder-pack/out/stage-197-better-auth-local-spike-approval-gate.md
+++ b/conclave-builder-pack/out/stage-197-better-auth-local-spike-approval-gate.md
@@ -1,0 +1,148 @@
+# Stage 197 — Better Auth Local Spike Approval Gate
+
+**Date:** 2026-06-25
+**Branch:** `docs/stage-197-better-auth-local-spike-gate` · **Base / main:** `6ac260b` · production deploy: `9b645af` (Plan Map) · live: https://app.trysimsa.com
+**Type:** approval gate / boundary document only. **No spike performed. No auth implementation, no Better Auth install, no package.json/lockfile change, no login routes, no session middleware, no OAuth, no migration, no local D1 migration run, no deploy, no MCP/npm publish, no payment/billing, no domain/DNS, no server write, no DB persistence, no token/secret request-print-store, no env-var change, no live-dashboard change. Stale dogfood PRs #121~130 not touched.**
+
+## 1. Executive gate decision
+- **This stage does NOT approve implementation.** It defines the **decision boundary** for a
+  *future* local-only spike.
+- **If approved later, the spike must be LOCAL-ONLY.**
+- **Production deploy** remains **forbidden** without separate approval.
+- **Production migration** remains **forbidden** without separate approval.
+- **Token/secret handling in chat or logs** remains **forbidden** at all times.
+
+## 2. Current main state
+- `main` = **`6ac260b`** (Release: Stage 192~194). Auth **planning docs merged** (187/188/189/192/
+  193/194).
+- **Better Auth is NOT installed**; **no auth routes**; **no migrations added**.
+- **Production** remains the prior dashboard deploy (`9b645af`).
+- `/account` = **local stub**. **Plan Map live and read-only.**
+
+## 3. What a future local-only spike MAY be allowed to test (max safe scope, Stage 198, only if Bae approves)
+Potentially allowed **later**:
+- **Install Better Auth** only **after explicit package/version approval**.
+- **Central-plane local auth route only** (`/api/auth/*`, local).
+- **Local D1 identity tables only** (`user`/`session`/`account`/`verification`).
+- **Feature flag default OFF for production.**
+- **Local login/logout proof** only · **local session-verification proof** only.
+- **No production credentials · no production env changes · no production deploy.**
+- **No** workspace-aware project-access changes · **no** role enforcement · **no** team invitation
+  flow · **no** Plan-Map approval audit · **no** IntegrationAccount ownership migration.
+
+## 4. What remains FORBIDDEN even in the future local spike
+Production deploy · production D1 migration · production env-var changes · OAuth provider setup
+with **real secrets** · printing/requesting secrets · workspace role enforcement · team invites ·
+share links · Plan-Map gate approval · IntegrationAccount token storage · GitHub/Vercel ownership
+migration · payment/billing · domain/DNS changes · MCP/npm publish · destructive data changes ·
+modifying live-dashboard behavior.
+
+## 5. Approval phrases required before future work (separate, non-transferable)
+| Future action | Required exact phrase |
+|---|---|
+| Future local-only spike | **"Better Auth local spike approved."** |
+| Package/version install | **"Better Auth package/version approved."** |
+| Local migration file creation | **"Local auth migration draft approved."** |
+| Production migration | **"Production auth migration approved."** |
+| Auth implementation beyond local spike | **"Better Auth implementation approved."** |
+| Production dashboard deploy | **"Dashboard deploy approved."** |
+**Each approval is separate and non-transferable** — one phrase never implies another; the local
+spike phrase does **not** authorize install, migration, implementation, or deploy.
+
+## 6. Future Stage 198 allowed file boundary (do NOT create now)
+Potential future files (only if approved): **central-plane auth config/helper** files ·
+**central-plane local auth route** · **local-only migration draft** · **test files** · **docs
+report**. **Explicitly excluded:** production env files · secrets · **dashboard production auth
+UI** · workspace access enforcement · payment/billing files · domain/DNS config.
+
+## 7. Future Stage 198 package/version boundary
+- **Exact Better Auth version must be re-checked immediately before install** (`[verify]` —
+  including #4203/#10021 status at that version).
+- **No broad dependency upgrades** · **no unrelated package changes**.
+- **Lockfile changes limited to the approved auth package(s)** (`better-auth`, in
+  `apps/central-plane` only).
+- **Any package-manager failure stops the spike.**
+
+## 8. Future Stage 198 migration boundary
+- Migration **draft may be local-only if approved**; **production migration must NOT run**.
+- **Additive only** · **no destructive changes** · **`userKey` columns remain**.
+- **Rollback = feature flag OFF + `userKey` read path preserved.**
+- **Migration number re-checked against `main` immediately before drafting** (current next =
+  `0047`; re-verify in case main advanced).
+
+## 9. Future Stage 198 runtime boundary
+- **Central-plane / Workers / D1 target.**
+- Dashboard **consumes** session state later — **not** source of truth.
+- **Local-only test route allowed only if approved**; **production route activation forbidden**.
+- **Cookie/CORS/CSRF strategy must be documented before any live route.**
+
+## 10. Future Stage 198 test boundary (minimum)
+`pnpm typecheck` · central-plane tests (if available) · auth-helper tests · **disabled-flag
+behavior** · **no-token-output scan** · **no-production-env-mutation scan** · migration **dry/local
+smoke only if approved** · **no dashboard regression** if the dashboard is touched.
+
+## 11. Stop conditions (the future spike must STOP if)
+Secrets are required · production env vars are needed · production migration is needed · Better
+Auth docs **contradict** the plan · package install causes **broad dependency churn** · the **D1
+adapter path is unclear** · cookie/session behavior **cannot be safely scoped locally** · **tests
+fail** · **any live production behavior would change**.
+
+## 12. Success criteria for a future local spike
+- Local-only proof **compiles**; **no production changes**; **no secrets exposed**; feature-flag
+  boundaries **clear**; the local auth route **can be reasoned about**; the migration path
+  **remains additive**; the rollback plan **remains valid**; the **next gate can be decided**.
+- **Success is NOT** defined as production-ready, secure, final, or complete.
+
+## 13. Relationship to Plan Map
+Plan Map remains **read-only**. `GateDecision` remains **future**. A local auth spike **does not
+enable** Plan-Map approval audit. The Plan-Map blocker can be updated only **after real auth
+implementation + deploy** — **not** after a local spike. (At most, a spike could justify wording
+like "Auth architecture selected", never "approval audit enabled".)
+
+## 14. Relationship to /account
+`/account` remains the **local stub in production**. A future local spike **may document** sign-in
+behavior **but must not ship production sign-in**. **Account-page changes require separate UI
+approval** if the page is touched.
+
+## 15. Relationship to collaboration
+Team/invite/share/roles remain **blocked**. Workspace/member enforcement remains **blocked**.
+`userKey` remains **insufficient**. A local identity spike is **only the first foundation layer**,
+not collaboration.
+
+## 16. Recommended Stage 198
+- **Option A — Stage 198: Better Auth Local Spike Plan / Approval Execution** — only if Bae
+  explicitly provides **"Better Auth local spike approved."**
+- **Option B — Stage 198: Better Auth Package / Version Final Check** — one more version
+  verification before any install.
+- **Option C — Stage 198: Session Cookie / CORS Strategy Deep Dive** — if cookie/domain risk feels
+  too high.
+- **Recommendation: Option C first** (Session Cookie / CORS Strategy Deep Dive) as the **safest
+  next step** — the Vercel↔Workers cross-origin cookie/CORS/CSRF design is the highest-uncertainty
+  area (Stage 192 flagged cookie defaults + cross-host as `[verify]`), and resolving it **on paper**
+  de-risks any later spike. Option B can fold into it. Option A only on the explicit spike phrase.
+
+## 17. Now-safe vs gated
+- **Now-safe:** this approval-gate doc · boundaries · stop conditions · success criteria · future
+  approval-phrase definitions.
+- **Requires Bae auth approval:** installing Better Auth · auth route handlers · session logic ·
+  local login/logout flow.
+- **Requires Bae package/version approval:** changing `package.json` · changing the lockfile.
+- **Requires Bae migration approval:** creating a SQL migration draft · running local D1 migration ·
+  running production migration.
+- **Requires Bae deploy approval:** any production route · any production session cookie · any
+  production env var · any live-dashboard change.
+- **Requires security review:** cookies/sessions · OAuth callback · CORS/CSRF · env-var handling ·
+  token storage · account deletion/export · rate limiting.
+
+## 18. Stage 197 decision — **Gate defined; no spike executed**
+The boundaries, forbidden actions, six separate approval phrases, file/package/migration/runtime/
+test boundaries, stop conditions, and success criteria for a **future local-only spike** are
+defined. **Nothing was implemented, installed, migrated, or deployed.** The recommended safest next
+step is **Stage 198 — Session Cookie / CORS Strategy Deep Dive** (Option C); a local spike proceeds
+only on the explicit phrase **"Better Auth local spike approved."**
+
+## 19. Out-of-scope confirmation
+No deploy · no payment/Stripe/billing · no hosted execution · no central-plane deploy · no
+migration · no MCP publish · no npm publish · no auth/OAuth · no Better Auth install · no package
+change · no token/secret · no domain/DNS · no server write · no DB persistence · no live-dashboard
+change · dogfood PRs #121~130 untouched.

--- a/conclave-builder-pack/out/stage-198-session-cookie-cors-strategy-deep-dive.md
+++ b/conclave-builder-pack/out/stage-198-session-cookie-cors-strategy-deep-dive.md
@@ -1,0 +1,221 @@
+# Stage 198 — Session Cookie / CORS Strategy Deep Dive
+
+**Date:** 2026-06-25
+**Branch:** `docs/stage-197-better-auth-local-spike-gate` (auth train, continues 197) · **Base / main:** `6ac260b` · production deploy: `9b645af` (Plan Map) · live: https://app.trysimsa.com
+**Type:** research / architecture strategy / docs only. **No auth implementation, no Better Auth install, no package.json/lockfile change, no login routes, no session middleware, no OAuth, no migration, no local D1 migration run, no deploy, no MCP/npm publish, no payment/billing, no domain/DNS, no server write, no DB persistence, no token/secret request-print-store, no env-var change, no live-dashboard change. Stale dogfood PRs #121~130 not touched.**
+
+> Verified against **current Better Auth + Hono docs + MDN cookie/CORS semantics** (URLs in
+> §Sources). Items not confirmable from a primary source are marked **[verify]**. No
+> tokens/secrets/private URLs. **No cookies set, no CORS code changed.**
+
+## 1. Executive summary
+**No implementation in this stage.** Recommended direction: run auth on **central-plane / Workers
+/ D1** (Stage 193) but expose it at a **first-party path** so the **session cookie is first-party
+and CORS is avoided** — **Option A: same-origin via a Vercel rewrite** (`app.trysimsa.com/api/auth/*`
+→ central-plane). **Fallback: Option B — an auth subdomain** (`api.trysimsa.com`, *same-site*) with
+`crossSubDomainCookies` + `SameSite=Lax` + a strict CORS allowlist. **Reject Option C** (cross-site
+`*.workers.dev` → `SameSite=None` → third-party-cookie blocking) and **Option D** (auth on the
+Vercel dashboard runtime → contradicts Stage 193 + breaks D1 locality). **Safest local spike:**
+localhost cross-origin (same-site) with `SameSite=Lax` + credentials + a localhost CORS allowlist,
+email/password (no OAuth secrets), flag off in production. **Production rollout stays gated**
+(rewrite/subdomain + cookies + env each need separate Bae approval + security review).
+
+## 2. Current architecture baseline
+Dashboard on **Vercel** (`app.trysimsa.com`). Auth target = **central-plane / Hono / Workers / D1**
+(Stage 193). **No auth deployed.** `/account` = local stub. **Plan Map live, read-only.** `userKey`
+= legacy fallback.
+
+## 3. Candidate session topology options
+> Key fact: a browser **"site"** = the **registrable domain (eTLD+1) = `trysimsa.com`**, **port- and
+> subdomain-agnostic** for `SameSite`. So `app.trysimsa.com` ↔ `api.trysimsa.com` are **same-site,
+> cross-origin**; `*.workers.dev` is a **different site** (cross-site).
+
+| Option | Shape | Cookie | CORS | Security | Deploy complexity | Local-dev | D1 locality | Fit w/ Stage 193 |
+|---|---|---|---|---|---|---|---|---|
+| **A — Same-origin proxy** | dashboard `app.trysimsa.com/api/auth/*` **Vercel rewrite →** central-plane Workers | **first-party**, `SameSite=Lax`/`Strict`, no third-party blocking | **none** (same origin) | **Best** (no cross-origin cookie) | Vercel rewrite (gated) | simple | **auth stays on Workers/D1** | **Best** |
+| **B — Auth subdomain** | `api.trysimsa.com` (same parent) | `Domain=.trysimsa.com`, `SameSite=Lax` (same-site → sent on fetch); `crossSubDomainCookies` | **required** (cross-origin, credentials + specific origin) | Good (no third-party blocking; same-site) | DNS subdomain (gated) | moderate | on Workers/D1 | Good |
+| **C — Cross-origin Workers domain** | dashboard → `*.workers.dev` directly | **cross-site** → `SameSite=None`+`Secure` → **third-party-cookie blocking** (Safari ITP; Chrome) | required | **Weak/fragile** | low | low | on Workers/D1 | poor (fragile cookies) |
+| **D — Dashboard-hosted auth** | auth runs in Vercel dashboard runtime | first-party (trivial) | none | ok cookies, but… | low | simple | **auth away from D1** | **contradicts Stage 193** |
+
+## 4. Recommended topology
+- **Primary: Option A — same-origin via a Vercel rewrite.** Auth runs on **Workers/D1** (Stage 193
+  honored) but is reached at `app.trysimsa.com/api/auth/*`, so the cookie is **first-party** (no
+  cross-origin cookie, **no CORS**, **no third-party-cookie blocking**). Cleanest, most robust.
+  *(Verify Vercel rewrite forwards method/body/cookies correctly to the Workers origin — [verify].)*
+- **Fallback: Option B — auth subdomain (`api.trysimsa.com`).** Same-site → `SameSite=Lax` cookies
+  are sent on fetch; set `Domain=.trysimsa.com` via `crossSubDomainCookies`; add a **strict CORS
+  allowlist** (credentials + the exact dashboard origin). Use if the rewrite proves limiting.
+- **Reject C and D** (fragile cross-site cookies / contradicts the Workers-D1 runtime decision).
+- Principles honored: central-plane/Workers/D1 runtime · **avoid browser-local truth** · **never
+  expose token values** · production rollout gated · **avoid cross-site cookies**.
+
+## 5. Cookie strategy (planning only — NO cookies set)
+- **Names (Better Auth defaults):** `${cookiePrefix}.session_token`, `.session_data` (only if
+  cookieCache — **avoid**, §13/#4203), `.dont_remember` (prefix default `better-auth`).
+- **HttpOnly: yes** (Better Auth default). **Secure: yes** in production (Better Auth default;
+  `useSecureCookies` to force in all envs).
+- **SameSite:** **`Lax`** recommended (works for Option A first-party and Option B same-site fetch;
+  also gives baseline CSRF protection). **Avoid `None`** (only needed for cross-site Option C, and
+  triggers third-party blocking). **Better Auth's SameSite default is [verify]** — set explicitly.
+- **Domain:** Option A → **host-only** (no Domain attr, first-party). Option B → **`.trysimsa.com`**
+  via `crossSubDomainCookies: { enabled: true, domain: "trysimsa.com" }` — **"most specific scope
+  needed"** (Better Auth guidance); never broader than required.
+- **Path:** `/` (or scope to `/api/auth` if feasible). **Max-Age/Expires:** session `expiresIn`
+  (Better Auth default 7d) + `updateAge` (1d) — value category only.
+- **Local dev:** `SameSite=Lax`; `Secure` relies on the **localhost secure-context exemption**
+  **[verify per browser]** (or omit Secure for `http://localhost`).
+- **`crossSubDomainCookies`:** **only for Option B** (not needed for Option A).
+- **Third-party-cookie-blocking risk:** applies to **cross-site** cookies (Option C). Options A/B
+  are **first-party/same-site → not blocked**.
+
+## 6. CORS strategy (planning only — NO CORS code change)
+- **Option A:** **no CORS** (same origin).
+- **Option B / local spike:** Hono `cors()` middleware with:
+  - **`origin`:** an **explicit allowlist** (exact dashboard origin(s)) — **string/array/callback**,
+    **never `*`**.
+  - **`credentials: true`** (required for cookies). **Wildcard origin + credentials is forbidden by
+    the CORS spec** — echo the specific origin + `Access-Control-Allow-Credentials: true`.
+  - **`allowMethods`:** `GET, POST` (+ `OPTIONS` auto) — minimal.
+  - **`allowHeaders`:** `Content-Type` (+ any Better Auth needs) — minimal.
+  - **Preflight:** Hono auto-handles `OPTIONS`; place `cors()` **before** routes.
+  - **`Vary: Origin`** so caches don't serve the wrong ACAO.
+  - **Local dev origin list** (e.g. localhost dashboard) vs **production origin list** kept
+    **separate** and explicit.
+
+## 7. CSRF strategy
+- **`SameSite=Lax` gives baseline CSRF protection** (cross-site requests don't carry the cookie),
+  but is **not sufficient alone** for all cases.
+- **State-changing routes** (sign-in/out, account mutations, later workspace writes) need
+  protection: **Better Auth's built-in CSRF/Origin checks + `trustedOrigins`** — **[verify Better
+  Auth's CSRF mechanism]**.
+- **Origin/Referer checks** on POST; consider **double-submit token** only if a gap remains.
+- **GET must be side-effect-free**; mutations are **POST**.
+- **OAuth callback `state`** parameter must be validated (later, when OAuth is added) — out of scope
+  for the email/password first slice.
+
+## 8. Local-only spike strategy (future, gated)
+- **Origins:** dashboard `http://localhost:<dash>` ↔ central-plane `http://localhost:<wrangler>`
+  (e.g. `wrangler dev`) — **same-site (`localhost`), cross-origin**.
+- **Cookie:** `SameSite=Lax` (sent on same-site fetch); `Secure` via localhost exemption **[verify]**.
+- **Credentials:** dashboard fetch with **`credentials: "include"`**; Hono CORS with the **localhost
+  allowlist + `credentials: true`**.
+- **Flag OFF in production**; **no production env**; **no real OAuth secrets**; **email/password (or
+  a dev-only provider) [verify]**.
+- **Reversible:** flag off + delete local D1 + drop the local route; no production change.
+
+## 9. Production rollout strategy (future, gated)
+- **Preferred: Option A** — add a **Vercel rewrite** `app.trysimsa.com/api/auth/*` → the central-
+  plane Workers endpoint (first-party cookies, no CORS). **Reverse proxy = the Vercel rewrite.**
+- **Else: Option B** — provision **`api.trysimsa.com`** (DNS, gated) + `crossSubDomainCookies` +
+  CORS allowlist.
+- **Approvals needed (separate):** the rewrite **or** subdomain/DNS · production cookies · production
+  env vars · any live-dashboard change — each is its **own** Bae approval + security review.
+- **Env-var categories** (no values): auth secret · base URL/trusted origins · cookie domain.
+- **Monitoring/logging:** session error rates, 401/403, CORS-rejection counts — **no token values in
+  logs**.
+- **Rollback:** flag off → dashboard falls back to `userKey`; remove the rewrite/subdomain route.
+
+## 10. Better Auth-specific implications (verified)
+- **Cookies are `httpOnly` + `secure` in production by default**; `useSecureCookies` forces in all
+  envs. Default cookies: `session_token`, `session_data`(cookieCache), `dont_remember`; prefix
+  `better-auth` (`cookiePrefix`/`cookies` to customize).
+- **`crossSubDomainCookies` = `{ enabled, domain }`** for subdomain sharing (Option B); guidance =
+  "most specific scope needed".
+- **`trustedOrigins`** array gates cross-domain requests (set the dashboard origin).
+- **`baseURL`** must point at the auth's reachable origin (**[verify behind a rewrite/proxy]**).
+- **DB-backed sessions avoid #4203/#10021** (those need `cookieCache` + secondary storage) → **use
+  DB-backed D1 sessions, no `cookieCache`+KV**.
+- **`SameSite` default + exact Hono/Workers `Set-Cookie` behavior = [verify before implementation]**.
+
+## 11. Hono / Workers-specific implications (verified)
+- **Hono `cors()`:** `origin` (string/array/callback; default `*`), `credentials: true` (adds
+  `Access-Control-Allow-Credentials`), `allowMethods` (default GET/HEAD/PUT/POST/DELETE/PATCH),
+  `allowHeaders` (default `[]`), `exposeHeaders`, `maxAge`; **auto OPTIONS preflight**; **call before
+  routes**. **Wildcard origin cannot be combined with credentials** (standard CORS).
+- **Workers headers:** `Set-Cookie` must be emitted by the Workers response; ensure the runtime
+  preserves it through any proxy/rewrite **[verify]**.
+- **`wrangler dev`** for local; D1 local binding for the spike.
+
+## 12. Dashboard / Vercel implications
+- Dashboard fetches to auth use **`credentials: "include"`** (Option B/local) or are **same-origin**
+  (Option A → no special handling).
+- **Vercel rewrites/proxy** (Option A) **reduce CORS to zero** by making auth same-origin — the key
+  reason A is preferred.
+- The **dashboard should know only**: signed-in boolean + minimal profile (from a session endpoint);
+  it must **not** hold tokens or be the source of truth.
+- **SSR vs client fetch:** session reads can be server-side (central-plane) or client; cookies must
+  be forwarded appropriately **[verify SSR cookie forwarding]**.
+- **Production env boundaries:** auth secrets live in **central-plane** env (Workers), not the
+  dashboard bundle.
+
+## 13. Security risk register
+| Risk | Class | Mitigation |
+|---|---|---|
+| Cross-site cookie rejection (Option C / `SameSite=None`) | **Caution→avoided** | choose Option A/B (first-party/same-site) |
+| `SameSite` misconfiguration | **Caution** | explicit `Lax`; test; [verify Better Auth default] |
+| Wildcard CORS + credentials | **Blocker (if done)** | forbidden; explicit origin allowlist only |
+| CSRF on state-changing routes | **Caution** | `SameSite=Lax` + Better Auth CSRF/`trustedOrigins` + Origin checks |
+| OAuth callback misconfig | **Watch** (later) | validate `state`; redirect allowlist (when OAuth added) |
+| Cookie domain too broad | **Caution** | host-only (A) or most-specific `.trysimsa.com` (B) |
+| localhost vs production mismatch | **Watch** | separate origin/env allowlists per env |
+| Session fixation | **Watch** | rotate session on login; Better Auth defaults [verify] |
+| Accidental production auth enablement | **Caution** | flag off by default; deploy-gated |
+| Token leakage in logs | **Caution** | never log tokens; no-token-output test |
+| Overbroad `trustedOrigins` | **Caution** | exact origins only |
+No standing **blocker** if Option A/B + explicit allowlists are used; wildcard-CORS-with-credentials
+is the one "blocker if done" to forbid.
+
+## 14. Decision questions for Bae
+1. **Same-origin proxy (Vercel rewrite, Option A)** or **auth subdomain (Option B)** as primary?
+   (recommended A)
+2. Can we **add an `api`/`auth` subdomain later** if A proves limiting?
+3. May the **local-only spike use localhost cross-origin cookies** (same-site, `Lax`)? (recommended
+   yes)
+4. Should the **first spike avoid OAuth** and use **email/password** (or a dev provider)?
+   (recommended yes)
+5. Should **production auth stay disabled** until the rewrite/subdomain + cookie strategy is
+   approved? (recommended yes)
+6. Is the **cookie/domain strategy a separate approval gate** (rewrite/DNS + cookies + env)?
+   (recommended yes)
+
+## 15. Recommended next stage
+- **Stage 199 — Auth Cookie/CORS PR Prep / Push / Review Gate** *(recommended, safest)*: put Stage
+  197+198 docs into a PR against `main` (docs-only), keeping the merge queue lean. Alternatively
+  **Stage 199 — Better Auth Package/Version Final Check** (one more version verify), or **Stage 199 —
+  Better Auth Local Spike Approval Gate Execution** *(only on the explicit phrase "Better Auth local
+  spike approved.")*. **Recommendation: PR prep first** — it banks the strategy on `main` before any
+  spike.
+
+## 16. Now-safe vs gated
+- **Now-safe:** this strategy doc · topology comparison · cookie/CORS/CSRF plan · risk register · PR
+  prep.
+- **Requires Bae auth approval:** auth routes · session logic · login/logout flow.
+- **Requires package/version approval:** installing Better Auth · `package.json` · lockfile.
+- **Requires migration approval:** creating/running local D1 migration · production D1 migration.
+- **Requires deploy approval:** production auth route · production cookies · production env vars ·
+  **Vercel rewrites/proxy** · **auth/API subdomain**.
+- **Requires security review:** cookies · CORS · CSRF · trusted origins · OAuth callback · token
+  logging.
+
+## 17. Stage 198 decision — **Strategy de-risked: Option A (same-origin rewrite) primary, Option B (auth subdomain) fallback**
+The cookie/CORS/CSRF design is resolved on paper: keep auth on **Workers/D1** but make it
+**first-party** via a **Vercel rewrite** (Option A) so the **session cookie is first-party and CORS
+is eliminated**; fallback to a **same-site auth subdomain** (Option B) with `crossSubDomainCookies` +
+`SameSite=Lax` + a strict CORS allowlist. **Cross-site cookies (Option C) and dashboard-runtime auth
+(Option D) are rejected.** `SameSite` default, `baseURL`-behind-proxy, and SSR cookie forwarding are
+flagged **[verify]** for implementation. **No code, no install, no migration, no deploy.**
+
+## 18. Out-of-scope confirmation
+No deploy · no payment/Stripe/billing · no hosted execution · no central-plane deploy · no migration
+· no MCP publish · no npm publish · no auth/OAuth · no Better Auth install · no package change · no
+token/secret · no domain/DNS · no server write · no DB persistence · no live-dashboard change ·
+dogfood PRs #121~130 untouched.
+
+## Sources (current)
+- Better Auth cookies: https://www.better-auth.com/docs/concepts/cookies
+- Better Auth options (trustedOrigins/baseURL): https://www.better-auth.com/docs/reference/options
+- Hono CORS middleware: https://hono.dev/docs/middleware/builtin/cors
+- MDN SameSite: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value
+- MDN Set-Cookie (Secure/HttpOnly): https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie
+- MDN CORS (credentials): https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS
+- Vercel rewrites: https://vercel.com/docs/projects/project-configuration#rewrites


### PR DESCRIPTION
## Stage 197~198 — Better Auth Local Spike Gate and Cookie/CORS Strategy

Planning/strategy-only auth train (continues the Stage 187~194 auth planning already on main). **No auth implementation, no Better Auth install, no package changes, no migration, no deploy, no Vercel rewrites, no DNS changes, no CORS code, no env-var changes, no token/secret handling.**

### What's in this PR (2 docs-only commits)
- **Stage 197 — Better Auth Local Spike Approval Gate:** boundary document for a *future* local-only spike — allowed/forbidden scope, **six separate non-transferable approval phrases**, file/package/migration/runtime/test boundaries, stop conditions, and success criteria. **The spike is not approved**; it requires the explicit phrase **"Better Auth local spike approved."**
- **Stage 198 — Session Cookie / CORS Strategy Deep Dive:** current-doc-grounded (Better Auth + Hono + MDN) cookie/CORS/CSRF design. Key insight: `app.trysimsa.com` ↔ `api.trysimsa.com` are **same-site, cross-origin** (so `SameSite=Lax` cookies are sent on fetch), while `*.workers.dev` is **cross-site** (needs `SameSite=None` → third-party-cookie blocking).

### Cookie / CORS recommendation
- **Primary: Option A — same-origin via a Vercel rewrite** (`app.trysimsa.com/api/auth/*` → central-plane Workers): auth stays on **Workers/D1** (Stage 193) while the **session cookie is first-party and CORS is eliminated**.
- **Fallback: Option B — auth/API subdomain** (`api.trysimsa.com`, same-site) with `crossSubDomainCookies` + `SameSite=Lax` + a strict CORS allowlist.
- **Rejected:** Option C (cross-site Workers domain primary → fragile cookies) and Option D (dashboard-hosted auth runtime → contradicts the Workers/D1 decision).
- Cookie plan (`HttpOnly`+`Secure` prod, `SameSite=Lax`, most-specific domain, **no `cookieCache`+KV** to avoid #4203/#10021); CORS plan (**explicit origin allowlist, `credentials:true`, never wildcard+credentials**, `Vary: Origin`); CSRF plan (`Lax` + Better Auth CSRF/`trustedOrigins` + Origin checks). `[verify]` flags: `SameSite` default, `baseURL` behind a proxy, SSR cookie forwarding, localhost `Secure` exemption.

### Gate state (nothing approved by this PR)
- Local spike **not approved** → needs **"Better Auth local spike approved."**
- Package/version install **not approved** → needs **"Better Auth package/version approved."**
- Migration draft / production migration / auth implementation / dashboard deploy each need their **own separate** Bae approval.
- Production env changes **not approved**; tokens/secrets never printed/requested; payment **TBD, no Stripe** (per the earlier auth docs already on main).

### Out of scope (not in this PR)
No auth/OAuth/session impl · no Better Auth install · no package/lockfile change · no migration · no deploy · no Vercel rewrite/DNS · no CORS code · no MCP/npm publish · no payment/billing · no central-plane change · no DB persistence · no server write · no token/secret · no live-dashboard change.

### Verification
`pnpm typecheck` — **57/57**. Docs-only; no code/config/package/secret change.

### Recommended next (after review)
A **merge approval gate** (Stage 200, only with explicit Bae merge approval), then **Stage 201 — Better Auth Package / Version Final Check** (docs/research) — or a **Local Spike Approval Gate Execution** only on the explicit spike phrase. **Not merged, not implemented.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
