### PR TITLE
Stage 257A — Simsa Acceptance Graph and Evidence Pack Foundation

### DIFF
--- a/apps/central-plane/src/acceptance-graph.ts
+++ b/apps/central-plane/src/acceptance-graph.ts
@@ -1,0 +1,365 @@
+/**
+ * acceptance-graph.ts — Stage 257A (Simsa Acceptance Graph foundation).
+ *
+ * Pure, deterministic data contracts + helpers for the gap between user intent, PRD,
+ * build plan, implementation evidence, review evidence, visual evidence, gate decision,
+ * and receipt. NO network, NO DB, NO env, NO LLM — deterministic output for deterministic
+ * input. This stage defines the *contract* (including the visual/interaction node) but does
+ * NOT run any browser/interaction runner.
+ *
+ * Policy source of truth: docs/simsa-autopilot-operating-model.md (Part II). Hard rules baked in:
+ *   - NO numeric scoring (readiness states only).
+ *   - Absent evidence is "Not Verified", never "Pass"/"Done".
+ *   - Implementation choices over an ambiguous PRD surface as "User Acceptance Required".
+ */
+
+/** Where the project entered Simsa. "mixed" = more than one of idea/prd/repo. */
+export type IntakeSource = "idea" | "prd" | "repo" | "mixed";
+
+/** Allowed decision states. NO numeric score is ever produced (policy §20). */
+export const DECISION_STATES = [
+  "Ready",
+  "Conditionally Ready",
+  "Needs Clarification",
+  "Needs Evidence",
+  "Needs Expert Review",
+  "Not Applicable",
+  "Not Judged",
+  "Do Not Build Yet",
+  "Not Verified",
+  "Needs Fix",
+  "User Acceptance Required",
+] as const;
+export type DecisionState = (typeof DECISION_STATES)[number];
+
+export function isDecisionState(v: unknown): v is DecisionState {
+  return typeof v === "string" && (DECISION_STATES as readonly string[]).includes(v);
+}
+
+/** A single acceptance criterion carried by the PRD. */
+export type AcceptanceCriterion = { id: string; text: string };
+
+/** 2. User intent. */
+export type UserIntentNode = {
+  id: string;
+  summary: string;
+  targetFirstUser: string;
+  desiredBehaviorChange: string;
+  nonGoals: string[];
+  assumptions: string[];
+  unknowns: string[];
+  sourceRefs: string[];
+};
+
+/** 3. Clarifying answer. */
+export type ClarifyingAnswerNode = {
+  question: string;
+  answer: string;
+  reasonAsked: string;
+  affects: string[];
+};
+
+/** 4. PRD artifact. */
+export type PrdArtifactNode = {
+  summary: string;
+  requirements: string[];
+  userFlows: string[];
+  acceptanceCriteria: AcceptanceCriterion[];
+  edgeCases: string[];
+  outOfScope: string[];
+  unknowns: string[];
+  sourceRefs: string[];
+};
+
+/** 5. Build plan. */
+export type BuildPlanNode = {
+  tasks: string[];
+  taskToAcceptanceCriteriaLinks: Array<{ task: string; criteriaIds: string[] }>;
+  dependencies: string[];
+  riskNotes: string[];
+};
+
+/** A test observation, linked to the acceptance criteria it exercises. */
+export type TestObservation = {
+  name: string;
+  status: "pass" | "fail" | "skipped";
+  criteriaIds: string[];
+};
+
+/** 6. Implementation evidence. */
+export type ImplementationEvidenceNode = {
+  repo: string | null;
+  branch: string | null;
+  prNumber: number | null;
+  changedFiles: string[];
+  diffSummary: string;
+  tests: TestObservation[];
+  ciStatus: "pass" | "fail" | "pending" | "unknown";
+  deploymentStatus: "deployed" | "not_deployed" | "unknown";
+  sourceRefs: string[];
+};
+
+/** 7. Cross-review evidence. */
+export type CrossReviewEvidenceNode = {
+  reviewer: string;
+  role: string;
+  findings: string[];
+  severity: "high" | "medium" | "low" | "none";
+  affectedCriteria: string[];
+  unresolvedBlockers: string[];
+};
+
+/**
+ * 8. Visual / interaction evidence. CONTRACT ONLY in this stage — there is no runner yet.
+ * When absent or `notVerified === true`, product/UI behavior must be reported Not Verified.
+ */
+export type VisualInteractionEvidenceNode = {
+  routesDetected: string[];
+  clickableElementsDetected: number;
+  clickedSafely: number;
+  skippedDestructive: number;
+  blockedByAuth: number;
+  failedInteractions: string[];
+  screenshots: string[];
+  consoleErrors: string[];
+  networkFailures: string[];
+  notVerified: boolean;
+};
+
+/** 9. Gate decision. */
+export type GateDecisionNode = {
+  decision: DecisionState;
+  reasons: string[];
+  verified: string[];
+  broken: string[];
+  notVerified: string[];
+  assumptions: string[];
+  userDecisionNeeded: string[];
+  humanGateRequired: boolean;
+  nextSafestAction: string;
+  doNotDoYet: string[];
+};
+
+/** 10. Receipt. */
+export type ReceiptType =
+  | "idea"
+  | "prd"
+  | "build"
+  | "release_gate"
+  | "progress"
+  | "technology_recommendation";
+
+export type ReceiptNode = {
+  receiptType: ReceiptType;
+  summary: string;
+  changed: string[];
+  improved: string[];
+  verified: string[];
+  broken: string[];
+  notVerified: string[];
+  skipped: string[];
+  userDecisionNeeded: string[];
+  requiredHumanGate: boolean;
+  nextSafestAction: string;
+  limitations: string[];
+};
+
+/** The full acceptance graph. All nodes optional except the project frame. */
+export type AcceptanceGraph = {
+  projectId: string;
+  intakeSource: IntakeSource;
+  intent: UserIntentNode | null;
+  clarifyingAnswers: ClarifyingAnswerNode[];
+  prd: PrdArtifactNode | null;
+  buildPlan: BuildPlanNode | null;
+  implementation: ImplementationEvidenceNode | null;
+  crossReviews: CrossReviewEvidenceNode[];
+  visual: VisualInteractionEvidenceNode | null;
+};
+
+/** Loose input shape accepted by createAcceptanceGraph (everything optional). */
+export type AcceptanceGraphInput = {
+  projectId?: string;
+  intakeSource?: IntakeSource;
+  intent?: Partial<UserIntentNode> | null;
+  clarifyingAnswers?: Array<Partial<ClarifyingAnswerNode>>;
+  prd?: Partial<PrdArtifactNode> | null;
+  buildPlan?: Partial<BuildPlanNode> | null;
+  implementation?: Partial<ImplementationEvidenceNode> | null;
+  crossReviews?: Array<Partial<CrossReviewEvidenceNode>>;
+  visual?: Partial<VisualInteractionEvidenceNode> | null;
+};
+
+const arr = <T>(v: T[] | undefined): T[] => (Array.isArray(v) ? v : []);
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+
+/** Infer intake source when not explicitly provided (deterministic). */
+export function deriveIntakeSource(input: AcceptanceGraphInput): IntakeSource {
+  if (input.intakeSource) return input.intakeSource;
+  const hasIdea = !!input.intent;
+  const hasPrd = !!input.prd;
+  const hasRepo = !!input.implementation;
+  const count = [hasIdea, hasPrd, hasRepo].filter(Boolean).length;
+  if (count > 1) return "mixed";
+  if (hasRepo) return "repo";
+  if (hasPrd) return "prd";
+  return "idea";
+}
+
+/**
+ * Build a normalized AcceptanceGraph from loose input. Pure, never throws — missing fields
+ * become null/[]; presence is what later gap analysis reads. Does NOT invent intent or PRD.
+ */
+export function createAcceptanceGraph(input: AcceptanceGraphInput = {}): AcceptanceGraph {
+  const intent: UserIntentNode | null = input.intent
+    ? {
+        id: str(input.intent.id) || "intent",
+        summary: str(input.intent.summary),
+        targetFirstUser: str(input.intent.targetFirstUser),
+        desiredBehaviorChange: str(input.intent.desiredBehaviorChange),
+        nonGoals: arr(input.intent.nonGoals),
+        assumptions: arr(input.intent.assumptions),
+        unknowns: arr(input.intent.unknowns),
+        sourceRefs: arr(input.intent.sourceRefs),
+      }
+    : null;
+
+  const prd: PrdArtifactNode | null = input.prd
+    ? {
+        summary: str(input.prd.summary),
+        requirements: arr(input.prd.requirements),
+        userFlows: arr(input.prd.userFlows),
+        acceptanceCriteria: arr(input.prd.acceptanceCriteria).filter(
+          (c): c is AcceptanceCriterion => !!c && typeof c.id === "string" && typeof c.text === "string",
+        ),
+        edgeCases: arr(input.prd.edgeCases),
+        outOfScope: arr(input.prd.outOfScope),
+        unknowns: arr(input.prd.unknowns),
+        sourceRefs: arr(input.prd.sourceRefs),
+      }
+    : null;
+
+  const buildPlan: BuildPlanNode | null = input.buildPlan
+    ? {
+        tasks: arr(input.buildPlan.tasks),
+        taskToAcceptanceCriteriaLinks: arr(input.buildPlan.taskToAcceptanceCriteriaLinks).map((l) => ({
+          task: str(l?.task),
+          criteriaIds: arr(l?.criteriaIds),
+        })),
+        dependencies: arr(input.buildPlan.dependencies),
+        riskNotes: arr(input.buildPlan.riskNotes),
+      }
+    : null;
+
+  const implementation: ImplementationEvidenceNode | null = input.implementation
+    ? {
+        repo: input.implementation.repo ?? null,
+        branch: input.implementation.branch ?? null,
+        prNumber: typeof input.implementation.prNumber === "number" ? input.implementation.prNumber : null,
+        changedFiles: arr(input.implementation.changedFiles),
+        diffSummary: str(input.implementation.diffSummary),
+        tests: arr(input.implementation.tests).map((t) => ({
+          name: str(t?.name),
+          status: t?.status === "pass" || t?.status === "fail" || t?.status === "skipped" ? t.status : "skipped",
+          criteriaIds: arr(t?.criteriaIds),
+        })),
+        ciStatus:
+          input.implementation.ciStatus === "pass" ||
+          input.implementation.ciStatus === "fail" ||
+          input.implementation.ciStatus === "pending"
+            ? input.implementation.ciStatus
+            : "unknown",
+        deploymentStatus:
+          input.implementation.deploymentStatus === "deployed" ||
+          input.implementation.deploymentStatus === "not_deployed"
+            ? input.implementation.deploymentStatus
+            : "unknown",
+        sourceRefs: arr(input.implementation.sourceRefs),
+      }
+    : null;
+
+  const crossReviews: CrossReviewEvidenceNode[] = arr(input.crossReviews).map((r) => ({
+    reviewer: str(r?.reviewer),
+    role: str(r?.role),
+    findings: arr(r?.findings),
+    severity: r?.severity === "high" || r?.severity === "medium" || r?.severity === "low" ? r.severity : "none",
+    affectedCriteria: arr(r?.affectedCriteria),
+    unresolvedBlockers: arr(r?.unresolvedBlockers),
+  }));
+
+  const visual: VisualInteractionEvidenceNode | null = input.visual
+    ? {
+        routesDetected: arr(input.visual.routesDetected),
+        clickableElementsDetected: Number(input.visual.clickableElementsDetected ?? 0) || 0,
+        clickedSafely: Number(input.visual.clickedSafely ?? 0) || 0,
+        skippedDestructive: Number(input.visual.skippedDestructive ?? 0) || 0,
+        blockedByAuth: Number(input.visual.blockedByAuth ?? 0) || 0,
+        failedInteractions: arr(input.visual.failedInteractions),
+        screenshots: arr(input.visual.screenshots),
+        consoleErrors: arr(input.visual.consoleErrors),
+        networkFailures: arr(input.visual.networkFailures),
+        notVerified: input.visual.notVerified !== false,
+      }
+    : null;
+
+  const graph: AcceptanceGraph = {
+    projectId: str(input.projectId) || "project",
+    intakeSource: "idea",
+    intent,
+    clarifyingAnswers: arr(input.clarifyingAnswers).map((c) => ({
+      question: str(c?.question),
+      answer: str(c?.answer),
+      reasonAsked: str(c?.reasonAsked),
+      affects: arr(c?.affects),
+    })),
+    prd,
+    buildPlan,
+    implementation,
+    crossReviews,
+    visual,
+  };
+  graph.intakeSource = deriveIntakeSource({ ...input, intent, prd, implementation });
+  return graph;
+}
+
+/** True when the intent is missing any of the three fields needed to evaluate a PRD. */
+export function isUserIntentAmbiguous(graph: AcceptanceGraph): boolean {
+  const i = graph.intent;
+  if (!i) return true;
+  return !i.summary || !i.targetFirstUser || !i.desiredBehaviorChange;
+}
+
+export type CriterionStatus = "verified" | "broken" | "not_verified";
+export type CriterionGap = { id: string; text: string; status: CriterionStatus };
+
+/**
+ * Per-criterion verification status, derived deterministically from test observations:
+ *   - any failing test referencing it           → broken
+ *   - else any passing test referencing it       → verified
+ *   - else (no test, or only skipped tests)      → not_verified
+ * Visual-dependent confirmation is intentionally NOT inferred here; absence stays not_verified.
+ */
+export function summarizeAcceptanceGap(graph: AcceptanceGraph): {
+  criteria: CriterionGap[];
+  missingCriteria: boolean;
+  verifiedCount: number;
+  brokenCount: number;
+  notVerifiedCount: number;
+} {
+  const criteria = graph.prd?.acceptanceCriteria ?? [];
+  const tests = graph.implementation?.tests ?? [];
+  const gaps: CriterionGap[] = criteria.map((c) => {
+    const refs = tests.filter((t) => t.criteriaIds.includes(c.id));
+    let status: CriterionStatus = "not_verified";
+    if (refs.some((t) => t.status === "fail")) status = "broken";
+    else if (refs.some((t) => t.status === "pass")) status = "verified";
+    return { id: c.id, text: c.text, status };
+  });
+  return {
+    criteria: gaps,
+    missingCriteria: criteria.length === 0,
+    verifiedCount: gaps.filter((g) => g.status === "verified").length,
+    brokenCount: gaps.filter((g) => g.status === "broken").length,
+    notVerifiedCount: gaps.filter((g) => g.status === "not_verified").length,
+  };
+}

