### PR TITLE
Stage 209 — Better Auth Local Route and D1 Migration Draft

### DIFF
--- a/apps/central-plane/migrations/0047_better_auth_identity_tables.sql
+++ b/apps/central-plane/migrations/0047_better_auth_identity_tables.sql
@@ -1,0 +1,74 @@
+-- Stage 209 — Better Auth LOCAL-ONLY identity tables (DRAFT).
+--
+-- Status: DRAFT. NOT applied to production. NOT applied locally by this stage.
+-- This file exists so a separately-approved stage can apply it (local first,
+-- then — only under "Production auth migration approved." — production).
+--
+-- Why the column names are camelCase (not the repo's snake_case convention):
+-- these four tables are consumed by the `better-auth` package's own data layer,
+-- which expects its documented default model field names (id, emailVerified,
+-- userId, createdAt, ...). They are NOT consumed by the existing workspace_*
+-- code, so they deliberately follow Better Auth's schema, not workspace naming.
+-- Quoting matches Better Auth's generated SQLite output and sidesteps the
+-- `user` identifier.
+--
+-- Safety properties (asserted by test/auth-migration-draft.test.mjs):
+--   * additive only — every statement is CREATE TABLE/INDEX IF NOT EXISTS
+--   * no DROP, no destructive ALTER, no DELETE/TRUNCATE
+--   * does not touch workspace / project / user_key tables or behavior
+--   * no backfill, no data writes
+--
+-- Source: Better Auth 1.6.20 core (email/password) documented schema —
+-- user / session / account / verification. Hand-written to match the
+-- documented field set; NOT produced by blindly running a generator.
+-- D1/SQLite-compatible types only (integer for booleans, date for timestamps).
+
+CREATE TABLE IF NOT EXISTS "user" (
+  "id" text NOT NULL PRIMARY KEY,
+  "name" text NOT NULL,
+  "email" text NOT NULL UNIQUE,
+  "emailVerified" integer NOT NULL DEFAULT 0,
+  "image" text,
+  "createdAt" date NOT NULL,
+  "updatedAt" date NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "session" (
+  "id" text NOT NULL PRIMARY KEY,
+  "expiresAt" date NOT NULL,
+  "token" text NOT NULL UNIQUE,
+  "createdAt" date NOT NULL,
+  "updatedAt" date NOT NULL,
+  "ipAddress" text,
+  "userAgent" text,
+  "userId" text NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "account" (
+  "id" text NOT NULL PRIMARY KEY,
+  "accountId" text NOT NULL,
+  "providerId" text NOT NULL,
+  "userId" text NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE,
+  "accessToken" text,
+  "refreshToken" text,
+  "idToken" text,
+  "accessTokenExpiresAt" date,
+  "refreshTokenExpiresAt" date,
+  "scope" text,
+  "password" text,
+  "createdAt" date NOT NULL,
+  "updatedAt" date NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "verification" (
+  "id" text NOT NULL PRIMARY KEY,
+  "identifier" text NOT NULL,
+  "value" text NOT NULL,
+  "expiresAt" date NOT NULL,
+  "createdAt" date NOT NULL,
+  "updatedAt" date NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_session_userId" ON "session" ("userId");
+CREATE INDEX IF NOT EXISTS "idx_account_userId" ON "account" ("userId");
+CREATE INDEX IF NOT EXISTS "idx_verification_identifier" ON "verification" ("identifier");

--- a/apps/central-plane/src/router.ts
+++ b/apps/central-plane/src/router.ts
@@ -38,6 +38,7 @@ import { createWorkspaceCreditsRoutes } from "./routes/workspace-credits.js";
 import { createWorkspaceBenchmarkRoutes } from "./routes/workspace-benchmark.js";
 import { createWorkspaceExperimentRoutes } from "./routes/workspace-experiment.js";
 import { createWorkspaceAgentWorkflowRoutes } from "./routes/workspace-agent-workflow.js";
+import { createAuthSpikeRoutes } from "./routes/auth-spike.js";
 import type { FetchLike } from "./github.js";
 
 /**
@@ -150,6 +151,10 @@ export function createApp(opts: { fetch?: FetchLike } = {}): Hono<{ Bindings: En
   app.route("/", createWorkspaceExperimentRoutes());
   // Stage 112 — Persisted Agent Workflow Records (intake snapshot save/list/read).
   app.route("/", createWorkspaceAgentWorkflowRoutes());
+  // Stage 209 — Better Auth LOCAL-ONLY spike route (/api/auth/*), gated by
+  // AUTH_ENABLED. Default off → 503 auth_disabled in production. No OAuth, no
+  // CORS, no dashboard UI; runtime D1 binding deferred (see auth-spike.ts).
+  app.route("/", createAuthSpikeRoutes());
   app.onError((err, c) => {
     console.error("central-plane error:", err);
     return c.json({ error: err.message || "internal error" }, 500);

--- a/apps/central-plane/src/routes/auth-spike.ts
+++ b/apps/central-plane/src/routes/auth-spike.ts
@@ -1,0 +1,49 @@
+/**
+ * Stage 209 — Better Auth LOCAL-ONLY route wiring.
+ *
+ * Mounts `/api/auth/*` for the local Better Auth spike, behind the AUTH_ENABLED
+ * flag. It is production-safe by construction:
+ *
+ *   - AUTH_ENABLED unset/!= "true"  → 503 { error: "auth_disabled" }  (the default,
+ *     and therefore the production behaviour — the route exists but never activates).
+ *   - AUTH_ENABLED === "true" but no local secret / runtime not ready
+ *                                   → 503 { error: "auth_not_configured" }
+ *   - AUTH_ENABLED === "true" AND a local secret present
+ *                                   → delegate to the Better Auth handler.
+ *
+ * It never reads back, echoes, or logs the secret/token/user/session/DB. It adds
+ * no OAuth provider, no CORS, no dashboard UI. The Better Auth instance is built
+ * only via createBetterAuthSpike(env) (which returns null on the production/test
+ * path), so the live auth surface activates only when AUTH_ENABLED is explicitly
+ * set with a local secret.
+ *
+ * Note: runtime D1 binding is intentionally deferred (the spike instance is
+ * stateless — no `database` option). The 0047 migration draft prepares the
+ * identity tables for a separately-approved D1-wiring stage; until then the
+ * enabled path delegates to a stateless handler and any DB-backed flow is not
+ * provisioned. See createBetterAuthSpike().
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import { getAuthSpikeConfig } from "../auth-spike-config.js";
+import { createBetterAuthSpike } from "../better-auth-spike.js";
+
+export function createAuthSpikeRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+
+  app.all("/api/auth/*", async (c) => {
+    const cfg = getAuthSpikeConfig(c.env);
+    if (!cfg.enabled) {
+      return c.json({ error: "auth_disabled" }, 503);
+    }
+    const auth = createBetterAuthSpike(c.env);
+    if (!auth) {
+      // Flag on but runtime not ready (e.g. no local secret). Never reveal why
+      // beyond this minimal, secret-free signal.
+      return c.json({ error: "auth_not_configured" }, 503);
+    }
+    return auth.handler(c.req.raw);
+  });
+
+  return app;
+}

--- a/apps/central-plane/test/auth-migration-draft.test.mjs
+++ b/apps/central-plane/test/auth-migration-draft.test.mjs
@@ -1,0 +1,63 @@
+/**
+ * auth-migration-draft.test.mjs
+ *
+ * Stage 209 — Better Auth LOCAL-ONLY D1 migration DRAFT safety checks. Reads the
+ * 0047 draft SQL straight from disk (no build needed) and asserts it is additive,
+ * non-destructive, contains exactly the expected Better Auth identity tables, and
+ * never touches the existing workspace / project / user_key surface.
+ *
+ * All structural/destructive scans run against the COMMENT-STRIPPED SQL so the
+ * file's own safety prose ("additive only", "no DROP", ...) is never matched.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const draftPath = join(here, "..", "migrations", "0047_better_auth_identity_tables.sql");
+
+/** SQL with `-- ...` comment lines removed (leading-whitespace tolerant). */
+function readCode() {
+  return readFileSync(draftPath, "utf8")
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("--"))
+    .join("\n");
+}
+
+test("0047 migration draft file exists", () => {
+  assert.ok(existsSync(draftPath), `expected draft at ${draftPath}`);
+});
+
+test("draft creates exactly the four Better Auth identity tables", () => {
+  const code = readCode();
+  for (const table of ['"user"', '"session"', '"account"', '"verification"']) {
+    assert.match(code, new RegExp(`CREATE TABLE IF NOT EXISTS ${table}`), `missing CREATE for ${table}`);
+  }
+});
+
+test("draft is additive-only — every CREATE guards with IF NOT EXISTS", () => {
+  const code = readCode();
+  const creates = code.match(/CREATE\s+(TABLE|INDEX)\b/gi) ?? [];
+  const guarded = code.match(/CREATE\s+(TABLE|INDEX)\s+IF\s+NOT\s+EXISTS\b/gi) ?? [];
+  assert.ok(creates.length > 0, "expected at least one CREATE statement");
+  assert.equal(creates.length, guarded.length, "every CREATE must use IF NOT EXISTS");
+});
+
+test("draft contains no DROP and no destructive statements", () => {
+  const code = readCode().toUpperCase();
+  assert.ok(!/\bDROP\b/.test(code), "must not contain DROP");
+  assert.ok(!/\bTRUNCATE\b/.test(code), "must not contain TRUNCATE");
+  assert.ok(!/\bDELETE\s+FROM\b/.test(code), "must not contain DELETE FROM");
+  assert.ok(!/\bUPDATE\s+\w/.test(code), "must not contain UPDATE statements");
+  assert.ok(!/\bALTER\s+TABLE\b/.test(code), "must not contain ALTER TABLE");
+});
+
+test("draft does not touch workspace / project / user_key surface", () => {
+  const code = readCode();
+  assert.ok(!/workspace_/.test(code), "must not reference workspace_ tables");
+  assert.ok(!/\buser_key\b/.test(code), "must not reference user_key");
+  assert.ok(!/\bproject_id\b/.test(code), "must not reference project_id");
+  assert.ok(!/\bprojects\b/.test(code), "must not reference projects table");
+});

--- a/apps/central-plane/test/auth-spike-route.test.mjs
+++ b/apps/central-plane/test/auth-spike-route.test.mjs
@@ -1,0 +1,92 @@
+/**
+ * auth-spike-route.test.mjs
+ *
+ * Stage 209 — Better Auth LOCAL-ONLY route (/api/auth/*). Verifies the route is
+ * disabled by default (503 auth_disabled), reports auth_not_configured when the
+ * flag is on but no local secret is present, never leaks the secret, and mounts
+ * safely inside the real router. Imports the built output (dist), matching the
+ * repo test convention. The route is exercised through createApp() so the actual
+ * router mount is covered.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../dist/router.js";
+
+function makeEnv(overrides = {}) {
+  return { DB: {}, ENVIRONMENT: "test", ...overrides };
+}
+
+async function fetchApp(app, path, init = {}, env = makeEnv()) {
+  const req = new Request(`http://localhost${path}`, init);
+  return app.fetch(req, env);
+}
+
+test("/api/auth/* returns 503 auth_disabled when AUTH_ENABLED is unset (production default)", async () => {
+  const app = createApp();
+  for (const env of [makeEnv(), makeEnv({ AUTH_ENABLED: "false" }), makeEnv({ AUTH_ENABLED: "1" })]) {
+    const res = await fetchApp(app, "/api/auth/ok", {}, env);
+    assert.equal(res.status, 503);
+    const body = await res.json();
+    assert.equal(body.error, "auth_disabled");
+  }
+});
+
+test("/api/auth/* returns 503 auth_disabled for any method/subpath by default", async () => {
+  const app = createApp();
+  const res = await fetchApp(app, "/api/auth/sign-in/email", { method: "POST" });
+  assert.equal(res.status, 503);
+  assert.equal((await res.json()).error, "auth_disabled");
+});
+
+test("/api/auth/* returns auth_not_configured when flag on but no local secret", async () => {
+  const app = createApp();
+  const res = await fetchApp(app, "/api/auth/ok", {}, makeEnv({ AUTH_ENABLED: "true" }));
+  assert.equal(res.status, 503);
+  assert.equal((await res.json()).error, "auth_not_configured");
+});
+
+test("disabled/not-configured responses never echo the secret value", async () => {
+  const app = createApp();
+  const secret = "super-secret-route-probe-value";
+  // flag off, secret present (shouldn't matter — still auth_disabled)
+  const off = await fetchApp(app, "/api/auth/ok", {}, makeEnv({ BETTER_AUTH_SECRET: secret }));
+  assert.ok(!(await off.text()).includes(secret));
+  // flag on, no secret -> not_configured
+  const notCfg = await fetchApp(app, "/api/auth/ok", {}, makeEnv({ AUTH_ENABLED: "true" }));
+  assert.ok(!(await notCfg.text()).includes(secret));
+});
+
+test("flag on + local secret: gate passes (not auth_disabled) and secret never leaks", async () => {
+  const app = createApp();
+  const secret = "super-secret-route-probe-value";
+  const res = await fetchApp(
+    app,
+    "/api/auth/ok",
+    {},
+    makeEnv({ AUTH_ENABLED: "true", BETTER_AUTH_SECRET: secret }),
+  );
+  const text = await res.text();
+  // The Better Auth handler (or the onError envelope) responds — what matters is
+  // that the gate did NOT short-circuit to disabled/not_configured, and nothing
+  // ever echoes the secret.
+  assert.ok(!text.includes(secret), "response must never contain the secret");
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = null;
+  }
+  if (parsed && typeof parsed.error === "string") {
+    assert.notEqual(parsed.error, "auth_disabled");
+    assert.notEqual(parsed.error, "auth_not_configured");
+  }
+});
+
+test("/api/auth/* does not collide with the existing /auth/github/callback surface", async () => {
+  const app = createApp();
+  // The saas-auth callback lives at /auth/github/callback (no /api prefix). A
+  // bare GET there must NOT be swallowed by the auth-spike disabled gate.
+  const res = await fetchApp(app, "/auth/github/callback");
+  const body = await res.json().catch(() => ({}));
+  assert.notEqual(body.error, "auth_disabled");
+});

--- a/conclave-builder-pack/out/stage-209-better-auth-local-route-d1-draft-execution.md
+++ b/conclave-builder-pack/out/stage-209-better-auth-local-route-d1-draft-execution.md
@@ -1,0 +1,100 @@
+# Stage 209 — Better Auth Local Route + Local Migration Draft Execution
+
+**Date:** 2026-06-25
+**Branch:** `feat/stage-209-better-auth-local-route-d1-draft` (from main `9bbdf99`)
+**Scope:** LOCAL-ONLY. Route wiring + migration draft. No deploy, no migration run, no OAuth, no production env, no CORS/Vercel.
+
+---
+
+## 1. Approval scope observed
+Two direct Bae approval phrases present at the top of the Stage 209 message:
+- **"Local auth migration draft approved."** → migration draft approved: **yes**
+- **"Better Auth implementation approved."** → route/config wiring approved: **yes**
+- production migration approved: **no** · deploy approved: **no** · OAuth: **no** · Vercel rewrite/CORS/DNS: **no**
+
+Both scopes present → Option A path (route + migration draft), both implemented.
+
+## 2. Branch / HEAD
+- Branch: `feat/stage-209-better-auth-local-route-d1-draft`
+- Base: main `9bbdf99` (clean working tree at branch creation)
+
+## 3. Files changed (Stage 209 only)
+- `apps/central-plane/migrations/0047_better_auth_identity_tables.sql` (NEW — migration DRAFT)
+- `apps/central-plane/src/routes/auth-spike.ts` (NEW — `/api/auth/*` route)
+- `apps/central-plane/src/router.ts` (MODIFIED — import + mount, +1 import line, +4 lines mount/comment)
+- `apps/central-plane/test/auth-spike-route.test.mjs` (NEW — 6 tests)
+- `apps/central-plane/test/auth-migration-draft.test.mjs` (NEW — 5 tests)
+- `conclave-builder-pack/out/stage-209-better-auth-local-route-d1-draft-execution.md` (this report)
+
+(Pre-existing untracked files — `.githooks/`, `AGENTS.md`, stale stage docs, HANDOFF-*.md, `.lnk` — were left untouched and NOT staged.)
+
+## 4. Routing baseline
+- `src/router.ts` composes Hono sub-apps via `app.route("/", createXxxRoutes(...))`.
+- Existing GitHub auth callback lives at `/auth/github/callback` (saas-auth.ts), NO `/api` prefix.
+- New route uses the distinct `/api/auth/*` namespace → no collision (covered by a regression test).
+- Mounted last among workspace routes, before `onError`.
+
+## 5. Migration baseline
+- Latest existing migration: `0046_workspace_agent_workflow_records.sql`.
+- Next number = **0047** (rechecked immediately before writing; nothing newer present).
+- DB binding confirmed: `env.DB` (D1), used by `/healthz` ping and all workspace routes.
+
+## 6. Migration draft result
+- `0047_better_auth_identity_tables.sql` created — DRAFT, **not applied** (local or production).
+- Tables: `"user"`, `"session"`, `"account"`, `"verification"` (Better Auth 1.6.20 core email/password schema).
+- D1/SQLite-compatible types (integer for booleans, date for timestamps). camelCase quoted identifiers to match Better Auth's own data layer (documented in the file header).
+- Additive only: every statement is `CREATE TABLE/INDEX IF NOT EXISTS`. No DROP, no destructive ALTER, no DELETE/TRUNCATE/UPDATE, no backfill.
+- Does not reference/alter `workspace_*`, `user_key`, `project_id`, or `projects` (asserted by test).
+- Hand-written from the documented schema (generator NOT run blindly).
+
+## 7. Route wiring result
+- `createAuthSpikeRoutes()` mounts `app.all("/api/auth/*")`, gated by `getAuthSpikeConfig`:
+  - `AUTH_ENABLED` unset / != "true" → **503 `{ "error": "auth_disabled" }`** (production default).
+  - `AUTH_ENABLED === "true"` but runtime not ready (no local secret) → **503 `{ "error": "auth_not_configured" }`**.
+  - `AUTH_ENABLED === "true"` AND local secret present → delegates to `createBetterAuthSpike(env)!.handler(c.req.raw)`.
+- Never echoes/logs secret/token/user/session/DB. No OAuth provider, no CORS, no dashboard UI, no Vercel rewrite.
+
+## 8. Better Auth D1 binding result
+- **Deferred (Step 6 safe path).** The spike instance stays stateless (no `database` option). Reason: the precise D1/Kysely 1.6.20 wiring would require a `kysely-d1` dialect dependency that is not installed and not in this stage's approved scope (no package install approved here).
+- The 0047 draft prepares the identity tables so a separately-approved D1-wiring stage can connect `env.DB` without re-deriving schema.
+- Until then the enabled path delegates to a stateless handler; DB-backed flows are simply not provisioned. Route remains production-safe (disabled by default).
+- No `wrangler.toml` change. No new binding. `env.DB` reused conceptually only; no runtime DB handle exposed.
+
+## 9. Tests added/updated
+- `auth-spike-route.test.mjs` (6): default 503 auth_disabled (multiple env shapes); any method/subpath disabled; auth_not_configured when flag on + no secret; secret never echoed in disabled/not-configured bodies; flag+secret gate passes without leaking secret; `/auth/github/callback` not swallowed by the spike gate.
+- `auth-migration-draft.test.mjs` (5): draft exists; four expected tables; additive-only (all CREATE … IF NOT EXISTS); no DROP/destructive SQL; does not touch workspace/project/user_key.
+- Existing `better-auth-spike.test.mjs` (7) unchanged and still passing.
+
+## 10. Verification results
+- `pnpm --filter @conclave-ai/central-plane build` — **pass**
+- `node --test test/auth-spike-route.test.mjs` — **6/6 pass**
+- `node --test test/auth-migration-draft.test.mjs` — **5/5 pass**
+- `node --test test/better-auth-spike.test.mjs` — **7/7 pass**
+- `pnpm typecheck` — **57/57** (FULL TURBO)
+
+## 11. Safety scan
+- Scanned all changed files for: `sk-`, `AKIA`, `ghp_`/`gho_`, `postgresql://`, `mongodb+srv://`, private keys, `client_secret`, access/refresh token literals, `Access-Control-Allow*`, `vercel.json`, `rewrites`.
+- Result: **NO hits.** No `.env` files staged. No tokens/secrets in any file (the migration `account` table has nullable `accessToken`/`refreshToken` *columns* only — schema, no values).
+
+## 12. Disabled / default-off behavior
+- `AUTH_ENABLED` remains default OFF in `env.ts` (optional, no `="true"` default). With the route mounted, production behavior is unchanged: every `/api/auth/*` request returns 503 `auth_disabled` until the flag is explicitly set with a local secret.
+
+## 13. Production impact analysis
+- **Zero.** No deploy. The route is dormant under production env (flag off). Migration is a draft on disk, never applied. No write path to production D1. Production remains `9b645af`.
+
+## 14. Rollback plan
+- Pure additive, single branch. Rollback = do not merge the PR, or revert the squash commit. The migration is never applied, so there is nothing to undo in D1. Removing the route mount line + files fully reverts behavior to main.
+
+## 15. Known issues / follow-ups
+- **D1 runtime binding deferred** — a future stage must wire `env.DB` into Better Auth (likely a `kysely-d1` dialect; needs a package-install approval) and then apply 0047 locally first.
+- Local migration apply, cookie/CORS strategy, OAuth providers, and dashboard auth UI all remain separate gated stages.
+- Better Auth `baseURL`/trustedOrigins config is not set yet (not needed while disabled/stateless).
+
+## 16. Stage 209 decision
+- **Option A — Local route + migration draft PR ready for review.** Both approved scopes implemented safely; D1 runtime binding deferred per Step 6 (documented), which does not block either deliverable.
+
+## 17. Out-of-scope confirmation
+No production migration, no local migration apply, no deploy, no OAuth, no production env vars, no `.env`, no Vercel rewrite, no CORS code, no DNS/domain, no dashboard UI, no workspace role enforcement, no team invite/share, no Plan Map audit, no IntegrationAccount migration, no token/secret storage or printing. Stale dogfood PRs #121~130 untouched.
+
+## 18. Recommended next stage
+**Stage 210 — Better Auth Local Route / Migration Draft PR Merge Gate**, only after an explicit "PR #<n> merge approved." Production migration ("Production auth migration approved.") and deploy ("Dashboard deploy approved.") remain separate future gates. D1 runtime binding likely needs its own package-install + implementation approval before 0047 is applied anywhere.


### PR DESCRIPTION
## Stage 209 — Better Auth Local Route + D1 Migration Draft

**Direct approval scope observed:** "Local auth migration draft approved." + "Better Auth implementation approved." (both present).

**Local-only. Production-safe. No deploy.**

### What this adds
- `/api/auth/*` route (`src/routes/auth-spike.ts`), gated by `AUTH_ENABLED`:
  - default / production → **503 `{ "error": "auth_disabled" }`**
  - flag on, no local secret → **503 `{ "error": "auth_not_configured" }`**
  - flag on + local secret → delegates to the Better Auth handler
- `migrations/0047_better_auth_identity_tables.sql` — additive **DRAFT** (user / session / account / verification). **Not applied** (local or production).
- 11 new tests (6 route + 5 migration safety); existing 7 spike tests still pass.

### Guarantees
- `AUTH_ENABLED` default **off** — route dormant in production.
- **Migration draft only** — no production migration run, no local apply.
- Runtime D1 binding **deferred** (no package install in scope; `kysely-d1` wiring is a future gated stage).
- No deploy · no OAuth · no dashboard UI · no Vercel rewrite / CORS code · no token/secret values.
- Disabled-route behavior proven by tests; secret never echoed.

### Verification
- central-plane build ✓ · route 6/6 · migration 5/5 · spike 7/7 · monorepo typecheck 57/57.
- Safety scan: no secrets / CORS / Vercel / .env.

### Rollback
Pure additive on one branch. Don't merge / revert the squash commit; migration never applied → nothing to undo in D1.

### Next gates
- Stage 210 — PR merge gate (needs "PR #<n> merge approved.").
- D1 runtime binding + local apply, production migration ("Production auth migration approved."), deploy ("Dashboard deploy approved.") all remain separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)