### PR TITLE
Stage 263 — SimsaInspector cloud runner (queued visual checks + container)

### DIFF
--- a/apps/central-plane/inspector-container/Dockerfile
+++ b/apps/central-plane/inspector-container/Dockerfile
@@ -1,0 +1,63 @@
+# Stage 263 — SimsaInspector container: Playwright + Chromium visual runner.
+#
+# Spawned by the Worker (apps/central-plane/src/inspector-container.ts) via the
+# INSPECTOR Durable-Object binding when POST /workspace/projects/:id/
+# visual-checks/run fires. Executes the Simsa deep-flow visual completion
+# check (same logic as tools/simsa-completion-loop-spike/visual-run.mjs) in a
+# real headless Chromium, uploads screenshots + video to the Stage 261
+# evidence endpoint, then reports the verdict to /internal/visual-check-done.
+#
+# Build context: repo root (wrangler.toml image_build_context = "../.."), same
+# as the autofix sandbox container. Built in CI by deploy-central-plane.yml.
+#
+# BASE IMAGE: the mcr playwright tag MUST match the `playwright` npm version
+# installed below AND the version pinned in
+# tools/simsa-completion-loop-spike/package.json — the browsers baked into the
+# image at /ms-playwright are only guaranteed compatible with that exact
+# library version. test/inspector-invariants.test.mjs pins this alignment.
+#
+# CODE-IN STRATEGY: unlike the sandbox container (full pnpm workspace build),
+# this image compiles ONLY the two canonical, dependency-free Simsa modules
+# (src/visual-flow-plan.ts + src/nondev-report.ts) with a standalone tsc.
+# Why not mirror the full workspace build: (1) the playwright base is already
+# ~2 GB and a full monorepo node_modules would push the image past the 4 GB
+# disk of the "basic" container instance; (2) the runner needs exactly these
+# two pure modules — nothing else from central-plane runs in the container.
+# The sources are the SAME files the Worker builds, so logic stays lock-step.
+#
+# IMAGE LAYOUT:
+#   /runner                  — app root (package.json type:module)
+#   /runner/server.mjs       — HTTP entry (the container's only API)
+#   /runner/inspector-run.mjs— Playwright deep-flow executor
+#   /runner/safety.mjs       — forbidden-action classifier (from the spike)
+#   /runner/dist/            — compiled visual-flow-plan.js + nondev-report.js
+#
+# RUNTIME: job payload arrives over POST /run (no secrets baked into the
+# image); evidence + callbacks use the URLs/token carried in the payload.
+
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy
+
+WORKDIR /runner
+
+# package.json first (type:module + pinned playwright/typescript versions).
+COPY apps/central-plane/inspector-container/package.json ./package.json
+RUN npm install --no-package-lock --loglevel=error
+
+# Canonical Simsa modules — compiled in-image from apps/central-plane/src so
+# the container always runs the exact logic the repo ships.
+COPY apps/central-plane/src/visual-flow-plan.ts apps/central-plane/src/nondev-report.ts ./src/
+RUN npx tsc src/visual-flow-plan.ts src/nondev-report.ts \
+    --outDir dist --module nodenext --moduleResolution nodenext \
+    --target es2022 --skipLibCheck
+
+# Runner scripts (plain .mjs — no TS build step for the runtime shell).
+COPY apps/central-plane/inspector-container/server.mjs ./server.mjs
+COPY apps/central-plane/inspector-container/inspector-run.mjs ./inspector-run.mjs
+COPY apps/central-plane/inspector-container/safety.mjs ./safety.mjs
+
+# Writable scratch space for per-run screenshots/video.
+RUN mkdir -p /var/lib/simsa && chmod 770 /var/lib/simsa
+
+EXPOSE 8080
+
+CMD ["node", "/runner/server.mjs"]

--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -1,0 +1,222 @@
+/**
+ * inspector-run.mjs — Stage 263: the SimsaInspector deep-flow executor.
+ *
+ * Adapted from tools/simsa-completion-loop-spike/visual-run.mjs (Stage 260A/261
+ * reference runner): goto → collect CTAs/inputs → planVisualFlow → execute
+ * only SAFE steps (classifyActionSafety re-checked at click time) → per-step
+ * screenshots + flow video → deterministic decideFromEvidence ladder →
+ * buildNonDevReport + buildAgentFixPrompt.
+ *
+ * Imports the canonical Simsa modules compiled into ./dist at image build
+ * time from apps/central-plane/src (see Dockerfile) — no duplicated logic.
+ *
+ * Safety rails:
+ *   - forbidden-action list (payment/delete/send/invite/publish/deploy/
+ *     logout + 결제/삭제/발행/배포/로그아웃) — never planned, never clicked
+ *   - viewport 1280x800, headless Chromium
+ *   - per-action timeouts; the caller (server.mjs) additionally enforces the
+ *     ~4-minute total wall clock
+ *   - --no-sandbox: the CF container runs as root; --disable-dev-shm-usage:
+ *     container /dev/shm is tiny and crashes Chromium tabs otherwise.
+ */
+import { chromium } from "playwright";
+import { mkdirSync, copyFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { planVisualFlow } from "./dist/visual-flow-plan.js";
+import { buildNonDevReport, buildAgentFixPrompt } from "./dist/nondev-report.js";
+import { classifyActionSafety } from "./safety.mjs";
+
+/** Forbidden action words handed to the planner (mirrors visual-run.mjs). */
+export const FORBIDDEN_ACTIONS = [
+  "payment", "pay", "checkout", "delete", "remove", "send", "invite",
+  "publish", "deploy", "logout", "sign out",
+  "결제", "구매", "삭제", "발행", "배포", "로그아웃",
+];
+
+async function collectCtas(page) {
+  return page.$$eval("a, button, [role=button]", (els) =>
+    els
+      .filter((el) => {
+        const r = el.getBoundingClientRect();
+        const s = getComputedStyle(el);
+        return r.width > 0 && r.height > 0 && s.visibility !== "hidden" && s.display !== "none";
+      })
+      .slice(0, 200)
+      .map((el) => ({ text: (el.innerText || el.textContent || el.getAttribute("aria-label") || "").trim().replace(/\s+/g, " ") }))
+      .filter((c) => c.text.length > 0)
+      .map((c) => ({ text: c.text, selector: `text=${c.text}` })),
+  );
+}
+
+async function collectInputs(page) {
+  return page.$$eval("input, textarea", (els) =>
+    els
+      .filter((el) => {
+        const r = el.getBoundingClientRect();
+        const t = (el.getAttribute("type") || "text").toLowerCase();
+        const ok = ["text", "search", "email", "tel", "url", "number", ""].includes(t) || el.tagName.toLowerCase() === "textarea";
+        return r.width > 0 && r.height > 0 && ok;
+      })
+      .slice(0, 50)
+      .map((el) => ({ type: (el.getAttribute("type") || "text").toLowerCase(), placeholder: (el.getAttribute("placeholder") || el.getAttribute("aria-label") || "").trim().slice(0, 80) }))
+      .map((i) => ({ ...i, selector: i.placeholder ? `[placeholder="${i.placeholder}"]` : "input" })),
+  );
+}
+
+/** Deterministic decision ladder from the deep-flow evidence (mirrors visual-run.mjs). */
+export function decideFromEvidence(e, steps) {
+  if (e.loadStatus && e.loadStatus >= 400) return "Not Verified";
+  if (e.networkFailures.length || e.consoleErrors.length) return "Needs Fix";
+  if (e.interacted && e.routeAfterClick && /\/undefined|\/null|\/404|not-found|error/i.test(e.routeAfterClick)) return "Needs Fix";
+  if (steps.some((s) => !s.ok)) return "Needs Fix";
+  if (!e.primaryActionFound) return "Needs Clarification";
+  if (e.interacted) return "User Acceptance Required"; // journey ran clean, but no visual oracle for "usable"
+  return "Not Verified";
+}
+
+/**
+ * Execute one inspection. Returns:
+ *   { report, agentPrompt, decision, works, evidenceFiles: [{ name, path }] }
+ * where `name` is the Stage 261 evidence name (screenshots/*.png | video/flow.webm)
+ * and `path` is the absolute file path inside the container.
+ */
+export async function runInspection({ targetUrl, intent, outDir, sampleQuery = "서울" }) {
+  const shotsDir = join(outDir, "screenshots");
+  const videoDir = join(outDir, "video");
+  mkdirSync(shotsDir, { recursive: true });
+  mkdirSync(videoDir, { recursive: true });
+
+  const browser = await chromium.launch({
+    headless: true,
+    args: ["--no-sandbox", "--disable-dev-shm-usage"],
+  });
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    recordVideo: { dir: videoDir, size: { width: 1280, height: 800 } },
+  });
+  const page = await context.newPage();
+
+  const consoleErrors = [];
+  const networkFailures = [];
+  page.on("console", (m) => m.type() === "error" && consoleErrors.push(m.text().slice(0, 300)));
+  page.on("requestfailed", (r) => networkFailures.push(`${r.method()} ${r.url().slice(0, 200)} (${r.failure()?.errorText ?? "failed"})`));
+  page.on("response", (r) => r.status() >= 500 && networkFailures.push(`HTTP ${r.status()} ${r.url().slice(0, 200)}`));
+
+  const evidenceFiles = [];
+  const stepOutcomes = [];
+  const evidence = {
+    urlLoaded: targetUrl,
+    loadStatus: null,
+    primaryActionFound: false,
+    interacted: false,
+    routeBeforeClick: null,
+    routeAfterClick: null,
+    routeChanged: false,
+    consoleErrors,
+    networkFailures,
+  };
+
+  async function snap(name) {
+    const p = join(shotsDir, name);
+    try {
+      await page.screenshot({ path: p, fullPage: false });
+      evidenceFiles.push({ name: `screenshots/${name}`, path: p });
+    } catch {
+      /* ignore screenshot failures */
+    }
+  }
+
+  try {
+    const resp = await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
+    evidence.loadStatus = resp ? resp.status() : null;
+    evidence.routeBeforeClick = page.url();
+    await page.waitForTimeout(1800);
+    await snap("step-00-initial.png");
+
+    const ctas = await collectCtas(page);
+    const inputs = await collectInputs(page);
+
+    const plan = planVisualFlow({
+      intentAnchor: intent,
+      ctas: ctas.map((c) => ({ text: c.text, selector: c.selector })),
+      inputs,
+      forbidden: FORBIDDEN_ACTIONS,
+      sampleQuery,
+    });
+    evidence.primaryActionFound = plan.some((s) => s.action === "click" || s.action === "type");
+
+    let stepIdx = 0;
+    for (const step of plan) {
+      stepIdx += 1;
+      const shotName = `step-${String(stepIdx).padStart(2, "0")}.png`;
+      try {
+        if (step.action === "click") {
+          const safety = classifyActionSafety(step.targetText);
+          if (!safety.safe) {
+            stepOutcomes.push({ label: step.label, ok: false, note: `안전하지 않아 건너뜀 (${safety.category})` });
+            continue;
+          }
+          await page.getByText(step.targetText, { exact: true }).first().click({ timeout: 8000 });
+          evidence.interacted = true;
+          await page.waitForLoadState("domcontentloaded", { timeout: 8000 }).catch(() => {});
+          await page.waitForTimeout(1500);
+          evidence.routeAfterClick = page.url();
+          evidence.routeChanged = evidence.routeAfterClick !== evidence.routeBeforeClick;
+          await snap(shotName);
+          stepOutcomes.push({ label: step.label, ok: true });
+        } else if (step.action === "type") {
+          const field = step.placeholder ? page.getByPlaceholder(step.placeholder).first() : page.locator("input").first();
+          await field.fill(step.value, { timeout: 8000 });
+          await field.press("Enter").catch(() => {});
+          evidence.interacted = true;
+          await page.waitForTimeout(1800);
+          await snap(shotName);
+          // Did results/content appear? Heuristic: page text grew and no fresh network failure.
+          const bodyLen = (await page.locator("body").innerText().catch(() => "")).length;
+          const ok = bodyLen > 200 && networkFailures.length === 0;
+          stepOutcomes.push({ label: step.label, ok, note: ok ? undefined : "검색 결과/내용이 확인되지 않음 (또는 데이터 요청 실패)" });
+        } else {
+          await snap(shotName);
+          stepOutcomes.push({ label: step.label, ok: networkFailures.length === 0, note: networkFailures.length ? "데이터 요청 실패가 관찰됨" : undefined });
+        }
+      } catch (err) {
+        await snap(shotName);
+        stepOutcomes.push({ label: step.label, ok: false, note: `동작 실패: ${String(err).slice(0, 100)}` });
+      }
+    }
+  } finally {
+    await context.close(); // finalizes the video
+    await browser.close();
+  }
+
+  // Save the recorded video next to the screenshots.
+  try {
+    const vp = await page.video()?.path();
+    if (vp && existsSync(vp)) {
+      const dest = join(videoDir, "flow.webm");
+      copyFileSync(vp, dest);
+      evidenceFiles.push({ name: "video/flow.webm", path: dest });
+    }
+  } catch {
+    /* video optional */
+  }
+
+  const decision = decideFromEvidence(evidence, stepOutcomes);
+  const reportInput = {
+    targetUrl,
+    intentAnchor: intent,
+    loadStatus: evidence.loadStatus,
+    primaryActionFound: evidence.primaryActionFound,
+    interacted: evidence.interacted,
+    routeAfterClick: evidence.routeAfterClick,
+    routeChanged: evidence.routeChanged,
+    consoleErrors,
+    networkFailures,
+    decision,
+    steps: stepOutcomes,
+  };
+  const report = buildNonDevReport(reportInput);
+  const agentPrompt = buildAgentFixPrompt(reportInput);
+
+  return { report, agentPrompt, decision, works: report.works, evidenceFiles };
+}