--- a/apps/central-plane/src/evidence-pack.ts
+++ b/apps/central-plane/src/evidence-pack.ts
@@ -1,0 +1,312 @@
+/**
+ * evidence-pack.ts — Stage 257A (Simsa deterministic Evidence Pack + Receipt).
+ *
+ * Pure helpers that turn an AcceptanceGraph into a deterministic evidence pack, a gate
+ * decision, and a receipt. NO network/DB/env/LLM. Per policy §12 (docs/simsa-autopilot-
+ * operating-model.md): risk flags are booleans derived from inputs (changed-file paths +
+ * structured nodes) — agent prose is NEVER treated as proof, and absent evidence is
+ * "Not Verified", never "Pass". Per policy §20: NO numeric scoring.
+ */
+import {
+  type AcceptanceGraph,
+  type DecisionState,
+  type GateDecisionNode,
+  type ReceiptNode,
+  type ReceiptType,
+  isUserIntentAmbiguous,
+  summarizeAcceptanceGap,
+} from "./acceptance-graph.js";
+
+/** Deterministic risk flags. Every flag is a boolean computed from provided inputs. */
+export type RiskFlags = {
+  migrationChanged: boolean;
+  deployConfigChanged: boolean;
+  envSecretTouched: boolean;
+  authPolicyTouched: boolean;
+  paymentTouched: boolean;
+  oauthTouched: boolean;
+  dnsCorsTouched: boolean;
+  d1WriteDetected: boolean;
+  destructiveActionDetected: boolean;
+  workspaceClaimTouched: boolean;
+  publicLaunchTouched: boolean;
+  visualEvidenceMissing: boolean;
+  acceptanceCriteriaMissing: boolean;
+  userIntentAmbiguous: boolean;
+};
+
+/** The flags that, when true, force a hard human gate (policy §7). */
+export const HARD_GATE_FLAGS: Array<keyof RiskFlags> = [
+  "migrationChanged",
+  "deployConfigChanged",
+  "envSecretTouched",
+  "authPolicyTouched",
+  "paymentTouched",
+  "oauthTouched",
+  "dnsCorsTouched",
+  "d1WriteDetected",
+  "destructiveActionDetected",
+  "workspaceClaimTouched",
+  "publicLaunchTouched",
+];
+
+export type EvidencePack = {
+  taskId: string | null;
+  stageId: string | null;
+  projectId: string;
+  intakeSource: AcceptanceGraph["intakeSource"];
+  branch: string | null;
+  base: string | null;
+  head: string | null;
+  prNumber: number | null;
+  artifactSummary: string;
+  changedFiles: string[];
+  productEvidence: { intentPresent: boolean; prdPresent: boolean; acceptanceCriteriaCount: number };
+  engineeringEvidence: {
+    testsPass: number;
+    testsFail: number;
+    testsSkipped: number;
+    ciStatus: string;
+    deploymentStatus: string;
+  };
+  crossReviewEvidence: { reviewers: number; unresolvedBlockers: string[] };
+  visualEvidence: { present: boolean; notVerified: boolean; failedInteractions: string[] };
+  riskFlags: RiskFlags;
+  verified: string[];
+  broken: string[];
+  skipped: string[];
+  notVerified: string[];
+  userDecisionNeeded: string[];
+  humanGateRequired: boolean;
+  requiredApprovalPhrase: string | null;
+  nextSafestAction: string;
+  doNotDoYet: string[];
+  limitations: string[];
+};
+
+const matchAny = (files: string[], re: RegExp): boolean => files.some((f) => re.test(f));
+
+/** Compute deterministic risk flags from the graph (changed-file paths + structured nodes). */
+export function deriveRiskFlags(graph: AcceptanceGraph): RiskFlags {
+  const files = graph.implementation?.changedFiles ?? [];
+  const diff = graph.implementation?.diffSummary ?? "";
+  const gap = summarizeAcceptanceGap(graph);
+  return {
+    migrationChanged: matchAny(files, /(^|\/)migrations\/.*\.sql$/i),
+    deployConfigChanged: matchAny(files, /(\.github\/workflows\/.*deploy|vercel\.json|\.github\/workflows\/release)/i),
+    envSecretTouched: matchAny(files, /(^|\/)(\.env|wrangler\.toml)(\.|$)|\.env($|\.)/i),
+    authPolicyTouched: matchAny(files, /auth-signup-policy|auth-topology|better-auth|auth-spike/i),
+    paymentTouched: matchAny(files, /billing|lemonsqueezy|payment|checkout/i),
+    oauthTouched: matchAny(files, /oauth/i),
+    dnsCorsTouched: matchAny(files, /(^|\/)cors\.|dns|domain/i),
+    d1WriteDetected: /\b(INSERT|UPDATE|DELETE)\b/i.test(diff),
+    destructiveActionDetected: /\b(DROP|TRUNCATE)\b/i.test(diff) || /\bDELETE\b.*\bWHERE\b/i.test(diff),
+    workspaceClaimTouched: matchAny(files, /claim/i) || /workspace_projects[\s\S]*\bUPDATE\b|\bUPDATE\b[\s\S]*workspace_projects/i.test(diff),
+    publicLaunchTouched: matchAny(files, /launch/i),
+    visualEvidenceMissing: !graph.visual || graph.visual.notVerified === true,
+    acceptanceCriteriaMissing: gap.missingCriteria,
+    userIntentAmbiguous: isUserIntentAmbiguous(graph),
+  };
+}
+
+function approvalPhraseFor(flags: RiskFlags): string | null {
+  if (flags.migrationChanged || flags.d1WriteDetected) return "<feature> production D1 apply approved.";
+  if (flags.envSecretTouched || flags.authPolicyTouched) return "<feature> production env provisioning approved.";
+  if (flags.deployConfigChanged) return "<feature> central-plane production deploy approved.";
+  if (flags.publicLaunchTouched) return "<feature> public launch approved.";
+  if (flags.paymentTouched || flags.oauthTouched || flags.dnsCorsTouched || flags.destructiveActionDetected || flags.workspaceClaimTouched)
+    return "<feature> production change approved.";
+  return null;
+}
+
+/**
+ * Build the deterministic evidence pack from the acceptance graph.
+ * Absent evidence becomes Not Verified, never Pass.
+ */
+export function deriveEvidencePack(
+  graph: AcceptanceGraph,
+  meta: { taskId?: string | null; stageId?: string | null; base?: string | null; head?: string | null } = {},
+): EvidencePack {
+  const gap = summarizeAcceptanceGap(graph);
+  const tests = graph.implementation?.tests ?? [];
+  const flags = deriveRiskFlags(graph);
+  const humanGateRequired = HARD_GATE_FLAGS.some((k) => flags[k]);
+
+  const verified: string[] = gap.criteria.filter((c) => c.status === "verified").map((c) => `criterion ${c.id}: ${c.text}`);
+  const broken: string[] = gap.criteria.filter((c) => c.status === "broken").map((c) => `criterion ${c.id}: ${c.text}`);
+  const notVerified: string[] = gap.criteria.filter((c) => c.status === "not_verified").map((c) => `criterion ${c.id}: ${c.text}`);
+  if (flags.acceptanceCriteriaMissing) notVerified.push("no acceptance criteria provided — nothing can be verified");
+  if (flags.visualEvidenceMissing) notVerified.push("visual/interaction evidence missing — product UI behavior not verified");
+
+  // Unresolved cross-review blockers are broken signals (something is wrong, not merely unproven).
+  for (const r of graph.crossReviews) for (const b of r.unresolvedBlockers) broken.push(`review blocker (${r.reviewer || r.role}): ${b}`);
+
+  const skipped: string[] = tests.filter((t) => t.status === "skipped").map((t) => `test skipped: ${t.name}`);
+
+  // User decision needed: an implementation choice over an ambiguous PRD (no criteria but code exists).
+  const userDecisionNeeded: string[] = [];
+  if (graph.implementation && flags.acceptanceCriteriaMissing && !flags.userIntentAmbiguous) {
+    userDecisionNeeded.push("implementation exists but PRD has no acceptance criteria — confirm the implemented behavior matches intent");
+  }
+  if (graph.implementation && graph.intent && !graph.prd) {
+    userDecisionNeeded.push("repo-first project without a PRD — confirm intent-to-implementation alignment");
+  }
+
+  const limitations = [
+    "Risk flags are derived from changed-file paths and diff text only; they do not execute the diff.",
+    "Visual/interaction evidence is a contract placeholder in this stage — no browser runner is invoked.",
+    "Simsa does not claim to find all bugs or to produce a perfect product.",
+  ];
+
+  return {
+    taskId: meta.taskId ?? null,
+    stageId: meta.stageId ?? null,
+    projectId: graph.projectId,
+    intakeSource: graph.intakeSource,
+    branch: graph.implementation?.branch ?? null,
+    base: meta.base ?? null,
+    head: meta.head ?? null,
+    prNumber: graph.implementation?.prNumber ?? null,
+    artifactSummary: graph.prd?.summary || graph.intent?.summary || "",
+    changedFiles: graph.implementation?.changedFiles ?? [],
+    productEvidence: {
+      intentPresent: !!graph.intent,
+      prdPresent: !!graph.prd,
+      acceptanceCriteriaCount: graph.prd?.acceptanceCriteria.length ?? 0,
+    },
+    engineeringEvidence: {
+      testsPass: tests.filter((t) => t.status === "pass").length,
+      testsFail: tests.filter((t) => t.status === "fail").length,
+      testsSkipped: tests.filter((t) => t.status === "skipped").length,
+      ciStatus: graph.implementation?.ciStatus ?? "unknown",
+      deploymentStatus: graph.implementation?.deploymentStatus ?? "unknown",
+    },
+    crossReviewEvidence: {
+      reviewers: graph.crossReviews.length,
+      unresolvedBlockers: graph.crossReviews.flatMap((r) => r.unresolvedBlockers),
+    },
+    visualEvidence: {
+      present: !!graph.visual,
+      notVerified: flags.visualEvidenceMissing,
+      failedInteractions: graph.visual?.failedInteractions ?? [],
+    },
+    riskFlags: flags,
+    verified,
+    broken,
+    skipped,
+    notVerified,
+    userDecisionNeeded,
+    humanGateRequired,
+    requiredApprovalPhrase: humanGateRequired ? approvalPhraseFor(flags) : null,
+    nextSafestAction: "", // filled by classifyGateDecision via createReceipt
+    doNotDoYet: humanGateRequired ? ["Do not auto-merge", "Do not deploy", "Do not mutate production"] : [],
+    limitations,
+  };
+}
+
+/**
+ * Deterministic gate decision from an evidence pack. Priority order is fixed so the same pack
+ * always yields the same decision. NO numeric score is produced.
+ */
+export function classifyGateDecision(pack: EvidencePack): GateDecisionNode {
+  const reasons: string[] = [];
+  let decision: DecisionState;
+
+  if (pack.riskFlags.userIntentAmbiguous && !pack.productEvidence.prdPresent) {
+    decision = "Needs Clarification";
+    reasons.push("user intent is incomplete and no PRD is present");
+  } else if (pack.broken.length > 0) {
+    decision = "Needs Fix";
+    reasons.push(`${pack.broken.length} broken item(s) detected`);
+  } else if (pack.userDecisionNeeded.length > 0) {
+    // An implementation exists but its behavior is unconfirmed against intent/PRD — a user
+    // accept/reject decision outranks "author more criteria", since code is already on the table.
+    decision = "User Acceptance Required";
+    reasons.push("an implementation choice requires user confirmation");
+  } else if (pack.riskFlags.acceptanceCriteriaMissing) {
+    decision = "Needs Evidence";
+    reasons.push("no acceptance criteria — there is nothing to verify against");
+  } else if (pack.notVerified.length > 0) {
+    decision = "Not Verified";
+    reasons.push(`${pack.notVerified.length} item(s) lack verifying evidence`);
+  } else if (pack.verified.length > 0) {
+    decision = pack.humanGateRequired ? "Conditionally Ready" : "Ready";
+    reasons.push(`${pack.verified.length} criterion(s) verified`);
+    if (pack.humanGateRequired) reasons.push("a hard human gate is required before production");
+  } else {
+    decision = "Not Judged";
+    reasons.push("insufficient signal to decide");
+  }
+
+  const nextSafestAction =
+    decision === "Needs Clarification"
+      ? "Ask the user the clarifying questions before generating or evaluating a PRD."
+      : decision === "Needs Evidence"
+        ? "Author acceptance criteria, then gather verifying evidence."
+        : decision === "Needs Fix"
+          ? "Fix the broken items and re-run verification."
+          : decision === "User Acceptance Required"
+            ? "Surface the implemented behavior to the user for an accept/reject decision."
+            : decision === "Not Verified"
+              ? "Add the missing verification (tests and/or visual/interaction evidence)."
+              : pack.humanGateRequired
+                ? "Request the required human approval; do not auto-advance."
+                : "Safe to advance under the autopilot low-risk policy.";
+
+  return {
+    decision,
+    reasons,
+    verified: pack.verified,
+    broken: pack.broken,
+    notVerified: pack.notVerified,
+    assumptions: [],
+    userDecisionNeeded: pack.userDecisionNeeded,
+    humanGateRequired: pack.humanGateRequired,
+    nextSafestAction,
+    doNotDoYet: pack.doNotDoYet,
+  };
+}
+
+export function listNotVerified(pack: EvidencePack): string[] {
+  return [...pack.notVerified];
+}
+
+export function listUserDecisionNeeded(pack: EvidencePack): string[] {
+  return [...pack.userDecisionNeeded];
+}
+
+/** Build a receipt from an evidence pack. NO numeric fields are produced (policy §20). */
+export function createReceipt(pack: EvidencePack, receiptType: ReceiptType = "release_gate"): ReceiptNode {
+  const gate = classifyGateDecision(pack);
+  return {
+    receiptType,
+    summary: `${gate.decision}: ${gate.reasons.join("; ")}`,
+    changed: pack.changedFiles,
+    improved: [],
+    verified: pack.verified,
+    broken: pack.broken,
+    notVerified: pack.notVerified,
+    skipped: pack.skipped,
+    userDecisionNeeded: pack.userDecisionNeeded,
+    requiredHumanGate: pack.humanGateRequired,
+    nextSafestAction: gate.nextSafestAction,
+    limitations: pack.limitations,
+  };
+}
+
+/**
+ * Guard: a receipt must never carry a numeric score. Returns true when clean, throws otherwise.
+ * Catches "82/100", "score: 76", and any key literally named *score*.
+ */
+export function assertNoNumericScores(receipt: ReceiptNode): true {
+  for (const [key, value] of Object.entries(receipt)) {
+    if (/score/i.test(key)) throw new Error(`numeric scoring is forbidden: receipt has a "${key}" field`);
+    const texts = Array.isArray(value) ? value : typeof value === "string" ? [value] : [];
+    for (const t of texts) {
+      if (typeof t !== "string") continue;
+      if (/\b\d{1,3}\s*\/\s*100\b/.test(t)) throw new Error(`numeric scoring is forbidden: found "${t}"`);
+      if (/\bscore\s*[:=]\s*\d/i.test(t)) throw new Error(`numeric scoring is forbidden: found "${t}"`);
+    }
+  }
+  return true;
+}

