### PR TITLE
Stage 216 — D1 Runtime Binding Package Version

### DIFF
--- a/apps/central-plane/package.json
+++ b/apps/central-plane/package.json
@@ -23,7 +23,8 @@
     "@cloudflare/containers": "^0.0.30",
     "@conclave-ai/core": "workspace:*",
     "better-auth": "1.6.20",
-    "hono": "^4.6.14"
+    "hono": "^4.6.14",
+    "kysely-d1": "0.4.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250101.0",

--- a/apps/central-plane/src/better-auth-d1.ts
+++ b/apps/central-plane/src/better-auth-d1.ts
@@ -1,0 +1,37 @@
+/**
+ * Stage 216 — Better Auth D1 runtime-binding package prep (COMPILE-LEVEL ONLY).
+ *
+ * Proves the `kysely-d1` D1 dialect resolves + type-checks under the central-plane
+ * TypeScript / Cloudflare Workers build, and provides the smallest helper a later
+ * (separately-approved) wiring stage will use to give Better Auth a D1-backed
+ * `database` config.
+ *
+ * Intentionally NOT wired into the route or `createBetterAuthSpike` yet:
+ *   - nothing runs at import time (the dialect is only constructed when called),
+ *   - no DB access happens here (the D1 binding is only read lazily by Kysely
+ *     inside a request, never at construction),
+ *   - no secret / production env required,
+ *   - the `/api/auth/*` route stays stateless + disabled-by-default (Stage 209).
+ *
+ * Better Auth accepts a Kysely `Dialect` via its `database` option as
+ * `{ dialect, type }`; for D1 the type is "sqlite" (D1 is SQLite-compatible).
+ */
+import { D1Dialect } from "kysely-d1";
+import type { D1Database } from "@cloudflare/workers-types";
+
+/** Import/availability proof: the kysely-d1 dialect resolved at build time. */
+export function d1DialectAvailable(): boolean {
+  return typeof D1Dialect === "function";
+}
+
+/**
+ * Build the Better Auth `database` config for a Cloudflare D1 binding.
+ *
+ * Construct this lazily, per request (the `env.DB` binding only exists inside a
+ * request handler in Workers). The dialect stores the binding; it does not touch
+ * the database here. The returned object is the shape Better Auth's kysely
+ * adapter expects: `{ dialect, type: "sqlite" }`.
+ */
+export function buildBetterAuthD1Database(db: D1Database) {
+  return { dialect: new D1Dialect({ database: db }), type: "sqlite" as const };
+}