--- a/apps/central-plane/inspector-container/package.json
+++ b/apps/central-plane/inspector-container/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "simsa-inspector-container",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Stage 263 — SimsaInspector container runtime deps. NOT a pnpm workspace package (workspace globs are packages/* + apps/* only); installed with npm inside the Docker image. The playwright version MUST match the mcr.microsoft.com/playwright base tag in the Dockerfile AND tools/simsa-completion-loop-spike/package.json.",
+  "dependencies": {
+    "playwright": "1.60.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/central-plane/inspector-container/safety.mjs
+++ b/apps/central-plane/inspector-container/safety.mjs
@@ -1,0 +1,44 @@
+/**
+ * safety.mjs — Stage 263 (copied from tools/simsa-completion-loop-spike/lib/safety.mjs).
+ *
+ * Pure, deterministic safety filter for clickable actions. The inspector must
+ * NEVER click destructive/irreversible actions (payment, delete, send, invite,
+ * publish, deploy, logout, destructive mutation). When risk is unclear, the
+ * action is SKIPPED, not clicked. Decides from visible text only — no network,
+ * no browser.
+ *
+ * Kept as a byte-level copy of the spike's classifier so both runners skip the
+ * same actions. If you change one, change the other in the same commit.
+ */
+
+/** Keyword groups that map to forbidden categories. Matched case-insensitively against text. */
+const FORBIDDEN_PATTERNS = [
+  { category: "payment", re: /\b(pay|payment|checkout|subscribe|buy|purchase|billing|upgrade|card)\b/i },
+  { category: "delete", re: /\b(delete|remove|destroy|drop|erase|wipe|reset)\b/i },
+  { category: "send email", re: /\b(send|email|e-mail|mail|notify)\b/i },
+  { category: "invite external users", re: /\b(invite|share|add member|add user)\b/i },
+  { category: "publish", re: /\b(publish|go live|make public|release)\b/i },
+  { category: "deploy", re: /\b(deploy|ship|promote to production)\b/i },
+  { category: "destructive data mutation", re: /\b(clear all|delete all|truncate|format)\b/i },
+  { category: "auth bypass / logout", re: /\b(logout|log out|sign out)\b/i },
+  // Korean forms of the same forbidden intents (the spike handles these via
+  // the planner's forbidden list; the runner double-checks at click time).
+  { category: "payment", re: /결제|구매/ },
+  { category: "delete", re: /삭제/ },
+  { category: "publish", re: /발행/ },
+  { category: "deploy", re: /배포/ },
+  { category: "auth bypass / logout", re: /로그아웃/ },
+];
+
+/**
+ * Classify a candidate action by its visible text. Returns { safe, category }.
+ * safe=false means: do NOT click; record as Skipped with the matched category.
+ */
+export function classifyActionSafety(text) {
+  const t = typeof text === "string" ? text.trim() : "";
+  if (!t) return { safe: false, category: "empty/unknown" }; // unclear → skip
+  for (const { category, re } of FORBIDDEN_PATTERNS) {
+    if (re.test(t)) return { safe: false, category };
+  }
+  return { safe: true, category: null };
+}

--- a/apps/central-plane/inspector-container/server.mjs
+++ b/apps/central-plane/inspector-container/server.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * Stage 263 — SimsaInspector container: HTTP server entry.
+ *
+ * Spawned per visual-check run by the Worker (INSPECTOR Durable Object).
+ * Listens on PORT (default 8080), accepts POST /run with the job payload,
+ * executes the Playwright deep-flow inspection (inspector-run.mjs), uploads
+ * evidence to the Stage 261 evidence endpoint, and reports the verdict to the
+ * Worker's /internal/visual-check-done callback.
+ *
+ * Mirrors container/server.mjs (the autofix sandbox shim): thin node:http
+ * server, 202 ack + async work, SIGTERM drain so killed-mid-run jobs still
+ * produce a failed callback instead of a silently stuck row.
+ *
+ * PRIVACY: userKey and callbackToken are never logged — log lines carry only
+ * the runId.
+ */
+import { createServer } from "node:http";
+import { promises as fs } from "node:fs";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const PORT = Number(process.env.PORT ?? 8080);
+const WORK_ROOT = process.env.WORK_ROOT ?? "/var/lib/simsa";
+/** Total wall-clock budget for one inspection (browser phase). */
+const INSPECTION_TIMEOUT_MS = 4 * 60 * 1000;
+
+/** Required job payload fields (Worker's dispatchInspection contract). */
+const REQUIRED_FIELDS = ["runId", "projectId", "userKey", "targetUrl", "intent", "baseUrl", "callbackUrl", "callbackToken"];
+
+export function validateJobPayload(payload) {
+  const missing = REQUIRED_FIELDS.filter(
+    (f) => typeof payload?.[f] !== "string" || payload[f].length === 0,
+  );
+  return missing.length === 0 ? { ok: true } : { ok: false, missing };
+}
+
+// In-flight registry, drained on SIGTERM (deploy rollouts / sleepAfter kills).
+const inFlightRuns = new Map();
+
+const server = createServer(async (req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true, ts: new Date().toISOString() }));
+    return;
+  }
+
+  if (req.method !== "POST" || req.url !== "/run") {
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "POST /run only" }));
+    return;
+  }
+
+  let body = "";
+  req.setEncoding("utf8");
+  for await (const chunk of req) body += chunk;
+
+  let payload;
+  try {
+    payload = JSON.parse(body);
+  } catch (err) {
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "invalid JSON body", detail: err.message }));
+    return;
+  }
+
+  const validation = validateJobPayload(payload);
+  if (!validation.ok) {
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: `missing fields: ${validation.missing.join(", ")}` }));
+    return;
+  }
+
+  // Ack immediately; the inspection runs async and reports via callbacks.
+  res.writeHead(202, { "content-type": "application/json" });
+  res.end(JSON.stringify({ runId: payload.runId, status: "accepted" }));
+
+  inFlightRuns.set(payload.runId, payload);
+  runJob(payload)
+    .catch(async (err) => {
+      console.error(`[run ${payload.runId}] crashed:`, err);
+      await postJson(payload.callbackUrl, payload.callbackToken, {
+        runId: payload.runId,
+        ok: false,
+        error: String(err?.message ?? err).slice(0, 500),
+      }).catch((cbErr) => {
+        console.error(`[run ${payload.runId}] callback also failed:`, cbErr);
+      });
+    })
+    .finally(() => inFlightRuns.delete(payload.runId));
+});
+
+server.listen(PORT, () => {
+  console.log(`simsa-inspector listening on :${PORT}`);
+});
+
+// Graceful shutdown — mirror container/server.mjs. Cap the drain at 5s.
+let shuttingDown = false;
+async function gracefulShutdown(sig) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`received ${sig} — draining ${inFlightRuns.size} in-flight run(s)`);
+  const drains = Array.from(inFlightRuns.values()).map((p) =>
+    postJson(p.callbackUrl, p.callbackToken, {
+      runId: p.runId,
+      ok: false,
+      error: `inspector container was killed by ${sig} mid-run (deploy rollout or sleepAfter)`,
+    }).catch((cbErr) => {
+      console.error(`[shutdown] callback failed for ${p.runId}:`, cbErr);
+    }),
+  );
+  const drainTimeout = new Promise((resolve) => setTimeout(resolve, 5000));
+  await Promise.race([Promise.all(drains), drainTimeout]);
+  server.close(() => process.exit(0));
+}
+for (const sig of ["SIGTERM", "SIGINT"]) {
+  process.on(sig, () => {
+    void gracefulShutdown(sig);
+  });
+}
+
+// --- Job runner -------------------------------------------------------------
+
+async function runJob(payload) {
+  const { runId, projectId, userKey, targetUrl, intent, baseUrl, callbackUrl, callbackToken, runningUrl } = payload;
+  const start = Date.now();
+  console.log(`[run ${runId}] start (target host: ${safeHost(targetUrl)})`);
+
+  // queued → running (best-effort; the inspection proceeds regardless).
+  if (typeof runningUrl === "string" && runningUrl) {
+    await postJson(runningUrl, callbackToken, { runId }).catch((err) => {
+      console.error(`[run ${runId}] running-ack failed:`, err?.message ?? err);
+    });
+  }
+
+  const outDir = await fs.mkdtemp(path.join(WORK_ROOT, `vc-`));
+  try {
+    // Lazy import keeps startup fast and lets a broken Playwright install
+    // surface as a per-run failure callback instead of a dead container.
+    const { runInspection } = await import("./inspector-run.mjs");
+
+    // Wall-clock rail: Chromium hangs (infinite spinners, slow hosts) must
+    // not exceed ~4 minutes. On timeout the run is reported failed; the
+    // leaked browser (if any) dies with the container's sleepAfter.
+    const result = await withTimeout(
+      runInspection({ targetUrl, intent, outDir }),
+      INSPECTION_TIMEOUT_MS,
+      `inspection timed out after ${Math.round(INSPECTION_TIMEOUT_MS / 1000)}s`,
+    );
+
+    // 1) Upload evidence through the EXISTING Stage 261 endpoint (it
+    //    validates names + sizes server-side). Failures are non-fatal —
+    //    the report is still worth delivering.
+    let uploaded = 0;
+    for (const file of result.evidenceFiles) {
+      try {
+        const bytes = readFileSync(file.path);
+        const url =
+          `${baseUrl}/workspace/projects/${encodeURIComponent(projectId)}/visual-checks/${encodeURIComponent(runId)}/evidence` +
+          `?userKey=${encodeURIComponent(userKey)}&name=${encodeURIComponent(file.name)}`;
+        const r = await fetch(url, { method: "POST", body: bytes });
+        if (r.ok) uploaded += 1;
+        else console.error(`[run ${runId}] evidence upload ${file.name} → ${r.status}`);
+      } catch (err) {
+        console.error(`[run ${runId}] evidence upload ${file.name} failed:`, err?.message ?? err);
+      }
+    }
+    console.log(`[run ${runId}] evidence uploaded ${uploaded}/${result.evidenceFiles.length}`);
+
+    // 2) Final verdict callback.
+    await postJson(callbackUrl, callbackToken, {
+      runId,
+      ok: true,
+      decision: result.decision,
+      works: result.works,
+      report: result.report,
+      agentPrompt: result.agentPrompt,
+    });
+    console.log(`[run ${runId}] done (decision=${result.decision}, ${Date.now() - start}ms)`);
+  } catch (err) {
+    console.error(`[run ${runId}] failed:`, err);
+    await postJson(callbackUrl, callbackToken, {
+      runId,
+      ok: false,
+      error: String(err?.message ?? err).slice(0, 500),
+    });
+  } finally {
+    try {
+      await fs.rm(outDir, { recursive: true, force: true });
+    } catch (cleanupErr) {
+      console.error(`[run ${runId}] cleanup failed:`, cleanupErr);
+    }
+  }
+}
+
+function withTimeout(promise, ms, message) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+function safeHost(url) {
+  try {
+    return new URL(url).host;
+  } catch {
+    return "invalid-url";
+  }
+}
+
+async function postJson(url, token, body) {
+  const r = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) {
+    const tail = await r.text();
+    throw new Error(`callback returned ${r.status}: ${tail.slice(0, 300)}`);
+  }
+}

