### PR TITLE
Stage 261 — Unified project sources + persisted visual checks (R2 evidence)

### DIFF
--- a/.github/workflows/deploy-central-plane.yml
+++ b/.github/workflows/deploy-central-plane.yml
@@ -63,6 +63,16 @@ jobs:
       - name: Build central-plane (+ core dep)
         run: pnpm turbo run build --filter @conclave-ai/central-plane
 
+      - name: Ensure R2 bucket (Stage 261 — idempotent)
+        working-directory: apps/central-plane
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Create the evidence bucket if missing; "already exists" is fine —
+          # the wrangler deploy step below fails loudly if it's truly absent.
+          npx wrangler r2 bucket create simsa-evidence || echo "bucket exists or create skipped (deploy verifies)"
+
       - name: Apply D1 migrations
         if: inputs.apply-migrations != 'false'
         working-directory: apps/central-plane

--- a/apps/central-plane/migrations/0049_project_sources.sql
+++ b/apps/central-plane/migrations/0049_project_sources.sql
@@ -1,0 +1,25 @@
+-- Stage 261 — Project source connections (ADDITIVE).
+--
+-- A project can be connected to multiple sources, unified in one table:
+--   * website     — deployed app URL (visual completion-check target)
+--   * github_repo — owner/repo (PR review / repair-PR target; the existing
+--                   workspace-github connection keeps working — this row is the
+--                   unified registry entry, no destructive change)
+--   * document    — uploaded PRD / spec / md file, stored in R2 (reference = R2 key)
+--
+-- Safety: CREATE TABLE/INDEX IF NOT EXISTS only. No ALTER, no data mutation.
+
+CREATE TABLE IF NOT EXISTS project_sources (
+  id           TEXT NOT NULL PRIMARY KEY,
+  project_id   TEXT NOT NULL,
+  user_key     TEXT NOT NULL,
+  type         TEXT NOT NULL CHECK (type IN ('website', 'github_repo', 'document')),
+  reference    TEXT NOT NULL,           -- url | owner/repo | R2 object key
+  label        TEXT,                    -- user-facing name (e.g. "PRD v2")
+  content_type TEXT,                    -- documents only
+  size_bytes   INTEGER,                 -- documents only
+  created_at   TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_sources_project ON project_sources (project_id);
+CREATE INDEX IF NOT EXISTS idx_project_sources_user ON project_sources (user_key);

--- a/apps/central-plane/migrations/0050_workspace_visual_checks.sql
+++ b/apps/central-plane/migrations/0050_workspace_visual_checks.sql
@@ -1,0 +1,34 @@
+-- Stage 261 — Simsa visual completion-check runs (ADDITIVE).
+--
+-- One row per visual inspection of a project's deployed app. The full Korean
+-- non-dev report (nondev-report.ts NonDevReport) is snapshotted in report_json;
+-- screenshots / video live in R2 under checks/{user_key}/{project_id}/{id}/
+-- and their keys are tracked in evidence_keys_json.
+--
+-- executor: 'local' = operator/concierge ran visual-run.mjs and uploaded;
+--           'container' = cloud SimsaInspector run (Phase 2).
+-- NO numeric score column by design (Simsa policy §20) — works is tri-state.
+--
+-- Safety: CREATE TABLE/INDEX IF NOT EXISTS only. No ALTER, no data mutation.
+
+CREATE TABLE IF NOT EXISTS workspace_visual_checks (
+  id                 TEXT NOT NULL PRIMARY KEY,
+  project_id         TEXT NOT NULL,
+  user_key           TEXT NOT NULL,
+  target_url         TEXT NOT NULL,
+  intent             TEXT NOT NULL,
+  decision           TEXT NOT NULL,          -- e.g. "Needs Fix" / "Ready" (11-state ladder)
+  works              INTEGER,                -- 1 = works, 0 = broken, NULL = not verified
+  status             TEXT NOT NULL DEFAULT 'uploaded'
+                     CHECK (status IN ('uploaded', 'queued', 'running', 'done', 'failed')),
+  executor           TEXT NOT NULL DEFAULT 'local'
+                     CHECK (executor IN ('local', 'container')),
+  report_json        TEXT NOT NULL,
+  agent_prompt       TEXT,
+  evidence_keys_json TEXT NOT NULL DEFAULT '[]',
+  created_at         TEXT NOT NULL,
+  updated_at         TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_visual_checks_project ON workspace_visual_checks (project_id);
+CREATE INDEX IF NOT EXISTS idx_workspace_visual_checks_user ON workspace_visual_checks (user_key);

--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -76,6 +76,14 @@ export interface Env {
    */
   SANDBOX?: DurableObjectNamespace;
   /**
+   * Stage 261 — R2 bucket `simsa-evidence`: visual-check evidence
+   * (screenshots/video under checks/{userKey}/{projectId}/{runId}/) and
+   * uploaded project documents (PRD/md under docs/{userKey}/{projectId}/).
+   * Optional: without the binding, document upload and evidence routes
+   * return 503 (evidence_storage_unconfigured); everything else works.
+   */
+  EVIDENCE?: R2Bucket;
+  /**
    * v0.16.2 — bearer token the container uses when calling back to
    * /internal/job-done. Random per deploy. Set via `wrangler secret put
    * INTERNAL_CALLBACK_TOKEN`. Without it /internal/job-done refuses calls.

--- a/apps/central-plane/src/router.ts
+++ b/apps/central-plane/src/router.ts
@@ -36,6 +36,8 @@ import { createWorkspaceAdminStatsRoutes } from "./routes/workspace-admin-stats.
 import { createWorkspaceAdminCreditsRoutes } from "./routes/workspace-admin-credits.js";
 import { createWorkspaceCreditsRoutes } from "./routes/workspace-credits.js";
 import { createWorkspaceBenchmarkRoutes } from "./routes/workspace-benchmark.js";
+import { createWorkspaceSourcesRoutes } from "./routes/workspace-sources.js";
+import { createWorkspaceVisualChecksRoutes } from "./routes/workspace-visual-checks.js";
 import { createWorkspaceExperimentRoutes } from "./routes/workspace-experiment.js";
 import { createWorkspaceAgentWorkflowRoutes } from "./routes/workspace-agent-workflow.js";
 import { createWorkspaceMembershipRoutes } from "./routes/workspace-membership.js";
@@ -148,6 +150,10 @@ export function createApp(opts: { fetch?: FetchLike } = {}): Hono<{ Bindings: En
   app.route("/", createWorkspaceCreditsRoutes());
   // Stage 65 — Persisted Multi-Agent Build Benchmark.
   app.route("/", createWorkspaceBenchmarkRoutes());
+  // Stage 261 — Unified project sources (website / github_repo / document upload → R2).
+  app.route("/", createWorkspaceSourcesRoutes());
+  // Stage 261 — Simsa visual completion-check runs (report snapshots + R2 evidence).
+  app.route("/", createWorkspaceVisualChecksRoutes());
   // Stage 72 — Persisted Manual Multi-Agent Experiments.
   app.route("/", createWorkspaceExperimentRoutes());
   // Stage 112 — Persisted Agent Workflow Records (intake snapshot save/list/read).

--- a/apps/central-plane/src/routes/workspace-sources.ts
+++ b/apps/central-plane/src/routes/workspace-sources.ts
@@ -1,0 +1,257 @@
+/**
+ * workspace-sources.ts — Stage 261
+ *
+ * Unified project source connections (website / github_repo / document).
+ *
+ * POST   /workspace/projects/:id/sources                    — connect website or github_repo (JSON)
+ * POST   /workspace/projects/:id/sources/document           — upload PRD/md/txt/pdf (multipart, R2)
+ * GET    /workspace/projects/:id/sources?userKey=            — list
+ * GET    /workspace/projects/:id/sources/:sourceId/file      — download an uploaded document (R2 proxy)
+ * DELETE /workspace/projects/:id/sources/:sourceId?userKey=  — disconnect (deletes R2 object for documents)
+ *
+ * Ownership is enforced server-side: the project must belong to the userKey.
+ * Document storage requires the EVIDENCE R2 binding; without it those routes
+ * return 503 (evidence_storage_unconfigured) and the JSON source types keep working.
+ */
+import { Hono } from "hono";
+import { corsMiddleware } from "./cors.js";
+import type { Env } from "../env.js";
+import { getProject } from "../workspace/db.js";
+import {
+  insertProjectSource,
+  listProjectSources,
+  getProjectSourceById,
+  deleteProjectSource,
+} from "../workspace/project-sources-db.js";
+
+const MAX_DOCUMENT_BYTES = 10 * 1024 * 1024; // 10MB
+const MAX_LABEL_LEN = 120;
+const MAX_REFERENCE_LEN = 500;
+const MAX_SOURCES_PER_PROJECT = 50;
+
+const DOCUMENT_EXTENSIONS: Record<string, string> = {
+  md: "text/markdown",
+  txt: "text/plain",
+  pdf: "application/pdf",
+};
+
+/** owner/repo — same shape GitHub accepts. */
+const GITHUB_REPO_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]{1,100}$/;
+
+function isValidHttpUrl(s: string): boolean {
+  try {
+    const u = new URL(s);
+    return u.protocol === "https:" || u.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+/** Keep only a safe basename for the R2 key (no traversal, no odd chars). */
+function safeFilename(name: string): string {
+  const base = name.split(/[\\/]/).pop() ?? "file";
+  return base.replace(/[^A-Za-z0-9._-]+/g, "_").slice(0, 120) || "file";
+}
+
+async function requireOwnedProject(
+  env: Env,
+  projectId: string,
+  userKey: string,
+): Promise<{ ok: true } | { ok: false; status: 403 | 404; error: string }> {
+  const project = await getProject(env, projectId);
+  if (!project) return { ok: false, status: 404, error: "project_not_found" };
+  if (project.userKey !== userKey) return { ok: false, status: 403, error: "forbidden" };
+  return { ok: true };
+}
+
+export function createWorkspaceSourcesRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", corsMiddleware);
+
+  // ── POST /workspace/projects/:id/sources (website | github_repo) ───────────
+  app.post("/workspace/projects/:id/sources", async (c) => {
+    const projectId = c.req.param("id");
+
+    let body: { userKey?: unknown; type?: unknown; reference?: unknown; label?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ ok: false, error: "invalid_json" }, 400);
+    }
+
+    const userKey = typeof body.userKey === "string" ? body.userKey : "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    const type = body.type;
+    if (type !== "website" && type !== "github_repo") {
+      // documents go through the multipart route
+      return c.json({ ok: false, error: "invalid_type" }, 400);
+    }
+
+    const reference = typeof body.reference === "string" ? body.reference.trim() : "";
+    if (!reference || reference.length > MAX_REFERENCE_LEN) {
+      return c.json({ ok: false, error: "invalid_reference" }, 400);
+    }
+    if (type === "website" && !isValidHttpUrl(reference)) {
+      return c.json({ ok: false, error: "invalid_url" }, 400);
+    }
+    if (type === "github_repo" && !GITHUB_REPO_RE.test(reference)) {
+      return c.json({ ok: false, error: "invalid_repo" }, 400);
+    }
+
+    const label = typeof body.label === "string" ? body.label.trim().slice(0, MAX_LABEL_LEN) : undefined;
+
+    const owned = await requireOwnedProject(c.env, projectId, userKey);
+    if (!owned.ok) return c.json({ ok: false, error: owned.error }, owned.status);
+
+    try {
+      const existing = await listProjectSources(c.env, projectId);
+      if (existing.length >= MAX_SOURCES_PER_PROJECT) {
+        return c.json({ ok: false, error: "source_limit_reached" }, 400);
+      }
+      const source = await insertProjectSource(c.env, { projectId, userKey, type, reference, label });
+      return c.json({ ok: true, source }, 201);
+    } catch (err) {
+      console.error("[workspace/sources POST] failed:", err);
+      return c.json({ ok: false, error: "save_failed" }, 500);
+    }
+  });
+
+  // ── POST /workspace/projects/:id/sources/document (multipart upload → R2) ──
+  app.post("/workspace/projects/:id/sources/document", async (c) => {
+    const projectId = c.req.param("id");
+    if (!c.env.EVIDENCE) return c.json({ ok: false, error: "evidence_storage_unconfigured" }, 503);
+
+    let form: FormData;
+    try {
+      form = await c.req.formData();
+    } catch {
+      return c.json({ ok: false, error: "invalid_form" }, 400);
+    }
+
+    const userKey = typeof form.get("userKey") === "string" ? (form.get("userKey") as string) : "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    // Workers' FormData typing narrows entries to string; duck-type the File.
+    const entry = form.get("file") as unknown;
+    const isFileLike =
+      entry !== null &&
+      typeof entry === "object" &&
+      typeof (entry as File).arrayBuffer === "function" &&
+      typeof (entry as File).size === "number";
+    if (!isFileLike) return c.json({ ok: false, error: "file_required" }, 400);
+    const file = entry as File;
+    if (file.size <= 0 || file.size > MAX_DOCUMENT_BYTES) {
+      return c.json({ ok: false, error: "file_too_large" }, 400);
+    }
+
+    const filename = safeFilename(file.name || "document");
+    const ext = filename.includes(".") ? filename.split(".").pop()!.toLowerCase() : "";
+    const contentType = DOCUMENT_EXTENSIONS[ext];
+    if (!contentType) return c.json({ ok: false, error: "unsupported_file_type" }, 400);
+
+    const rawLabel = form.get("label");
+    const label = typeof rawLabel === "string" && rawLabel.trim() ? rawLabel.trim().slice(0, MAX_LABEL_LEN) : filename;
+
+    const owned = await requireOwnedProject(c.env, projectId, userKey);
+    if (!owned.ok) return c.json({ ok: false, error: owned.error }, owned.status);
+
+    try {
+      const existing = await listProjectSources(c.env, projectId);
+      if (existing.length >= MAX_SOURCES_PER_PROJECT) {
+        return c.json({ ok: false, error: "source_limit_reached" }, 400);
+      }
+
+      // Insert first so the R2 key embeds the source id (stable, collision-free).
+      const source = await insertProjectSource(c.env, {
+        projectId,
+        userKey,
+        type: "document",
+        reference: "pending",
+        label,
+        contentType,
+        sizeBytes: file.size,
+      });
+      const key = `docs/${userKey}/${projectId}/${source.id}/${filename}`;
+      await c.env.EVIDENCE.put(key, await file.arrayBuffer(), { httpMetadata: { contentType } });
+      await c.env.DB.prepare(`UPDATE project_sources SET reference = ? WHERE id = ?`).bind(key, source.id).run();
+
+      return c.json({ ok: true, source: { ...source, reference: key } }, 201);
+    } catch (err) {
+      console.error("[workspace/sources document POST] failed:", err);
+      return c.json({ ok: false, error: "upload_failed" }, 500);
+    }
+  });
+
+  // ── GET /workspace/projects/:id/sources ────────────────────────────────────
+  app.get("/workspace/projects/:id/sources", async (c) => {
+    const projectId = c.req.param("id");
+    const userKey = c.req.query("userKey") ?? "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    const owned = await requireOwnedProject(c.env, projectId, userKey);
+    if (!owned.ok) return c.json({ ok: false, error: owned.error }, owned.status);
+
+    try {
+      const sources = await listProjectSources(c.env, projectId);
+      return c.json({ ok: true, sources });
+    } catch (err) {
+      console.error("[workspace/sources GET] failed:", err);
+      return c.json({ ok: false, error: "query_failed" }, 500);
+    }
+  });
+
+  // ── GET /workspace/projects/:id/sources/:sourceId/file (document download) ─
+  app.get("/workspace/projects/:id/sources/:sourceId/file", async (c) => {
+    const projectId = c.req.param("id");
+    const sourceId = c.req.param("sourceId");
+    const userKey = c.req.query("userKey") ?? "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+    if (!c.env.EVIDENCE) return c.json({ ok: false, error: "evidence_storage_unconfigured" }, 503);
+
+    try {
+      const source = await getProjectSourceById(c.env, sourceId);
+      if (!source || source.projectId !== projectId || source.type !== "document") {
+        return c.json({ ok: false, error: "not_found" }, 404);
+      }
+      if (source.userKey !== userKey) return c.json({ ok: false, error: "forbidden" }, 403);
+
+      const obj = await c.env.EVIDENCE.get(source.reference);
+      if (!obj) return c.json({ ok: false, error: "not_found" }, 404);
+      return new Response(obj.body, {
+        headers: {
+          "content-type": source.contentType ?? "application/octet-stream",
+          "cache-control": "private, max-age=60",
+        },
+      });
+    } catch (err) {
+      console.error("[workspace/sources file GET] failed:", err);
+      return c.json({ ok: false, error: "query_failed" }, 500);
+    }
+  });
+
+  // ── DELETE /workspace/projects/:id/sources/:sourceId ───────────────────────
+  app.delete("/workspace/projects/:id/sources/:sourceId", async (c) => {
+    const projectId = c.req.param("id");
+    const sourceId = c.req.param("sourceId");
+    const userKey = c.req.query("userKey") ?? "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    try {
+      const source = await getProjectSourceById(c.env, sourceId);
+      if (!source || source.projectId !== projectId) return c.json({ ok: false, error: "not_found" }, 404);
+      if (source.userKey !== userKey) return c.json({ ok: false, error: "forbidden" }, 403);
+
+      if (source.type === "document" && c.env.EVIDENCE && source.reference !== "pending") {
+        await c.env.EVIDENCE.delete(source.reference).catch(() => {});
+      }
+      await deleteProjectSource(c.env, sourceId);
+      return c.json({ ok: true });
+    } catch (err) {
+      console.error("[workspace/sources DELETE] failed:", err);
+      return c.json({ ok: false, error: "delete_failed" }, 500);
+    }
+  });
+
+  return app;
+}

