### PR TITLE
Stage 254 — Auth user workspace bridge (read-only) code readiness

### DIFF
--- a/apps/central-plane/docs/workspace-membership-bridge.md
+++ b/apps/central-plane/docs/workspace-membership-bridge.md
@@ -1,0 +1,63 @@
+# Workspace membership bridge (Stage 254)
+
+Status: **code-readiness, read-only.** Adds `GET /workspace/membership/me` on main — NOT yet a deployed
+behaviour change of any existing route, and it creates/mutates nothing. Broad launch remains blocked.
+
+## Purpose
+The first runtime step of the governance bridge: REPORT the caller's auth-user + legacy-userKey + workspace
+readiness against the (now-applied) 0048 schema, WITHOUT creating a personal workspace, a member, or claiming
+any project. Read-only first; mutation lands in later, separately-gated stages.
+
+## Endpoint contract — `GET /workspace/membership/me`
+Reads (read-only): the Better Auth session (server-side, `createBetterAuthRuntime(env).api.getSession({ headers })`)
+and the legacy `userKey`. Response:
+```json
+{
+  "ok": true,
+  "authenticated": false,
+  "authUserId": null,
+  "email": null,
+  "userKey": "uk_...",            // or null
+  "hasPersonalWorkspace": false,
+  "workspaces": [],                // [{ id, name, role }] only when authenticated + rows exist
+  "legacyProjectCount": 0,         // count of workspace_projects for the provided userKey
+  "bridgeMode": "read_only",
+  "canCreatePersonalWorkspace": false,
+  "canClaimProjects": false
+}
+```
+- `userKey` transport: prefer the **`x-simsa-user-key` header** (keeps the key out of URLs/logs); the
+  `?userKey=` query param is accepted for parity with the existing workspace GET convention.
+- Fail-safe: auth runtime unavailable / DB read failure / invalid userKey → unauthenticated, empty
+  workspaces, `legacyProjectCount: 0`, never a 5xx-leak. No tokens/secrets/session material in the response.
+
+## Read-only-first strategy (why no writes here)
+- The endpoint only READS. It does NOT `INSERT` into `workspaces`/`workspace_members`, does NOT `UPDATE`
+  `workspace_projects` (no `workspace_id` assignment), and does NOT migrate legacy `user_key` data. A test
+  asserts the route source contains no write statements.
+- `canCreatePersonalWorkspace` / `canClaimProjects` are hard-coded `false`. Those capabilities arrive in later
+  gated stages so each production write has its own approval.
+
+## Legacy userKey compatibility
+- `userKey` is the LEGACY anonymous scope, **never** an authenticated identity. It is not trusted for auth and
+  is not auto-linked to any auth user. Existing `user_key`-scoped workspace endpoints are unchanged.
+
+## ★ Dashboard wiring + same-origin note (deferred)
+The bridge's session read only sees a session when the request carries the first-party session cookie. Today
+the same-origin Vercel rewrite covers `/api/auth/*` ONLY — the dashboard calls `/workspace/*` cross-origin
+(`*.workers.dev`), which does NOT send the `app.trysimsa.com` cookie. So a dashboard call to
+`/workspace/membership/me` would currently read as unauthenticated. Therefore the dashboard client + `/account`
+display are **deferred to a later stage** that also extends the same-origin rewrite (e.g. `/workspace/membership/*`)
+so the cookie is first-party. This PR ships the verified read-only endpoint + helper + tests only.
+
+## Future stages (not in this PR)
+- **Stage A — personal workspace creation:** an authenticated call creates a personal `workspace` + owner
+  `workspace_members` row (no `workspace_projects` touch). Separately gated.
+- **Stage B — explicit project claim:** authenticated, user-confirmed claim of legacy `user_key` projects into a
+  personal workspace (`workspace_projects.workspace_id` set), audited. Separately gated.
+- **Stage C — invite/share + roles enforcement; audit_events.**
+- **Dashboard wiring + same-origin rewrite extension** for first-party membership reads.
+
+## Production rollout gates
+Deploy of this endpoint (central-plane Worker) is separate (`"…deploy approved."`). Broad user-facing launch
+remains blocked until membership creation, claim, invite/share, audit, and the launch checklist land.

