### PR TITLE
Stage 249 — Workspace membership schema foundation code readiness

### DIFF
--- a/apps/central-plane/docs/workspace-membership-schema.md
+++ b/apps/central-plane/docs/workspace-membership-schema.md
@@ -1,0 +1,52 @@
+# Workspace membership schema (Stage 249)
+
+Status: **code-readiness DRAFT.** The migration `0048_workspace_membership_foundation.sql` is on main but
+**NOT applied to production** by this stage. It is additive and changes no behaviour until a separately
+approved apply + endpoint work. Broad user-facing launch remains blocked.
+
+## Purpose
+The additive backbone for enterprise governance: **auth user → workspace → membership role → project
+ownership** (with invite/share/audit as later stages). It introduces ownership WITHOUT migrating or mutating
+the existing anonymous `user_key`-scoped data.
+
+## Tables
+| Object | Summary |
+|---|---|
+| `workspaces` | `id` PK, `name`, `type` (`personal`\|`team`), `created_by_auth_user_id` (logical → Better Auth `user.id`), `legacy_user_key` (nullable), `created_at`/`updated_at`, `archived_at` (nullable). |
+| `workspace_members` | PK `(workspace_id, auth_user_id)`, `role` (`owner`\|`admin`\|`member`\|`viewer`), `status` (`active`\|`invited`\|`removed`), `invited_by_auth_user_id` (nullable), `joined_at` (nullable), timestamps. |
+| `workspace_projects.workspace_id` | NEW nullable column (`ALTER TABLE … ADD COLUMN`). `NULL` = legacy `user_key`-scoped (unchanged). |
+
+Indexes: `idx_workspaces_created_by_auth_user_id`, `idx_workspaces_legacy_user_key`,
+`idx_workspace_members_auth_user_id`, `idx_workspace_members_role`, `idx_workspace_projects_workspace_id`.
+
+Convention: snake_case (repo `workspace_*` style); plain `TEXT` ids with **no FK enforcement** — references to
+`user("id")` are logical (documented in comments), with **no `ON DELETE CASCADE`** to the auth user. Role/
+status/type vocabularies mirror `src/workspace-membership.ts` (single source of truth).
+
+## Role semantics (initial)
+- **owner** — workspace settings, members, ownership transfer, delete/archive, project access, audit.
+- **admin** — invite/remove members (except owner), manage projects/sharing, most audit.
+- **member** — create/use projects (if policy allows), run checks/fixes/reviews, view assigned/shared.
+- **viewer** — read-only (schema value present; product UI may use it later).
+
+## Legacy userKey compatibility (non-destructive)
+- `workspace_projects.user_key` is untouched; `workspace_id` is nullable and stays `NULL` for all legacy rows.
+- Signed-out users keep using `user_key`. Authenticated users do **not** auto-claim local `user_key` projects.
+- Cross-device auto-merge is forbidden. No legacy rows are deleted/updated. No access is granted merely
+  because an auth email matches.
+
+## No auto-claim rule
+A project's `workspace_id` is assigned **only** by a future explicit, user-confirmed (or admin-reviewed)
+claim flow — never automatically on sign-in. Rollback leaves the legacy `user_key` reference intact.
+
+## Production apply safety (future, separately approved)
+- Targeted single-file apply only (`d1 execute --remote --file`), **never** bulk `migrations apply`.
+- Local/dry-run apply first; read-only pre/post checks (table/index/column existence).
+- `CREATE … IF NOT EXISTS` is idempotent; **`ALTER … ADD COLUMN workspace_id` is NOT idempotent** in
+  SQLite/D1 — pre-check the column's absence before apply (or accept the error on re-run). No data backfill.
+- Rollback note: dropping the new tables / added column is destructive and affects only the new additive
+  objects — never legacy data; coordinate via a separately-approved teardown if ever needed.
+
+## Future stages (not in this PR)
+- Project claim flow (explicit, audited); `workspace_invites` + `audit_events` tables; membership endpoints;
+  userKey → auth-user bridge; invite/share permissions. Broad launch stays blocked until these land.