--- a/apps/central-plane/src/routes/workspace-visual-checks.ts
+++ b/apps/central-plane/src/routes/workspace-visual-checks.ts
@@ -1,0 +1,278 @@
+/**
+ * workspace-visual-checks.ts — Stage 261
+ *
+ * Simsa visual completion-check runs: persisted reports + R2 evidence.
+ *
+ * POST /workspace/projects/:id/visual-checks                        — save a run (report + prompt, JSON)
+ * POST /workspace/projects/:id/visual-checks/:runId/evidence?name=  — upload one evidence file (raw body → R2)
+ * GET  /workspace/projects/:id/visual-checks?userKey=                — list (lightweight)
+ * GET  /workspace/projects/:id/visual-checks/:runId?userKey=         — detail (report + agent prompt + evidence keys)
+ * GET  /workspace/projects/:id/visual-checks/:runId/evidence/*       — serve one evidence file (R2 proxy)
+ *
+ * Ownership enforced server-side (project belongs to userKey; run belongs to
+ * both). Evidence names are allowlisted (screenshots/*.png|jpg, video/*.webm)
+ * so R2 keys are always checks/{userKey}/{projectId}/{runId}/{name}.
+ * NO numeric score anywhere (Simsa policy §20).
+ */
+import { Hono } from "hono";
+import { corsMiddleware } from "./cors.js";
+import type { Env } from "../env.js";
+import { getProject } from "../workspace/db.js";
+import {
+  insertVisualCheck,
+  listVisualChecks,
+  getVisualCheckById,
+  appendVisualCheckEvidenceKey,
+  VISUAL_CHECK_EXECUTORS,
+} from "../workspace/visual-check-db.js";
+import type { VisualCheckExecutor, DbVisualCheck } from "../workspace/visual-check-db.js";
+
+const MAX_REPORT_BYTES = 512 * 1024; // 512KB report snapshot
+const MAX_PROMPT_BYTES = 64 * 1024;
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024; // 8MB per screenshot
+const MAX_VIDEO_BYTES = 100 * 1024 * 1024; // 100MB flow video
+const MAX_EVIDENCE_FILES = 30;
+
+/** Allowed evidence names → content type. Keeps R2 keys fully server-shaped. */
+const EVIDENCE_NAME_RE = /^(screenshots\/[A-Za-z0-9._-]{1,80}\.(png|jpg|jpeg)|video\/[A-Za-z0-9._-]{1,80}\.webm)$/;
+
+function evidenceContentType(name: string): string {
+  if (name.endsWith(".webm")) return "video/webm";
+  if (name.endsWith(".png")) return "image/png";
+  return "image/jpeg";
+}
+
+async function requireOwnedProject(
+  env: Env,
+  projectId: string,
+  userKey: string,
+): Promise<{ ok: true } | { ok: false; status: 403 | 404; error: string }> {
+  const project = await getProject(env, projectId);
+  if (!project) return { ok: false, status: 404, error: "project_not_found" };
+  if (project.userKey !== userKey) return { ok: false, status: 403, error: "forbidden" };
+  return { ok: true };
+}
+
+async function requireOwnedRun(
+  env: Env,
+  projectId: string,
+  runId: string,
+  userKey: string,
+): Promise<{ ok: true; run: DbVisualCheck } | { ok: false; status: 403 | 404; error: string }> {
+  const run = await getVisualCheckById(env, runId);
+  if (!run || run.projectId !== projectId) return { ok: false, status: 404, error: "not_found" };
+  if (run.userKey !== userKey) return { ok: false, status: 403, error: "forbidden" };
+  return { ok: true, run };
+}
+
+export function createWorkspaceVisualChecksRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", corsMiddleware);
+
+  // ── POST /workspace/projects/:id/visual-checks ─────────────────────────────
+  app.post("/workspace/projects/:id/visual-checks", async (c) => {
+    const projectId = c.req.param("id");
+
+    let body: {
+      userKey?: unknown;
+      targetUrl?: unknown;
+      intent?: unknown;
+      decision?: unknown;
+      works?: unknown;
+      executor?: unknown;
+      report?: unknown;
+      agentPrompt?: unknown;
+    };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ ok: false, error: "invalid_json" }, 400);
+    }
+
+    const userKey = typeof body.userKey === "string" ? body.userKey : "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    const targetUrl = typeof body.targetUrl === "string" ? body.targetUrl.trim() : "";
+    const intent = typeof body.intent === "string" ? body.intent.trim() : "";
+    const decision = typeof body.decision === "string" ? body.decision.trim() : "";
+    if (!targetUrl || targetUrl.length > 500) return c.json({ ok: false, error: "invalid_target_url" }, 400);
+    if (!intent || intent.length > 1000) return c.json({ ok: false, error: "invalid_intent" }, 400);
+    if (!decision || decision.length > 64) return c.json({ ok: false, error: "invalid_decision" }, 400);
+
+    const works = body.works === true ? true : body.works === false ? false : null;
+
+    const executor: VisualCheckExecutor = VISUAL_CHECK_EXECUTORS.includes(body.executor as VisualCheckExecutor)
+      ? (body.executor as VisualCheckExecutor)
+      : "local";
+
+    if (body.report === undefined || body.report === null || typeof body.report !== "object") {
+      return c.json({ ok: false, error: "report_required" }, 400);
+    }
+    const reportJson = JSON.stringify(body.report);
+    if (reportJson.length > MAX_REPORT_BYTES) return c.json({ ok: false, error: "report_too_large" }, 400);
+
+    const agentPrompt = typeof body.agentPrompt === "string" ? body.agentPrompt : undefined;
+    if (agentPrompt && agentPrompt.length > MAX_PROMPT_BYTES) {
+      return c.json({ ok: false, error: "agent_prompt_too_large" }, 400);
+    }
+
+    const owned = await requireOwnedProject(c.env, projectId, userKey);
+    if (!owned.ok) return c.json({ ok: false, error: owned.error }, owned.status);
+
+    try {
+      const run = await insertVisualCheck(c.env, {
+        projectId,
+        userKey,
+        targetUrl,
+        intent,
+        decision,
+        works,
+        executor,
+        reportJson,
+        agentPrompt,
+      });
+      return c.json(
+        {
+          ok: true,
+          check: {
+            id: run.id,
+            projectId,
+            targetUrl: run.targetUrl,
+            decision: run.decision,
+            works: run.works,
+            status: run.status,
+            executor: run.executor,
+            createdAt: run.createdAt,
+          },
+        },
+        201,
+      );
+    } catch (err) {
+      console.error("[workspace/visual-checks POST] failed:", err);
+      return c.json({ ok: false, error: "save_failed" }, 500);
+    }
+  });
+
+  // ── POST /workspace/projects/:id/visual-checks/:runId/evidence?name=... ────
+  app.post("/workspace/projects/:id/visual-checks/:runId/evidence", async (c) => {
+    const projectId = c.req.param("id");
+    const runId = c.req.param("runId");
+    const userKey = c.req.query("userKey") ?? "";
+    const name = c.req.query("name") ?? "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+    if (!c.env.EVIDENCE) return c.json({ ok: false, error: "evidence_storage_unconfigured" }, 503);
+    if (!EVIDENCE_NAME_RE.test(name)) return c.json({ ok: false, error: "invalid_evidence_name" }, 400);
+
+    const owned = await requireOwnedRun(c.env, projectId, runId, userKey);
+    if (!owned.ok) return c.json({ ok: false, error: owned.error }, owned.status);
+    if (owned.run.evidenceKeys.length >= MAX_EVIDENCE_FILES) {
+      return c.json({ ok: false, error: "evidence_limit_reached" }, 400);
+    }
+
+    const bytes = await c.req.arrayBuffer();
+    const maxBytes = name.endsWith(".webm") ? MAX_VIDEO_BYTES : MAX_IMAGE_BYTES;
+    if (bytes.byteLength <= 0 || bytes.byteLength > maxBytes) {
+      return c.json({ ok: false, error: "evidence_too_large" }, 400);
+    }
+
+    try {
+      const key = `checks/${userKey}/${projectId}/${runId}/${name}`;
+      await c.env.EVIDENCE.put(key, bytes, { httpMetadata: { contentType: evidenceContentType(name) } });
+      const keys = await appendVisualCheckEvidenceKey(c.env, runId, name);
+      return c.json({ ok: true, name, evidenceCount: keys.length }, 201);
+    } catch (err) {
+      console.error("[workspace/visual-checks evidence POST] failed:", err);
+      return c.json({ ok: false, error: "upload_failed" }, 500);
+    }
+  });
+
+  // ── GET /workspace/projects/:id/visual-checks ──────────────────────────────
+  app.get("/workspace/projects/:id/visual-checks", async (c) => {
+    const projectId = c.req.param("id");
+    const userKey = c.req.query("userKey") ?? "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    const owned = await requireOwnedProject(c.env, projectId, userKey);
+    if (!owned.ok) return c.json({ ok: false, error: owned.error }, owned.status);
+
+    try {
+      const checks = await listVisualChecks(c.env, projectId);
+      return c.json({ ok: true, checks });
+    } catch (err) {
+      console.error("[workspace/visual-checks GET] failed:", err);
+      return c.json({ ok: false, error: "query_failed" }, 500);
+    }
+  });
+
+  // ── GET /workspace/projects/:id/visual-checks/:runId/evidence/* ────────────
+  // (registered BEFORE the :runId detail route so the wildcard wins)
+  app.get("/workspace/projects/:id/visual-checks/:runId/evidence/*", async (c) => {
+    const projectId = c.req.param("id");
+    const runId = c.req.param("runId");
+    const userKey = c.req.query("userKey") ?? "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+    if (!c.env.EVIDENCE) return c.json({ ok: false, error: "evidence_storage_unconfigured" }, 503);
+
+    const marker = `/evidence/`;
+    const path = new URL(c.req.url).pathname;
+    const name = decodeURIComponent(path.slice(path.indexOf(marker) + marker.length));
+    if (!EVIDENCE_NAME_RE.test(name)) return c.json({ ok: false, error: "invalid_evidence_name" }, 400);
+
+    const owned = await requireOwnedRun(c.env, projectId, runId, userKey);
+    if (!owned.ok) return c.json({ ok: false, error: owned.error }, owned.status);
+    if (!owned.run.evidenceKeys.includes(name)) return c.json({ ok: false, error: "not_found" }, 404);
+
+    try {
+      const key = `checks/${userKey}/${projectId}/${runId}/${name}`;
+      const obj = await c.env.EVIDENCE.get(key);
+      if (!obj) return c.json({ ok: false, error: "not_found" }, 404);
+      return new Response(obj.body, {
+        headers: {
+          "content-type": evidenceContentType(name),
+          "cache-control": "private, max-age=300",
+        },
+      });
+    } catch (err) {
+      console.error("[workspace/visual-checks evidence GET] failed:", err);
+      return c.json({ ok: false, error: "query_failed" }, 500);
+    }
+  });
+
+  // ── GET /workspace/projects/:id/visual-checks/:runId ───────────────────────
+  app.get("/workspace/projects/:id/visual-checks/:runId", async (c) => {
+    const projectId = c.req.param("id");
+    const runId = c.req.param("runId");
+    const userKey = c.req.query("userKey") ?? "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    const owned = await requireOwnedRun(c.env, projectId, runId, userKey);
+    if (!owned.ok) return c.json({ ok: false, error: owned.error }, owned.status);
+
+    let report: unknown = null;
+    try {
+      report = JSON.parse(owned.run.reportJson);
+    } catch {
+      report = null;
+    }
+
+    return c.json({
+      ok: true,
+      check: {
+        id: owned.run.id,
+        projectId: owned.run.projectId,
+        targetUrl: owned.run.targetUrl,
+        intent: owned.run.intent,
+        decision: owned.run.decision,
+        works: owned.run.works,
+        status: owned.run.status,
+        executor: owned.run.executor,
+        report,
+        agentPrompt: owned.run.agentPrompt,
+        evidenceKeys: owned.run.evidenceKeys,
+        createdAt: owned.run.createdAt,
+      },
+    });
+  });
+
+  return app;
+}