--- a/apps/central-plane/src/router.ts
+++ b/apps/central-plane/src/router.ts
@@ -38,6 +38,7 @@ import { createWorkspaceCreditsRoutes } from "./routes/workspace-credits.js";
 import { createWorkspaceBenchmarkRoutes } from "./routes/workspace-benchmark.js";
 import { createWorkspaceExperimentRoutes } from "./routes/workspace-experiment.js";
 import { createWorkspaceAgentWorkflowRoutes } from "./routes/workspace-agent-workflow.js";
+import { createWorkspaceMembershipRoutes } from "./routes/workspace-membership.js";
 import { createAuthSpikeRoutes } from "./routes/auth-spike.js";
 import type { FetchLike } from "./github.js";
 
@@ -151,6 +152,8 @@ export function createApp(opts: { fetch?: FetchLike } = {}): Hono<{ Bindings: En
   app.route("/", createWorkspaceExperimentRoutes());
   // Stage 112 — Persisted Agent Workflow Records (intake snapshot save/list/read).
   app.route("/", createWorkspaceAgentWorkflowRoutes());
+  // Stage 254 — read-only auth-user ↔ workspace bridge (GET /workspace/membership/me).
+  app.route("/", createWorkspaceMembershipRoutes());
   // Stage 209 / 221 — Better Auth LOCAL-ONLY route (/api/auth/*), gated by
   // AUTH_ENABLED. Default off → 503 auth_disabled in production. The D1-backed
   // runtime is constructed per-request ONLY behind AUTH_ENABLED + secret + env.DB

--- a/apps/central-plane/src/routes/workspace-membership.ts
+++ b/apps/central-plane/src/routes/workspace-membership.ts
@@ -1,0 +1,95 @@
+/**
+ * workspace-membership.ts — Stage 254 (auth-user ↔ workspace bridge, READ-ONLY).
+ *
+ * `GET /workspace/membership/me` reports the caller's auth/userKey/workspace readiness for the
+ * 0048 membership schema. It is the FIRST endpoint to read the Better Auth session server-side
+ * (the rest of the workspace API is anonymous-userKey-scoped). It is strictly READ-ONLY:
+ *   - no INSERT into workspaces / workspace_members,
+ *   - no UPDATE of workspace_projects (no claim, no workspace_id assignment),
+ *   - no legacy userKey migration, no audit rows.
+ *
+ * userKey is the legacy anonymous scope, never an authenticated identity. Personal-workspace
+ * creation and project claim are deliberately disabled here (canCreatePersonalWorkspace /
+ * canClaimProjects = false) and land in later, separately-approved stages.
+ */
+import { Hono } from "hono";
+import { corsMiddleware } from "./cors.js";
+import type { Env } from "../env.js";
+import { createBetterAuthRuntime } from "../better-auth-spike.js";
+import {
+  buildMembershipResponse,
+  parseUserKey,
+  type BridgeWorkspace,
+} from "../workspace-membership-bridge.js";
+
+export function createWorkspaceMembershipRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+
+  // Stage 91: browser-facing CORS (preflight + headers on every response).
+  app.use("*", corsMiddleware);
+
+  app.get("/workspace/membership/me", async (c) => {
+    // 1) Read the Better Auth session server-side (read-only). Fail safe → unauthenticated.
+    let authUserId: string | null = null;
+    let email: string | null = null;
+    try {
+      const auth = createBetterAuthRuntime(c.env);
+      if (auth) {
+        const session = await auth.api.getSession({ headers: c.req.raw.headers });
+        const user = session?.user;
+        if (user && typeof user.id === "string" && user.id) {
+          authUserId = user.id;
+          email = typeof user.email === "string" ? user.email : null;
+        }
+      }
+    } catch {
+      authUserId = null;
+      email = null;
+    }
+
+    // 2) Legacy userKey: prefer the header (keeps it out of URLs), else ?userKey= (existing convention).
+    const userKey = parseUserKey(c.req.header("x-simsa-user-key"), c.req.query("userKey"));
+
+    // 3) READ-ONLY lookups. No writes anywhere.
+    let workspaces: BridgeWorkspace[] = [];
+    let legacyProjectCount = 0;
+    const db = c.env?.DB;
+
+    if (authUserId && db) {
+      try {
+        const res = await db
+          .prepare(
+            'SELECT w."id" AS id, w."name" AS name, m."role" AS role ' +
+              'FROM workspace_members m JOIN workspaces w ON w."id" = m."workspace_id" ' +
+              'WHERE m."auth_user_id" = ? AND m."status" = ?',
+          )
+          .bind(authUserId, "active")
+          .all();
+        workspaces = (res?.results ?? []).map((r: Record<string, unknown>) => ({
+          id: String(r.id),
+          name: String(r.name),
+          role: String(r.role),
+        }));
+      } catch {
+        workspaces = [];
+      }
+    }
+
+    if (userKey && db) {
+      try {
+        const row = await db
+          .prepare('SELECT COUNT(*) AS n FROM workspace_projects WHERE user_key = ?')
+          .bind(userKey)
+          .first<{ n?: number }>();
+        const n = Number(row?.n ?? 0);
+        legacyProjectCount = Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+      } catch {
+        legacyProjectCount = 0;
+      }
+    }
+
+    return c.json(buildMembershipResponse({ authUserId, email, userKey, workspaces, legacyProjectCount }));
+  });
+
+  return app;
+}