--- a/apps/central-plane/migrations/0048_workspace_membership_foundation.sql
+++ b/apps/central-plane/migrations/0048_workspace_membership_foundation.sql
@@ -1,0 +1,58 @@
+-- Stage 249 — Workspace membership foundation (ADDITIVE, code-readiness DRAFT).
+--
+-- Status: DRAFT. NOT applied to production by this stage. A separately-approved stage
+-- (Production apply gate) applies it — local first, then targeted `d1 execute --remote
+-- --file` (NOT bulk `migrations apply`).
+--
+-- Purpose: the additive backbone for workspace membership / project ownership
+-- (auth user -> workspace -> role -> project), WITHOUT migrating or mutating any legacy
+-- user_key-scoped data. `workspace_projects` keeps its `user_key` column unchanged; the new
+-- `workspace_id` column is NULLABLE and stays NULL for all legacy rows until a separately
+-- built, explicit claim flow assigns it. No invite/share/audit tables yet (later stages).
+--
+-- Convention: follows the repo's snake_case workspace_* style (plain TEXT ids; no FK
+-- enforcement — references to Better Auth `user("id")` are LOGICAL, documented in comments,
+-- with no ON DELETE CASCADE to the auth user by design).
+--
+-- Safety properties (asserted by test/workspace-membership-migration.test.mjs):
+--   * additive only — CREATE TABLE/INDEX IF NOT EXISTS + one ADD COLUMN
+--   * no DROP, no destructive ALTER, no DELETE/UPDATE/TRUNCATE, no data backfill
+--   * does not redefine the Better Auth 0047 tables (user/session/account/verification)
+--   * does not remove or alter workspace_projects.user_key
+--   * new workspace_id is NULLABLE (legacy rows unaffected)
+--
+-- NOTE: `ALTER TABLE ... ADD COLUMN` is additive but NOT idempotent in SQLite/D1; the
+-- production apply must pre-check column existence (see docs/workspace-membership-schema.md).
+
+CREATE TABLE IF NOT EXISTS workspaces (
+  id                       TEXT NOT NULL PRIMARY KEY,
+  name                     TEXT NOT NULL,
+  type                     TEXT NOT NULL DEFAULT 'personal' CHECK (type IN ('personal', 'team')),
+  created_by_auth_user_id  TEXT,                 -- logical -> "user"("id") (Better Auth); no FK/cascade by design
+  legacy_user_key          TEXT,                 -- nullable; set only when a personal ws is bound to a claimed user_key
+  created_at               TEXT NOT NULL,
+  updated_at               TEXT NOT NULL,
+  archived_at              TEXT                  -- nullable
+);
+
+CREATE TABLE IF NOT EXISTS workspace_members (
+  workspace_id             TEXT NOT NULL,        -- logical -> workspaces("id")
+  auth_user_id             TEXT NOT NULL,        -- logical -> "user"("id")
+  role                     TEXT NOT NULL CHECK (role IN ('owner', 'admin', 'member', 'viewer')),
+  status                   TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'invited', 'removed')),
+  invited_by_auth_user_id  TEXT,                 -- nullable; logical -> "user"("id")
+  joined_at                TEXT,                 -- nullable
+  created_at               TEXT NOT NULL,
+  updated_at               TEXT NOT NULL,
+  PRIMARY KEY (workspace_id, auth_user_id)
+);
+
+-- Additive link from existing projects to a workspace. NULL = legacy user_key-scoped (unchanged).
+-- user_key is intentionally left in place and untouched.
+ALTER TABLE workspace_projects ADD COLUMN workspace_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_workspaces_created_by_auth_user_id ON workspaces (created_by_auth_user_id);
+CREATE INDEX IF NOT EXISTS idx_workspaces_legacy_user_key ON workspaces (legacy_user_key);
+CREATE INDEX IF NOT EXISTS idx_workspace_members_auth_user_id ON workspace_members (auth_user_id);
+CREATE INDEX IF NOT EXISTS idx_workspace_members_role ON workspace_members (role);
+CREATE INDEX IF NOT EXISTS idx_workspace_projects_workspace_id ON workspace_projects (workspace_id);