--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -76,6 +76,18 @@ export interface Env {
    */
   SANDBOX?: DurableObjectNamespace;
   /**
+   * Stage 263 — SimsaInspector container binding
+   * (apps/central-plane/inspector-container/). One instance per visual-check
+   * run: the Worker calls
+   *   c.env.INSPECTOR.idFromName(`vc-${runId}`).get().fetch(...)
+   * to forward the inspection job into a Playwright + Chromium container that
+   * executes the deep-flow check, uploads evidence via the Stage 261 evidence
+   * endpoint, and reports back to /internal/visual-check-done. Optional:
+   * without the binding, POST .../visual-checks/run still creates the queued
+   * row and returns dispatched:false (note inspector_unavailable).
+   */
+  INSPECTOR?: DurableObjectNamespace;
+  /**
    * Stage 261 — R2 bucket `simsa-evidence`: visual-check evidence
    * (screenshots/video under checks/{userKey}/{projectId}/{runId}/) and
    * uploaded project documents (PRD/md under docs/{userKey}/{projectId}/).

--- a/apps/central-plane/src/index.ts
+++ b/apps/central-plane/src/index.ts
@@ -2,7 +2,7 @@ import { createApp } from "./router.js";
 import type { Env } from "./env.js";
 import { assertPreflight } from "./preflight.js";
 import { selfHealWebhook } from "./webhook-heal.js";
-import { cleanupStuckJobs } from "./stuck-cleanup.js";
+import { cleanupStuckJobs, cleanupStuckVisualChecks } from "./stuck-cleanup.js";
 import { refreshAllSources } from "./external-references.js";
 import { retryPendingFeedback } from "./routes/feedback.js";
 import { promoteSeedsPass } from "./seed-promoter.js";
@@ -51,6 +51,14 @@ export default {
         console.log(JSON.stringify({ cron: "stuck-cleanup", cronExpression: event.cron, ...result }));
       } catch (err) {
         console.error("[stuck-cleanup] crashed:", err);
+      }
+      // Stage 263 — same tick also sweeps visual-check runs stuck in
+      // queued|running (SimsaInspector container killed / dispatch lost).
+      try {
+        const result = await cleanupStuckVisualChecks(env);
+        console.log(JSON.stringify({ cron: "stuck-cleanup-visual-checks", cronExpression: event.cron, ...result }));
+      } catch (err) {
+        console.error("[stuck-cleanup-visual-checks] crashed:", err);
       }
       return;
     }
@@ -237,4 +245,8 @@ export { createApp } from "./router.js";
 // --test consumers of router.ts don't transitively pull in the Workers-
 // only `@cloudflare/containers` runtime imports.
 export { ConclaveSandbox } from "./container.js";
+// Stage 263 — SimsaInspector container DO (Playwright visual inspections).
+// Same rule as ConclaveSandbox: exported ONLY from index.ts so node --test
+// consumers of router.ts never pull in `@cloudflare/containers`.
+export { SimsaInspector } from "./inspector-container.js";
 export type { Env } from "./env.js";

--- a/apps/central-plane/src/inspector-container.ts
+++ b/apps/central-plane/src/inspector-container.ts
@@ -1,0 +1,40 @@
+/**
+ * Stage 263 — SimsaInspector Cloudflare Container Durable Object.
+ *
+ * Wraps the Playwright + Chromium container (inspector-container/Dockerfile)
+ * that executes Simsa visual completion checks in the cloud. Mirrors the
+ * ConclaveSandbox pattern (src/container.ts):
+ *   - extends Container<Env>
+ *   - declared in wrangler.toml under a second [[containers]] block
+ *   - bound as a Durable Object (INSPECTOR) so the Worker can address one
+ *     instance per run (`vc-<runId>`) for isolation
+ *   - exported ONLY from src/index.ts — never imported into router.ts —
+ *     so node --test consumers stay free of `cloudflare:workers` imports.
+ *
+ * sleepAfter 10m: a single inspection is hard-capped at ~4 minutes inside the
+ * container (wall-clock rail in server.mjs); 10 minutes covers evidence
+ * upload + callback with margin while releasing the instance before cost
+ * matters. defaultPort matches the EXPOSE in inspector-container/Dockerfile.
+ */
+import { Container } from "@cloudflare/containers";
+import type { Env } from "./env.js";
+
+export class SimsaInspector extends Container<Env> {
+  override defaultPort = 8080;
+  override sleepAfter = "10m";
+  override envVars = {
+    NODE_ENV: "production",
+  };
+
+  override onStart() {
+    console.log("simsa-inspector container started");
+  }
+
+  override onStop() {
+    console.log("simsa-inspector container stopped");
+  }
+
+  override onError(err: unknown) {
+    console.error("simsa-inspector container error:", err);
+  }
+}

--- a/apps/central-plane/src/router.ts
+++ b/apps/central-plane/src/router.ts
@@ -38,6 +38,7 @@ import { createWorkspaceCreditsRoutes } from "./routes/workspace-credits.js";
 import { createWorkspaceBenchmarkRoutes } from "./routes/workspace-benchmark.js";
 import { createWorkspaceSourcesRoutes } from "./routes/workspace-sources.js";
 import { createWorkspaceVisualChecksRoutes } from "./routes/workspace-visual-checks.js";
+import { createWorkspaceVisualCheckRunRoutes } from "./routes/workspace-visual-check-runs.js";
 import { createWorkspaceExperimentRoutes } from "./routes/workspace-experiment.js";
 import { createWorkspaceAgentWorkflowRoutes } from "./routes/workspace-agent-workflow.js";
 import { createWorkspaceMembershipRoutes } from "./routes/workspace-membership.js";
@@ -154,6 +155,10 @@ export function createApp(opts: { fetch?: FetchLike } = {}): Hono<{ Bindings: En
   app.route("/", createWorkspaceSourcesRoutes());
   // Stage 261 — Simsa visual completion-check runs (report snapshots + R2 evidence).
   app.route("/", createWorkspaceVisualChecksRoutes());
+  // Stage 263 — cloud runner dispatch: POST .../visual-checks/run queues a
+  // SimsaInspector container job; /internal/visual-check-{running,done} are
+  // the container's callbacks (Bearer INTERNAL_CALLBACK_TOKEN).
+  app.route("/", createWorkspaceVisualCheckRunRoutes());
   // Stage 72 — Persisted Manual Multi-Agent Experiments.
   app.route("/", createWorkspaceExperimentRoutes());
   // Stage 112 — Persisted Agent Workflow Records (intake snapshot save/list/read).

--- a/apps/central-plane/src/routes/workspace-visual-check-runs.ts
+++ b/apps/central-plane/src/routes/workspace-visual-check-runs.ts
@@ -1,0 +1,323 @@
+/**
+ * workspace-visual-check-runs.ts — Stage 263
+ *
+ * Cloud execution of Simsa visual completion checks. A dashboard/API client
+ * asks "run inspection"; the Worker inserts a queued workspace_visual_checks
+ * row (Stage 261 storage) and dispatches the job into the SimsaInspector
+ * Cloudflare Container (Playwright + Chromium). The container uploads
+ * evidence through the EXISTING Stage 261 evidence endpoint and reports the
+ * result back here.
+ *
+ *   POST /workspace/projects/:id/visual-checks/run   — queue + dispatch a run
+ *   POST /internal/visual-check-running              — container ack: queued → running
+ *   POST /internal/visual-check-done                 — container result: → done|failed
+ *
+ * SECURITY:
+ *   - Ownership enforced (project belongs to userKey) — same pattern as the
+ *     Stage 261 routes.
+ *   - The Worker NEVER inspects arbitrary URLs. The target must be (or origin-
+ *     match) one of the project's registered `website` sources; a project with
+ *     no website source gets 400 website_source_required.
+ *   - /internal/* endpoints require Bearer INTERNAL_CALLBACK_TOKEN (mirrors
+ *     /internal/job-done in saas.ts).
+ *
+ * Graceful degradation: when the INSPECTOR DO binding or the callback token is
+ * absent, the queued row is still created and the response carries
+ * dispatched:false — the stuck sweep (stuck-cleanup.ts) fails it after 30 min.
+ */
+import { Hono } from "hono";
+import { corsMiddleware } from "./cors.js";
+import type { Env } from "../env.js";
+import { getProject } from "../workspace/db.js";
+import { getProjectSourceById, listProjectSources } from "../workspace/project-sources-db.js";
+import {
+  findActiveVisualCheckForProject,
+  getVisualCheckById,
+  insertQueuedVisualCheck,
+  markVisualCheckDone,
+  markVisualCheckFailed,
+  markVisualCheckRunning,
+} from "../workspace/visual-check-db.js";
+
+const MAX_INTENT_CHARS = 1000;
+const MAX_TARGET_URL_CHARS = 500;
+const MAX_REPORT_BYTES = 512 * 1024; // matches Stage 261 create route
+const MAX_PROMPT_BYTES = 64 * 1024;
+const MAX_ERROR_CHARS = 500;
+
+/** Generic Korean intent used when the caller doesn't provide one. */
+export const DEFAULT_INSPECTION_INTENT =
+  "사용자가 앱을 열어 핵심 기능이 실제로 작동하는지 눈으로 확인할 수 있어야 한다";
+
+function parseHttpUrl(raw: string): URL | null {
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    return u;
+  } catch {
+    return null;
+  }
+}
+
+/** True when `target` shares an origin with any registered website source. */
+export function targetMatchesWebsiteSources(target: URL, references: string[]): boolean {
+  for (const ref of references) {
+    const src = parseHttpUrl(ref.trim());
+    if (src && src.origin === target.origin) return true;
+  }
+  return false;
+}
+
+function requireInternalToken(c: {
+  env: Env;
+  req: { header: (name: string) => string | undefined };
+}): { ok: true } | { ok: false; status: 401 | 503; error: string } {
+  const expected = c.env.INTERNAL_CALLBACK_TOKEN;
+  if (!expected) return { ok: false, status: 503, error: "callback_disabled" };
+  const auth = c.req.header("authorization") ?? c.req.header("Authorization") ?? "";
+  const m = /^Bearer\s+(.+)$/i.exec(auth);
+  if (!m || m[1] !== expected) return { ok: false, status: 401, error: "unauthorized" };
+  return { ok: true };
+}
+
+/**
+ * Dispatch the queued run into the SimsaInspector container DO. Mirrors
+ * spawnSandbox in saas.ts: fire-and-forget from the caller's perspective —
+ * the container acks 202 and reports back via /internal/visual-check-*.
+ */
+export async function dispatchInspection(
+  env: Env,
+  args: {
+    runId: string;
+    projectId: string;
+    userKey: string;
+    targetUrl: string;
+    intent: string;
+    publicBaseUrl: string;
+  },
+): Promise<{ dispatched: boolean; note?: string }> {
+  if (!env.INSPECTOR) {
+    return { dispatched: false, note: "inspector_unavailable" };
+  }
+  if (!env.INTERNAL_CALLBACK_TOKEN) {
+    return { dispatched: false, note: "callback_token_missing" };
+  }
+  const base = args.publicBaseUrl.replace(/\/+$/, "");
+  const payload = {
+    runId: args.runId,
+    projectId: args.projectId,
+    userKey: args.userKey,
+    targetUrl: args.targetUrl,
+    intent: args.intent,
+    baseUrl: base,
+    callbackUrl: `${base}/internal/visual-check-done`,
+    runningUrl: `${base}/internal/visual-check-running`,
+    callbackToken: env.INTERNAL_CALLBACK_TOKEN,
+  };
+  try {
+    const id = env.INSPECTOR.idFromName(`vc-${args.runId}`);
+    const stub = env.INSPECTOR.get(id);
+    const r = await stub.fetch("http://inspector/run", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!r.ok) {
+      const tail = await r.text();
+      return { dispatched: false, note: `container returned ${r.status}: ${tail.slice(0, 200)}` };
+    }
+    return { dispatched: true };
+  } catch (err) {
+    return { dispatched: false, note: `container fetch failed: ${(err as Error).message.slice(0, 200)}` };
+  }
+}
+
+export function createWorkspaceVisualCheckRunRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("/workspace/*", corsMiddleware);
+
+  // ── POST /workspace/projects/:id/visual-checks/run ─────────────────────────
+  app.post("/workspace/projects/:id/visual-checks/run", async (c) => {
+    const projectId = c.req.param("id");
+
+    let body: { userKey?: unknown; sourceId?: unknown; targetUrl?: unknown; intent?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ ok: false, error: "invalid_json" }, 400);
+    }
+
+    const userKey = typeof body.userKey === "string" ? body.userKey : "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    // Ownership — identical pattern to the Stage 261 routes.
+    const project = await getProject(c.env, projectId);
+    if (!project) return c.json({ ok: false, error: "project_not_found" }, 404);
+    if (project.userKey !== userKey) return c.json({ ok: false, error: "forbidden" }, 403);
+
+    // Intent: optional, ≤1000 chars, sensible Korean generic default.
+    let intent = DEFAULT_INSPECTION_INTENT;
+    if (body.intent !== undefined) {
+      if (typeof body.intent !== "string" || body.intent.trim().length === 0 || body.intent.length > MAX_INTENT_CHARS) {
+        return c.json({ ok: false, error: "invalid_intent" }, 400);
+      }
+      intent = body.intent.trim();
+    }
+
+    // Resolve the inspection target. NEVER an arbitrary URL: it must come
+    // from — or origin-match — a registered website source of THIS project.
+    let targetUrl: string;
+    if (body.sourceId !== undefined) {
+      const sourceId = typeof body.sourceId === "string" ? body.sourceId : "";
+      const source = sourceId ? await getProjectSourceById(c.env, sourceId) : null;
+      if (!source || source.projectId !== projectId || source.userKey !== userKey || source.type !== "website") {
+        return c.json({ ok: false, error: "invalid_source" }, 400);
+      }
+      const parsed = parseHttpUrl(source.reference.trim());
+      if (!parsed) return c.json({ ok: false, error: "invalid_target_url" }, 400);
+      targetUrl = parsed.toString();
+    } else {
+      const sources = await listProjectSources(c.env, projectId);
+      const websites = sources.filter((s) => s.type === "website");
+      if (websites.length === 0) return c.json({ ok: false, error: "website_source_required" }, 400);
+
+      if (body.targetUrl !== undefined) {
+        const raw = typeof body.targetUrl === "string" ? body.targetUrl.trim() : "";
+        if (!raw || raw.length > MAX_TARGET_URL_CHARS) return c.json({ ok: false, error: "invalid_target_url" }, 400);
+        const parsed = parseHttpUrl(raw);
+        if (!parsed) return c.json({ ok: false, error: "invalid_target_url" }, 400);
+        if (!targetMatchesWebsiteSources(parsed, websites.map((w) => w.reference))) {
+          return c.json({ ok: false, error: "target_url_not_registered" }, 400);
+        }
+        targetUrl = parsed.toString();
+      } else {
+        // Convenience: no explicit target → most recent website source.
+        const latest = websites[0]!;
+        const parsed = parseHttpUrl(latest.reference.trim());
+        if (!parsed) return c.json({ ok: false, error: "invalid_target_url" }, 400);
+        targetUrl = parsed.toString();
+      }
+    }
+
+    // Concurrency guard: one active cloud run per project.
+    const active = await findActiveVisualCheckForProject(c.env, projectId);
+    if (active) {
+      return c.json({ ok: false, error: "run_already_active", activeRunId: active.id }, 409);
+    }
+
+    let run;
+    try {
+      run = await insertQueuedVisualCheck(c.env, { projectId, userKey, targetUrl, intent });
+    } catch (err) {
+      console.error("[visual-check-runs POST run] insert failed:", err);
+      return c.json({ ok: false, error: "save_failed" }, 500);
+    }
+
+    const publicBaseUrl = c.env.PUBLIC_BASE_URL ?? new URL(c.req.url).origin;
+    const dispatch = await dispatchInspection(c.env, {
+      runId: run.id,
+      projectId,
+      userKey,
+      targetUrl,
+      intent,
+      publicBaseUrl,
+    });
+
+    return c.json(
+      {
+        ok: true,
+        check: {
+          id: run.id,
+          projectId,
+          targetUrl: run.targetUrl,
+          intent: run.intent,
+          decision: run.decision,
+          works: run.works,
+          status: run.status,
+          executor: run.executor,
+          createdAt: run.createdAt,
+        },
+        dispatched: dispatch.dispatched,
+        ...(dispatch.note ? { note: dispatch.note } : {}),
+      },
+      202,
+    );
+  });
+
+  // ── POST /internal/visual-check-running ────────────────────────────────────
+  // Container ack: the job actually started executing (queued → running).
+  // Bearer INTERNAL_CALLBACK_TOKEN required, mirroring /internal/job-done.
+  app.post("/internal/visual-check-running", async (c) => {
+    const auth = requireInternalToken(c);
+    if (!auth.ok) return c.json({ error: auth.error }, auth.status);
+
+    const body = (await c.req.json().catch(() => null)) as { runId?: string } | null;
+    if (!body || typeof body.runId !== "string" || !body.runId) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+    const run = await getVisualCheckById(c.env, body.runId);
+    if (!run) return c.json({ error: "not_found" }, 404);
+
+    const transitioned = await markVisualCheckRunning(c.env, body.runId);
+    return c.json({ ok: true, transitioned });
+  });
+
+  // ── POST /internal/visual-check-done ───────────────────────────────────────
+  // Container result callback. Evidence files were already uploaded via the
+  // Stage 261 evidence endpoint (which validates names/sizes) — this endpoint
+  // only finalizes the row.
+  app.post("/internal/visual-check-done", async (c) => {
+    const auth = requireInternalToken(c);
+    if (!auth.ok) return c.json({ error: auth.error }, auth.status);
+
+    const body = (await c.req.json().catch(() => null)) as
+      | {
+          runId?: string;
+          ok?: boolean;
+          decision?: string;
+          works?: boolean | null;
+          report?: unknown;
+          agentPrompt?: string;
+          error?: string;
+        }
+      | null;
+    if (!body || typeof body.runId !== "string" || !body.runId || typeof body.ok !== "boolean") {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+
+    const run = await getVisualCheckById(c.env, body.runId);
+    if (!run) return c.json({ error: "not_found" }, 404);
+
+    if (!body.ok) {
+      const error = typeof body.error === "string" && body.error ? body.error : "inspection failed";
+      await markVisualCheckFailed(c.env, body.runId, error.slice(0, MAX_ERROR_CHARS));
+      return c.json({ ok: true, status: "failed" });
+    }
+
+    const decision = typeof body.decision === "string" && body.decision.trim() && body.decision.length <= 64
+      ? body.decision.trim()
+      : "Not Judged";
+    const works = body.works === true ? true : body.works === false ? false : null;
+
+    let reportJson = "{}";
+    if (body.report !== undefined && body.report !== null && typeof body.report === "object") {
+      const serialized = JSON.stringify(body.report);
+      if (serialized.length > MAX_REPORT_BYTES) return c.json({ error: "report_too_large" }, 400);
+      reportJson = serialized;
+    }
+    const agentPrompt = typeof body.agentPrompt === "string" && body.agentPrompt ? body.agentPrompt : undefined;
+    if (agentPrompt && agentPrompt.length > MAX_PROMPT_BYTES) {
+      return c.json({ error: "agent_prompt_too_large" }, 400);
+    }
+
+    await markVisualCheckDone(c.env, body.runId, {
+      decision,
+      works,
+      reportJson,
+      ...(agentPrompt ? { agentPrompt } : {}),
+    });
+    return c.json({ ok: true, status: "done" });
+  });
+
+  return app;
+}

