### PR TITLE
Stage 227 — Auth Cookie/CORS Topology Code Readiness (optional, non-activating)

### DIFF
--- a/apps/central-plane/docs/auth-topology.md
+++ b/apps/central-plane/docs/auth-topology.md
@@ -1,0 +1,62 @@
+# Auth topology — env config + same-origin rewrite plan (Stage 227)
+
+Status: **code-readiness only.** No production env is set, no deploy, no `AUTH_ENABLED` activation.
+The Better Auth route is wired but gated (`AUTH_ENABLED` unset → `503 auth_disabled`).
+
+## Topology env (optional, additive, non-activating)
+
+Both are OPTIONAL and map 1:1 to verified Better Auth 1.6.20 options
+(`@better-auth/core` init-options). When unset, the runtime behaves exactly as today (Better Auth
+derives the origin from the incoming request). Setting them does **not** activate auth — that stays
+gated by `AUTH_ENABLED`.
+
+| Env var | Better Auth option | Meaning |
+|---|---|---|
+| `BETTER_AUTH_BASE_URL` | `baseURL: string` | Production base URL, e.g. `https://app.trysimsa.com`. |
+| `BETTER_AUTH_TRUSTED_ORIGINS` | `trustedOrigins: string[]` | Comma-separated allowed origins. |
+
+Parsing is fail-closed: empty / whitespace-only values are ignored (treated as unset); a comma list is
+trimmed and empties dropped (`src/auth-topology.ts`, tested in `test/auth-topology.test.mjs`). Cookie /
+`advanced` options are intentionally deferred (see below).
+
+## Recommended production path — same-origin Vercel rewrite (preferred)
+
+Route the auth API under the dashboard's own origin so Better Auth cookies are first-party:
+
+```
+app.trysimsa.com/api/auth/*   →   <central-plane worker>/api/auth/*
+```
+
+- **Why preferred:** first-party cookies on `app.trysimsa.com`, minimal CORS surface, safest session
+  behavior (no SameSite=None / cross-site cookie fragility).
+- With this rewrite, set `BETTER_AUTH_BASE_URL=https://app.trysimsa.com` and
+  `BETTER_AUTH_TRUSTED_ORIGINS=https://app.trysimsa.com` so callbacks/redirects and origin checks resolve
+  to the user-facing origin rather than the worker host.
+
+### Why NOT workers.dev cross-site as the primary path
+The dashboard today calls the worker cross-origin (`*.workers.dev`). Driving auth that way needs
+`SameSite=None; Secure` cookies + CORS credentials + trusted origins — fragile and easy to misconfigure.
+Use only for temporary diagnostics, if ever, and never as the production default.
+
+### Subdomain fallback (e.g. `api.trysimsa.com`)
+If a same-origin rewrite is not feasible, a dedicated auth/API subdomain is the fallback. It requires
+cookie-domain config (`.trysimsa.com`) via Better Auth `advanced.cookies` (a code addition deferred from
+this stage) plus DNS — higher session-bug risk than same-origin.
+
+## What must be tested before deploy/activation
+1. With the rewrite in place (preview), sign-up → session cookie is set on `app.trysimsa.com` and sent on
+   the follow-up request; sign-in round-trips.
+2. `trustedOrigins` accepts the dashboard origin and rejects others.
+3. With `AUTH_ENABLED` unset, `/api/auth/*` still returns `503 auth_disabled` in the deployed worker.
+
+## Gates (each separate; never bundled)
+- This stage (227): code + config support + docs only — **no** env/deploy/activation.
+- Vercel rewrite to production: requires explicit approval before any `vercel.json`/rewrite change is shipped.
+- `"Dashboard deploy approved."` — deploy the auth-disabled worker/dashboard.
+- `"Production auth activation approved."` — set `AUTH_ENABLED=true` only after D1 (done), secret (done),
+  topology env, rewrite, and deploy are all confirmed.
+
+## Deferred (not in this stage)
+- Cookie config via `advanced.cookies` (domain/secure/sameSite) — only needed for the subdomain fallback;
+  same-origin uses first-party defaults.
+- `userKey` → real-user migration; OAuth providers; `/account` UI productization.