--- a/apps/central-plane/src/workspace-membership.ts
+++ b/apps/central-plane/src/workspace-membership.ts
@@ -1,0 +1,43 @@
+/**
+ * Stage 249 — Workspace membership types + validators (schema foundation, code-readiness).
+ *
+ * Pure constants/types/guards for the `0048_workspace_membership_foundation.sql` schema. NO
+ * endpoint behaviour, NO DB access, NO auto-claim, NO userKey migration — just the role/status/
+ * type vocabulary so later stages (membership endpoints, claim flow) share one source of truth.
+ */
+
+/** Membership roles. `owner` > `admin` > `member` > `viewer`. */
+export const WORKSPACE_ROLES = ["owner", "admin", "member", "viewer"] as const;
+export type WorkspaceRole = (typeof WORKSPACE_ROLES)[number];
+
+/** Membership status lifecycle. */
+export const WORKSPACE_MEMBER_STATUSES = ["active", "invited", "removed"] as const;
+export type WorkspaceMemberStatus = (typeof WORKSPACE_MEMBER_STATUSES)[number];
+
+/** Workspace kind. A personal workspace is auto-implied per auth user; team is explicit. */
+export const WORKSPACE_TYPES = ["personal", "team"] as const;
+export type WorkspaceType = (typeof WORKSPACE_TYPES)[number];
+
+/** The default role assigned to a newly-invited member (until a richer policy exists). */
+export const DEFAULT_INVITED_ROLE: WorkspaceRole = "member";
+
+export function isWorkspaceRole(value: unknown): value is WorkspaceRole {
+  return typeof value === "string" && (WORKSPACE_ROLES as readonly string[]).includes(value);
+}
+
+export function isWorkspaceMemberStatus(value: unknown): value is WorkspaceMemberStatus {
+  return typeof value === "string" && (WORKSPACE_MEMBER_STATUSES as readonly string[]).includes(value);
+}
+
+export function isWorkspaceType(value: unknown): value is WorkspaceType {
+  return typeof value === "string" && (WORKSPACE_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * Coarse role capability check (planning-level; not an authorization enforcement layer yet).
+ * Returns true if `role` is at least as privileged as `minimum` in the owner>admin>member>viewer order.
+ */
+export function roleAtLeast(role: WorkspaceRole, minimum: WorkspaceRole): boolean {
+  const rank: Record<WorkspaceRole, number> = { owner: 3, admin: 2, member: 1, viewer: 0 };
+  return rank[role] >= rank[minimum];
+}

--- a/apps/central-plane/test/workspace-membership-migration.test.mjs
+++ b/apps/central-plane/test/workspace-membership-migration.test.mjs
@@ -1,0 +1,92 @@
+/**
+ * workspace-membership-migration.test.mjs
+ *
+ * Stage 249 — additive-safety + shape checks for `0048_workspace_membership_foundation.sql`.
+ * Reads the SQL straight from disk (no build) and asserts it is additive, non-destructive,
+ * creates the two new tables + the nullable workspace_id column, never touches `user_key` or the
+ * Better Auth 0047 tables. Mirrors test/auth-migration-draft.test.mjs (comment-stripped scans).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const file = join(here, "..", "migrations", "0048_workspace_membership_foundation.sql");
+
+function readCode() {
+  // Strip BOTH full-line and inline `--` comments so prose / logical-reference comments
+  // (e.g. `-- logical -> "user"("id")`) are never matched by the structural scans.
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .map((line) => line.replace(/--.*$/, ""))
+    .join("\n");
+}
+
+test("0048 migration file exists", () => {
+  assert.ok(existsSync(file), `expected migration at ${file}`);
+});
+
+test("creates the two new membership tables (IF NOT EXISTS)", () => {
+  const code = readCode();
+  assert.match(code, /CREATE TABLE IF NOT EXISTS workspaces\b/);
+  assert.match(code, /CREATE TABLE IF NOT EXISTS workspace_members\b/);
+});
+
+test("adds a NULLABLE workspace_id column to workspace_projects (additive)", () => {
+  const code = readCode();
+  assert.match(code, /ALTER TABLE workspace_projects ADD COLUMN workspace_id TEXT/);
+  // The added column must NOT be NOT NULL (legacy rows have no value).
+  assert.doesNotMatch(code, /ADD COLUMN workspace_id TEXT\s+NOT NULL/i);
+});
+
+test("additive only — every CREATE guards with IF NOT EXISTS", () => {
+  const code = readCode();
+  const creates = code.match(/CREATE\s+(TABLE|INDEX)\b/gi) ?? [];
+  const guarded = code.match(/CREATE\s+(TABLE|INDEX)\s+IF\s+NOT\s+EXISTS\b/gi) ?? [];
+  assert.ok(creates.length > 0, "expected CREATE statements");
+  assert.equal(creates.length, guarded.length, "every CREATE must use IF NOT EXISTS");
+});
+
+test("no destructive statements (DROP/DELETE/TRUNCATE/UPDATE/destructive ALTER)", () => {
+  const code = readCode();
+  assert.doesNotMatch(code, /\bDROP\b/i);
+  assert.doesNotMatch(code, /\bDELETE\b/i);
+  assert.doesNotMatch(code, /\bTRUNCATE\b/i);
+  assert.doesNotMatch(code, /\bUPDATE\b/i);
+  // The only ALTER permitted is the additive ADD COLUMN above.
+  const alters = code.match(/\bALTER TABLE\b[^;]*/gi) ?? [];
+  for (const a of alters) assert.match(a, /ADD COLUMN/i, `non-additive ALTER: ${a}`);
+});
+
+test("does not drop/alter the existing workspace_projects.user_key, nor redefine the 0047 tables", () => {
+  const code = readCode();
+  // The ONLY change to workspace_projects is the additive ADD COLUMN workspace_id — never user_key.
+  const wpAlters = code.match(/ALTER TABLE workspace_projects[^;]*/gi) ?? [];
+  assert.equal(wpAlters.length, 1, "expected exactly one workspace_projects ALTER (the ADD COLUMN)");
+  assert.match(wpAlters[0], /ADD COLUMN workspace_id TEXT/);
+  assert.doesNotMatch(wpAlters[0], /user_key/i, "must not touch workspace_projects.user_key");
+  // `legacy_user_key` on the NEW workspaces table is a new column, not the legacy scope key — allowed.
+  // No CREATE may redefine the Better Auth 0047 identity tables.
+  for (const t of ['"user"', '"session"', '"account"', '"verification"']) {
+    // The quoted table name must follow CREATE TABLE [IF NOT EXISTS] directly to count as a redefinition.
+    assert.doesNotMatch(code, new RegExp(`CREATE TABLE\\s+(IF NOT EXISTS\\s+)?${t}`), `must not redefine ${t}`);
+  }
+});
+
+test("role/status/type CHECK constraints + expected indexes present", () => {
+  const code = readCode();
+  assert.match(code, /role\s+TEXT NOT NULL CHECK \(role IN \('owner', 'admin', 'member', 'viewer'\)\)/);
+  assert.match(code, /status\s+TEXT NOT NULL DEFAULT 'active' CHECK \(status IN \('active', 'invited', 'removed'\)\)/);
+  assert.match(code, /type\s+TEXT NOT NULL DEFAULT 'personal' CHECK \(type IN \('personal', 'team'\)\)/);
+  for (const idx of [
+    "idx_workspaces_created_by_auth_user_id",
+    "idx_workspaces_legacy_user_key",
+    "idx_workspace_members_auth_user_id",
+    "idx_workspace_members_role",
+    "idx_workspace_projects_workspace_id",
+  ]) {
+    assert.match(code, new RegExp(`CREATE INDEX IF NOT EXISTS ${idx}\\b`), `missing index ${idx}`);
+  }
+});