--- a/apps/central-plane/src/stuck-cleanup.ts
+++ b/apps/central-plane/src/stuck-cleanup.ts
@@ -15,6 +15,7 @@
 import type { Env } from "./env.js";
 import { findInstallationByRepoSlug } from "./db/saas.js";
 import { postPrComment } from "./gh-app.js";
+import { listStuckVisualChecks, markVisualCheckFailed } from "./workspace/visual-check-db.js";
 
 const STUCK_AFTER_MS = 30 * 60 * 1000; // 30 minutes
 const SWEEP_LIMIT = 50; // safety cap; never touch more than 50 rows in a single tick
@@ -76,4 +77,40 @@ export async function cleanupStuckJobs(
     }
   }
   return { swept: rows.length, commented, errors };
+}
+
+/**
+ * Stage 263 — sweep Simsa visual-check runs stuck in queued|running >30 min.
+ *
+ * Mirrors cleanupStuckJobs: the SimsaInspector container was killed mid-run
+ * (deploy rollout, OOM, wall-clock timeout) or the dispatch was lost, so no
+ * /internal/visual-check-done callback will ever arrive. Uses updated_at as
+ * the staleness clock (the row is touched on queue + on the running ack).
+ * Runs on the same `*\/5 * * * *` cron tick as the saas jobs sweep.
+ */
+export async function cleanupStuckVisualChecks(
+  env: Env,
+): Promise<{ swept: number; errors: number }> {
+  const cutoff = new Date(Date.now() - STUCK_AFTER_MS).toISOString();
+  let rows: Array<{ id: string; status: string }>;
+  try {
+    rows = await listStuckVisualChecks(env, cutoff, SWEEP_LIMIT);
+  } catch (err) {
+    // Table may not exist yet on a fresh D1 (migration 0050 unapplied) —
+    // don't let the visual sweep break the jobs sweep sharing this cron.
+    console.error("[stuck-cleanup] visual-check query failed:", err);
+    return { swept: 0, errors: 1 };
+  }
+  let errors = 0;
+  const reason =
+    "inspector container did not report a result within 30 minutes — likely killed by a deploy rollout or a hung page load. Run the inspection again.";
+  for (const r of rows) {
+    try {
+      await markVisualCheckFailed(env, r.id, reason);
+    } catch (err) {
+      errors += 1;
+      console.error(`[stuck-cleanup] visual-check ${r.id} failed:`, err);
+    }
+  }
+  return { swept: rows.length, errors };
 }