--- a/apps/central-plane/src/auth-topology.ts
+++ b/apps/central-plane/src/auth-topology.ts
@@ -1,0 +1,47 @@
+import type { Env } from "./env.js";
+
+/**
+ * Stage 227 — Better Auth topology config (cookie / CORS readiness).
+ *
+ * Resolves the OPTIONAL production topology options for the local Better Auth runtime from
+ * env, lazily per request. It is purely additive and fail-safe:
+ *   - with no topology env set, this returns `{}` and the runtime behaves exactly as before
+ *     (Better Auth derives the origin from the incoming request — current behaviour),
+ *   - it NEVER activates auth (that stays gated by AUTH_ENABLED) and NEVER throws,
+ *   - invalid / empty values are ignored (fail closed to "unset"), never fabricated.
+ *
+ * The fields map 1:1 to verified Better Auth 1.6.20 options (`@better-auth/core` init-options):
+ *   - `baseURL?: string`           ← BETTER_AUTH_BASE_URL
+ *   - `trustedOrigins?: string[]`  ← BETTER_AUTH_TRUSTED_ORIGINS (comma-separated)
+ * Cookie/`advanced` options are intentionally deferred (same-origin needs no special cookie
+ * config; a subdomain topology would add `advanced.cookies` — a separate, later decision).
+ */
+export type AuthTopologyConfig = {
+  baseURL?: string;
+  trustedOrigins?: string[];
+};
+
+/** Parse a comma-separated trusted-origins env value into a clean list (or undefined). */
+export function parseTrustedOrigins(value: string | undefined): string[] | undefined {
+  if (typeof value !== "string") return undefined;
+  const list = value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return list.length > 0 ? list : undefined;
+}
+
+/**
+ * Resolve the optional topology config from env. Returns an object containing ONLY the
+ * fields that are explicitly, non-emptily set — so an empty/absent env yields `{}` and the
+ * caller spreads nothing into the Better Auth options (unchanged behaviour).
+ */
+export function resolveAuthTopologyConfig(env: Partial<Env> | undefined): AuthTopologyConfig {
+  const e = env ?? {};
+  const cfg: AuthTopologyConfig = {};
+  const baseURL = typeof e.BETTER_AUTH_BASE_URL === "string" ? e.BETTER_AUTH_BASE_URL.trim() : "";
+  if (baseURL) cfg.baseURL = baseURL;
+  const trustedOrigins = parseTrustedOrigins(e.BETTER_AUTH_TRUSTED_ORIGINS);
+  if (trustedOrigins) cfg.trustedOrigins = trustedOrigins;
+  return cfg;
+}

--- a/apps/central-plane/src/better-auth-spike.ts
+++ b/apps/central-plane/src/better-auth-spike.ts
@@ -2,6 +2,7 @@ import { betterAuth } from "better-auth";
 import type { Env } from "./env.js";
 import { getAuthSpikeConfig } from "./auth-spike-config.js";
 import { buildBetterAuthD1Database } from "./better-auth-d1.js";
