### PR TITLE
Stage 232 — Same-origin auth rewrite code readiness (not live until deploy)

### DIFF
--- a/apps/dashboard/docs/auth-same-origin-rewrite.md
+++ b/apps/dashboard/docs/auth-same-origin-rewrite.md
@@ -1,0 +1,45 @@
+# Same-origin auth rewrite (Stage 232)
+
+Status: **code readiness only.** Merging this does NOT change live behavior — the dashboard deploys
+manually (`vercel deploy --prod`); the rewrite goes live only on the next dashboard deploy (a separate,
+explicitly-approved step). It does NOT activate auth.
+
+## What it does
+`next.config.ts` proxies first-party `/api/auth/*` on the dashboard origin to the central-plane Worker:
+
+```
+app.trysimsa.com/api/auth/:path*  →  ${CENTRAL_PLANE_AUTH_ORIGIN}/api/auth/:path*
+```
+
+This makes Better Auth cookies first-party on `app.trysimsa.com` once auth is later activated (the
+preferred same-origin topology from Stage 225/227). Scoped to `/api/auth/:path*` only — it does not
+shadow any other dashboard route (the dashboard has no `/api/auth` handler today; `…/api/auth/ok`
+currently 404s).
+
+## Destination env (server-side only)
+| Env | Used by | Default |
+|---|---|---|
+| `CENTRAL_PLANE_AUTH_ORIGIN` | `next.config.ts` rewrite (build/server only — NOT exposed to client) | `https://conclave-ai.seunghunbae.workers.dev` (documented production Worker origin) |
+
+Fail-safe: missing / empty / non-`http(s)` values fall back to the default; trailing slashes are
+stripped (`src/lib/auth-rewrite.mjs`, tested in `test/auth-rewrite.test.mjs`). No secret/URL value is
+required in the repo; the default already points at the production Worker.
+
+## Why this is not activation
+While `AUTH_ENABLED` is unset on the Worker, `/api/auth/*` returns `503 auth_disabled`. After a future
+dashboard deploy, `app.trysimsa.com/api/auth/ok` will return that same `503 auth_disabled` (proxied) —
+no sign-up/sign-in, no D1 rows. Activation is a separate, later gate.
+
+## Future deploy + verification (NOT executed here)
+Future dashboard deploy requires explicit approval, e.g. `"Auth same-origin rewrite deploy approved."`
+After that deploy, verify (auth still disabled):
+- `GET https://app.trysimsa.com/api/auth/ok` → `503 auth_disabled` (proxied to the Worker)
+- `POST https://app.trysimsa.com/api/auth/sign-up/email` → `503 auth_disabled`
+- Worker direct `…workers.dev/api/auth/ok` → still `503 auth_disabled`
+- production D1 auth rows remain `0`; `AUTH_ENABLED` remains unset; dashboard loads normally
+
+## Gates (separate; never bundled)
+- This stage (232): code/config + tests + docs only — no deploy, no env set, no activation.
+- `"Auth same-origin rewrite deploy approved."` — deploy the dashboard so the rewrite goes live (disabled).
+- `"Production auth activation approved."` — set `AUTH_ENABLED=true` only after the rewrite is live +
+  verified disabled and `BETTER_AUTH_BASE_URL`/`BETTER_AUTH_TRUSTED_ORIGINS` are set on the Worker.

--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -1,5 +1,22 @@
 import type { NextConfig } from "next";
+import { resolveCentralPlaneAuthOrigin, buildAuthRewrites } from "./src/lib/auth-rewrite.mjs";
 
-const nextConfig: NextConfig = {};
+/**
+ * Stage 232 — same-origin auth rewrite (code readiness; NOT live until a dashboard deploy).
+ *
+ * Proxies first-party `/api/auth/*` on the dashboard origin (app.trysimsa.com) to the
+ * central-plane Worker's `/api/auth/*`, so Better Auth cookies become first-party once auth is
+ * later activated. This does NOT activate auth: while `AUTH_ENABLED` is unset the worker route
+ * returns `503 auth_disabled`, so the proxied path returns 503 too. Merging changes no live
+ * behaviour until a separately-approved Vercel deploy.
+ *
+ * Destination origin: `CENTRAL_PLANE_AUTH_ORIGIN` (server-side only), defaulting to the
+ * documented production Worker origin. See src/lib/auth-rewrite.mjs + docs/auth-same-origin-rewrite.md.
+ */
+const nextConfig: NextConfig = {
+  async rewrites() {
+    return buildAuthRewrites(resolveCentralPlaneAuthOrigin(process.env));
+  },
+};
 
 export default nextConfig;