--- a/apps/central-plane/src/workspace/visual-check-db.ts
+++ b/apps/central-plane/src/workspace/visual-check-db.ts
@@ -188,6 +188,139 @@ export async function getVisualCheckById(env: Env, id: string): Promise<DbVisual
   return row ? fromRow(row) : null;
 }
 
+/**
+ * Stage 263 — insert a QUEUED cloud-runner row. The container fills the real
+ * report/decision later via /internal/visual-check-done; until then the row
+ * carries a placeholder report and a 'Not Judged' decision so list/detail
+ * render consistently while the run is in flight.
+ */
+export async function insertQueuedVisualCheck(
+  env: Env,
+  input: {
+    projectId: string;
+    userKey: string;
+    targetUrl: string;
+    intent: string;
+    now?: string;
+  },
+): Promise<DbVisualCheck> {
+  const id = randId();
+  const now = input.now ?? new Date().toISOString();
+  await env.DB.prepare(
+    `INSERT INTO workspace_visual_checks
+       (id, project_id, user_key, target_url, intent, decision, works,
+        status, executor, report_json, agent_prompt, evidence_keys_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, 'Not Judged', NULL, 'queued', 'container', '{}', NULL, '[]', ?, ?)`,
+  )
+    .bind(id, input.projectId, input.userKey, input.targetUrl, input.intent, now, now)
+    .run();
+  return {
+    id,
+    projectId: input.projectId,
+    userKey: input.userKey,
+    targetUrl: input.targetUrl,
+    intent: input.intent,
+    decision: "Not Judged",
+    works: null,
+    status: "queued",
+    executor: "container",
+    reportJson: "{}",
+    evidenceKeys: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/** Stage 263 — a project's currently active (queued|running) cloud run, if any. */
+export async function findActiveVisualCheckForProject(
+  env: Env,
+  projectId: string,
+): Promise<{ id: string; status: VisualCheckStatus } | null> {
+  const row = (await env.DB.prepare(
+    `SELECT id, status FROM workspace_visual_checks
+      WHERE project_id = ? AND status IN ('queued', 'running')
+      ORDER BY created_at DESC
+      LIMIT 1`,
+  )
+    .bind(projectId)
+    .first()) as { id: string; status: VisualCheckStatus } | null;
+  return row ?? null;
+}
+
+/** Stage 263 — queued → running (only from an in-flight state; done/failed are final). */
+export async function markVisualCheckRunning(env: Env, id: string): Promise<boolean> {
+  const res = await env.DB.prepare(
+    `UPDATE workspace_visual_checks
+        SET status = 'running', updated_at = ?
+      WHERE id = ? AND status IN ('queued', 'running')`,
+  )
+    .bind(new Date().toISOString(), id)
+    .run();
+  return (res.meta?.changes ?? 0) > 0;
+}
+
+/** Stage 263 — terminal success: store the container's report + verdict. */
+export async function markVisualCheckDone(
+  env: Env,
+  id: string,
+  input: { decision: string; works: boolean | null; reportJson: string; agentPrompt?: string },
+): Promise<void> {
+  await env.DB.prepare(
+    `UPDATE workspace_visual_checks
+        SET status = 'done', decision = ?, works = ?, report_json = ?, agent_prompt = ?, updated_at = ?
+      WHERE id = ?`,
+  )
+    .bind(
+      input.decision,
+      input.works === null ? null : input.works ? 1 : 0,
+      input.reportJson,
+      input.agentPrompt ?? null,
+      new Date().toISOString(),
+      id,
+    )
+    .run();
+}
+
+/**
+ * Stage 263 — terminal failure. Keeps works NULL (we could not verify) and
+ * snapshots the error into report_json only when the run still carries the
+ * queued placeholder, so a partial report the container managed to send is
+ * never clobbered.
+ */
+export async function markVisualCheckFailed(env: Env, id: string, error: string): Promise<void> {
+  const truncated = error.slice(0, 500);
+  await env.DB.prepare(
+    `UPDATE workspace_visual_checks
+        SET status = 'failed',
+            decision = 'Not Verified',
+            report_json = CASE WHEN report_json = '{}' THEN ? ELSE report_json END,
+            updated_at = ?
+      WHERE id = ?`,
+  )
+    .bind(JSON.stringify({ error: truncated }), new Date().toISOString(), id)
+    .run();
+}
+
+/**
+ * Stage 263 — cloud runs stuck in queued|running past the cutoff (container
+ * killed mid-run / dispatch lost). Mirrors the saas jobs stuck sweep.
+ */
+export async function listStuckVisualChecks(
+  env: Env,
+  cutoffIso: string,
+  limit: number,
+): Promise<Array<{ id: string; status: VisualCheckStatus }>> {
+  const rs = await env.DB.prepare(
+    `SELECT id, status FROM workspace_visual_checks
+      WHERE status IN ('queued', 'running') AND updated_at < ?
+      ORDER BY updated_at ASC
+      LIMIT ?`,
+  )
+    .bind(cutoffIso, limit)
+    .all<{ id: string; status: VisualCheckStatus }>();
+  return rs.results ?? [];
+}
+
 /** Append an uploaded evidence key to the run's manifest (read-modify-write). */
 export async function appendVisualCheckEvidenceKey(env: Env, id: string, key: string): Promise<string[]> {
   const row = await getVisualCheckById(env, id);

--- a/apps/central-plane/test/inspector-invariants.test.mjs
+++ b/apps/central-plane/test/inspector-invariants.test.mjs
@@ -1,0 +1,127 @@
+/**
+ * Stage 263 — live invariants across inspector-container.ts /
+ * inspector-container/Dockerfile / inspector-container/server.mjs /
+ * wrangler.toml / env.ts / index.ts / router.ts.
+ *
+ * Same discipline as container-invariants.test.mjs (the autofix sandbox):
+ * the port, image path, DO class registration and playwright version are
+ * expressed in several surfaces; drift deploys fine but breaks at runtime.
+ * Pin the alignment so CI fails before deploy.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, "..");
+const REPO = path.resolve(ROOT, "../..");
+
+const inspectorTs = readFileSync(path.join(ROOT, "src/inspector-container.ts"), "utf8");
+const dockerfile = readFileSync(path.join(ROOT, "inspector-container/Dockerfile"), "utf8");
+const serverMjs = readFileSync(path.join(ROOT, "inspector-container/server.mjs"), "utf8");
+const wranglerToml = readFileSync(path.join(ROOT, "wrangler.toml"), "utf8");
+const indexTs = readFileSync(path.join(ROOT, "src/index.ts"), "utf8");
+const routerTs = readFileSync(path.join(ROOT, "src/router.ts"), "utf8");
+const envTs = readFileSync(path.join(ROOT, "src/env.ts"), "utf8");
+const containerPkg = JSON.parse(readFileSync(path.join(ROOT, "inspector-container/package.json"), "utf8"));
+
+// ---- port alignment -------------------------------------------------------
+
+test("SimsaInspector defaultPort matches inspector Dockerfile EXPOSE and server.mjs default", () => {
+  const doMatch = /defaultPort\s*=\s*(\d+)/.exec(inspectorTs);
+  assert.ok(doMatch, "inspector-container.ts must declare defaultPort");
+  const exposeMatch = /^EXPOSE\s+(\d+)/m.exec(dockerfile);
+  assert.ok(exposeMatch, "inspector Dockerfile must EXPOSE a port");
+  assert.equal(doMatch[1], exposeMatch[1], "DO defaultPort vs Dockerfile EXPOSE drift");
+  const serverMatch = /PORT\s*=\s*Number\(process\.env\.PORT\s*\?\?\s*(\d+)\)/.exec(serverMjs);
+  assert.ok(serverMatch, "server.mjs must read PORT from env with a default literal");
+  assert.equal(doMatch[1], serverMatch[1], "DO defaultPort vs server.mjs PORT default drift");
+});
+
+// ---- DO class registration --------------------------------------------------
+
+test("wrangler.toml declares SimsaInspector container + INSPECTOR binding + v2 migration", () => {
+  const containersBlock = /\[\[containers\]\]\s*\nclass_name\s*=\s*"SimsaInspector"[\s\S]*?image\s*=\s*"([^"]+)"/.exec(wranglerToml);
+  assert.ok(containersBlock, "wrangler.toml must have a [[containers]] block for SimsaInspector");
+  const resolved = path.resolve(ROOT, containersBlock[1]);
+  assert.doesNotThrow(() => readFileSync(resolved, "utf8"), `image path must resolve (${resolved})`);
+
+  assert.match(
+    wranglerToml,
+    /\[\[durable_objects\.bindings\]\]\s*\nclass_name\s*=\s*"SimsaInspector"\s*\nname\s*=\s*"INSPECTOR"/,
+    "INSPECTOR DO binding must exist for SimsaInspector",
+  );
+  assert.match(
+    wranglerToml,
+    /tag\s*=\s*"v2-inspector"\s*\nnew_sqlite_classes\s*=\s*\["SimsaInspector"\]/,
+    "v2-inspector DO migration must register SimsaInspector",
+  );
+});
+
+test("SimsaInspector is exported from index.ts and NEVER imported into router.ts", () => {
+  assert.match(indexTs, /export\s+\{\s*SimsaInspector\s*\}/, "src/index.ts must export SimsaInspector");
+  // router.ts must stay free of the cloudflare:workers import chain so
+  // node --test consumers of createApp keep working (see router.ts header).
+  // Match import statements only — the header comment MENTIONS the package.
+  assert.doesNotMatch(routerTs, /from\s+["'][^"']*inspector-container/, "router.ts must not import inspector-container");
+  assert.doesNotMatch(routerTs, /from\s+["']@cloudflare\/containers/, "router.ts must not import @cloudflare/containers");
+});
+
+test("Env.INSPECTOR is typed as an optional DurableObjectNamespace", () => {
+  assert.match(envTs, /INSPECTOR\?:\s*DurableObjectNamespace/, "env.ts must type the INSPECTOR binding");
+});
+
+// ---- playwright version lock-step ------------------------------------------
+
+test("playwright version pinned identically in base image, container package.json, and the spike", () => {
+  const baseTag = /FROM\s+mcr\.microsoft\.com\/playwright:v(\d+\.\d+\.\d+)-/.exec(dockerfile);
+  assert.ok(baseTag, "Dockerfile must use a pinned mcr.microsoft.com/playwright base tag");
+  assert.equal(
+    containerPkg.dependencies?.playwright,
+    baseTag[1],
+    "inspector-container/package.json playwright must exactly match the base image tag " +
+      "(browsers baked at /ms-playwright are version-locked to the library)",
+  );
+  const spikePkg = JSON.parse(
+    readFileSync(path.join(REPO, "tools/simsa-completion-loop-spike/package.json"), "utf8"),
+  );
+  assert.equal(
+    spikePkg.devDependencies?.playwright,
+    baseTag[1],
+    "spike playwright version must match the container so local + cloud runs use the same browser",
+  );
+});
+
+// ---- canonical Simsa modules compiled in-image -------------------------------
+
+test("Dockerfile copies the canonical Simsa modules + runner scripts into the image", () => {
+  assert.match(dockerfile, /COPY\s+apps\/central-plane\/src\/visual-flow-plan\.ts/, "must COPY visual-flow-plan.ts");
+  assert.match(dockerfile, /apps\/central-plane\/src\/nondev-report\.ts/, "must COPY nondev-report.ts");
+  assert.match(dockerfile, /COPY\s+apps\/central-plane\/inspector-container\/server\.mjs/, "must COPY server.mjs");
+  assert.match(dockerfile, /COPY\s+apps\/central-plane\/inspector-container\/inspector-run\.mjs/, "must COPY inspector-run.mjs");
+  assert.match(dockerfile, /COPY\s+apps\/central-plane\/inspector-container\/safety\.mjs/, "must COPY safety.mjs");
+});
+
+test("the canonical Simsa modules stay dependency-free (standalone tsc compilable)", () => {
+  // The Dockerfile compiles these two files with a bare tsc invocation —
+  // an `import` added to either would silently break the image build.
+  for (const f of ["src/visual-flow-plan.ts", "src/nondev-report.ts"]) {
+    const src = readFileSync(path.join(ROOT, f), "utf8");
+    assert.doesNotMatch(src, /^\s*import\s/m, `${f} must not import anything (compiled standalone in the inspector image)`);
+  }
+});
+
+// ---- runner safety rails -----------------------------------------------------
+
+test("inspector runner keeps the forbidden-action + headless/viewport/timeout rails", () => {
+  const runMjs = readFileSync(path.join(ROOT, "inspector-container/inspector-run.mjs"), "utf8");
+  for (const word of ["payment", "delete", "invite", "publish", "deploy", "결제", "삭제", "발행", "배포", "로그아웃"]) {
+    assert.ok(runMjs.includes(word), `forbidden-action list must include "${word}"`);
+  }
+  assert.match(runMjs, /classifyActionSafety/, "runner must re-check safety at click time");
+  assert.match(runMjs, /headless:\s*true/, "runner must run headless");
+  assert.match(runMjs, /width:\s*1280,\s*height:\s*800/, "viewport must be 1280x800");
+  assert.match(serverMjs, /INSPECTION_TIMEOUT_MS\s*=\s*4\s*\*\s*60\s*\*\s*1000/, "wall-clock rail must be ~4 minutes");
+});

--- a/apps/central-plane/test/workspace-visual-check-runs.test.mjs
+++ b/apps/central-plane/test/workspace-visual-check-runs.test.mjs
@@ -1,0 +1,481 @@
+/**
+ * workspace-visual-check-runs.test.mjs — Stage 263
+ *
+ * Cloud runner dispatch for Simsa visual checks:
+ *   - POST /workspace/projects/:id/visual-checks/run — target resolution
+ *     (registered website sources ONLY), ownership, concurrency guard,
+ *     graceful degradation without the INSPECTOR binding, DO dispatch payload.
+ *   - POST /internal/visual-check-running / -done — bearer-token gate +
+ *     queued → running → done|failed transitions.
+ *   - cleanupStuckVisualChecks — 30-min stuck sweep.
+ *
+ * Mocks at the seam: fake D1, stub DurableObjectNamespace. No network, no
+ * containers.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { createApp } = await import("../dist/router.js");
+const { cleanupStuckVisualChecks } = await import("../dist/stuck-cleanup.js");
+
+const USER = "uk_owner";
+const OTHER = "uk_intruder";
+const PROJECT = "proj_vcr";
+const OTHER_PROJECT = "proj_other";
+const TOKEN = "tok_internal_secret";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+function makeDb({ projects = new Map(), sources = [], checks = [] } = {}) {
+  return {
+    _checks: checks,
+    prepare(sql) {
+      function handler(args) {
+        return {
+          async run() {
+            if (sql.includes("INSERT INTO workspace_visual_checks") && sql.includes("'queued', 'container'")) {
+              const [id, project_id, user_key, target_url, intent, created_at, updated_at] = args;
+              checks.push({
+                id, project_id, user_key, target_url, intent,
+                decision: "Not Judged", works: null, status: "queued", executor: "container",
+                report_json: "{}", agent_prompt: null, evidence_keys_json: "[]",
+                created_at, updated_at,
+              });
+              return { meta: { changes: 1 } };
+            }
+            if (sql.includes("SET status = 'running'")) {
+              const [updated_at, id] = args;
+              const row = checks.find((r) => r.id === id && (r.status === "queued" || r.status === "running"));
+              if (row) { row.status = "running"; row.updated_at = updated_at; }
+              return { meta: { changes: row ? 1 : 0 } };
+            }
+            if (sql.includes("SET status = 'done'")) {
+              const [decision, works, report_json, agent_prompt, updated_at, id] = args;
+              const row = checks.find((r) => r.id === id);
+              if (row) Object.assign(row, { status: "done", decision, works, report_json, agent_prompt, updated_at });
+              return { meta: { changes: row ? 1 : 0 } };
+            }
+            if (sql.includes("SET status = 'failed'")) {
+              const [errJson, updated_at, id] = args;
+              const row = checks.find((r) => r.id === id);
+              if (row) {
+                row.status = "failed";
+                row.decision = "Not Verified";
+                if (row.report_json === "{}") row.report_json = errJson;
+                row.updated_at = updated_at;
+              }
+              return { meta: { changes: row ? 1 : 0 } };
+            }
+            return { meta: { changes: 0 } };
+          },
+          async first() {
+            if (sql.includes("FROM workspace_projects WHERE id = ?")) {
+              return projects.get(args[0]) ?? null;
+            }
+            if (sql.includes("FROM project_sources") && sql.includes("WHERE id = ?")) {
+              return sources.find((s) => s.id === args[0]) ?? null;
+            }
+            if (sql.includes("FROM workspace_visual_checks") && sql.includes("status IN ('queued', 'running')") && sql.includes("project_id = ?")) {
+              return checks.find((r) => r.project_id === args[0] && (r.status === "queued" || r.status === "running")) ?? null;
+            }
+            if (sql.includes("FROM workspace_visual_checks") && sql.includes("WHERE id = ?")) {
+              return checks.find((r) => r.id === args[0]) ?? null;
+            }
+            return null;
+          },
+          async all() {
+            if (sql.includes("FROM project_sources") && sql.includes("WHERE project_id = ?")) {
+              return { results: sources.filter((s) => s.project_id === args[0]) };
+            }
+            if (sql.includes("FROM workspace_visual_checks") && sql.includes("updated_at < ?")) {
+              const [cutoff, limit] = args;
+              return {
+                results: checks
+                  .filter((r) => (r.status === "queued" || r.status === "running") && r.updated_at < cutoff)
+                  .slice(0, limit)
+                  .map((r) => ({ id: r.id, status: r.status })),
+              };
+            }
+            if (sql.includes("FROM workspace_visual_checks") && sql.includes("WHERE project_id = ?")) {
+              return { results: checks.filter((r) => r.project_id === args[0]) };
+            }
+            return { results: [] };
+          },
+        };
+      }
+      return {
+        bind(...args) { return handler(args); },
+        run() { return handler([]).run(); },
+        first() { return handler([]).first(); },
+        all() { return handler([]).all(); },
+      };
+    },
+  };
+}
+
+function makeProjectRow(id, userKey) {
+  return {
+    id, user_key: userKey, title: "t", idea: "i",
+    understood_json: "{}", product_spec_json: "{}", items_json: "[]",
+    created_at: "2026-07-02T00:00:00.000Z", updated_at: "2026-07-02T00:00:00.000Z",
+  };
+}
+
+function makeSource(over = {}) {
+  return {
+    id: "psrc_web1", project_id: PROJECT, user_key: USER, type: "website",
+    reference: "https://golf-now.example.app/", label: null, content_type: null,
+    size_bytes: null, created_at: "2026-07-02T00:00:00.000Z",
+    ...over,
+  };
+}
+
+/** Stub DurableObjectNamespace recording idFromName + fetch payloads. */
+function makeInspector(recorder, { status = 202 } = {}) {
+  return {
+    idFromName(name) {
+      recorder.names.push(name);
+      return { name };
+    },
+    get() {
+      return {
+        async fetch(url, init) {
+          recorder.calls.push({ url, body: JSON.parse(init.body) });
+          return new Response(JSON.stringify({ status: "accepted" }), { status });
+        },
+      };
+    },
+  };
+}
+
+function makeEnv({ sources = [makeSource()], checks = [], inspector, token = TOKEN } = {}) {
+  const env = {
+    ENVIRONMENT: "test",
+    DB: makeDb({
+      projects: new Map([
+        [PROJECT, makeProjectRow(PROJECT, USER)],
+        [OTHER_PROJECT, makeProjectRow(OTHER_PROJECT, OTHER)],
+      ]),
+      sources,
+      checks,
+    }),
+  };
+  if (inspector) env.INSPECTOR = inspector;
+  if (token) env.INTERNAL_CALLBACK_TOKEN = token;
+  return env;
+}
+
+async function req(env, method, path, body, headers = {}) {
+  const app = createApp();
+  const init = { method, headers: { "content-type": "application/json", ...headers } };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  const res = await app.fetch(new Request(`http://localhost${path}`, init), env);
+  let json = null;
+  try { json = await res.clone().json(); } catch { /* non-json */ }
+  return { status: res.status, json };
+}
+
+const RUN_PATH = `/workspace/projects/${PROJECT}/visual-checks/run`;
+
+// ─── POST .../visual-checks/run — ownership ───────────────────────────────────
+
+test("run: unknown project → 404 project_not_found", async () => {
+  const env = makeEnv();
+  const r = await req(env, "POST", `/workspace/projects/proj_nope/visual-checks/run`, { userKey: USER });
+  assert.equal(r.status, 404);
+  assert.equal(r.json.error, "project_not_found");
+});
+
+test("run: wrong userKey → 403 forbidden; missing userKey → 400", async () => {
+  const env = makeEnv();
+  const r = await req(env, "POST", RUN_PATH, { userKey: OTHER });
+  assert.equal(r.status, 403);
+  assert.equal(r.json.error, "forbidden");
+
+  const missing = await req(env, "POST", RUN_PATH, {});
+  assert.equal(missing.status, 400);
+  assert.equal(missing.json.error, "userKey_required");
+});
+
+// ─── target resolution (SECURITY: registered website sources only) ───────────
+
+test("run: project with no website source → 400 website_source_required", async () => {
+  const env = makeEnv({ sources: [makeSource({ type: "github_repo", reference: "owner/repo" })] });
+  const r = await req(env, "POST", RUN_PATH, { userKey: USER, targetUrl: "https://golf-now.example.app/" });
+  assert.equal(r.status, 400);
+  assert.equal(r.json.error, "website_source_required");
+});
+
+test("run: sourceId of wrong type → 400 invalid_source", async () => {
+  const env = makeEnv({ sources: [makeSource({ id: "psrc_gh", type: "github_repo", reference: "owner/repo" })] });
+  const r = await req(env, "POST", RUN_PATH, { userKey: USER, sourceId: "psrc_gh" });
+  assert.equal(r.status, 400);
+  assert.equal(r.json.error, "invalid_source");
+});
+
+test("run: sourceId belonging to another project/user → 400 invalid_source", async () => {
+  const env = makeEnv({
+    sources: [
+      makeSource(),
+      makeSource({ id: "psrc_foreign", project_id: OTHER_PROJECT, user_key: OTHER }),
+    ],
+  });
+  const wrongProject = await req(env, "POST", RUN_PATH, { userKey: USER, sourceId: "psrc_foreign" });
+  assert.equal(wrongProject.status, 400);
+  assert.equal(wrongProject.json.error, "invalid_source");
+
+  const unknown = await req(env, "POST", RUN_PATH, { userKey: USER, sourceId: "psrc_nope" });
+  assert.equal(unknown.status, 400);
+  assert.equal(unknown.json.error, "invalid_source");
+});
+
+test("run: malformed / non-http targetUrl → 400 invalid_target_url", async () => {
+  const env = makeEnv();
+  for (const bad of ["not a url", "ftp://golf-now.example.app/", "javascript:alert(1)"]) {
+    const r = await req(env, "POST", RUN_PATH, { userKey: USER, targetUrl: bad });
+    assert.equal(r.status, 400, `expected 400 for ${bad}`);
+    assert.equal(r.json.error, "invalid_target_url");
+  }
+});
+
+test("run: targetUrl not matching any registered website source → 400 target_url_not_registered", async () => {
+  const env = makeEnv();
+  const r = await req(env, "POST", RUN_PATH, { userKey: USER, targetUrl: "https://evil.example.com/" });
+  assert.equal(r.status, 400);
+  assert.equal(r.json.error, "target_url_not_registered");
+});
+
+test("run: targetUrl on a registered origin (subpath) is accepted", async () => {
+  const env = makeEnv();
+  const r = await req(env, "POST", RUN_PATH, { userKey: USER, targetUrl: "https://golf-now.example.app/courses" });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.ok, true);
+  assert.equal(r.json.check.targetUrl, "https://golf-now.example.app/courses");
+});
+
+test("run: intent over 1000 chars → 400 invalid_intent; default Korean intent when absent", async () => {
+  const env = makeEnv();
+  const tooLong = await req(env, "POST", RUN_PATH, { userKey: USER, intent: "x".repeat(1001) });
+  assert.equal(tooLong.status, 400);
+  assert.equal(tooLong.json.error, "invalid_intent");
+
+  const ok = await req(env, "POST", RUN_PATH, { userKey: USER });
+  assert.equal(ok.status, 202);
+  assert.match(ok.json.check.intent, /핵심 기능/);
+});
+
+// ─── queue row + dispatch ─────────────────────────────────────────────────────
+
+test("run: INSPECTOR absent → row created (queued/container) + dispatched:false inspector_unavailable", async () => {
+  const env = makeEnv(); // no inspector binding
+  const r = await req(env, "POST", RUN_PATH, { userKey: USER });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.ok, true);
+  assert.equal(r.json.dispatched, false);
+  assert.equal(r.json.note, "inspector_unavailable");
+  assert.equal(r.json.check.status, "queued");
+  assert.equal(r.json.check.executor, "container");
+  assert.equal(r.json.check.decision, "Not Judged");
+
+  const row = env.DB._checks.find((c) => c.id === r.json.check.id);
+  assert.ok(row, "queued row must be persisted");
+  assert.equal(row.status, "queued");
+  assert.equal(row.executor, "container");
+  assert.equal(row.report_json, "{}");
+});
+
+test("run: INSPECTOR bound but callback token missing → row created + dispatched:false", async () => {
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({ inspector: makeInspector(recorder), token: null });
+  const r = await req(env, "POST", RUN_PATH, { userKey: USER });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.dispatched, false);
+  assert.equal(r.json.note, "callback_token_missing");
+  assert.equal(recorder.calls.length, 0, "must not dispatch without the callback token");
+  assert.equal(env.DB._checks.length, 1);
+});
+
+test("run: INSPECTOR present → dispatched:true, DO named vc-<runId>, payload carries job contract", async () => {
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({ inspector: makeInspector(recorder) });
+  const r = await req(env, "POST", RUN_PATH, { userKey: USER, intent: "골퍼가 코스 상태를 확인할 수 있어야 한다" });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.dispatched, true);
+
+  const runId = r.json.check.id;
+  assert.deepEqual(recorder.names, [`vc-${runId}`]);
+  assert.equal(recorder.calls.length, 1);
+  const payload = recorder.calls[0].body;
+  assert.equal(payload.runId, runId);
+  assert.equal(payload.projectId, PROJECT);
+  assert.equal(payload.userKey, USER);
+  assert.equal(payload.targetUrl, "https://golf-now.example.app/");
+  assert.equal(payload.intent, "골퍼가 코스 상태를 확인할 수 있어야 한다");
+  assert.equal(payload.callbackToken, TOKEN);
+  assert.match(payload.callbackUrl, /\/internal\/visual-check-done$/);
+  assert.match(payload.runningUrl, /\/internal\/visual-check-running$/);
+  assert.ok(payload.baseUrl.startsWith("http"), "baseUrl for evidence uploads");
+});
+
+test("run: container dispatch failure → row stays queued, dispatched:false with note", async () => {
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({ inspector: makeInspector(recorder, { status: 500 }) });
+  const r = await req(env, "POST", RUN_PATH, { userKey: USER });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.dispatched, false);
+  assert.match(r.json.note, /container returned 500/);
+  assert.equal(env.DB._checks[0].status, "queued"); // stuck sweep will fail it later
+});
+
+test("run: concurrency guard — active queued|running run → 409 run_already_active", async () => {
+  const env = makeEnv();
+  const first = await req(env, "POST", RUN_PATH, { userKey: USER });
+  assert.equal(first.status, 202);
+
+  const second = await req(env, "POST", RUN_PATH, { userKey: USER });
+  assert.equal(second.status, 409);
+  assert.equal(second.json.error, "run_already_active");
+  assert.equal(second.json.activeRunId, first.json.check.id);
+
+  // running (not just queued) also blocks
+  env.DB._checks[0].status = "running";
+  const third = await req(env, "POST", RUN_PATH, { userKey: USER });
+  assert.equal(third.status, 409);
+});
+
+test("run: sourceId happy path uses the source's own URL", async () => {
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({ inspector: makeInspector(recorder) });
+  const r = await req(env, "POST", RUN_PATH, { userKey: USER, sourceId: "psrc_web1" });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.check.targetUrl, "https://golf-now.example.app/");
+  assert.equal(r.json.dispatched, true);
+});
+
+// ─── /internal/visual-check-running ───────────────────────────────────────────
+
+test("internal running: 503 when token unset, 401 on wrong bearer", async () => {
+  const noToken = makeEnv({ token: null });
+  const disabled = await req(noToken, "POST", "/internal/visual-check-running", { runId: "x" });
+  assert.equal(disabled.status, 503);
+
+  const env = makeEnv();
+  const wrong = await req(env, "POST", "/internal/visual-check-running", { runId: "x" }, { authorization: "Bearer nope" });
+  assert.equal(wrong.status, 401);
+  const missing = await req(env, "POST", "/internal/visual-check-running", { runId: "x" });
+  assert.equal(missing.status, 401);
+});
+
+test("internal running: queued → running; unknown runId 404", async () => {
+  const env = makeEnv();
+  const created = await req(env, "POST", RUN_PATH, { userKey: USER });
+  const runId = created.json.check.id;
+
+  const r = await req(env, "POST", "/internal/visual-check-running", { runId }, { authorization: `Bearer ${TOKEN}` });
+  assert.equal(r.status, 200);
+  assert.equal(r.json.transitioned, true);
+  assert.equal(env.DB._checks[0].status, "running");
+
+  const unknown = await req(env, "POST", "/internal/visual-check-running", { runId: "wvc_nope" }, { authorization: `Bearer ${TOKEN}` });
+  assert.equal(unknown.status, 404);
+});
+
+// ─── /internal/visual-check-done ──────────────────────────────────────────────
+
+test("internal done: 503 when token unset, 401 on missing/wrong bearer", async () => {
+  const noToken = makeEnv({ token: null });
+  const disabled = await req(noToken, "POST", "/internal/visual-check-done", { runId: "x", ok: true });
+  assert.equal(disabled.status, 503);
+
+  const env = makeEnv();
+  const wrong = await req(env, "POST", "/internal/visual-check-done", { runId: "x", ok: true }, { authorization: "Bearer nope" });
+  assert.equal(wrong.status, 401);
+  const missing = await req(env, "POST", "/internal/visual-check-done", { runId: "x", ok: true });
+  assert.equal(missing.status, 401);
+});
+
+test("internal done: ok:true updates row (status/decision/works/report/prompt)", async () => {
+  const env = makeEnv();
+  const created = await req(env, "POST", RUN_PATH, { userKey: USER });
+  const runId = created.json.check.id;
+
+  const report = { title: "Simsa 검수 리포트", verdict: "작동 안 해요 — 고쳐야 해요", works: false, findings: [] };
+  const r = await req(
+    env, "POST", "/internal/visual-check-done",
+    { runId, ok: true, decision: "Needs Fix", works: false, report, agentPrompt: "당신은 이 프로젝트의 코드를 수정하는 개발 에이전트입니다." },
+    { authorization: `Bearer ${TOKEN}` },
+  );
+  assert.equal(r.status, 200);
+  assert.equal(r.json.status, "done");
+
+  const row = env.DB._checks[0];
+  assert.equal(row.status, "done");
+  assert.equal(row.decision, "Needs Fix");
+  assert.equal(row.works, 0);
+  assert.deepEqual(JSON.parse(row.report_json), report);
+  assert.match(row.agent_prompt, /개발 에이전트/);
+});
+
+test("internal done: ok:false stores truncated error → status failed", async () => {
+  const env = makeEnv();
+  const created = await req(env, "POST", RUN_PATH, { userKey: USER });
+  const runId = created.json.check.id;
+
+  const r = await req(
+    env, "POST", "/internal/visual-check-done",
+    { runId, ok: false, error: "inspection timed out after 240s " + "x".repeat(600) },
+    { authorization: `Bearer ${TOKEN}` },
+  );
+  assert.equal(r.status, 200);
+  assert.equal(r.json.status, "failed");
+
+  const row = env.DB._checks[0];
+  assert.equal(row.status, "failed");
+  assert.equal(row.decision, "Not Verified");
+  const stored = JSON.parse(row.report_json);
+  assert.match(stored.error, /inspection timed out/);
+  assert.ok(stored.error.length <= 500, "error must be truncated");
+});
+
+test("internal done: unknown runId → 404; missing ok flag → 400", async () => {
+  const env = makeEnv();
+  const unknown = await req(env, "POST", "/internal/visual-check-done", { runId: "wvc_nope", ok: true }, { authorization: `Bearer ${TOKEN}` });
+  assert.equal(unknown.status, 404);
+
+  const invalid = await req(env, "POST", "/internal/visual-check-done", { runId: "wvc_x" }, { authorization: `Bearer ${TOKEN}` });
+  assert.equal(invalid.status, 400);
+});
+
+// ─── stuck sweep ──────────────────────────────────────────────────────────────
+
+test("stuck sweep: queued run older than 30 min → failed; fresh run untouched", async () => {
+  const old = new Date(Date.now() - 45 * 60 * 1000).toISOString();
+  const fresh = new Date().toISOString();
+  const checks = [
+    {
+      id: "wvc_old", project_id: PROJECT, user_key: USER, target_url: "https://golf-now.example.app/",
+      intent: "i", decision: "Not Judged", works: null, status: "queued", executor: "container",
+      report_json: "{}", agent_prompt: null, evidence_keys_json: "[]", created_at: old, updated_at: old,
+    },
+    {
+      id: "wvc_running_old", project_id: OTHER_PROJECT, user_key: OTHER, target_url: "https://x.example/",
+      intent: "i", decision: "Not Judged", works: null, status: "running", executor: "container",
+      report_json: "{}", agent_prompt: null, evidence_keys_json: "[]", created_at: old, updated_at: old,
+    },
+    {
+      id: "wvc_fresh", project_id: PROJECT, user_key: USER, target_url: "https://golf-now.example.app/",
+      intent: "i", decision: "Not Judged", works: null, status: "queued", executor: "container",
+      report_json: "{}", agent_prompt: null, evidence_keys_json: "[]", created_at: fresh, updated_at: fresh,
+    },
+  ];
+  const env = makeEnv({ checks });
+
+  const result = await cleanupStuckVisualChecks(env);
+  assert.equal(result.swept, 2);
+  assert.equal(result.errors, 0);
+
+  assert.equal(checks[0].status, "failed");
+  assert.match(JSON.parse(checks[0].report_json).error, /30 minutes/);
+  assert.equal(checks[1].status, "failed");
+  assert.equal(checks[2].status, "queued", "fresh run must not be swept");
+});