+import { resolveAuthTopologyConfig } from "./auth-topology.js";
 
 /**
  * Stage 204 / 221 — Better Auth LOCAL-ONLY runtime (gated D1 wiring).
@@ -63,9 +64,14 @@ export function createBetterAuthRuntime(env: Partial<Env> | undefined) {
   // Narrowing guard (also defensive — resolveAuthRuntimeGate already required it).
   if (!db) return null;
   const secret = e.BETTER_AUTH_SECRET as string;
+  // Optional topology config (Stage 227): spread ONLY when set, so an unset env leaves the
+  // options identical to before (origin derived from the request). Never activates auth.
+  const topology = resolveAuthTopologyConfig(e);
   return betterAuth({
     secret,
     database: buildBetterAuthD1Database(db),
     emailAndPassword: { enabled: true },
+    ...(topology.baseURL ? { baseURL: topology.baseURL } : {}),
+    ...(topology.trustedOrigins ? { trustedOrigins: topology.trustedOrigins } : {}),
   });
 }

--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -191,8 +191,17 @@ export interface Env {
    * BETTER_AUTH_SECRET:  server-side signing secret for the local spike (local dev only).
    *   Never commit a real value; set via local env. The spike stays disabled when unset.
    *   Real secret handling, D1 wiring, and any production rollout are separately gated.
+   *
+   * Stage 227 — optional Better Auth topology config (cookie/CORS readiness). Both are
+   * OPTIONAL and purely additive: when unset, the runtime behaves exactly as before (Better
+   * Auth derives the origin from the incoming request). Setting them does NOT activate auth
+   * (still gated by AUTH_ENABLED). They map directly to Better Auth options of the same name:
+   * BETTER_AUTH_BASE_URL:        production base URL, e.g. "https://app.trysimsa.com" → `baseURL`.
+   * BETTER_AUTH_TRUSTED_ORIGINS: comma-separated allowed origins → `trustedOrigins: string[]`.
    */
   AUTH_ENABLED?: string;
   AUTH_PROVIDER?: string;
   BETTER_AUTH_SECRET?: string;
+  BETTER_AUTH_BASE_URL?: string;
+  BETTER_AUTH_TRUSTED_ORIGINS?: string;
 }

--- a/apps/central-plane/test/auth-spike-route.test.mjs
+++ b/apps/central-plane/test/auth-spike-route.test.mjs
@@ -92,6 +92,22 @@ test("flag on + local secret: gate passes (not auth_disabled) and secret never l
   }
 });
 