--- a/apps/central-plane/src/workspace-membership-bridge.ts
+++ b/apps/central-plane/src/workspace-membership-bridge.ts
@@ -1,0 +1,75 @@
+/**
+ * Stage 254 — auth-user ↔ workspace bridge (READ-ONLY).
+ *
+ * Pure response builder + input parsing for `GET /workspace/membership/me`. This bridge only
+ * REPORTS the caller's auth/userKey/workspace readiness — it never creates a workspace, never
+ * creates a member, never claims or updates projects, and never migrates legacy userKey data.
+ *
+ * Privacy/identity rules baked in here:
+ *   - `userKey` is the LEGACY anonymous scope, NEVER an authenticated identity.
+ *   - Only safe, non-sensitive fields are returned (id/name/role + email). No tokens/secrets.
+ *   - `canCreatePersonalWorkspace` / `canClaimProjects` are hard-coded false (later, gated stages).
+ */
+
+/** A workspace membership row, reduced to safe display fields (no tokens). */
+export type BridgeWorkspace = { id: string; name: string; role: string };
+
+export type MembershipBridgeInput = {
+  authUserId: string | null;
+  email: string | null;
+  userKey: string | null;
+  /** Already-read membership rows (safe fields only). Ignored unless authenticated. */
+  workspaces: BridgeWorkspace[];
+  /** Count of legacy projects for the provided userKey (read-only). */
+  legacyProjectCount: number;
+};
+
+export type MembershipBridgeResponse = {
+  ok: true;
+  authenticated: boolean;
+  authUserId: string | null;
+  email: string | null;
+  userKey: string | null;
+  hasPersonalWorkspace: boolean;
+  workspaces: BridgeWorkspace[];
+  legacyProjectCount: number;
+  bridgeMode: "read_only";
+  canCreatePersonalWorkspace: false;
+  canClaimProjects: false;
+};
+
+/**
+ * Parse the caller's legacy userKey from the request. Header `x-simsa-user-key` is preferred
+ * (keeps the key out of URLs/logs); the `?userKey=` query param is accepted for parity with the
+ * existing workspace GET convention. Returns null for missing/blank/implausible values — the
+ * endpoint stays read-only and simply omits the legacy count rather than failing.
+ */
+export function parseUserKey(headerValue?: string | null, queryValue?: string | null): string | null {
+  const raw = (typeof headerValue === "string" && headerValue.trim()) || (typeof queryValue === "string" && queryValue.trim()) || "";
+  if (!raw) return null;
+  // Plausibility guard only (NOT authentication): non-empty, single token, bounded length.
+  if (raw.length > 200 || /\s/.test(raw)) return null;
+  return raw;
+}
+
+/**
+ * Build the read-only membership bridge response. Deterministic; never throws.
+ * `workspaces` is only surfaced when authenticated; `hasPersonalWorkspace` derives from it.
+ */
+export function buildMembershipResponse(input: MembershipBridgeInput): MembershipBridgeResponse {
+  const authenticated = typeof input.authUserId === "string" && input.authUserId.length > 0;
+  const workspaces = authenticated ? input.workspaces ?? [] : [];
+  return {
+    ok: true,
+    authenticated,
+    authUserId: authenticated ? input.authUserId : null,
+    email: authenticated && typeof input.email === "string" ? input.email : null,
+    userKey: typeof input.userKey === "string" ? input.userKey : null,
+    hasPersonalWorkspace: authenticated && workspaces.length > 0,
+    workspaces,
+    legacyProjectCount: Number.isFinite(input.legacyProjectCount) && input.legacyProjectCount > 0 ? Math.floor(input.legacyProjectCount) : 0,
+    bridgeMode: "read_only",
+    canCreatePersonalWorkspace: false,
+    canClaimProjects: false,
+  };
+}