--- a/apps/central-plane/wrangler.toml
+++ b/apps/central-plane/wrangler.toml
@@ -108,3 +108,30 @@ name = "SANDBOX"
 [[migrations]]
 tag = "v1-sandbox"
 new_sqlite_classes = ["ConclaveSandbox"]
+
+# Stage 263 — SimsaInspector container (Playwright + Chromium).
+#
+# Runs the Simsa deep-flow visual completion check per
+# POST /workspace/projects/:id/visual-checks/run. One instance per run
+# (named vc-<runId>). Executes the same logic as
+# tools/simsa-completion-loop-spike/visual-run.mjs, uploads screenshots/video
+# via the Stage 261 evidence endpoint, then reports to
+# /internal/visual-check-done (Bearer INTERNAL_CALLBACK_TOKEN).
+#
+# instance_type "basic" (1 GiB memory / 4 GB disk): headless Chromium OOMs on
+# the default "dev" (256 MiB) instance. Image is built in CI by
+# deploy-central-plane.yml — first deploy after this lands builds + pushes it.
+[[containers]]
+class_name = "SimsaInspector"
+image = "./inspector-container/Dockerfile"
+image_build_context = "../.."
+max_instances = 5
+instance_type = "basic"
+
+[[durable_objects.bindings]]
+class_name = "SimsaInspector"
+name = "INSPECTOR"
+
+[[migrations]]
+tag = "v2-inspector"
+new_sqlite_classes = ["SimsaInspector"]