+test("Stage 227: topology env present but AUTH_ENABLED absent → still 503 auth_disabled", async () => {
+  const app = createApp();
+  const res = await fetchApp(
+    app,
+    "/api/auth/ok",
+    {},
+    makeEnv({
+      BETTER_AUTH_BASE_URL: "https://app.trysimsa.com",
+      BETTER_AUTH_TRUSTED_ORIGINS: "https://app.trysimsa.com",
+      BETTER_AUTH_SECRET: "x",
+    }),
+  );
+  assert.equal(res.status, 503);
+  assert.equal((await res.json()).error, "auth_disabled");
+});
+
 test("/api/auth/* does not collide with the existing /auth/github/callback surface", async () => {
   const app = createApp();
   // The saas-auth callback lives at /auth/github/callback (no /api prefix). A

--- a/apps/central-plane/test/auth-topology.test.mjs
+++ b/apps/central-plane/test/auth-topology.test.mjs
@@ -1,0 +1,68 @@
+/**
+ * auth-topology.test.mjs
+ *
+ * Stage 227 — Better Auth topology config (cookie/CORS readiness). Verifies the optional
+ * env parsing is safe, additive, and fail-closed: no topology env → empty config (unchanged
+ * behaviour); base URL + comma-separated trusted origins parsed and trimmed; empty/whitespace
+ * values ignored. Imports the built output (dist), matching the repo test convention.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveAuthTopologyConfig, parseTrustedOrigins } from "../dist/auth-topology.js";
+
+test("no topology env → empty config (unchanged runtime behaviour)", () => {
+  for (const env of [undefined, {}, { AUTH_ENABLED: "true", BETTER_AUTH_SECRET: "x", DB: {} }]) {
+    assert.deepEqual(resolveAuthTopologyConfig(env), {});
+  }
+});
+
+test("BETTER_AUTH_BASE_URL is parsed and trimmed; empty/whitespace ignored", () => {
+  assert.deepEqual(resolveAuthTopologyConfig({ BETTER_AUTH_BASE_URL: "https://app.trysimsa.com" }), {
+    baseURL: "https://app.trysimsa.com",
+  });
+  assert.deepEqual(resolveAuthTopologyConfig({ BETTER_AUTH_BASE_URL: "  https://app.trysimsa.com  " }), {
+    baseURL: "https://app.trysimsa.com",
+  });
+  assert.deepEqual(resolveAuthTopologyConfig({ BETTER_AUTH_BASE_URL: "" }), {});
+  assert.deepEqual(resolveAuthTopologyConfig({ BETTER_AUTH_BASE_URL: "   " }), {});
+});
+
+test("parseTrustedOrigins: comma list, trimmed, empties filtered", () => {
+  assert.deepEqual(parseTrustedOrigins("https://app.trysimsa.com"), ["https://app.trysimsa.com"]);
+  assert.deepEqual(parseTrustedOrigins("https://a.com, https://b.com ,https://c.com"), [
+    "https://a.com",
+    "https://b.com",
+    "https://c.com",
+  ]);
+  assert.deepEqual(parseTrustedOrigins("https://a.com, ,, https://b.com,"), [
+    "https://a.com",
+    "https://b.com",
+  ]);
+  // empty / whitespace-only / non-string → undefined (fail closed to "unset")
+  assert.equal(parseTrustedOrigins(""), undefined);
+  assert.equal(parseTrustedOrigins("   "), undefined);
+  assert.equal(parseTrustedOrigins(","), undefined);
+  assert.equal(parseTrustedOrigins(undefined), undefined);
+});
+
+test("BETTER_AUTH_TRUSTED_ORIGINS parsed into config.trustedOrigins; empty ignored", () => {
+  assert.deepEqual(resolveAuthTopologyConfig({ BETTER_AUTH_TRUSTED_ORIGINS: "https://app.trysimsa.com, https://x.dev" }), {
+    trustedOrigins: ["https://app.trysimsa.com", "https://x.dev"],
+  });
+  assert.deepEqual(resolveAuthTopologyConfig({ BETTER_AUTH_TRUSTED_ORIGINS: "  ,  " }), {});
+});
+
+test("both fields together resolve into a combined config", () => {
+  assert.deepEqual(
+    resolveAuthTopologyConfig({
+      BETTER_AUTH_BASE_URL: "https://app.trysimsa.com",
+      BETTER_AUTH_TRUSTED_ORIGINS: "https://app.trysimsa.com",
+    }),
+    { baseURL: "https://app.trysimsa.com", trustedOrigins: ["https://app.trysimsa.com"] },
+  );
+});
+
+test("resolveAuthTopologyConfig never throws on odd input", () => {
+  assert.doesNotThrow(() => resolveAuthTopologyConfig({ BETTER_AUTH_BASE_URL: 123 }));
+  assert.doesNotThrow(() => resolveAuthTopologyConfig({ BETTER_AUTH_TRUSTED_ORIGINS: 123 }));
+});

--- a/apps/central-plane/test/better-auth-spike.test.mjs
+++ b/apps/central-plane/test/better-auth-spike.test.mjs
@@ -82,3 +82,29 @@ test("createBetterAuthRuntime builds a DB-backed handler ONLY when all gates are
   assert.ok(auth, "expected a Better Auth instance when flag + secret + DB are present");
   assert.equal(typeof auth.handler, "function");
 });
+
+test("Stage 227: topology env does NOT activate auth (still null without AUTH_ENABLED)", () => {
+  // Setting topology env must never construct a runtime on its own — AUTH_ENABLED still gates.
+  assert.equal(
+    createBetterAuthRuntime({
+      BETTER_AUTH_BASE_URL: "https://app.trysimsa.com",
+      BETTER_AUTH_TRUSTED_ORIGINS: "https://app.trysimsa.com",
+      BETTER_AUTH_SECRET: "x",
+      DB: {},
+    }),
+    null,
+    "topology env without AUTH_ENABLED must NOT build a runtime",
+  );
+});
+
+test("Stage 227: runtime builds with topology config when all gates present", () => {
+  const auth = createBetterAuthRuntime({
+    AUTH_ENABLED: "true",
+    BETTER_AUTH_SECRET: "x",
+    DB: {},
+    BETTER_AUTH_BASE_URL: "https://app.trysimsa.com",
+    BETTER_AUTH_TRUSTED_ORIGINS: "https://app.trysimsa.com, https://x.dev",
+  });
+  assert.ok(auth, "expected a Better Auth instance with topology config + all gates");
+  assert.equal(typeof auth.handler, "function");
+});


### PR DESCRIPTION
## Stage 227 — Auth Cookie / CORS / Topology Code Readiness

Approval: `"Auth cookie/CORS topology approved."`

**Code-readiness only.** Adds optional Better Auth topology config so production cookie/CORS topology can be configured later via env — while keeping the route **gated** and production behaviour **unchanged**. No production env values, no `AUTH_ENABLED` activation, no deploy, no OAuth, no DNS/Vercel-rewrite/wrangler.toml/migration change.

### Verified Better Auth option names (not guessed)
From installed `@better-auth/core@1.6.20` `init-options.d.mts`: `baseURL?: string | {allowedHosts,fallback}`, `trustedOrigins?: string[] | fn`, `basePath?: string` (default `/api/auth`), `advanced?` (cookies — deferred).

### Changes
- `env.ts` — add optional `BETTER_AUTH_BASE_URL` + `BETTER_AUTH_TRUSTED_ORIGINS` (both default unset).
- `auth-topology.ts` (new) — `resolveAuthTopologyConfig(env)` + `parseTrustedOrigins(value)`. Pure, fail-closed, never throws. No topology env → `{}` (unchanged behaviour). Maps 1:1 to Better Auth options (`baseURL: string`, `trustedOrigins: string[]`); cookie/`advanced` deferred.
- `better-auth-spike.ts` — `createBetterAuthRuntime` spreads `baseURL`/`trustedOrigins` **only when set**, so an unset env leaves options identical to before. Topology env **never activates auth** (still gated by `AUTH_ENABLED` + secret + DB).
- `docs/auth-topology.md` (new) — env config table + same-origin Vercel rewrite plan (preferred), subdomain fallback, why workers.dev cross-site is not primary, pre-deploy tests, gates.
- Tests — `auth-topology` (parsing, fail-closed), `better-auth-spike` (topology does not activate; builds with topology + all gates), `auth-spike-route` (topology env + `AUTH_ENABLED` absent → `503 auth_disabled`).

### Route gating invariant (unchanged)
`AUTH_ENABLED` absent/false → `503 auth_disabled` · no secret → `503 auth_not_configured` · no DB → `503 auth_db_unavailable` · all gates → DB-backed handler. Topology env alone never builds a runtime.

### Verification
- central-plane **1219/1219** tests · typecheck **57/57** · `pnpm verify` green
- helper smoke `smoke:better-auth-d1` → **7/7** · route smoke `smoke:auth-route-d1` → **8/8** (default-disabled preserved)
- CI Node 20 + 22 expected green

### Explicitly NOT in this PR
No production env values, no `AUTH_ENABLED` activation, no deploy, no OAuth, no Vercel production rewrite, no CORS production config, no DNS/domain, no production D1 mutation, no secrets/.env, no MCP/npm publish, no dashboard live behavior change. `app.trysimsa.com` appears only as doc/example text.

### M&A / enterprise readiness
Turns auth topology into a configurable, auditable, env-driven surface (not a hardcoded one-off): verified option names, fail-closed parsing, decoupled from activation/deploy, documented rollout plan + gates.

### Rollback
Additive + revertible: `git revert` the squash commit. Production unaffected (route dormant, no env set).

### Next gates (not requested here)
- `"PR #<this> merge approved."` — merge
- Vercel rewrite to prod (separate approval) · `"Dashboard deploy approved."` · `"Production auth activation approved."`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