--- a/apps/central-plane/test/workspace-membership-bridge.test.mjs
+++ b/apps/central-plane/test/workspace-membership-bridge.test.mjs
@@ -1,0 +1,59 @@
+/**
+ * workspace-membership-bridge.test.mjs
+ *
+ * Stage 254 — pure read-only bridge response builder + userKey parsing. Imports dist.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildMembershipResponse, parseUserKey } from "../dist/workspace-membership-bridge.js";
+
+test("signed-out: read-only contract, empty workspaces, no identity leaked", () => {
+  const r = buildMembershipResponse({ authUserId: null, email: "ignored@x.test", userKey: "uk_abc", workspaces: [{ id: "w", name: "n", role: "owner" }], legacyProjectCount: 3 });
+  assert.equal(r.ok, true);
+  assert.equal(r.authenticated, false);
+  assert.equal(r.authUserId, null);
+  assert.equal(r.email, null); // email not surfaced when unauthenticated
+  assert.equal(r.userKey, "uk_abc");
+  assert.equal(r.hasPersonalWorkspace, false);
+  assert.deepEqual(r.workspaces, []); // workspaces never surfaced when unauthenticated
+  assert.equal(r.legacyProjectCount, 3);
+  assert.equal(r.bridgeMode, "read_only");
+  assert.equal(r.canCreatePersonalWorkspace, false);
+  assert.equal(r.canClaimProjects, false);
+});
+
+test("authenticated, no workspace rows: authenticated true, hasPersonalWorkspace false", () => {
+  const r = buildMembershipResponse({ authUserId: "u1", email: "a@example.test", userKey: "uk_x", workspaces: [], legacyProjectCount: 0 });
+  assert.equal(r.authenticated, true);
+  assert.equal(r.authUserId, "u1");
+  assert.equal(r.email, "a@example.test");
+  assert.equal(r.hasPersonalWorkspace, false);
+  assert.deepEqual(r.workspaces, []);
+  assert.equal(r.canCreatePersonalWorkspace, false);
+  assert.equal(r.canClaimProjects, false);
+});
+
+test("authenticated with workspaces: hasPersonalWorkspace true, only safe fields", () => {
+  const r = buildMembershipResponse({ authUserId: "u1", email: "a@example.test", userKey: null, workspaces: [{ id: "ws_1", name: "Personal", role: "owner" }], legacyProjectCount: 2 });
+  assert.equal(r.hasPersonalWorkspace, true);
+  assert.deepEqual(r.workspaces, [{ id: "ws_1", name: "Personal", role: "owner" }]);
+  assert.equal(r.userKey, null);
+  // no token/secret fields anywhere in the response
+  assert.ok(!JSON.stringify(r).match(/token|secret|password|session/i));
+});
+
+test("legacyProjectCount is coerced to a non-negative integer", () => {
+  assert.equal(buildMembershipResponse({ authUserId: "u", email: null, userKey: "uk", workspaces: [], legacyProjectCount: -5 }).legacyProjectCount, 0);
+  assert.equal(buildMembershipResponse({ authUserId: "u", email: null, userKey: "uk", workspaces: [], legacyProjectCount: 2.9 }).legacyProjectCount, 2);
+  assert.equal(buildMembershipResponse({ authUserId: "u", email: null, userKey: "uk", workspaces: [], legacyProjectCount: NaN }).legacyProjectCount, 0);
+});
+
+test("parseUserKey: header preferred, query fallback, plausibility guard", () => {
+  assert.equal(parseUserKey("uk_abc", "uk_query"), "uk_abc"); // header wins
+  assert.equal(parseUserKey(undefined, "uk_query"), "uk_query"); // query fallback
+  assert.equal(parseUserKey("  uk_trim  ", null), "uk_trim");
+  assert.equal(parseUserKey(null, null), null);
+  assert.equal(parseUserKey("", ""), null);
+  assert.equal(parseUserKey("has space", null), null); // whitespace → rejected (not auth, just a scope key)
+  assert.equal(parseUserKey("x".repeat(201), null), null); // too long
+});

--- a/apps/central-plane/test/workspace-membership-route.test.mjs
+++ b/apps/central-plane/test/workspace-membership-route.test.mjs
@@ -1,0 +1,75 @@
+/**
+ * workspace-membership-route.test.mjs
+ *
+ * Stage 254 — GET /workspace/membership/me through the real router (createApp). Verifies the
+ * read-only contract on the signed-out path and that the route source performs NO writes.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createApp } from "../dist/router.js";
+
+function makeEnv(overrides = {}) {
+  return { DB: {}, ENVIRONMENT: "test", ...overrides };
+}
+
+test("GET /workspace/membership/me (signed out) → read-only contract, no auth, empty workspaces", async () => {
+  const app = createApp();
+  // No AUTH_ENABLED → no session runtime; no userKey header/query → legacy count omitted.
+  const res = await app.fetch(new Request("http://localhost/workspace/membership/me"), makeEnv());
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.authenticated, false);
+  assert.equal(body.authUserId, null);
+  assert.equal(body.email, null);
+  assert.equal(body.userKey, null);
+  assert.equal(body.hasPersonalWorkspace, false);
+  assert.deepEqual(body.workspaces, []);
+  assert.equal(body.legacyProjectCount, 0);
+  assert.equal(body.bridgeMode, "read_only");
+  assert.equal(body.canCreatePersonalWorkspace, false);
+  assert.equal(body.canClaimProjects, false);
+});
+
+test("userKey is echoed from header but DB read failure is fail-safe (count 0), still no auth", async () => {
+  const app = createApp();
+  // DB:{} has no .prepare → the legacy-count query throws and is caught → count 0 (no crash, no write).
+  const res = await app.fetch(
+    new Request("http://localhost/workspace/membership/me", { headers: { "x-simsa-user-key": "uk_test123" } }),
+    makeEnv(),
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.userKey, "uk_test123");
+  assert.equal(body.authenticated, false); // userKey is NOT an authenticated identity
+  assert.equal(body.legacyProjectCount, 0);
+});
+
+test("response never leaks tokens/secrets/session material", async () => {
+  const app = createApp();
+  const res = await app.fetch(
+    new Request("http://localhost/workspace/membership/me?userKey=uk_q"),
+    makeEnv({ AUTH_ENABLED: "true", BETTER_AUTH_SECRET: "super-secret-probe-value" }),
+  );
+  const text = await res.text();
+  assert.ok(!text.includes("super-secret-probe-value"), "must never echo the secret");
+  assert.ok(!/"(token|sessionToken|password)"/i.test(text), "must not include token/session fields");
+});
+
+test("the membership route source contains NO write statements (read-only guarantee)", () => {
+  const raw = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "src", "routes", "workspace-membership.ts"),
+    "utf8",
+  );
+  // Strip block + line comments so the read-only PROSE (e.g. "no INSERT/UPDATE") is not matched;
+  // only real code is scanned.
+  const code = raw.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+  assert.doesNotMatch(code, /\bINSERT\b/i, "no INSERT");
+  assert.doesNotMatch(code, /\bUPDATE\b/i, "no UPDATE");
+  assert.doesNotMatch(code, /\bDELETE\b/i, "no DELETE");
+  assert.doesNotMatch(code, /\.run\(/, "no .run() (writes); reads use .all()/.first()");
+  assert.doesNotMatch(code, /\bDROP\b|\bALTER\b/i, "no schema mutation");
+});


### PR DESCRIPTION
## Stage 254 — Auth user workspace bridge (read-only) code readiness

Approval: `"Auth user workspace bridge code readiness approved."`

**Code-readiness only — read-only bridge endpoint. No production deploy, no new migration, no production D1 mutation, no workspace/member row creation, no project claim, no `workspace_projects` update, no legacy userKey migration, no invite/share, no broad launch. Legacy userKey preserved; dashboard untouched.**

Adds **`GET /workspace/membership/me`** — the first endpoint to read the Better Auth session server-side — reporting auth/userKey/workspace readiness against the (now-applied) 0048 schema **without creating or mutating anything**.

### Changes (5 new + 1 modified, central-plane only)
- `routes/workspace-membership.ts` (A) — `GET /workspace/membership/me`. Session via `createBetterAuthRuntime(env).api.getSession({headers})` (fail-safe → unauthenticated) + legacy `userKey` (`x-simsa-user-key` header preferred, `?userKey=` fallback). **READ-ONLY**: `SELECT` of `workspace_members`/`workspaces` (only when authenticated) + a legacy `workspace_projects` `COUNT` (only when userKey present), both `try/catch` → safe defaults. No `INSERT`/`UPDATE`/`DELETE`; no personal-workspace creation; no claim; no migration.
- `workspace-membership-bridge.ts` (A) — pure `buildMembershipResponse` + `parseUserKey`. Safe fields only (id/name/role + email); no tokens/secrets; `canCreatePersonalWorkspace`/`canClaimProjects` hard-coded `false`.
- `router.ts` (M) — mount `createWorkspaceMembershipRoutes()`.
- tests (A×2) — bridge helper (shapes / no-leak / parse) + route (signed-out contract via `createApp`, userKey echo + fail-safe DB, no-secret-leak, **static guard: route source has NO write statements**).
- `docs/workspace-membership-bridge.md` (A) — contract, read-only-first rationale, legacy compatibility, future creation/claim/invite stages, rollout gates.

### Response contract
`{ ok, authenticated, authUserId, email, userKey, hasPersonalWorkspace:false, workspaces:[], legacyProjectCount, bridgeMode:"read_only", canCreatePersonalWorkspace:false, canClaimProjects:false }`. No tokens/secrets/session material. `userKey` is the legacy anonymous scope — never an authenticated identity.

### ★ Dashboard wiring deferred (documented)
The session read only sees a session with the first-party cookie. The same-origin rewrite covers `/api/auth/*` only; `/workspace/*` is cross-origin (`*.workers.dev`) and would not carry the `app.trysimsa.com` cookie. So the dashboard client + `/account` display are **deferred** to a later stage that also extends the rewrite (e.g. `/workspace/membership/*`). This PR ships the verified read-only endpoint only.

### Verification
- central-plane **65/65** (auth + workspace + bridge) · helper smoke **7/7** · route smoke **8/8** · dashboard **10/10** · `pnpm typecheck` **57/57** · `pnpm verify` green
- CI Node 20 + 22 expected green

### Next gates
- `"PR #<this> merge approved."` — merge (still not deployed)
- Bridge deploy (central-plane Worker), then personal-workspace creation, project claim, invite/share — each separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