--- a/apps/central-plane/test/workspace-membership.test.mjs
+++ b/apps/central-plane/test/workspace-membership.test.mjs
@@ -1,0 +1,43 @@
+/**
+ * workspace-membership.test.mjs
+ *
+ * Stage 249 — workspace membership types/validators. Imports the built output (dist).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  WORKSPACE_ROLES,
+  WORKSPACE_MEMBER_STATUSES,
+  WORKSPACE_TYPES,
+  DEFAULT_INVITED_ROLE,
+  isWorkspaceRole,
+  isWorkspaceMemberStatus,
+  isWorkspaceType,
+  roleAtLeast,
+} from "../dist/workspace-membership.js";
+
+test("role / status / type vocabularies match the 0048 CHECK constraints", () => {
+  assert.deepEqual([...WORKSPACE_ROLES], ["owner", "admin", "member", "viewer"]);
+  assert.deepEqual([...WORKSPACE_MEMBER_STATUSES], ["active", "invited", "removed"]);
+  assert.deepEqual([...WORKSPACE_TYPES], ["personal", "team"]);
+  assert.equal(DEFAULT_INVITED_ROLE, "member");
+});
+
+test("validators accept valid values and reject everything else", () => {
+  for (const r of WORKSPACE_ROLES) assert.equal(isWorkspaceRole(r), true);
+  for (const s of WORKSPACE_MEMBER_STATUSES) assert.equal(isWorkspaceMemberStatus(s), true);
+  for (const t of WORKSPACE_TYPES) assert.equal(isWorkspaceType(t), true);
+  for (const bad of [undefined, null, "", "OWNER", "guest", 1, {}]) {
+    assert.equal(isWorkspaceRole(bad), false);
+    assert.equal(isWorkspaceMemberStatus(bad), false);
+    assert.equal(isWorkspaceType(bad), false);
+  }
+});
+
+test("roleAtLeast honours owner > admin > member > viewer", () => {
+  assert.equal(roleAtLeast("owner", "admin"), true);
+  assert.equal(roleAtLeast("admin", "admin"), true);
+  assert.equal(roleAtLeast("member", "admin"), false);
+  assert.equal(roleAtLeast("viewer", "member"), false);
+  assert.equal(roleAtLeast("admin", "viewer"), true);
+});


### PR DESCRIPTION
## Stage 249 — Workspace membership schema foundation (code readiness)

Approval: `"Workspace membership schema code readiness approved."`

**Code-readiness only — additive schema, NOT applied to production, no deploy.** Adds the additive backbone for enterprise governance (auth user → workspace → membership role → project ownership) **without migrating or mutating any legacy `user_key`-scoped data.**

### Changes (5 new files, central-plane)
- `migrations/0048_workspace_membership_foundation.sql` — `CREATE TABLE IF NOT EXISTS` **`workspaces`** + **`workspace_members`** (roles `owner|admin|member|viewer`, status `active|invited|removed`, `CHECK` constraints, type `personal|team`) + **`ALTER TABLE workspace_projects ADD COLUMN workspace_id TEXT`** (NULLABLE) + 5 indexes. **Additive only**: no DROP/DELETE/UPDATE/backfill; `user_key` untouched (NULL `workspace_id` = legacy scope); does not redefine the 0047 auth tables. snake_case repo convention; no FK enforcement (logical refs to `user(id)`, no cascade).
- `src/workspace-membership.ts` — pure role/status/type unions + constants + validators + `roleAtLeast`.
- `test/workspace-membership-migration.test.mjs` — additive-safety + shape scans (comment-stripped; asserts no destructive ops, no `user_key` touch, no 0047 redefine, CHECK/index presence).
- `test/workspace-membership.test.mjs` — validator + `roleAtLeast` tests.
- `docs/workspace-membership-schema.md` — tables, roles, legacy compatibility, **no-auto-claim rule**, production apply safety (targeted file, `ADD COLUMN` not idempotent → pre-check column), future stages.

### Legacy userKey preserved (non-destructive)
`workspace_projects.user_key` untouched; `workspace_id` is nullable and `NULL` for all legacy rows. No auto-claim, no cross-device merge, no project-ownership migration, no data backfill.

### Verification
- central-plane **1237/1237** tests (new **10**: 7 migration shape + 3 helpers) · auth regression **46/46** · helper smoke **7/7** · route smoke **8/8** · `pnpm typecheck` **57/57** · `pnpm verify` green
- CI Node 20 + 22 expected green

### Explicitly NOT in this PR
No production D1 apply, no deploy, no user creation, no sign-up/sign-in, no auth/env/secret change, no `AUTH_SIGNUP_MODE` change, no userKey migration/claim, no invite/share, no broad launch, no `wrangler.toml`/`.env` change.

### Bae decisions flagged for later (membership endpoints)
member can create projects? auto personal workspace per user? multiple owners? sole-owner leave? viewer in first UI? default invited role (= `member`).

### Next gates
- `"PR #<this> merge approved."` — merge (still not applied)
- Production D1 apply remains a separate gate (targeted `d1 execute --remote --file`, not bundled with merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