--- a/apps/central-plane/test/better-auth-d1.test.mjs
+++ b/apps/central-plane/test/better-auth-d1.test.mjs
@@ -1,0 +1,34 @@
+/**
+ * better-auth-d1.test.mjs
+ *
+ * Stage 216 — verifies the kysely-d1 D1 dialect package resolves under the
+ * central-plane build and that the compile-level helper builds the Better Auth
+ * D1 `database` config shape WITHOUT requiring a live DB. Imports the built
+ * output (dist), matching the repo convention. No secret/token/DB access.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { d1DialectAvailable, buildBetterAuthD1Database } from "../dist/better-auth-d1.js";
+
+test("kysely-d1 D1Dialect resolves + imports under the central-plane build", () => {
+  assert.equal(d1DialectAvailable(), true);
+});
+
+test("buildBetterAuthD1Database returns the Better Auth { dialect, type:'sqlite' } shape", () => {
+  // A bare object stands in for the D1 binding — the dialect only stores it and
+  // does not touch the database at construction, so no live D1 is required.
+  const fakeDb = {};
+  const cfg = buildBetterAuthD1Database(fakeDb);
+  assert.equal(cfg.type, "sqlite");
+  assert.ok(cfg.dialect, "expected a dialect instance");
+  // Kysely Dialect contract surface is present (lazy — nothing has run yet).
+  assert.equal(typeof cfg.dialect.createDriver, "function");
+  assert.equal(typeof cfg.dialect.createAdapter, "function");
+});
+
+test("helper does not require a live DB and exposes no secret", () => {
+  const cfg = buildBetterAuthD1Database({});
+  // The config carries only the dialect + type — no secret/token field.
+  const keys = Object.keys(cfg).sort();
+  assert.deepEqual(keys, ["dialect", "type"]);
+});

--- a/conclave-builder-pack/out/stage-216-d1-runtime-binding-package-version.md
+++ b/conclave-builder-pack/out/stage-216-d1-runtime-binding-package-version.md
@@ -1,0 +1,78 @@
+# Stage 216 — D1 Runtime Binding Package/Version Check + Install
+
+**Date:** 2026-06-25
+**Branch:** `feat/stage-216-d1-runtime-binding-package-version` (from main `a2499ff`)
+**Scope:** Package/version check + minimum install + compile-level prep. No runtime smoke, no migration apply, no deploy.
+
+---
+
+## 1. Approval phrase observed
+> "D1 runtime binding package/version approved."
+
+Recorded: D1 runtime binding package/version = **approved**. local runtime smoke = not approved. local migration apply = not approved. production migration = not approved. deploy = not approved.
+
+## 2. Branch / HEAD
+- `feat/stage-216-d1-runtime-binding-package-version` off main `a2499ff` (Release: Stage 214). Working tree clean at branch creation.
+
+## 3. Package requirement findings (read-only + online recheck)
+- Better Auth 1.6.20's `database` option **accepts a Kysely `Dialect`** (typed in `adapters/kysely-adapter`; docs example `database: new PostgresDialect({...})`). It does **not** natively detect D1.
+- Better Auth bundles `kysely@0.29.2` + `@better-auth/kysely-adapter`, but **no D1/Cloudflare dialect**. A D1 Kysely dialect is the missing piece.
+- **Online recheck (npm + Cloudflare community projects):** `kysely-d1` latest = **0.4.0** (published 2025-04-19), **MIT**, peerDependency `kysely: *` (no conflict with bundled 0.29.2). It is the canonical D1 dialect for Kysely (aidenwallis/kysely-d1), listed in Cloudflare's D1 community projects. Surface is tiny/stable (`D1Dialect implements Dialect`, constructor `{ database: D1Database }`). Low churn, low risk. Single clear candidate (no ambiguity).
+- Documented better-auth+D1 pattern: pass `{ dialect: new D1Dialect({ database }), type: "sqlite" }` and **construct per request** (the `env.DB` binding only exists inside a request) — which matches our Stage 209 per-request `createBetterAuthSpike(c.env)`.
+
+## 4. Package/version decision
+- **Route α — install `kysely-d1@0.4.0`** (exact pin), central-plane only. Chosen because it is the single, canonical, peer-compatible (MIT) D1 dialect; bundled `kysely@0.29.2` satisfies its `*` peer exactly. (Route β = in-repo custom dialect was viable but adds owned code beyond a package gate; α is the smallest approved action.)
+
+## 5. Install result
+- `pnpm --filter @conclave-ai/central-plane add kysely-d1@0.4.0` → `+1` package, done.
+- `apps/central-plane/package.json` dependency: `"kysely-d1": "0.4.0"` (exact pin).
+- pnpm store: `kysely-d1@0.4.0_kysely@0.29.2` — bound to the already-present bundled `kysely@0.29.2` (no second kysely copy, peer satisfied).
+- **No root `package.json` change.** No dashboard package change. No better-auth upgrade. No unrelated package churn.
+
+## 6. Files changed (Stage 216)
+- `apps/central-plane/package.json` (+1 dep, exact pin)
+- `pnpm-lock.yaml` (kysely-d1 + its kysely peer link only)
+- `apps/central-plane/src/better-auth-d1.ts` (NEW — compile-level helper)
+- `apps/central-plane/test/better-auth-d1.test.mjs` (NEW — 3 tests)
+- `conclave-builder-pack/out/stage-216-d1-runtime-binding-package-version.md` (this report)
+- **Unchanged:** `router.ts`, `routes/auth-spike.ts`, `better-auth-spike.ts`, `wrangler.toml`, `env.ts`, `migrations/0047*`.
+
+## 7. Compile-level helper result
+- `src/better-auth-d1.ts` exports:
+  - `d1DialectAvailable()` — import/availability proof (`typeof D1Dialect === "function"`).
+  - `buildBetterAuthD1Database(db)` — returns `{ dialect: new D1Dialect({ database: db }), type: "sqlite" as const }`, the Better Auth kysely-adapter shape.
+- **Deliberately NOT wired** into `router.ts` / `createBetterAuthSpike`. Nothing runs at import time; the dialect is constructed only when called; no DB access at construction; no secret/production env required. The `/api/auth/*` route stays stateless + disabled-by-default (Stage 209 contract unchanged). This is compile-level proof only — runtime wiring is a later gated stage.
+
+## 8. Tests added/updated
+- `better-auth-d1.test.mjs` (3): dialect package resolves under the build; helper returns `{ dialect, type:"sqlite" }` (Dialect contract surface present, lazy); helper needs no live DB and exposes only `dialect` + `type` (no secret field).
+- Existing `better-auth-spike` (7) + `auth-spike-route` (6) + `auth-migration-draft` (5) unchanged and passing.
+
+## 9. Verification results
+- central-plane build: **pass**
+- `better-auth-d1.test.mjs`: **3/3 pass**
+- existing auth tests: **18/18 pass**
+- monorepo typecheck: **57/57** (kysely-d1 resolves cleanly under NodeNext ESM)
+
+## 10. Safety scan
+- Changed files scanned for secrets / tokens / private keys / client_secret / access-refresh token literals / CORS (`Access-Control-Allow*`) / `vercel.json` / `rewrites` / `.env` → **no hits**. No local D1 state files. Package churn bounded to `kysely-d1` (+ its kysely peer link).
+
+## 11. Production impact analysis
+- **Zero.** A new dev/runtime dependency + an unused compile-level helper. The route is unchanged and dormant (AUTH_ENABLED off → 503 auth_disabled). No deploy. Production remains `9b645af`.
+
+## 12. Rollback plan
+- Single branch. Rollback = don't merge / revert the squash commit: `pnpm remove kysely-d1` (reverts package.json + lockfile) and delete `better-auth-d1.ts` + its test. No runtime/behavior change to undo (helper is unwired).
+
+## 13. Known issues / follow-ups
+- `kysely-d1@0.4.0` last published 2025-04-19 — low maintenance cadence, but peer `*` + tiny stable surface keep risk low. Re-evaluate (or switch to an in-repo dialect, Route β) only if a future kysely/Workers change breaks it.
+- Runtime wiring (`createBetterAuthSpike` → `database: buildBetterAuthD1Database(env.DB)`), per-request construction, and local runtime smoke remain a **separate** gated stage.
+
+## 14. Stage 216 decision
+- **Option A — D1 runtime binding package PR ready for review.** Required package clearly identified + exact-pinned install succeeded (central-plane only), compile-level helper + tests prove integration, all green, no production impact.
+
+## 15. Out-of-scope confirmation
+No local runtime smoke, no local migration apply, no production migration, no deploy, no OAuth, no production env, no `.env`, no Vercel rewrite, no CORS, no DNS, no dashboard UI, no token/secret, no route activation. Stale dogfood PRs #121~130 untouched.
+
+## 16. Recommended next stage
+- **Stage 217 — D1 Runtime Binding Package PR Merge Gate** — only after "PR #<n> merge approved."
+- Then **Stage 218 — Better Auth Local Runtime Smoke Gate** — only after "Better Auth local runtime smoke approved." (the smoke stage wires `buildBetterAuthD1Database` into the route + uses the locally-applied 0047 schema).
+- Production migration ("Production auth migration approved.") and deploy ("Dashboard deploy approved.") remain separate gates.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       hono:
         specifier: ^4.6.14
         version: 4.12.14
+      kysely-d1:
+        specifier: 0.4.0
+        version: 0.4.0(kysely@0.29.2)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250101.0
@@ -2556,6 +2559,11 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  kysely-d1@0.4.0:
+    resolution: {integrity: sha512-wUcVvQNtm30OTfuo7Ad5vYJ1qHqPXOCZc+zWchVKNyuvqY3u8OuGw4gmUx1Ypdx2wRVFLHVQC9I7v0pTmF7Nkw==}
+    peerDependencies:
+      kysely: '*'
 
   kysely@0.29.2:
     resolution: {integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==}
@@ -5431,6 +5439,10 @@ snapshots:
       json-buffer: 3.0.1
 
   kleur@4.1.5: {}
+
+  kysely-d1@0.4.0(kysely@0.29.2):
+    dependencies:
+      kysely: 0.29.2
 
   kysely@0.29.2: {}
 


### PR DESCRIPTION
## Stage 216 — D1 Runtime Binding Package Version

**Direct approval observed:** "D1 runtime binding package/version approved."

### Package/version decision
- Better Auth 1.6.20 accepts a Kysely `Dialect` via its `database` option but ships no D1 dialect.
- **Installed: `kysely-d1@0.4.0`** (exact pin, **MIT**, peer `kysely: *` → bound to the bundled `kysely@0.29.2`). Canonical D1 dialect (Cloudflare community projects). Single clear candidate; tiny stable surface.

### Boundary
- **apps/central-plane only** — root `package.json` unchanged, no dashboard change, no better-auth upgrade, no unrelated churn. Only `package.json` + `pnpm-lock.yaml` + a new helper + its test changed.
- Compile-level helper `buildBetterAuthD1Database()` returns `{ dialect: new D1Dialect({ database }), type: "sqlite" }` — **NOT wired into the route**; nothing runs at import, no DB access, no secret/prod env.

### Guarantees
- No runtime smoke · no migration apply · no production migration · no deploy · no OAuth · no production env · no CORS/Vercel/DNS · no token/secret.
- `/api/auth/*` stays disabled-by-default (AUTH_ENABLED off → 503 auth_disabled); route/router/spike unchanged.

### Verification
- central-plane build ✓ · new D1 helper test 3/3 · existing auth tests 18/18 · monorepo typecheck 57/57. Safety scan: no secrets/CORS/Vercel.

### Rollback
`pnpm remove kysely-d1` + delete helper/test, or revert the squash commit. Helper is unwired → no behavior to undo.

### Next gates
- Stage 217 — package PR merge gate ("PR #<n> merge approved.")
- Stage 218 — Better Auth local runtime smoke ("Better Auth local runtime smoke approved.")
- Production migration ("Production auth migration approved.") / deploy ("Dashboard deploy approved.")

🤖 Generated with [Claude Code](https://claude.com/claude-code)