### PR DESCRIPTION
## What

Phase 2 of the Simsa final model: **cloud execution of visual completion checks**. A dashboard/API client calls "run inspection" → the Worker queues it → a Cloudflare Container (Playwright + Chromium, `SimsaInspector`) executes the real-browser deep-flow check → results land in the same D1/R2 storage Stage 261 built → the run row transitions `queued → running → done|failed`.

### Run-dispatch API (`src/routes/workspace-visual-check-runs.ts`)
- `POST /workspace/projects/:id/visual-checks/run` `{userKey, sourceId?, targetUrl?, intent?}`
  - Ownership via `getProject` (404 `project_not_found` / 403 `forbidden` — Stage 261 pattern).
  - **Security: never inspects arbitrary URLs.** `sourceId` must be a `website` source of THIS project+userKey; a raw `targetUrl` must be valid http(s) AND origin-match a registered website source; no website source → 400 `website_source_required`. No explicit target → most recent website source.
  - Optional intent ≤1000 chars, Korean generic default.
  - Concurrency guard: one active (`queued|running`) run per project → 409 `run_already_active`.
  - Inserts via new `insertQueuedVisualCheck` (status `queued`, executor `container`, `report_json` `'{}'` placeholder, decision `Not Judged`).
  - Graceful degradation: INSPECTOR binding or callback token absent → row still created, `dispatched:false` (+ note); present → fire-and-forget dispatch to `INSPECTOR.idFromName('vc-'+runId)` with runId/targetUrl/intent/userKey/baseUrl/callback URLs/INTERNAL_CALLBACK_TOKEN.