--- a/apps/dashboard/src/lib/auth-rewrite.d.mts
+++ b/apps/dashboard/src/lib/auth-rewrite.d.mts
@@ -1,0 +1,7 @@
+export const DEFAULT_CENTRAL_PLANE_AUTH_ORIGIN: string;
+export function resolveCentralPlaneAuthOrigin(
+  env: Record<string, string | undefined> | undefined,
+): string;
+export function buildAuthRewrites(
+  origin: string,
+): { source: string; destination: string }[];

--- a/apps/dashboard/src/lib/auth-rewrite.mjs
+++ b/apps/dashboard/src/lib/auth-rewrite.mjs
@@ -1,0 +1,46 @@
+/**
+ * Stage 232 — same-origin auth rewrite config (code readiness; NOT live until a dashboard deploy).
+ *
+ * Pure, server-side helpers used by `next.config.ts` to proxy first-party
+ * `app.trysimsa.com/api/auth/*` to the central-plane Worker's `/api/auth/*`, so Better Auth
+ * cookies are first-party once auth is later activated. This does NOT activate auth — the worker
+ * route stays `503 auth_disabled` while `AUTH_ENABLED` is unset, and merging this changes no live
+ * behaviour until a separately-approved dashboard (Vercel) deploy.
+ *
+ * Server-side only (read in next.config at build time); the origin is NOT exposed to the client.
+ */
+
+/** The documented production central-plane Worker origin (existing dashboard convention). */
+export const DEFAULT_CENTRAL_PLANE_AUTH_ORIGIN = "https://conclave-ai.seunghunbae.workers.dev";
+
+/**
+ * Resolve the central-plane origin the auth rewrite proxies to. Fail-safe + never throws:
+ * a missing / empty / non-absolute value falls back to the documented production origin; a
+ * valid http(s) origin is used with any trailing slash(es) stripped.
+ *
+ * @param {Record<string, string | undefined> | undefined} env
+ * @returns {string} an absolute origin with no trailing slash
+ */
+export function resolveCentralPlaneAuthOrigin(env) {
+  const raw = env && typeof env.CENTRAL_PLANE_AUTH_ORIGIN === "string" ? env.CENTRAL_PLANE_AUTH_ORIGIN.trim() : "";
+  if (/^https?:\/\/\S+$/.test(raw)) {
+    return raw.replace(/\/+$/, "");
+  }
+  return DEFAULT_CENTRAL_PLANE_AUTH_ORIGIN;
+}
+
+/**
+ * Build the Next.js rewrite list that proxies first-party `/api/auth/*` to the central-plane
+ * Worker. Scoped to `/api/auth/:path*` only (does not shadow other dashboard routes).
+ *
+ * @param {string} origin absolute central-plane origin (no trailing slash)
+ * @returns {{ source: string, destination: string }[]}
+ */
+export function buildAuthRewrites(origin) {
+  return [
+    {
+      source: "/api/auth/:path*",
+      destination: `${origin}/api/auth/:path*`,
+    },
+  ];
+}

