### PR TITLE
Release: Stage 218 — Better Auth Local Runtime Smoke (isolated; route unwired)

### DIFF
--- a/apps/central-plane/package.json
+++ b/apps/central-plane/package.json
@@ -11,6 +11,7 @@
     "dev": "wrangler dev",
     "ship": "node scripts/preflight.mjs && wrangler deploy",
     "test": "node --test test/*.test.mjs",
+    "smoke:better-auth-d1": "node scripts/smoke-better-auth-d1.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "clean": "rm -rf dist .tsbuildinfo",
     "migrate:local": "wrangler d1 execute conclave-ai --local --file=./migrations/0001_initial.sql",

--- a/apps/central-plane/scripts/smoke-better-auth-d1.mjs
+++ b/apps/central-plane/scripts/smoke-better-auth-d1.mjs
@@ -1,0 +1,184 @@
+/**
+ * smoke-better-auth-d1.mjs
+ *
+ * Stage 218 — Better Auth LOCAL runtime smoke (ISOLATED, throwaway harness).
+ *
+ * Proves that the committed, compile-level helper `buildBetterAuthD1Database`
+ * (Stage 216) actually drives a working Better Auth email/password runtime over a
+ * local Cloudflare D1 backed by the `0047_better_auth_identity_tables.sql` schema —
+ * i.e. sign-up + sign-in succeed and write real rows.
+ *
+ * What this is NOT (the Stage 218 scope guard — keep the route UNWIRED):
+ *   - It does NOT import or touch `createBetterAuthSpike` or the `/api/auth/*` route.
+ *     The deployed Worker (src/index.ts → router) never references this file; wrangler
+ *     bundles only `src/index.ts`, and `scripts/` is dev-only + unpackaged.
+ *   - It does NOT mutate the real local D1 under `.wrangler/` or any shared state.
+ *     A fresh in-memory D1 (persist:false) is created from a throwaway minimal config,
+ *     so containers/Durable Objects from the real wrangler.toml are not loaded.
+ *   - It does NOT use a production secret, real credential, network, or migration of
+ *     production. The secret is a local throwaway literal; nothing is persisted.
+ *
+ * It exercises the REAL helper from the built output (../dist/better-auth-d1.js),
+ * matching the repo's "tests import dist" convention, so this is a true runtime proof
+ * of the same code path a later (separately-approved) wiring stage would use.
+ *
+ * Run: pnpm --filter @conclave-ai/central-plane smoke:better-auth-d1
+ *      (build first; the harness imports ../dist)
+ */
+import { getPlatformProxy } from "wrangler";
+import { betterAuth } from "better-auth";
+import { buildBetterAuthD1Database } from "../dist/better-auth-d1.js";
+import { readFile, mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MIGRATION = join(HERE, "..", "migrations", "0047_better_auth_identity_tables.sql");
+const BASE_URL = "http://localhost:8787";
+const LOCAL_SMOKE_SECRET = "local-smoke-secret-not-a-real-credential-0123456789";
+
+/** Split a SQL file into individual executable statements (strip `--` comments). */
+function splitSqlStatements(sql) {
+  return sql
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("--"))
+    .join("\n")
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+async function applySchema(db, sql) {
+  const statements = splitSqlStatements(sql);
+  for (const stmt of statements) {
+    await db.prepare(stmt).run();
+  }
+  return statements.length;
+}
+
+/** Minimal D1-only config so getPlatformProxy never loads containers / Durable Objects. */
+async function withIsolatedD1(fn) {
+  const dir = await mkdtemp(join(tmpdir(), "simsa-auth-d1-smoke-"));
+  const configPath = join(dir, "wrangler.smoke.toml");
+  await writeFile(
+    configPath,
+    [
+      'name = "conclave-ai-auth-smoke"',
+      'compatibility_date = "2026-04-20"',
+      'compatibility_flags = ["nodejs_compat"]',
+      "[[d1_databases]]",
+      'binding = "DB"',
+      'database_name = "conclave-ai"',
+      'database_id = "local-smoke"',
+      "",
+    ].join("\n"),
+  );
+  const proxy = await getPlatformProxy({ configPath, persist: false });
+  try {
+    return await fn(proxy.env.DB);
+  } finally {
+    await proxy.dispose();
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Run the isolated smoke. Returns a structured, secret-free result.
+ * Throws on any hard failure so the CLI can exit non-zero.
+ */
+export async function runBetterAuthD1Smoke() {
+  const checks = [];
+  const record = (name, ok, detail = "") => checks.push({ name, ok, detail });
+
+  const email = `smoke-user-${Date.now()}@example.test`;
+  const password = "Smoke-pass-ABC-12345";
+
+  const result = await withIsolatedD1(async (db) => {
+    const sql = await readFile(MIGRATION, "utf8");
+    const applied = await applySchema(db, sql);
+    record("0047 schema applied to fresh local D1", applied >= 4, `${applied} statements`);
+
+    // The actual code path under test: real helper → Better Auth database config.
+    const auth = betterAuth({
+      baseURL: BASE_URL,
+      secret: LOCAL_SMOKE_SECRET,
+      database: buildBetterAuthD1Database(db),
+      emailAndPassword: { enabled: true },
+    });
+    record("Better Auth instance built via buildBetterAuthD1Database", typeof auth?.handler === "function");
+
+    // Sign-up (email/password) through the Better Auth handler.
+    const signUpRes = await auth.handler(
+      new Request(`${BASE_URL}/api/auth/sign-up/email`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email, password, name: "Smoke User" }),
+      }),
+    );
+    record("sign-up handler returned 2xx", signUpRes.ok, `status ${signUpRes.status}`);
+    if (!signUpRes.ok) {
+      const body = await signUpRes.text();
+      throw new Error(`sign-up failed (${signUpRes.status}): ${body.slice(0, 200)}`);
+    }
+
+    // Verify a real user row was written to D1.
+    const userRow = await db
+      .prepare('SELECT "id", "email" FROM "user" WHERE "email" = ?')
+      .bind(email)
+      .first();
+    record("user row persisted in D1", !!userRow?.id);
+
+    // Verify a credential account row exists (email/password stores a hashed password here).
+    const accountRow = await db
+      .prepare('SELECT "id", "providerId" FROM "account" WHERE "userId" = ?')
+      .bind(userRow?.id ?? "")
+      .first();
+    record("credential account row persisted in D1", !!accountRow?.id, `provider ${accountRow?.providerId ?? "?"}`);
+
+    // Sign-in with the same credentials.
+    const signInRes = await auth.handler(
+      new Request(`${BASE_URL}/api/auth/sign-in/email`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      }),
+    );
+    record("sign-in handler returned 2xx", signInRes.ok, `status ${signInRes.status}`);
+
+    // Verify a session row was written for the user.
+    const sessionRow = await db
+      .prepare('SELECT "id" FROM "session" WHERE "userId" = ?')
+      .bind(userRow?.id ?? "")
+      .first();
+    record("session row persisted in D1", !!sessionRow?.id);
+
+    return { userId: userRow?.id ?? null };
+  });
+
+  const passed = checks.filter((c) => c.ok).length;
+  const failed = checks.filter((c) => !c.ok);
+  return { ok: failed.length === 0, passed, total: checks.length, checks, userIdPresent: !!result.userId };
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  runBetterAuthD1Smoke()
+    .then((r) => {
+      for (const c of r.checks) {
+        const mark = c.ok ? "PASS" : "FAIL";
+        console.log(`  [${mark}] ${c.name}${c.detail ? ` (${c.detail})` : ""}`);
+      }
+      console.log(`\nBetter Auth D1 smoke: ${r.passed}/${r.total} checks passed.`);
+      if (!r.ok) {
+        console.error("SMOKE FAILED");
+        process.exit(1);
+      }
+      console.log("SMOKE OK — helper + better-auth + local D1 sign-up/sign-in verified (route stays unwired).");
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error("SMOKE ERROR:", err?.message ?? err);
+      process.exit(1);
+    });
+}