--- a/apps/central-plane/src/workspace/project-sources-db.ts
+++ b/apps/central-plane/src/workspace/project-sources-db.ts
@@ -1,0 +1,128 @@
+/**
+ * workspace/project-sources-db.ts — Stage 261
+ *
+ * D1 persistence for project source connections (website / github_repo /
+ * document). Documents live in R2 (reference = object key); this table is the
+ * unified registry a project's "connections" panel reads.
+ */
+import type { Env } from "../env.js";
+
+export const SOURCE_TYPES = ["website", "github_repo", "document"] as const;
+export type SourceType = (typeof SOURCE_TYPES)[number];
+
+export type DbProjectSource = {
+  id: string;
+  projectId: string;
+  userKey: string;
+  type: SourceType;
+  reference: string;
+  label?: string;
+  contentType?: string;
+  sizeBytes?: number;
+  createdAt: string;
+};
+
+type RawRow = {
+  id: string;
+  project_id: string;
+  user_key: string;
+  type: SourceType;
+  reference: string;
+  label: string | null;
+  content_type: string | null;
+  size_bytes: number | null;
+  created_at: string;
+};
+
+function randId(): string {
+  const ts = Date.now().toString(36).slice(-6);
+  const r = Math.random().toString(36).slice(2, 6);
+  return `psrc_${ts}${r}`;
+}
+
+function fromRow(row: RawRow): DbProjectSource {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    userKey: row.user_key,
+    type: row.type,
+    reference: row.reference,
+    label: row.label ?? undefined,
+    contentType: row.content_type ?? undefined,
+    sizeBytes: row.size_bytes ?? undefined,
+    createdAt: row.created_at,
+  };
+}
+
+export async function insertProjectSource(
+  env: Env,
+  input: {
+    projectId: string;
+    userKey: string;
+    type: SourceType;
+    reference: string;
+    label?: string;
+    contentType?: string;
+    sizeBytes?: number;
+    now?: string;
+  },
+): Promise<DbProjectSource> {
+  const id = randId();
+  const now = input.now ?? new Date().toISOString();
+  await env.DB.prepare(
+    `INSERT INTO project_sources
+       (id, project_id, user_key, type, reference, label, content_type, size_bytes, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      id,
+      input.projectId,
+      input.userKey,
+      input.type,
+      input.reference,
+      input.label ?? null,
+      input.contentType ?? null,
+      input.sizeBytes ?? null,
+      now,
+    )
+    .run();
+  return {
+    id,
+    projectId: input.projectId,
+    userKey: input.userKey,
+    type: input.type,
+    reference: input.reference,
+    label: input.label,
+    contentType: input.contentType,
+    sizeBytes: input.sizeBytes,
+    createdAt: now,
+  };
+}
+
+export async function listProjectSources(env: Env, projectId: string): Promise<DbProjectSource[]> {
+  const res = await env.DB.prepare(
+    `SELECT id, project_id, user_key, type, reference, label, content_type, size_bytes, created_at
+       FROM project_sources
+      WHERE project_id = ?
+      ORDER BY created_at DESC
+      LIMIT 100`,
+  )
+    .bind(projectId)
+    .all();
+  return ((res?.results ?? []) as RawRow[]).map(fromRow);
+}
+
+export async function getProjectSourceById(env: Env, id: string): Promise<DbProjectSource | null> {
+  const row = (await env.DB.prepare(
+    `SELECT id, project_id, user_key, type, reference, label, content_type, size_bytes, created_at
+       FROM project_sources
+      WHERE id = ?`,
+  )
+    .bind(id)
+    .first()) as RawRow | null;
+  return row ? fromRow(row) : null;
+}
+
+export async function deleteProjectSource(env: Env, id: string): Promise<void> {
+  await env.DB.prepare(`DELETE FROM project_sources WHERE id = ?`).bind(id).run();
+}

--- a/apps/central-plane/src/workspace/visual-check-db.ts
+++ b/apps/central-plane/src/workspace/visual-check-db.ts
@@ -1,0 +1,202 @@
+/**
+ * workspace/visual-check-db.ts — Stage 261
+ *
+ * D1 persistence for Simsa visual completion-check runs. The full non-dev
+ * report snapshot lives in report_json; screenshots/video live in R2 and their
+ * keys are tracked in evidence_keys_json (appended as each file is uploaded).
+ */
+import type { Env } from "../env.js";
+
+export const VISUAL_CHECK_STATUSES = ["uploaded", "queued", "running", "done", "failed"] as const;
+export type VisualCheckStatus = (typeof VISUAL_CHECK_STATUSES)[number];
+
+export const VISUAL_CHECK_EXECUTORS = ["local", "container"] as const;
+export type VisualCheckExecutor = (typeof VISUAL_CHECK_EXECUTORS)[number];
+
+export type DbVisualCheck = {
+  id: string;
+  projectId: string;
+  userKey: string;
+  targetUrl: string;
+  intent: string;
+  decision: string;
+  works: boolean | null;
+  status: VisualCheckStatus;
+  executor: VisualCheckExecutor;
+  reportJson: string;
+  agentPrompt?: string;
+  evidenceKeys: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type VisualCheckListItem = {
+  id: string;
+  targetUrl: string;
+  decision: string;
+  works: boolean | null;
+  status: VisualCheckStatus;
+  executor: VisualCheckExecutor;
+  evidenceCount: number;
+  createdAt: string;
+};
+
+type RawRow = {
+  id: string;
+  project_id: string;
+  user_key: string;
+  target_url: string;
+  intent: string;
+  decision: string;
+  works: number | null;
+  status: VisualCheckStatus;
+  executor: VisualCheckExecutor;
+  report_json: string;
+  agent_prompt: string | null;
+  evidence_keys_json: string;
+  created_at: string;
+  updated_at: string;
+};
+
+function randId(): string {
+  const ts = Date.now().toString(36).slice(-6);
+  const r = Math.random().toString(36).slice(2, 6);
+  return `wvc_${ts}${r}`;
+}
+
+function parseKeys(json: string): string[] {
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((k): k is string => typeof k === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function worksFromDb(n: number | null): boolean | null {
+  if (n === null) return null;
+  return n === 1;
+}
+
+function fromRow(row: RawRow): DbVisualCheck {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    userKey: row.user_key,
+    targetUrl: row.target_url,
+    intent: row.intent,
+    decision: row.decision,
+    works: worksFromDb(row.works),
+    status: row.status,
+    executor: row.executor,
+    reportJson: row.report_json,
+    agentPrompt: row.agent_prompt ?? undefined,
+    evidenceKeys: parseKeys(row.evidence_keys_json),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function insertVisualCheck(
+  env: Env,
+  input: {
+    projectId: string;
+    userKey: string;
+    targetUrl: string;
+    intent: string;
+    decision: string;
+    works: boolean | null;
+    executor: VisualCheckExecutor;
+    reportJson: string;
+    agentPrompt?: string;
+    now?: string;
+  },
+): Promise<DbVisualCheck> {
+  const id = randId();
+  const now = input.now ?? new Date().toISOString();
+  await env.DB.prepare(
+    `INSERT INTO workspace_visual_checks
+       (id, project_id, user_key, target_url, intent, decision, works,
+        status, executor, report_json, agent_prompt, evidence_keys_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'uploaded', ?, ?, ?, '[]', ?, ?)`,
+  )
+    .bind(
+      id,
+      input.projectId,
+      input.userKey,
+      input.targetUrl,
+      input.intent,
+      input.decision,
+      input.works === null ? null : input.works ? 1 : 0,
+      input.executor,
+      input.reportJson,
+      input.agentPrompt ?? null,
+      now,
+      now,
+    )
+    .run();
+  return {
+    id,
+    projectId: input.projectId,
+    userKey: input.userKey,
+    targetUrl: input.targetUrl,
+    intent: input.intent,
+    decision: input.decision,
+    works: input.works,
+    status: "uploaded",
+    executor: input.executor,
+    reportJson: input.reportJson,
+    agentPrompt: input.agentPrompt,
+    evidenceKeys: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export async function listVisualChecks(env: Env, projectId: string): Promise<VisualCheckListItem[]> {
+  const res = await env.DB.prepare(
+    `SELECT id, project_id, user_key, target_url, intent, decision, works,
+            status, executor, report_json, agent_prompt, evidence_keys_json, created_at, updated_at
+       FROM workspace_visual_checks
+      WHERE project_id = ?
+      ORDER BY created_at DESC
+      LIMIT 50`,
+  )
+    .bind(projectId)
+    .all();
+  return ((res?.results ?? []) as RawRow[]).map((row) => ({
+    id: row.id,
+    targetUrl: row.target_url,
+    decision: row.decision,
+    works: worksFromDb(row.works),
+    status: row.status,
+    executor: row.executor,
+    evidenceCount: parseKeys(row.evidence_keys_json).length,
+    createdAt: row.created_at,
+  }));
+}
+
+export async function getVisualCheckById(env: Env, id: string): Promise<DbVisualCheck | null> {
+  const row = (await env.DB.prepare(
+    `SELECT id, project_id, user_key, target_url, intent, decision, works,
+            status, executor, report_json, agent_prompt, evidence_keys_json, created_at, updated_at
+       FROM workspace_visual_checks
+      WHERE id = ?`,
+  )
+    .bind(id)
+    .first()) as RawRow | null;
+  return row ? fromRow(row) : null;
+}
+
+/** Append an uploaded evidence key to the run's manifest (read-modify-write). */
+export async function appendVisualCheckEvidenceKey(env: Env, id: string, key: string): Promise<string[]> {
+  const row = await getVisualCheckById(env, id);
+  if (!row) throw new Error("visual_check_not_found");
+  const keys = row.evidenceKeys.includes(key) ? row.evidenceKeys : [...row.evidenceKeys, key];
+  await env.DB.prepare(
+    `UPDATE workspace_visual_checks SET evidence_keys_json = ?, updated_at = ? WHERE id = ?`,
+  )
+    .bind(JSON.stringify(keys), new Date().toISOString(), id)
+    .run();
+  return keys;
+}

--- a/apps/central-plane/test/workspace-sources.test.mjs
+++ b/apps/central-plane/test/workspace-sources.test.mjs
@@ -1,0 +1,227 @@
+/**
+ * workspace-sources.test.mjs — Stage 261
+ *
+ * Unified project sources: website/github_repo JSON connect, document upload
+ * to R2 (multipart), list, download proxy, delete. Ownership + validation.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { createApp } = await import("../dist/router.js");
+
+const USER = "uk_owner";
+const OTHER = "uk_intruder";
+const PROJECT = "proj_src";
+
+function makeDb({ projects = new Map(), sources = [] } = {}) {
+  return {
+    _sources: sources,
+    prepare(sql) {
+      function handler(args) {
+        return {
+          async run() {
+            if (sql.includes("INSERT INTO project_sources")) {
+              const [id, project_id, user_key, type, reference, label, content_type, size_bytes, created_at] = args;
+              sources.push({ id, project_id, user_key, type, reference, label, content_type, size_bytes, created_at });
+              return { meta: { changes: 1 } };
+            }
+            if (sql.includes("UPDATE project_sources SET reference")) {
+              const [reference, id] = args;
+              const row = sources.find((s) => s.id === id);
+              if (row) row.reference = reference;
+              return { meta: { changes: row ? 1 : 0 } };
+            }
+            if (sql.includes("DELETE FROM project_sources")) {
+              const idx = sources.findIndex((s) => s.id === args[0]);
+              if (idx >= 0) sources.splice(idx, 1);
+              return { meta: { changes: idx >= 0 ? 1 : 0 } };
+            }
+            return { meta: { changes: 0 } };
+          },
+          async first() {
+            if (sql.includes("FROM workspace_projects WHERE id = ?")) {
+              return projects.get(args[0]) ?? null;
+            }
+            if (sql.includes("FROM project_sources") && sql.includes("WHERE id = ?")) {
+              return sources.find((s) => s.id === args[0]) ?? null;
+            }
+            return null;
+          },
+          async all() {
+            if (sql.includes("FROM project_sources") && sql.includes("WHERE project_id = ?")) {
+              return { results: sources.filter((s) => s.project_id === args[0]) };
+            }
+            return { results: [] };
+          },
+        };
+      }
+      return {
+        bind(...args) { return handler(args); },
+        run() { return handler([]).run(); },
+        first() { return handler([]).first(); },
+        all() { return handler([]).all(); },
+      };
+    },
+  };
+}
+
+function makeProjectRow(id, userKey) {
+  return {
+    id,
+    user_key: userKey,
+    title: "t",
+    idea: "i",
+    understood_json: "{}",
+    product_spec_json: "{}",
+    items_json: "[]",
+    created_at: "2026-07-02T00:00:00.000Z",
+    updated_at: "2026-07-02T00:00:00.000Z",
+  };
+}
+
+function makeR2() {
+  const store = new Map();
+  return {
+    _store: store,
+    async put(key, value, opts) { store.set(key, { value, opts }); },
+    async get(key) {
+      const hit = store.get(key);
+      return hit ? { body: hit.value } : null;
+    },
+    async delete(key) { store.delete(key); },
+  };
+}
+
+function makeEnv({ withR2 = true, projects, sources } = {}) {
+  const env = {
+    ENVIRONMENT: "test",
+    DB: makeDb({ projects: projects ?? new Map([[PROJECT, makeProjectRow(PROJECT, USER)]]), sources }),
+  };
+  if (withR2) env.EVIDENCE = makeR2();
+  return env;
+}
+
+async function req(env, method, path, body) {
+  const app = createApp();
+  const init = { method };
+  if (body instanceof FormData) {
+    init.body = body;
+  } else if (body !== undefined) {
+    init.headers = { "content-type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await app.fetch(new Request(`http://localhost${path}`, init), env);
+  let json = null;
+  try { json = await res.json(); } catch { /* binary */ }
+  return { status: res.status, json };
+}
+
+// ─── JSON sources ─────────────────────────────────────────────────────────────
+
+test("POST website source: 201 + persisted; list returns it", async () => {
+  const env = makeEnv();
+  const { status, json } = await req(env, "POST", `/workspace/projects/${PROJECT}/sources`, {
+    userKey: USER, type: "website", reference: "https://my-vibe-app.vercel.app/", label: "배포 앱",
+  });
+  assert.equal(status, 201);
+  assert.equal(json.source.type, "website");
+
+  const list = await req(env, "GET", `/workspace/projects/${PROJECT}/sources?userKey=${USER}`);
+  assert.equal(list.status, 200);
+  assert.equal(list.json.sources.length, 1);
+  assert.equal(list.json.sources[0].reference, "https://my-vibe-app.vercel.app/");
+});
+
+test("POST website: invalid URL rejected; github_repo: bad format rejected", async () => {
+  const env = makeEnv();
+  const bad = await req(env, "POST", `/workspace/projects/${PROJECT}/sources`, {
+    userKey: USER, type: "website", reference: "not-a-url",
+  });
+  assert.equal(bad.status, 400);
+  assert.equal(bad.json.error, "invalid_url");
+
+  const badRepo = await req(env, "POST", `/workspace/projects/${PROJECT}/sources`, {
+    userKey: USER, type: "github_repo", reference: "no-slash-here",
+  });
+  assert.equal(badRepo.status, 400);
+  assert.equal(badRepo.json.error, "invalid_repo");
+
+  const goodRepo = await req(env, "POST", `/workspace/projects/${PROJECT}/sources`, {
+    userKey: USER, type: "github_repo", reference: "seunghunbae-3svs/golf-now",
+  });
+  assert.equal(goodRepo.status, 201);
+});
+
+test("ownership: other user forbidden (403), unknown project 404", async () => {
+  const env = makeEnv();
+  const forbidden = await req(env, "POST", `/workspace/projects/${PROJECT}/sources`, {
+    userKey: OTHER, type: "website", reference: "https://x.dev/",
+  });
+  assert.equal(forbidden.status, 403);
+
+  const missing = await req(env, "GET", `/workspace/projects/proj_nope/sources?userKey=${USER}`);
+  assert.equal(missing.status, 404);
+});
+
+// ─── Document upload ──────────────────────────────────────────────────────────
+
+function formWith(file, userKey = USER, label) {
+  const form = new FormData();
+  form.set("userKey", userKey);
+  if (label) form.set("label", label);
+  form.set("file", file);
+  return form;
+}
+
+test("POST document: uploads to R2 under docs/, row reference = R2 key", async () => {
+  const env = makeEnv();
+  const file = new File(["# PRD\n골프장 컨디션 앱"], "prd v2.md", { type: "text/markdown" });
+  const { status, json } = await req(env, "POST", `/workspace/projects/${PROJECT}/sources/document`, formWith(file, USER, "PRD v2"));
+  assert.equal(status, 201);
+  assert.equal(json.source.type, "document");
+  assert.ok(json.source.reference.startsWith(`docs/${USER}/${PROJECT}/`));
+  assert.ok(json.source.reference.endsWith("prd_v2.md")); // sanitized filename
+  assert.equal(env.EVIDENCE._store.size, 1);
+
+  // download proxy round-trip
+  const dl = await fetchRaw(env, `/workspace/projects/${PROJECT}/sources/${json.source.id}/file?userKey=${USER}`);
+  assert.equal(dl.status, 200);
+  assert.equal(dl.headers.get("content-type"), "text/markdown");
+});
+
+test("POST document: unsupported extension rejected; no R2 binding → 503", async () => {
+  const env = makeEnv();
+  const exe = new File(["MZ"], "malware.exe");
+  const bad = await req(env, "POST", `/workspace/projects/${PROJECT}/sources/document`, formWith(exe));
+  assert.equal(bad.status, 400);
+  assert.equal(bad.json.error, "unsupported_file_type");
+
+  const noR2 = makeEnv({ withR2: false });
+  const md = new File(["# hi"], "a.md");
+  const blocked = await req(noR2, "POST", `/workspace/projects/${PROJECT}/sources/document`, formWith(md));
+  assert.equal(blocked.status, 503);
+  assert.equal(blocked.json.error, "evidence_storage_unconfigured");
+});
+
+test("DELETE document: removes row and R2 object; other user forbidden", async () => {
+  const env = makeEnv();
+  const file = new File(["# PRD"], "prd.md");
+  const created = await req(env, "POST", `/workspace/projects/${PROJECT}/sources/document`, formWith(file));
+  const id = created.json.source.id;
+  assert.equal(env.EVIDENCE._store.size, 1);
+
+  const forbidden = await req(env, "DELETE", `/workspace/projects/${PROJECT}/sources/${id}?userKey=${OTHER}`);
+  assert.equal(forbidden.status, 403);
+
+  const del = await req(env, "DELETE", `/workspace/projects/${PROJECT}/sources/${id}?userKey=${USER}`);
+  assert.equal(del.status, 200);
+  assert.equal(env.EVIDENCE._store.size, 0);
+
+  const list = await req(env, "GET", `/workspace/projects/${PROJECT}/sources?userKey=${USER}`);
+  assert.equal(list.json.sources.length, 0);
+});
+
+async function fetchRaw(env, path) {
+  const app = createApp();
+  return app.fetch(new Request(`http://localhost${path}`), env);
+}

--- a/apps/central-plane/test/workspace-visual-checks.test.mjs
+++ b/apps/central-plane/test/workspace-visual-checks.test.mjs
@@ -1,0 +1,232 @@
+/**
+ * workspace-visual-checks.test.mjs — Stage 261
+ *
+ * Visual completion-check runs: create (report snapshot), evidence upload to
+ * R2 (allowlisted names), list/detail, evidence serving. Ownership + limits.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { createApp } = await import("../dist/router.js");
+
+const USER = "uk_owner";
+const OTHER = "uk_intruder";
+const PROJECT = "proj_vc";
+
+function makeDb({ projects = new Map(), checks = [] } = {}) {
+  return {
+    _checks: checks,
+    prepare(sql) {
+      function handler(args) {
+        return {
+          async run() {
+            if (sql.includes("INSERT INTO workspace_visual_checks")) {
+              const [id, project_id, user_key, target_url, intent, decision, works, executor, report_json, agent_prompt, created_at, updated_at] = args;
+              checks.push({
+                id, project_id, user_key, target_url, intent, decision, works,
+                status: "uploaded", executor, report_json, agent_prompt,
+                evidence_keys_json: "[]", created_at, updated_at,
+              });
+              return { meta: { changes: 1 } };
+            }
+            if (sql.includes("UPDATE workspace_visual_checks SET evidence_keys_json")) {
+              const [keysJson, updatedAt, id] = args;
+              const row = checks.find((r) => r.id === id);
+              if (row) { row.evidence_keys_json = keysJson; row.updated_at = updatedAt; }
+              return { meta: { changes: row ? 1 : 0 } };
+            }
+            return { meta: { changes: 0 } };
+          },
+          async first() {
+            if (sql.includes("FROM workspace_projects WHERE id = ?")) {
+              return projects.get(args[0]) ?? null;
+            }
+            if (sql.includes("FROM workspace_visual_checks") && sql.includes("WHERE id = ?")) {
+              return checks.find((r) => r.id === args[0]) ?? null;
+            }
+            return null;
+          },
+          async all() {
+            if (sql.includes("FROM workspace_visual_checks") && sql.includes("WHERE project_id = ?")) {
+              return { results: checks.filter((r) => r.project_id === args[0]) };
+            }
+            return { results: [] };
+          },
+        };
+      }
+      return {
+        bind(...args) { return handler(args); },
+        run() { return handler([]).run(); },
+        first() { return handler([]).first(); },
+        all() { return handler([]).all(); },
+      };
+    },
+  };
+}
+
+function makeProjectRow(id, userKey) {
+  return {
+    id, user_key: userKey, title: "t", idea: "i",
+    understood_json: "{}", product_spec_json: "{}", items_json: "[]",
+    created_at: "2026-07-02T00:00:00.000Z", updated_at: "2026-07-02T00:00:00.000Z",
+  };
+}
+
+function makeR2() {
+  const store = new Map();
+  return {
+    _store: store,
+    async put(key, value, opts) { store.set(key, { value, opts }); },
+    async get(key) {
+      const hit = store.get(key);
+      return hit ? { body: hit.value } : null;
+    },
+    async delete(key) { store.delete(key); },
+  };
+}
+
+function makeEnv({ withR2 = true } = {}) {
+  const env = {
+    ENVIRONMENT: "test",
+    DB: makeDb({ projects: new Map([[PROJECT, makeProjectRow(PROJECT, USER)]]) }),
+  };
+  if (withR2) env.EVIDENCE = makeR2();
+  return env;
+}
+
+const REPORT = {
+  title: "Simsa 검수 리포트",
+  verdict: "작동 안 해요 — 고쳐야 해요",
+  works: false,
+  findings: [{ severity: "high", what: "서버 주소를 찾지 못했어요", why: "w", how: "h", evidence: "net::ERR_NAME_NOT_RESOLVED" }],
+  nextSteps: [], notes: [],
+};
+
+function createBody(over = {}) {
+  return {
+    userKey: USER,
+    targetUrl: "https://golf-now.example.app/",
+    intent: "골퍼가 코스 상태를 확인할 수 있어야 한다",
+    decision: "Needs Fix",
+    works: false,
+    report: REPORT,
+    agentPrompt: "당신은 이 프로젝트의 코드를 수정하는 개발 에이전트입니다...",
+    ...over,
+  };
+}
+
+async function req(env, method, path, body, raw) {
+  const app = createApp();
+  const init = { method };
+  if (raw !== undefined) {
+    init.body = raw;
+  } else if (body !== undefined) {
+    init.headers = { "content-type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await app.fetch(new Request(`http://localhost${path}`, init), env);
+  let json = null;
+  try { json = await res.clone().json(); } catch { /* binary */ }
+  return { status: res.status, json, res };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test("POST create: 201 with tri-state works; report required", async () => {
+  const env = makeEnv();
+  const { status, json } = await req(env, "POST", `/workspace/projects/${PROJECT}/visual-checks`, createBody());
+  assert.equal(status, 201);
+  assert.equal(json.check.decision, "Needs Fix");
+  assert.equal(json.check.works, false);
+  assert.equal(json.check.status, "uploaded");
+  assert.equal(json.check.executor, "local");
+
+  const missing = await req(env, "POST", `/workspace/projects/${PROJECT}/visual-checks`, createBody({ report: undefined }));
+  assert.equal(missing.status, 400);
+  assert.equal(missing.json.error, "report_required");
+});
+
+test("ownership: wrong user 403; unknown project 404", async () => {
+  const env = makeEnv();
+  const forbidden = await req(env, "POST", `/workspace/projects/${PROJECT}/visual-checks`, createBody({ userKey: OTHER }));
+  assert.equal(forbidden.status, 403);
+  const missing = await req(env, "POST", `/workspace/projects/proj_nope/visual-checks`, createBody());
+  assert.equal(missing.status, 404);
+});
+
+test("evidence upload: allowlisted name → R2 key + manifest; bad name rejected", async () => {
+  const env = makeEnv();
+  const created = await req(env, "POST", `/workspace/projects/${PROJECT}/visual-checks`, createBody());
+  const runId = created.json.check.id;
+
+  const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+  const up = await req(env, "POST",
+    `/workspace/projects/${PROJECT}/visual-checks/${runId}/evidence?userKey=${USER}&name=${encodeURIComponent("screenshots/step-00-initial.png")}`,
+    undefined, png);
+  assert.equal(up.status, 201);
+  assert.equal(up.json.evidenceCount, 1);
+  assert.ok(env.EVIDENCE._store.has(`checks/${USER}/${PROJECT}/${runId}/screenshots/step-00-initial.png`));
+
+  const bad = await req(env, "POST",
+    `/workspace/projects/${PROJECT}/visual-checks/${runId}/evidence?userKey=${USER}&name=${encodeURIComponent("../../etc/passwd")}`,
+    undefined, png);
+  assert.equal(bad.status, 400);
+  assert.equal(bad.json.error, "invalid_evidence_name");
+});
+
+test("list + detail: report round-trip, agent prompt, evidence keys", async () => {
+  const env = makeEnv();
+  const created = await req(env, "POST", `/workspace/projects/${PROJECT}/visual-checks`, createBody());
+  const runId = created.json.check.id;
+  await req(env, "POST",
+    `/workspace/projects/${PROJECT}/visual-checks/${runId}/evidence?userKey=${USER}&name=${encodeURIComponent("video/flow.webm")}`,
+    undefined, new Uint8Array([1, 2, 3]));
+
+  const list = await req(env, "GET", `/workspace/projects/${PROJECT}/visual-checks?userKey=${USER}`);
+  assert.equal(list.status, 200);
+  assert.equal(list.json.checks.length, 1);
+  assert.equal(list.json.checks[0].evidenceCount, 1);
+
+  const detail = await req(env, "GET", `/workspace/projects/${PROJECT}/visual-checks/${runId}?userKey=${USER}`);
+  assert.equal(detail.status, 200);
+  assert.deepEqual(detail.json.check.report, REPORT);
+  assert.ok(detail.json.check.agentPrompt.includes("개발 에이전트"));
+  assert.deepEqual(detail.json.check.evidenceKeys, ["video/flow.webm"]);
+
+  // detail is owner-only
+  const forbidden = await req(env, "GET", `/workspace/projects/${PROJECT}/visual-checks/${runId}?userKey=${OTHER}`);
+  assert.equal(forbidden.status, 403);
+});
+
+test("evidence serving: uploaded name streams with content-type; unknown name 404", async () => {
+  const env = makeEnv();
+  const created = await req(env, "POST", `/workspace/projects/${PROJECT}/visual-checks`, createBody());
+  const runId = created.json.check.id;
+  await req(env, "POST",
+    `/workspace/projects/${PROJECT}/visual-checks/${runId}/evidence?userKey=${USER}&name=${encodeURIComponent("screenshots/step-01.png")}`,
+    undefined, new Uint8Array([0x89]));
+
+  const ok = await req(env, "GET",
+    `/workspace/projects/${PROJECT}/visual-checks/${runId}/evidence/screenshots/step-01.png?userKey=${USER}`);
+  assert.equal(ok.status, 200);
+  assert.equal(ok.res.headers.get("content-type"), "image/png");
+
+  const missing = await req(env, "GET",
+    `/workspace/projects/${PROJECT}/visual-checks/${runId}/evidence/screenshots/step-99.png?userKey=${USER}`);
+  assert.equal(missing.status, 404);
+});
+
+test("no R2 binding: evidence routes 503, create/list/detail still work", async () => {
+  const env = makeEnv({ withR2: false });
+  const created = await req(env, "POST", `/workspace/projects/${PROJECT}/visual-checks`, createBody());
+  assert.equal(created.status, 201);
+  const runId = created.json.check.id;
+
+  const up = await req(env, "POST",
+    `/workspace/projects/${PROJECT}/visual-checks/${runId}/evidence?userKey=${USER}&name=${encodeURIComponent("screenshots/a.png")}`,
+    undefined, new Uint8Array([1]));
+  assert.equal(up.status, 503);
+
+  const detail = await req(env, "GET", `/workspace/projects/${PROJECT}/visual-checks/${runId}?userKey=${USER}`);
+  assert.equal(detail.status, 200);
+});