--- a/apps/dashboard/test/auth-rewrite.test.mjs
+++ b/apps/dashboard/test/auth-rewrite.test.mjs
@@ -1,0 +1,68 @@
+/**
+ * auth-rewrite.test.mjs
+ *
+ * Stage 232 — same-origin auth rewrite config. Verifies the rewrite destination resolves
+ * fail-safe (missing/empty/invalid env → documented default), trims trailing slashes, and that
+ * the rewrite is scoped to /api/auth/:path* only (no shadowing of other dashboard routes).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_CENTRAL_PLANE_AUTH_ORIGIN,
+  resolveCentralPlaneAuthOrigin,
+  buildAuthRewrites,
+} from "../src/lib/auth-rewrite.mjs";
+
+test("default origin is the documented production Worker origin", () => {
+  assert.equal(DEFAULT_CENTRAL_PLANE_AUTH_ORIGIN, "https://conclave-ai.seunghunbae.workers.dev");
+});
+
+test("missing / empty / invalid env → documented default (fail-safe)", () => {
+  for (const env of [
+    undefined,
+    {},
+    { CENTRAL_PLANE_AUTH_ORIGIN: "" },
+    { CENTRAL_PLANE_AUTH_ORIGIN: "   " },
+    { CENTRAL_PLANE_AUTH_ORIGIN: "not-a-url" },
+    { CENTRAL_PLANE_AUTH_ORIGIN: "ftp://evil" },
+    { CENTRAL_PLANE_AUTH_ORIGIN: 123 },
+  ]) {
+    assert.equal(resolveCentralPlaneAuthOrigin(env), DEFAULT_CENTRAL_PLANE_AUTH_ORIGIN);
+  }
+});
+
+test("valid http(s) origin is used and trailing slashes stripped", () => {
+  assert.equal(
+    resolveCentralPlaneAuthOrigin({ CENTRAL_PLANE_AUTH_ORIGIN: "https://api.trysimsa.com" }),
+    "https://api.trysimsa.com",
+  );
+  assert.equal(
+    resolveCentralPlaneAuthOrigin({ CENTRAL_PLANE_AUTH_ORIGIN: "https://api.trysimsa.com/" }),
+    "https://api.trysimsa.com",
+  );
+  assert.equal(
+    resolveCentralPlaneAuthOrigin({ CENTRAL_PLANE_AUTH_ORIGIN: "  https://api.trysimsa.com//  " }),
+    "https://api.trysimsa.com",
+  );
+  assert.equal(
+    resolveCentralPlaneAuthOrigin({ CENTRAL_PLANE_AUTH_ORIGIN: "http://localhost:8787" }),
+    "http://localhost:8787",
+  );
+});
+
+test("buildAuthRewrites maps /api/auth/:path* to the worker, scoped only to /api/auth", () => {
+  const rules = buildAuthRewrites("https://conclave-ai.seunghunbae.workers.dev");
+  assert.equal(rules.length, 1);
+  assert.deepEqual(rules[0], {
+    source: "/api/auth/:path*",
+    destination: "https://conclave-ai.seunghunbae.workers.dev/api/auth/:path*",
+  });
+  // Scoped to /api/auth — does not match other dashboard routes.
+  assert.ok(rules[0].source.startsWith("/api/auth/"));
+  assert.ok(!rules.some((r) => r.source === "/:path*" || r.source === "/api/:path*"));
+});
+
+test("end-to-end: default env produces the worker-proxying rule", () => {
+  const rules = buildAuthRewrites(resolveCentralPlaneAuthOrigin(undefined));
+  assert.equal(rules[0].destination, "https://conclave-ai.seunghunbae.workers.dev/api/auth/:path*");
+});


### PR DESCRIPTION
## Stage 232 — Same-origin auth rewrite code readiness

Approval: `"Auth same-origin rewrite readiness approved."`

**Code readiness only — not live until a dashboard deploy.** Adds a first-party same-origin rewrite so `app.trysimsa.com/api/auth/*` proxies to the central-plane Worker `/api/auth/*` (Better Auth cookies become first-party once auth is later activated — the preferred Stage 225/227 topology). It does **not** activate auth and changes **no live behaviour**: the dashboard deploys manually (`vercel deploy --prod`), so merging stays non-live until a separate, explicitly-approved dashboard deploy; while `AUTH_ENABLED` is unset the proxied route returns `503 auth_disabled`.

### Routing facts (verified)
- `next.config.ts` was empty (no `output: 'export'`) → normal Next.js app, **rewrites supported**.
- No `vercel.json`; no GitHub Actions deploy the dashboard → **merge does not auto-deploy** (non-live).
- Dashboard has **no `/api/auth` handler** today (`…/api/auth/ok` → 404) → the scoped rewrite shadows nothing.

### Changes (5 files, dashboard only)
- `next.config.ts` — `async rewrites()` → `/api/auth/:path*` → `${CENTRAL_PLANE_AUTH_ORIGIN}/api/auth/:path*`.
- `src/lib/auth-rewrite.mjs` (+ `.d.mts`) — pure `resolveCentralPlaneAuthOrigin(env)` + `buildAuthRewrites(origin)`. Server-side only (not client-exposed). Fail-safe: missing/empty/non-`http(s)` → documented default `https://conclave-ai.seunghunbae.workers.dev` (existing dashboard convention); trailing slashes stripped.
- `test/auth-rewrite.test.mjs` — default/empty/invalid → fallback, trailing-slash strip, `/api/auth` scoping.
- `docs/auth-same-origin-rewrite.md` — behaviour, server-side env, future deploy + disabled verification, gates.

### Destination env (server-side only)
`CENTRAL_PLANE_AUTH_ORIGIN` (build/server only, NOT `NEXT_PUBLIC`), default = documented production Worker origin. No URL/secret value required in repo.

### Rewrite behaviour after a FUTURE dashboard deploy (auth still disabled)
- `app.trysimsa.com/api/auth/ok` → `503 auth_disabled` (proxied) · `…/sign-up/email` → `503 auth_disabled` · Worker direct still `503` · D1 auth rows remain `0` · `AUTH_ENABLED` unset · dashboard loads normally.

### Verification
- dashboard **259/259** (auth-rewrite **5/5**) · central-plane auth **38/38** · typecheck **57/57** · `pnpm verify` green
- CI Node 20 + 22 expected green

### Explicitly NOT in this PR
No dashboard/Vercel deploy, no env set, no `AUTH_ENABLED` activation, no central-plane change, no `wrangler.toml`/migration/`.env`, no secrets, no DNS/CORS/OAuth, no live dashboard behavior change.

### Next gates (not requested here)
- `"PR #<this> merge approved."` — merge (still non-live)
- `"Auth same-origin rewrite deploy approved."` — dashboard deploy (rewrite goes live, still disabled)
- `"Production auth activation approved."` — set `AUTH_ENABLED=true` (separate, last)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