--- a/apps/central-plane/test/auth-route-unwired.test.mjs
+++ b/apps/central-plane/test/auth-route-unwired.test.mjs
@@ -1,0 +1,55 @@
+/**
+ * auth-route-unwired.test.mjs
+ *
+ * Stage 218 PASS-condition guard (static, fast, no runtime).
+ *
+ * The Better Auth D1 runtime was proven to work in an ISOLATED local smoke
+ * (scripts/smoke-better-auth-d1.mjs: real helper + better-auth + local D1 →
+ * sign-up/sign-in write rows). That smoke must NOT change the deployed surface:
+ * the committed `/api/auth/*` route and `createBetterAuthSpike` MUST stay UNWIRED
+ * from the D1 runtime helper, so the production path never constructs a DB-backed
+ * handler until a separately-approved wiring stage.
+ *
+ * This locks that invariant — the aborted first Stage 218 attempt wired
+ * `createBetterAuthSpike` to `buildBetterAuthD1Database`; this test makes that
+ * regression fail CI instead of silently shipping.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
+
+// The deployed Better Auth surface: the spike factory + the route handler that
+// delegates to it. Neither may pull in the D1 runtime binding.
+const GUARDED_FILES = ["better-auth-spike.ts", join("routes", "auth-spike.ts")];
+const FORBIDDEN = [
+  /better-auth-d1/, // the helper module
+  /buildBetterAuthD1Database/, // the helper function
+  /D1Dialect/, // kysely-d1 dialect
+  /kysely/i, // any kysely import
+];
+
+for (const rel of GUARDED_FILES) {
+  test(`${rel} stays unwired from the D1 runtime helper (Stage 218)`, () => {
+    const text = readFileSync(join(SRC, rel), "utf8");
+    for (const pat of FORBIDDEN) {
+      assert.ok(!pat.test(text), `${rel} must not reference ${pat} — the route must stay unwired`);
+    }
+  });
+}
+
+test("createBetterAuthSpike passes no D1 `database` option (stateless on the deployed path)", () => {
+  const text = readFileSync(join(SRC, "better-auth-spike.ts"), "utf8");
+  const callIdx = text.indexOf("betterAuth({");
+  assert.ok(callIdx > 0, "expected a betterAuth({ ... }) call in better-auth-spike.ts");
+  // Only the doc comment may mention the word `database`; the actual factory call must not
+  // pass a `database:` option (that would be the aborted D1 wiring).
+  const callBody = text.slice(callIdx);
+  assert.ok(
+    !/database\s*:/.test(callBody),
+    "createBetterAuthSpike must not pass a `database:` option (keep it stateless / unwired)",
+  );
+});


### PR DESCRIPTION
## Stage 218 — Better Auth Local Runtime Smoke (isolated; route stays UNWIRED)

Approval: `"Better Auth local runtime smoke approved."`

### What this proves
The Stage 216 compile-level helper `buildBetterAuthD1Database` actually drives a **working** Better Auth email/password runtime over a local Cloudflare D1 backed by the `0047_better_auth_identity_tables.sql` schema. The smoke runs the **real** helper (imported from `../dist`) and verifies, end to end:

| Check | Result |
|---|---|
| 0047 schema applied to fresh local D1 | ✅ 7 statements |
| Better Auth instance built via `buildBetterAuthD1Database` | ✅ |
| sign-up handler → 2xx | ✅ 200 |
| user row persisted in D1 | ✅ |
| credential account row persisted in D1 | ✅ provider `credential` |
| sign-in handler → 2xx | ✅ 200 |
| session row persisted in D1 | ✅ |

`pnpm --filter @conclave-ai/central-plane smoke:better-auth-d1` → **7/7**, deterministic across runs.

### Scope guard (this is the corrected Stage 218)
The first Stage 218 attempt over-reached by wiring `createBetterAuthSpike` to the D1 dialect; that was discarded. This PR keeps the deployed surface **unwired**:

- **No route wiring.** `/api/auth/*` stays disabled-by-default (`503 auth_disabled`); `createBetterAuthSpike` stays stateless (no `database:` option).
- **No production migration, no deploy.** The smoke uses a fresh in-memory D1 (`getPlatformProxy` + a throwaway minimal D1-only config — no containers/Durable Objects), applies `0047` locally, and leaves no shared state. It never touches the real `.wrangler` D1, a production secret, or the network.
- **`test/auth-route-unwired.test.mjs`** is a static guard that fails CI if the route or spike ever references the D1 helper (`better-auth-d1` / `buildBetterAuthD1Database` / `D1Dialect` / `kysely`) or passes a `database:` option — locking the invariant the aborted attempt broke.

### Files
- `apps/central-plane/scripts/smoke-better-auth-d1.mjs` — isolated harness (dev-only, unpackaged; wrangler bundles only `src/index.ts`).
- `apps/central-plane/test/auth-route-unwired.test.mjs` — PASS-condition guard (fast, no runtime).
- `apps/central-plane/package.json` — `smoke:better-auth-d1` script.

### Verification
central-plane **1205/1205** tests · typecheck clean · smoke **7/7** · monorepo `pnpm verify` green.

### Still gated (NOT in this PR)
- Production auth migration — needs `"Production auth migration approved."`
- Deploy — needs `"Dashboard deploy approved."`
- Permanent route wiring — separate approved stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