--- a/apps/central-plane/wrangler.toml
+++ b/apps/central-plane/wrangler.toml
@@ -44,6 +44,13 @@ ENABLE_CREDIT_BLOCKING = "false"
 # "*" wildcard is NOT supported.
 ACTUAL_DEBIT_ALLOWED_USER_KEYS = ""
 
+# Stage 261 — R2 evidence + document storage (Simsa visual checks, PRD uploads).
+# Bucket must exist before deploy; deploy-central-plane.yml has an idempotent
+# "Ensure R2 bucket" step (`wrangler r2 bucket create simsa-evidence`).
+[[r2_buckets]]
+binding = "EVIDENCE"
+bucket_name = "simsa-evidence"
+
 # Observability. Logs retained 3 days on free tier, sufficient for v0.4-alpha.
 [observability]
 enabled = true

--- a/tools/simsa-completion-loop-spike/visual-run.mjs
+++ b/tools/simsa-completion-loop-spike/visual-run.mjs
@@ -12,7 +12,7 @@
  * Usage: node visual-run.mjs <targetUrl> <outDir> [sampleQuery]
  */
 import { chromium } from "playwright";
-import { mkdirSync, writeFileSync, copyFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, copyFileSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { planVisualFlow } from "../../apps/central-plane/dist/visual-flow-plan.js";
@@ -198,7 +198,7 @@ export async function visualRun(config, outDir) {
   writeFileSync(join(outDir, "report.html"), html);
   writeFileSync(join(outDir, "report.md"), toMarkdown(report));
   writeFileSync(join(outDir, "agent-prompt.md"), agentPrompt);
-  return { report, decision, shots, videoRel };
+  return { report, reportInput, agentPrompt, decision, shots, videoRel };
 }
 
 /** Deterministic decision from the deep-flow evidence (mirrors the spike's ladder, journey-aware). */
@@ -224,11 +224,51 @@ function toMarkdown(r) {
   return lines.join("\n");
 }
 
+/**
+ * Stage 261 — upload a finished run to the central plane so it shows on the
+ * dashboard (app.trysimsa.com). Uploads run metadata + report + agent prompt,
+ * then each screenshot and the flow video as evidence files. The userKey
+ * travels only in the request body/query (never logged).
+ */
+export async function uploadRun({ apiBase, userKey, projectId, reportInput, report, agentPrompt, shots, videoRel, outDir }) {
+  const base = apiBase.replace(/\/$/, "");
+  const createRes = await fetch(`${base}/workspace/projects/${projectId}/visual-checks`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      userKey,
+      targetUrl: reportInput.targetUrl,
+      intent: reportInput.intentAnchor,
+      decision: reportInput.decision,
+      works: report.works,
+      executor: "local",
+      report,
+      agentPrompt,
+    }),
+  });
+  const created = await createRes.json();
+  if (!createRes.ok || !created.ok) throw new Error(`create failed: ${createRes.status} ${created?.error ?? ""}`);
+  const runId = created.check.id;
+
+  const files = [...shots.map((s) => s.src), ...(videoRel ? [videoRel] : [])];
+  let uploaded = 0;
+  for (const rel of files) {
+    const body = readFileSync(join(outDir, rel));
+    const url = `${base}/workspace/projects/${projectId}/visual-checks/${runId}/evidence?userKey=${encodeURIComponent(userKey)}&name=${encodeURIComponent(rel)}`;
+    const res = await fetch(url, { method: "POST", body });
+    if (res.ok) uploaded += 1;
+    else console.error(`[upload] evidence failed (${res.status}): ${rel}`);
+  }
+  return { runId, uploaded, total: files.length };
+}
+
 // CLI
 if (process.argv[1] && process.argv[1].endsWith("visual-run.mjs")) {
-  const targetUrl = process.argv[2] || "http://localhost:3000/";
-  const outDir = process.argv[3] || join(here, "out", "visual");
-  const sampleQuery = process.argv[4] || "서울";
+  const wantUpload = process.argv.includes("--upload");
+  const args = process.argv.slice(2).filter((a) => a !== "--upload");
+  const targetUrl = args[0] || "http://localhost:3000/";
+  const outDir = args[1] || join(here, "out", "visual");
+  const sampleQuery = args[2] || "서울";
   const config = {
     targetUrl,
     intentAnchor: INTENT_DEFAULT,
@@ -236,7 +276,19 @@ if (process.argv[1] && process.argv[1].endsWith("visual-run.mjs")) {
     forbidden: ["payment", "delete", "send", "invite", "publish", "deploy", "결제", "삭제", "발행", "배포", "로그아웃"],
   };
   visualRun(config, outDir)
-    .then((r) => console.log(`[visual] decision: ${r.decision} | works: ${r.report.works} | shots: ${r.shots.length} | video: ${r.videoRel ?? "none"}`))
+    .then(async (r) => {
+      console.log(`[visual] decision: ${r.decision} | works: ${r.report.works} | shots: ${r.shots.length} | video: ${r.videoRel ?? "none"}`);
+      if (wantUpload) {
+        const apiBase = process.env.SIMSA_API_BASE;
+        const userKey = process.env.SIMSA_USER_KEY;
+        const projectId = process.env.SIMSA_PROJECT_ID;
+        if (!apiBase || !userKey || !projectId) {
+          throw new Error("--upload requires SIMSA_API_BASE, SIMSA_USER_KEY, SIMSA_PROJECT_ID env vars");
+        }
+        const up = await uploadRun({ ...r, apiBase, userKey, projectId, outDir });
+        console.log(`[upload] run ${up.runId}: ${up.uploaded}/${up.total} evidence files uploaded`);
+      }
+    })
     .catch((e) => {
       console.error("[visual] error:", e);
       process.exit(1);


### PR DESCRIPTION
## What

Final-model foundation: visual inspection reports and project connections become server-side so they can render on app.trysimsa.com.

- **migration 0049 `project_sources`** — one registry per project: `website` / `github_repo` / `document` (PRD/md/txt/pdf uploads → R2 `docs/{userKey}/{projectId}/…`)
- **migration 0050 `workspace_visual_checks`** — one row per inspection: decision + tri-state works (no numeric score), full NonDevReport snapshot, agent fix prompt, evidence manifest, `executor local|container` (Phase 2 cloud runner reuses this path)
- **routes**: sources connect/list/delete + multipart upload + download proxy; visual-checks create/evidence-upload/list/detail/evidence-serving. Ownership via `getProject` (404/403), server-shaped R2 keys, name allowlists, size caps
- **env.EVIDENCE** optional R2 binding — absent binding degrades to 503 on storage routes only
- **deploy workflow**: idempotent `Ensure R2 bucket` step; **wrangler.toml**: `[[r2_buckets]] simsa-evidence`
- **visual-run.mjs `--upload`** — concierge runs land on the dashboard

## Tests

central-plane **1299/1299** (12 new: validation, ownership, R2 round-trips, allowlists, 503 degradation). `pnpm verify` green (pre-push hook).

## Deploy notes

Next production deploy applies 0049+0050 (both additive, IF NOT EXISTS only — ledger for 0048 already reconciled) and creates the R2 bucket if missing.

Next: Stage 262 — dashboard visual-check section + sources panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)