- `POST /internal/visual-check-running` — container ack, `queued → running` (Bearer `INTERNAL_CALLBACK_TOKEN`, mirrors `/internal/job-done`). *Small additive deviation from the brief so the running state is real and observable, not implied.*
- `POST /internal/visual-check-done` — done path stores decision/works/report/agentPrompt (Stage 261 size caps); failed path stores a truncated error into the placeholder report; unknown runId → 404. Evidence files are uploaded by the container through the **existing** Stage 261 evidence endpoint (validates names/sizes) — no new evidence route.
- `cleanupStuckVisualChecks` in `stuck-cleanup.ts` fails runs stuck in `queued|running` >30 min, on the same `*/5` cron tick as the saas jobs sweep.

### Container runner (`apps/central-plane/inspector-container/`)
- Base image `mcr.microsoft.com/playwright:v1.60.0-jammy` — pinned to the spike's playwright version (invariant-tested).
- `server.mjs` mirrors the sandbox shim: 202 ack, async run, SIGTERM drain → failed callback, **~4 min wall-clock rail**, userKey/token never logged.
- `inspector-run.mjs` executes the `visual-run.mjs` deep flow: goto → collect CTAs/inputs → `planVisualFlow` → safe steps only (`classifyActionSafety` re-checked at click time; forbidden list incl. payment/delete/send/invite/publish/deploy/결제/삭제/발행/배포/로그아웃) → per-step screenshots + video → deterministic `decideFromEvidence` ladder → `buildNonDevReport` + `buildAgentFixPrompt`. Viewport 1280x800, headless.
- `src/inspector-container.ts` `SimsaInspector` DO **exported only from `index.ts`** (never router.ts) — same discipline as `ConclaveSandbox`, keeps `node --test` consumers free of `cloudflare:workers` imports.
- `wrangler.toml`: second `[[containers]]` block (image `./inspector-container/Dockerfile`, `image_build_context ../..`, `max_instances 5`, `instance_type "basic"` — Chromium OOMs on the default dev/256MiB instance) + `INSPECTOR` DO binding + `[[migrations]]` `v2-inspector`. New blocks appended AFTER the existing ones so `container-invariants.test.mjs` first-match regexes still resolve to `ConclaveSandbox`.

### Deviation (with reason)
The inspector Dockerfile does **not** mirror the sandbox's full pnpm-workspace build. The runner needs exactly two pure, dependency-free modules (`visual-flow-plan.ts`, `nondev-report.ts`); a full monorepo `node_modules` on top of the ~2GB playwright base would crowd the 4GB disk of the `basic` container instance. Instead, the canonical sources are COPY'd from `apps/central-plane/src` and compiled in-image with a standalone `tsc` — zero logic duplication, and `test/inspector-invariants.test.mjs` pins the lock-step (no-imports guard on both modules + playwright version alignment across base image / container package.json / spike).

## Tests

- **30 new tests** (`node --test`, mocked at the seam — no network, no containers):
  - `test/workspace-visual-check-runs.test.mjs` (22): website-source-required, sourceId wrong type/project, unregistered targetUrl, malformed URLs, ownership 403/404, intent validation + Korean default, concurrency 409, INSPECTOR absent → row + `dispatched:false`, INSPECTOR stub → `dispatched:true` + payload contract (`vc-<runId>`, callback token/URLs), dispatch failure → row stays queued, `/internal/*` bearer gates (503/401), done/failed/unknown-runId paths, stuck sweep (old queued+running failed, fresh untouched).
  - `test/inspector-invariants.test.mjs` (8): port alignment (DO/Dockerfile/server), wrangler blocks + v2 migration, index-only DO export + router import ban, `Env.INSPECTOR` typing, playwright version lock-step, canonical-module COPY + no-imports guard, safety rails (forbidden words, headless, 1280x800, 4-min rail).
- Full central-plane suite: **1329/1329** (was 1299). `pnpm turbo run build/typecheck --filter @conclave-ai/central-plane` green; no lint task exists for this package. Pre-push `pnpm verify` passed.

## Deploy notes (nothing deployed in this PR)

- The next `deploy-central-plane` run (manual `workflow_dispatch`) **builds + pushes the new container image in CI** — expect a noticeably longer first deploy (playwright base ~2GB; CF Containers paid plan already provisioned).
- The DO migration `v2-inspector` and the `INSPECTOR` binding apply automatically on that deploy; D1 needs no new migration (Stage 261's 0050 already has the `queued|running|done|failed` states and `container` executor).
- First live run prerequisites: `INTERNAL_CALLBACK_TOKEN` secret must already be set (it is — shared with the autofix sandbox callback path); the target project needs a registered `website` source.
- `instance_type = "basic"` (1GiB) chosen for headless Chromium; if live runs OOM on heavy pages, bump to `standard`.
- Rollback safety: without the binding (or on any dispatch failure) the API degrades to `dispatched:false` and the 30-min stuck sweep fails orphaned rows — no user-facing hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