--- a/apps/central-plane/test/acceptance-graph.test.mjs
+++ b/apps/central-plane/test/acceptance-graph.test.mjs
@@ -1,0 +1,112 @@
+/**
+ * acceptance-graph.test.mjs — Stage 257A.
+ *
+ * Pure deterministic contracts for the Simsa Acceptance Graph. Imports dist. Verifies intake
+ * inference, intent-ambiguity detection, and per-criterion gap status (verified/broken/not_verified)
+ * — including the rule that absent evidence is never "verified".
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createAcceptanceGraph,
+  deriveIntakeSource,
+  isUserIntentAmbiguous,
+  summarizeAcceptanceGap,
+  isDecisionState,
+  DECISION_STATES,
+} from "../dist/acceptance-graph.js";
+
+test("createAcceptanceGraph is pure and fills safe defaults without inventing intent/PRD", () => {
+  const g = createAcceptanceGraph({ projectId: "p1" });
+  assert.equal(g.projectId, "p1");
+  assert.equal(g.intent, null);
+  assert.equal(g.prd, null);
+  assert.equal(g.implementation, null);
+  assert.deepEqual(g.clarifyingAnswers, []);
+  assert.deepEqual(g.crossReviews, []);
+});
+
+test("intake source is inferred: idea-only → idea, repo-only → repo, idea+prd+repo → mixed", () => {
+  assert.equal(deriveIntakeSource({ intent: { summary: "x" } }), "idea");
+  assert.equal(deriveIntakeSource({ implementation: { repo: "r" } }), "repo");
+  assert.equal(deriveIntakeSource({ prd: { summary: "p" } }), "prd");
+  assert.equal(
+    deriveIntakeSource({ intent: { summary: "x" }, prd: { summary: "p" }, implementation: { repo: "r" } }),
+    "mixed",
+  );
+  // explicit override wins
+  assert.equal(deriveIntakeSource({ intakeSource: "prd", intent: { summary: "x" } }), "prd");
+});
+
+test("intent is ambiguous unless summary + targetFirstUser + desiredBehaviorChange are all present", () => {
+  assert.equal(isUserIntentAmbiguous(createAcceptanceGraph({})), true); // no intent
+  assert.equal(isUserIntentAmbiguous(createAcceptanceGraph({ intent: { summary: "s" } })), true); // missing two
+  const full = createAcceptanceGraph({
+    intent: { summary: "s", targetFirstUser: "u", desiredBehaviorChange: "b" },
+  });
+  assert.equal(isUserIntentAmbiguous(full), false);
+});
+
+test("summarizeAcceptanceGap: passing test → verified, failing → broken, no/skip → not_verified", () => {
+  const g = createAcceptanceGraph({
+    prd: {
+      summary: "p",
+      acceptanceCriteria: [
+        { id: "AC1", text: "login works" },
+        { id: "AC2", text: "logout works" },
+        { id: "AC3", text: "reset works" },
+      ],
+    },
+    implementation: {
+      repo: "r",
+      tests: [
+        { name: "t-login", status: "pass", criteriaIds: ["AC1"] },
+        { name: "t-logout", status: "fail", criteriaIds: ["AC2"] },
+        { name: "t-reset", status: "skipped", criteriaIds: ["AC3"] },
+      ],
+    },
+  });
+  const gap = summarizeAcceptanceGap(g);
+  assert.equal(gap.missingCriteria, false);
+  assert.equal(gap.verifiedCount, 1);
+  assert.equal(gap.brokenCount, 1);
+  assert.equal(gap.notVerifiedCount, 1);
+  assert.equal(gap.criteria.find((c) => c.id === "AC1").status, "verified");
+  assert.equal(gap.criteria.find((c) => c.id === "AC2").status, "broken");
+  assert.equal(gap.criteria.find((c) => c.id === "AC3").status, "not_verified"); // skipped ≠ verified
+});
+
+test("a criterion with NO referencing test is not_verified (absent evidence is never a pass)", () => {
+  const g = createAcceptanceGraph({
+    prd: { summary: "p", acceptanceCriteria: [{ id: "AC1", text: "thing" }] },
+    implementation: { repo: "r", tests: [{ name: "unrelated", status: "pass", criteriaIds: ["OTHER"] }] },
+  });
+  const gap = summarizeAcceptanceGap(g);
+  assert.equal(gap.criteria[0].status, "not_verified");
+  assert.equal(gap.verifiedCount, 0);
+});
+
+test("missingCriteria is true when the PRD has no acceptance criteria (or no PRD)", () => {
+  assert.equal(summarizeAcceptanceGap(createAcceptanceGraph({})).missingCriteria, true);
+  assert.equal(
+    summarizeAcceptanceGap(createAcceptanceGraph({ prd: { summary: "p", acceptanceCriteria: [] } })).missingCriteria,
+    true,
+  );
+});
+
+test("decision states are a closed set and exclude any numeric notion", () => {
+  assert.ok(isDecisionState("Ready"));
+  assert.ok(isDecisionState("Not Verified"));
+  assert.ok(!isDecisionState("82/100"));
+  assert.ok(!isDecisionState("Pass"));
+  // no state contains a digit
+  for (const s of DECISION_STATES) assert.ok(!/\d/.test(s), `${s} must not contain a number`);
+});
+
+test("malformed acceptanceCriteria entries are dropped (no throw, deterministic)", () => {
+  const g = createAcceptanceGraph({
+    prd: { summary: "p", acceptanceCriteria: [{ id: "AC1", text: "ok" }, { id: 5 }, null, { text: "no id" }] },
+  });
+  assert.equal(g.prd.acceptanceCriteria.length, 1);
+  assert.equal(g.prd.acceptanceCriteria[0].id, "AC1");
+});

--- a/apps/central-plane/test/evidence-pack.test.mjs
+++ b/apps/central-plane/test/evidence-pack.test.mjs
@@ -1,0 +1,191 @@
+/**
+ * evidence-pack.test.mjs — Stage 257A.
+ *
+ * Deterministic evidence pack → gate decision → receipt. Imports dist. Verifies the 8 mandated
+ * cases: idea-only, PRD-first (no impl), repo-first (no PRD), PRD+impl partial coverage, visual
+ * evidence missing, implementation-choice → user decision, risk-flag detection, and the hard
+ * no-numeric-scoring guarantee.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createAcceptanceGraph } from "../dist/acceptance-graph.js";
+import {
+  deriveEvidencePack,
+  deriveRiskFlags,
+  classifyGateDecision,
+  createReceipt,
+  assertNoNumericScores,
+  listNotVerified,
+  listUserDecisionNeeded,
+} from "../dist/evidence-pack.js";
+
+// 1. Idea-only project: intent but no PRD → Needs Clarification, never a fake Done.
+test("idea-only project → Needs Clarification (ambiguous intent, no PRD), no fake Done", () => {
+  const g = createAcceptanceGraph({ intent: { summary: "an app" } }); // missing targetFirstUser/behavior
+  const pack = deriveEvidencePack(g);
+  const gate = classifyGateDecision(pack);
+  assert.equal(gate.decision, "Needs Clarification");
+  assert.equal(pack.verified.length, 0);
+});
+
+// 2. PRD-first project: criteria but no implementation → not Ready, implementation Not Verified.
+test("PRD-first with criteria but no implementation → Not Verified, not Ready", () => {
+  const g = createAcceptanceGraph({
+    intent: { summary: "s", targetFirstUser: "u", desiredBehaviorChange: "b" },
+    prd: { summary: "p", acceptanceCriteria: [{ id: "AC1", text: "does X" }] },
+  });
+  const pack = deriveEvidencePack(g);
+  const gate = classifyGateDecision(pack);
+  assert.notEqual(gate.decision, "Ready");
+  assert.equal(gate.decision, "Not Verified");
+  assert.ok(listNotVerified(pack).some((s) => s.includes("AC1")));
+});
+
+// 3. Repo-first without PRD → user decision / clarification required.
+test("repo-first without PRD → user decision needed (intent present) or needs evidence", () => {
+  const g = createAcceptanceGraph({
+    intent: { summary: "s", targetFirstUser: "u", desiredBehaviorChange: "b" },
+    implementation: { repo: "r", branch: "main", changedFiles: ["src/x.ts"], tests: [] },
+  });
+  const pack = deriveEvidencePack(g);
+  const gate = classifyGateDecision(pack);
+  assert.ok(listUserDecisionNeeded(pack).length > 0);
+  assert.equal(gate.decision, "User Acceptance Required");
+});
+
+// 4. PRD + implementation, one criterion covered, one missing → receipt separates verified/not.
+test("PRD + impl partial coverage → receipt separates verified and not verified", () => {
+  const g = createAcceptanceGraph({
+    intent: { summary: "s", targetFirstUser: "u", desiredBehaviorChange: "b" },
+    prd: {
+      summary: "p",
+      acceptanceCriteria: [
+        { id: "AC1", text: "covered" },
+        { id: "AC2", text: "uncovered" },
+      ],
+    },
+    visual: { notVerified: false, routesDetected: ["/"], clickableElementsDetected: 1, clickedSafely: 1 },
+    implementation: {
+      repo: "r",
+      changedFiles: ["src/x.ts"],
+      tests: [{ name: "t1", status: "pass", criteriaIds: ["AC1"] }],
+    },
+  });
+  const pack = deriveEvidencePack(g);
+  assert.ok(pack.verified.some((s) => s.includes("AC1")));
+  assert.ok(pack.notVerified.some((s) => s.includes("AC2")));
+  const gate = classifyGateDecision(pack);
+  assert.equal(gate.decision, "Not Verified"); // AC2 still unproven
+});
+
+// 5. Build/test pass but visual evidence missing → must NOT claim product Done.
+test("tests pass but visual evidence missing → product not claimed Done (Not Verified)", () => {
+  const g = createAcceptanceGraph({
+    intent: { summary: "s", targetFirstUser: "u", desiredBehaviorChange: "b" },
+    prd: { summary: "p", acceptanceCriteria: [{ id: "AC1", text: "ui works" }] },
+    implementation: {
+      repo: "r",
+      changedFiles: ["src/x.ts"],
+      ciStatus: "pass",
+      tests: [{ name: "t1", status: "pass", criteriaIds: ["AC1"] }],
+    },
+    // no visual node → visualEvidenceMissing
+  });
+  const pack = deriveEvidencePack(g);
+  assert.equal(pack.riskFlags.visualEvidenceMissing, true);
+  assert.ok(pack.notVerified.some((s) => /visual\/interaction evidence missing/.test(s)));
+  const gate = classifyGateDecision(pack);
+  assert.notEqual(gate.decision, "Ready");
+});
+
+// 6. Implementation makes a UX choice the PRD left ambiguous → userDecisionNeeded populated.
+test("implementation choice over ambiguous PRD → userDecisionNeeded populated", () => {
+  const g = createAcceptanceGraph({
+    intent: { summary: "s", targetFirstUser: "u", desiredBehaviorChange: "b" },
+    // PRD present but no acceptance criteria = ambiguous spec
+    prd: { summary: "p", acceptanceCriteria: [] },
+    implementation: { repo: "r", changedFiles: ["src/ui.tsx"], tests: [] },
+  });
+  const pack = deriveEvidencePack(g);
+  assert.ok(listUserDecisionNeeded(pack).length > 0);
+});
+
+// 7. Risk flag detection from changedFiles + diff text.
+test("risk flags detect migration/deploy/env/auth/payment/oauth/D1/destructive deterministically", () => {
+  const g = createAcceptanceGraph({
+    implementation: {
+      repo: "r",
+      changedFiles: [
+        "apps/central-plane/migrations/0049_x.sql",
+        ".github/workflows/deploy-central-plane.yml",
+        "apps/central-plane/wrangler.toml",
+        "apps/central-plane/src/auth-signup-policy.ts",
+        "apps/central-plane/src/routes/billing.ts",
+        "apps/central-plane/src/routes/oauth.ts",
+        "apps/central-plane/src/routes/cors.ts",
+      ],
+      diffSummary: "INSERT INTO workspace_members ...; DROP TABLE old;",
+      tests: [],
+    },
+  });
+  const f = deriveRiskFlags(g);
+  assert.equal(f.migrationChanged, true);
+  assert.equal(f.deployConfigChanged, true);
+  assert.equal(f.envSecretTouched, true);
+  assert.equal(f.authPolicyTouched, true);
+  assert.equal(f.paymentTouched, true);
+  assert.equal(f.oauthTouched, true);
+  assert.equal(f.dnsCorsTouched, true);
+  assert.equal(f.d1WriteDetected, true);
+  assert.equal(f.destructiveActionDetected, true);
+  const pack = deriveEvidencePack(g);
+  assert.equal(pack.humanGateRequired, true);
+  assert.ok(pack.requiredApprovalPhrase && pack.requiredApprovalPhrase.length > 0);
+});
+
+test("no risk → no hard gate, no approval phrase required", () => {
+  const g = createAcceptanceGraph({
+    intent: { summary: "s", targetFirstUser: "u", desiredBehaviorChange: "b" },
+    prd: { summary: "p", acceptanceCriteria: [{ id: "AC1", text: "x" }] },
+    visual: { notVerified: false },
+    implementation: { repo: "r", changedFiles: ["docs/readme.md"], diffSummary: "text", tests: [{ name: "t1", status: "pass", criteriaIds: ["AC1"] }] },
+  });
+  const pack = deriveEvidencePack(g);
+  assert.equal(pack.humanGateRequired, false);
+  assert.equal(pack.requiredApprovalPhrase, null);
+  assert.equal(classifyGateDecision(pack).decision, "Ready");
+});
+
+// 8. No numeric scoring anywhere in the receipt.
+test("receipt carries NO numeric score; assertNoNumericScores passes for valid receipts", () => {
+  const g = createAcceptanceGraph({
+    intent: { summary: "s", targetFirstUser: "u", desiredBehaviorChange: "b" },
+    prd: { summary: "p", acceptanceCriteria: [{ id: "AC1", text: "x" }] },
+    implementation: { repo: "r", tests: [{ name: "t1", status: "pass", criteriaIds: ["AC1"] }] },
+  });
+  const receipt = createReceipt(deriveEvidencePack(g));
+  assert.equal(assertNoNumericScores(receipt), true);
+  assert.ok(!("score" in receipt));
+  // summary uses a readiness state, not a number
+  assert.ok(!/\b\d{1,3}\s*\/\s*100\b/.test(receipt.summary));
+});
+
+test("assertNoNumericScores throws if a score field or NN/100 string is injected", () => {
+  const bad1 = { receiptType: "build", summary: "ok", changed: [], improved: [], verified: ["score: 82"], broken: [], notVerified: [], skipped: [], userDecisionNeeded: [], requiredHumanGate: false, nextSafestAction: "", limitations: [] };
+  assert.throws(() => assertNoNumericScores(bad1), /numeric scoring is forbidden/);
+  const bad2 = { receiptType: "build", summary: "quality 82/100", changed: [], improved: [], verified: [], broken: [], notVerified: [], skipped: [], userDecisionNeeded: [], requiredHumanGate: false, nextSafestAction: "", limitations: [] };
+  assert.throws(() => assertNoNumericScores(bad2), /numeric scoring is forbidden/);
+  const bad3 = { receiptType: "build", summary: "ok", overallScore: 90, changed: [], improved: [], verified: [], broken: [], notVerified: [], skipped: [], userDecisionNeeded: [], requiredHumanGate: false, nextSafestAction: "", limitations: [] };
+  assert.throws(() => assertNoNumericScores(bad3), /numeric scoring is forbidden/);
+});
+
+test("createReceipt is deterministic: same input → identical receipt", () => {
+  const input = {
+    intent: { summary: "s", targetFirstUser: "u", desiredBehaviorChange: "b" },
+    prd: { summary: "p", acceptanceCriteria: [{ id: "AC1", text: "x" }] },
+    implementation: { repo: "r", changedFiles: ["src/x.ts"], tests: [{ name: "t1", status: "pass", criteriaIds: ["AC1"] }] },
+  };
+  const r1 = createReceipt(deriveEvidencePack(createAcceptanceGraph(input)));
+  const r2 = createReceipt(deriveEvidencePack(createAcceptanceGraph(input)));
+  assert.deepEqual(r1, r2);
+});

--- a/docs/simsa-acceptance-graph.md
+++ b/docs/simsa-acceptance-graph.md
@@ -1,0 +1,116 @@
+# Simsa Acceptance Graph
+
+> **Status:** Foundation (Stage 257A). Defines the data contracts and pure deterministic helpers
+> for Simsa's core acceptance system. This stage ships **contracts + helpers + tests only** — it does
+> NOT run a browser/interaction runner, does NOT mutate data, and does NOT enable auto-merge. See
+> `docs/simsa-autopilot-operating-model.md` for the governing policy (this file implements its
+> Part II product-boundary rules).
+
+## Why Simsa is not a code-review wrapper
+
+A code-review tool answers "is this diff acceptable?" Simsa answers a larger question: **"has the
+user's intent been translated, without silent gaps, into a PRD, a build plan, an implementation, and
+verifiable acceptance evidence?"** The diff is one node in that chain, not the whole story.
+
+## Why Simsa is not a generic QA tool
+
+A generic QA tool runs tests and reports pass/fail. Simsa tracks **what could not be verified** as a
+first-class outcome. Absent evidence is reported **Not Verified**, never **Pass**. Tests passing while
+the product UI was never exercised is reported honestly, not as "Done".
+
+## The Acceptance Graph
+
+A normalized, deterministic graph linking the artifacts of a project:
+
+```
+Idea / Intent → Clarifying Answers → PRD → Acceptance Criteria
+   → Build Plan → Implementation Evidence → Cross-Review Evidence
+   → Visual / Interaction Evidence → Gate Decision → Receipt
+```
+
+Nodes (see `apps/central-plane/src/acceptance-graph.ts`):
+
+1. **User Intent** — summary, target first user, desired behavior change, non-goals, assumptions, unknowns.
+2. **Clarifying Answers** — question/answer pairs with why they were asked and what they affect.
+3. **PRD** — requirements, user flows, **acceptance criteria** (id + text), edge cases, out-of-scope.
+4. **Build Plan** — tasks, task→criteria links, dependencies, risk notes.
+5. **Implementation Evidence** — repo/branch/PR, changed files, diff summary, **tests linked to criteria**, CI status, deployment status.
+6. **Cross-Review Evidence** — reviewer/role, findings, severity, affected criteria, unresolved blockers.
+7. **Visual / Interaction Evidence** — *contract only in this stage*: routes detected, clickable elements, safe clicks, skipped-destructive, auth-blocked, failed interactions, screenshots, console/network errors, `notVerified`.
+8. **Gate Decision** — decision state, reasons, verified / broken / not-verified, user decision needed, human-gate required, next safest action.
+9. **Receipt** — the durable, shareable artifact (no numeric score).
+
+## Intake support: idea / PRD / repo / mixed
+
+Simsa supports projects that enter from any direction:
+
+- **idea-only** → has intent, lacks PRD → decision tends to *Needs Clarification* / *Needs Evidence*.
+- **PRD-first** → criteria exist, implementation does not → implementation is *Not Verified*.
+- **repo-first** → code exists, intent/PRD missing → *User Acceptance Required* (confirm the code matches intent).
+- **mixed** → more than one of the above.
+
+Intake is inferred deterministically (`deriveIntakeSource`) when not declared.
+
+## Product evidence vs engineering evidence vs visual evidence
+
+- **Product evidence** — is there intent? a PRD? acceptance criteria to verify against?
+- **Engineering evidence** — tests (pass/fail/skipped, linked to criteria), CI status, deployment status.
+- **Visual evidence** — did the actual rendered product behave? **When missing, product/UI behavior is
+  Not Verified** regardless of how many unit tests passed (`visualEvidenceMissing` risk flag).
+
+## Verified / Broken / Not Verified / User Decision Needed
+
+Per acceptance criterion, status is derived deterministically from linked test observations:
+
+- a **failing** linked test → **broken**
+- else a **passing** linked test → **verified**
+- else (no linked test, or only skipped) → **not verified**
+
+`User Acceptance Required` is raised when an implementation makes a choice the PRD left ambiguous, or a
+repo-first project lacks a PRD — a human accept/reject is needed, not a Simsa verdict.
+
+## Decision states (no numeric scoring)
+
+`Ready · Conditionally Ready · Needs Clarification · Needs Evidence · Needs Expert Review · Not
+Applicable · Not Judged · Do Not Build Yet · Not Verified · Needs Fix · User Acceptance Required`.
+
+There is **no** "82/100", no "PRD Score", no "Founder Score". `assertNoNumericScores` guards receipts
+against any numeric-score field or `NN/100` string.
+
+## Evidence pack & risk flags
+
+`deriveEvidencePack` (see `apps/central-plane/src/evidence-pack.ts`) compiles the graph into a
+deterministic pack. Risk flags are **booleans derived from changed-file paths + diff text**, never from
+agent prose (policy §12): `migrationChanged · deployConfigChanged · envSecretTouched · authPolicyTouched
+· paymentTouched · oauthTouched · dnsCorsTouched · d1WriteDetected · destructiveActionDetected ·
+workspaceClaimTouched · publicLaunchTouched · visualEvidenceMissing · acceptanceCriteriaMissing ·
+userIntentAmbiguous`. Any of the first eleven forces a **hard human gate** and a required approval
+phrase.
+
+## Cross-agent review position
+
+Cross-review evidence is a node, not a score. Unresolved blockers are treated as **broken** signals
+(something is actively wrong), which outrank "not verified" in the gate decision. Automated cross-agent
+review wiring is a later stage (259A); this stage only defines where its evidence attaches.
+
+## Visual / interaction gate position
+
+The visual node is a **contract** here. A real runner (route discovery, safe-click coverage, skip of
+destructive actions, screenshot/console/network capture) is a later spike (260A). Until then, every
+project with UI behavior reports `visualEvidenceMissing = true` and is **Not Verified** at the product
+level — by design, so Simsa never over-claims.
+
+## Limitations (explicit)
+
+- Simsa does **not** claim to find all bugs.
+- Simsa does **not** claim to produce a perfect or "100% ideal" product.
+- Risk flags read file paths and diff text; they do not execute the diff.
+- Visual evidence is not yet collected — UI behavior is unverified until the runner lands.
+- Simsa does not certify market/founder/legal/medical/financial/scientific claims (policy §22).
+
+## Future stages
+
+- **258A** — Artifact Alignment Gate (PRD ↔ implementation coverage).
+- **259A** — Cross-Agent Review Evidence automation.
+- **260A** — Visual / Interaction Coverage Gate (the real runner).
+- later — Receipt UI surface in the dashboard.


### PR DESCRIPTION
Adds the foundational, pure-deterministic data contracts + helpers + tests for Simsa's intent-to-implementation acceptance system. Implements the Part II product-boundary rules from `docs/simsa-autopilot-operating-model.md`.

**What's added (code-readiness only):**
- `apps/central-plane/src/acceptance-graph.ts` — Acceptance Graph contracts (intent → clarifying answers → PRD → build plan → implementation → cross-review → visual/interaction → gate decision → receipt), intake inference, per-criterion gap status (verified/broken/not_verified).
- `apps/central-plane/src/evidence-pack.ts` — deterministic evidence pack, risk flags (booleans from changed-file paths + diff text, never agent prose), gate decision classifier, receipt builder, `assertNoNumericScores` guard.
- `apps/central-plane/test/{acceptance-graph,evidence-pack}.test.mjs` — 19 tests covering idea-only / PRD-first / repo-first / partial coverage / visual-missing / implementation-choice / risk-flag detection / no-numeric-scoring.
- `docs/simsa-acceptance-graph.md` — contract + boundary documentation.

**Boundaries honored:**
- pure helpers/tests/docs only — **no route wired into the router**, no DB, no env, no LLM, no network
- no production deploy · no production D1 mutation · no migration · no env/secret changes
- no auth policy change · no auto-merge enabled · **no browser automation against production**
- **no numeric scoring** — readiness states only; absent evidence is Not Verified, never Pass
- no claim that Simsa finds all bugs or produces a perfect product (documented limitations)

**Verification:** central-plane build OK · new tests 19/19 · full central-plane suite 1265/1265 · typecheck 57/57 · pnpm verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)