### PR TITLE
Stage 265 — Document intake → spec draft (PRD/md upload to draft spec)

### DIFF
--- a/apps/central-plane/src/router.ts
+++ b/apps/central-plane/src/router.ts
@@ -37,6 +37,7 @@ import { createWorkspaceAdminCreditsRoutes } from "./routes/workspace-admin-cred
 import { createWorkspaceCreditsRoutes } from "./routes/workspace-credits.js";
 import { createWorkspaceBenchmarkRoutes } from "./routes/workspace-benchmark.js";
 import { createWorkspaceSourcesRoutes } from "./routes/workspace-sources.js";
+import { createWorkspaceDocumentIntakeRoutes } from "./routes/workspace-document-intake.js";
 import { createWorkspaceVisualChecksRoutes } from "./routes/workspace-visual-checks.js";
 import { createWorkspaceVisualCheckRunRoutes } from "./routes/workspace-visual-check-runs.js";
 import { createWorkspaceExperimentRoutes } from "./routes/workspace-experiment.js";
@@ -153,6 +154,10 @@ export function createApp(opts: { fetch?: FetchLike } = {}): Hono<{ Bindings: En
   app.route("/", createWorkspaceBenchmarkRoutes());
   // Stage 261 — Unified project sources (website / github_repo / document upload → R2).
   app.route("/", createWorkspaceSourcesRoutes());
+  // Stage 265 — Document intake → spec draft (PRD/md upload to draft spec).
+  // POST /workspace/projects/:id/sources/:sourceId/spec-draft — draft only,
+  // same generation path + hourly rate-limit bucket as idea-to-spec-draft.
+  app.route("/", createWorkspaceDocumentIntakeRoutes());
   // Stage 261 — Simsa visual completion-check runs (report snapshots + R2 evidence).
   app.route("/", createWorkspaceVisualChecksRoutes());
   // Stage 263 — cloud runner dispatch: POST .../visual-checks/run queues a

--- a/apps/central-plane/src/routes/workspace-document-intake.ts
+++ b/apps/central-plane/src/routes/workspace-document-intake.ts
@@ -1,0 +1,207 @@
+/**
+ * workspace-document-intake.ts — Stage 265 (Phase 3.5: document intake → spec draft)
+ *
+ * POST /workspace/projects/:id/sources/:sourceId/spec-draft
+ *   Body: { userKey, locale? }
+ *   Turns an uploaded PRD/기획서 (Stage 261 document source, R2-stored md/txt)
+ *   into a DRAFT product spec + acceptance items via the SAME generation path
+ *   as POST /workspace/idea-to-spec-draft (generateIdeaToSpecDraft — mock
+ *   fallback when ANTHROPIC_API_KEY is absent, so the flow never hard-fails).
+ *
+ *   DRAFT ONLY — this endpoint never writes productSpec/items to the project
+ *   row. The dashboard confirm flow persists via POST /workspace/projects.
+ *
+ *   Rate limit: shares the SAME hourly per-IP counter as idea-to-spec-draft
+ *   (bucket namespace `workspace::`, WORKSPACE_GENERATION_LIMIT_PER_HOUR).
+ *
+ *   Errors:
+ *     400 invalid_json | userKey_required | source_not_document
+ *         | pdf_text_extraction_unsupported | unsupported_content_type
+ *         | document_too_short | document_too_long
+ *     403 forbidden          — project or source belongs to another userKey
+ *     404 project_not_found | source_not_found | document_not_found
+ *     429 rate_limited
+ *     503 evidence_storage_unconfigured — EVIDENCE R2 binding absent
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import { corsMiddleware } from "./cors.js";
+import { getProject } from "../workspace/db.js";
+import { getProjectSourceById } from "../workspace/project-sources-db.js";
+import {
+  extractDocumentText,
+  buildDocumentDraftPrompt,
+} from "../workspace/document-intake.js";
+import { generateIdeaToSpecDraft } from "../workspace/generate.js";
+import { insertUsageEvent } from "../workspace/usage-events-db.js";
+
+const DEFAULT_LIMIT_PER_HOUR = 20;
+
+// ─── Rate limit helpers ──────────────────────────────────────────────────────
+// Same D1 table + SAME bucket namespace (`workspace::`) as the idea-to-spec
+// endpoint in routes/workspace.ts, so document intake and idea intake share
+// one hourly generation counter per IP.
+
+async function sha256Hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function currentHourUtc(): string {
+  return new Date().toISOString().slice(0, 13); // "2026-07-02T15"
+}
+
+function secondsUntilNextHour(): number {
+  const now = new Date();
+  const next = new Date(now);
+  next.setUTCMinutes(0, 0, 0);
+  next.setUTCHours(next.getUTCHours() + 1);
+  return Math.max(60, Math.floor((next.getTime() - now.getTime()) / 1000));
+}
+
+async function getRateLimitCount(db: D1Database, ipHash: string, hourUtc: string): Promise<number> {
+  try {
+    const row = await db
+      .prepare("SELECT count FROM workspace_rate_limit WHERE ip_hash = ? AND hour_utc = ?")
+      .bind(ipHash, hourUtc)
+      .first<{ count: number }>();
+    return row?.count ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function incrementRateLimitCount(db: D1Database, ipHash: string, hourUtc: string): Promise<void> {
+  const now = new Date().toISOString();
+  try {
+    await db
+      .prepare(
+        `INSERT INTO workspace_rate_limit (ip_hash, hour_utc, count, first_at, last_at)
+         VALUES (?, ?, 1, ?, ?)
+         ON CONFLICT (ip_hash, hour_utc) DO UPDATE SET
+           count = count + 1, last_at = excluded.last_at`,
+      )
+      .bind(ipHash, hourUtc, now, now)
+      .run();
+  } catch (err) {
+    console.warn("[workspace/document-intake] rate-limit upsert failed (non-fatal):", err);
+  }
+}
+
+// ─── Route factory ───────────────────────────────────────────────────────────
+
+export function createWorkspaceDocumentIntakeRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", corsMiddleware);
+
+  app.post("/workspace/projects/:id/sources/:sourceId/spec-draft", async (c) => {
+    const projectId = c.req.param("id");
+    const sourceId = c.req.param("sourceId");
+
+    // ── Body ────────────────────────────────────────────────────────────────
+    let body: { userKey?: unknown; locale?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ ok: false, error: "invalid_json" }, 400);
+    }
+    const userKey = typeof body.userKey === "string" ? body.userKey : "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+    const locale: "ko" | "en" = body.locale === "en" ? "en" : "ko";
+
+    // ── Ownership: project ──────────────────────────────────────────────────
+    const project = await getProject(c.env, projectId);
+    if (!project) return c.json({ ok: false, error: "project_not_found" }, 404);
+    if (project.userKey !== userKey) return c.json({ ok: false, error: "forbidden" }, 403);
+
+    // ── Ownership: source ───────────────────────────────────────────────────
+    const source = await getProjectSourceById(c.env, sourceId);
+    if (!source || source.projectId !== projectId) {
+      return c.json({ ok: false, error: "source_not_found" }, 404);
+    }
+    if (source.userKey !== userKey) return c.json({ ok: false, error: "forbidden" }, 403);
+    if (source.type !== "document") {
+      return c.json({ ok: false, error: "source_not_document" }, 400);
+    }
+
+    // ── Fetch document from R2 ──────────────────────────────────────────────
+    if (!c.env.EVIDENCE) return c.json({ ok: false, error: "evidence_storage_unconfigured" }, 503);
+    if (source.reference === "pending") {
+      return c.json({ ok: false, error: "document_not_found" }, 404);
+    }
+    const obj = await c.env.EVIDENCE.get(source.reference);
+    if (!obj) return c.json({ ok: false, error: "document_not_found" }, 404);
+    const bytes = await obj.arrayBuffer();
+
+    // ── Extract + guard (deterministic, no LLM) ─────────────────────────────
+    const extracted = extractDocumentText(bytes, source.contentType);
+    if (!extracted.ok) {
+      const message =
+        extracted.error === "pdf_text_extraction_unsupported"
+          ? "PDF 텍스트 추출은 아직 지원되지 않습니다. 문서를 md 또는 txt로 저장해 다시 업로드해주세요."
+          : undefined;
+      return c.json({ ok: false, error: extracted.error, ...(message ? { message } : {}) }, 400);
+    }
+
+    // ── Rate limit (same bucket as idea-to-spec-draft) ──────────────────────
+    const limitPerHour =
+      parseInt(c.env.WORKSPACE_GENERATION_LIMIT_PER_HOUR ?? "", 10) || DEFAULT_LIMIT_PER_HOUR;
+    const rawIp =
+      c.req.header("cf-connecting-ip") ??
+      (c.req.header("x-forwarded-for") ?? "").split(",")[0]?.trim() ??
+      "unknown";
+    const ipHash = await sha256Hex(`workspace::${rawIp}`);
+    const hourUtc = currentHourUtc();
+    const currentCount = await getRateLimitCount(c.env.DB, ipHash, hourUtc);
+    if (currentCount >= limitPerHour) {
+      const retryAfterSeconds = secondsUntilNextHour();
+      return c.json(
+        {
+          ok: false,
+          error: "rate_limited",
+          message: "잠시 후 다시 시도해주세요. 제품 설명서 만들기 요청이 짧은 시간에 많이 발생했어요.",
+          retryAfterSeconds,
+        },
+        429,
+        { "retry-after": String(retryAfterSeconds) },
+      );
+    }
+
+    // ── Generate via the SAME path as idea-to-spec-draft ────────────────────
+    // generateIdeaToSpecDraft degrades to a deterministic mock-fallback when
+    // ANTHROPIC_API_KEY is absent or the LLM call fails — preserved here.
+    const input = buildDocumentDraftPrompt(extracted.text, {
+      title: project.title,
+      idea: typeof project.idea === "string" ? project.idea : "",
+    });
+
+    let result;
+    try {
+      result = await generateIdeaToSpecDraft({ idea: input, locale }, c.env.ANTHROPIC_API_KEY);
+    } catch (err) {
+      console.error("[workspace/document-intake] unexpected generate error:", err);
+      return c.json({ ok: false, error: "internal_error" }, 500);
+    }
+
+    await incrementRateLimitCount(c.env.DB, ipHash, hourUtc);
+
+    // Record usage event (non-fatal)
+    await insertUsageEvent(c.env, {
+      userKey,
+      projectId,
+      eventType: "workspace_document_spec_draft_generated",
+      metadata: { source: result.source, sourceId, contentType: source.contentType },
+    });
+
+    // DRAFT ONLY — never persist productSpec/items here; the dashboard confirm
+    // flow saves via the existing POST /workspace/projects endpoint.
+    const { ok: _ok, ...draft } = result;
+    return c.json({
+      ok: true,
+      draft,
+      source: { id: source.id, label: source.label ?? source.reference },
+    });
+  });
+
+  return app;
+}

--- a/apps/central-plane/src/workspace/document-intake.ts
+++ b/apps/central-plane/src/workspace/document-intake.ts
@@ -1,0 +1,135 @@
+/**
+ * workspace/document-intake.ts — Stage 265
+ *
+ * Deterministic pre-processing for "document → spec draft" (Phase 3.5).
+ * A user uploads a PRD/기획서 (Stage 261 document source, R2-stored md/txt/pdf)
+ * and asks for a draft product spec. Before anything touches the LLM path,
+ * the raw bytes are normalized and guarded here — pure functions, no I/O.
+ *
+ * v1 honest limitation: PDF text extraction is NOT supported (no pdf parsing
+ * dependency). PDFs return `pdf_text_extraction_unsupported` so the client can
+ * tell the user to upload md/txt instead.
+ */
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const MIN_DOCUMENT_TEXT_CHARS = 50;
+export const MAX_DOCUMENT_TEXT_CHARS = 100_000;
+
+/** Content types we can decode as plain UTF-8 text. */
+const TEXT_CONTENT_TYPES = new Set(["text/markdown", "text/plain"]);
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ExtractDocumentTextError =
+  | "pdf_text_extraction_unsupported"
+  | "unsupported_content_type"
+  | "document_too_short"
+  | "document_too_long";
+
+export type ExtractDocumentTextResult =
+  | { ok: true; text: string }
+  | { ok: false; error: ExtractDocumentTextError };
+
+// ─── Normalization helpers (charCode-based; no control chars in source) ─────
+
+const CODE_TAB = 0x09;
+const CODE_LF = 0x0a;
+const CODE_CR = 0x0d;
+const CODE_DEL = 0x7f;
+const CODE_BOM = 0xfeff;
+
+/**
+ * Strip C0 control characters (except LF and TAB) and DEL. CR is handled by
+ * the CRLF normalization pass before this runs.
+ */
+function stripControlChars(s: string): string {
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    const isControl = (code <= 0x1f && code !== CODE_LF && code !== CODE_TAB) || code === CODE_DEL;
+    if (!isControl) out += s.charAt(i);
+  }
+  return out;
+}
+
+/** Normalize CRLF and lone CR to LF. */
+function normalizeNewlines(s: string): string {
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    if (code === CODE_CR) {
+      out += "\n";
+      if (i + 1 < s.length && s.charCodeAt(i + 1) === CODE_LF) i++; // swallow LF of CRLF
+    } else {
+      out += s.charAt(i);
+    }
+  }
+  return out;
+}
+
+// ─── extractDocumentText ──────────────────────────────────────────────────────
+
+/**
+ * Decode uploaded document bytes into normalized text.
+ *
+ * - `application/pdf` → `pdf_text_extraction_unsupported` (v1 limitation)
+ * - other non-text content types → `unsupported_content_type`
+ * - md/txt → UTF-8 decode, BOM strip, CRLF→LF normalize, control-char strip
+ *   (keeps LF and TAB), trim, then length guards (50..100_000 chars).
+ */
+export function extractDocumentText(
+  bytes: ArrayBuffer | Uint8Array,
+  contentType: string | undefined,
+): ExtractDocumentTextResult {
+  const normalizedType = (contentType ?? "").split(";")[0]?.trim().toLowerCase() ?? "";
+  if (normalizedType === "application/pdf") {
+    return { ok: false, error: "pdf_text_extraction_unsupported" };
+  }
+  if (!TEXT_CONTENT_TYPES.has(normalizedType)) {
+    return { ok: false, error: "unsupported_content_type" };
+  }
+
+  let raw = new TextDecoder("utf-8").decode(bytes);
+  if (raw.charCodeAt(0) === CODE_BOM) raw = raw.slice(1);
+
+  const text = stripControlChars(normalizeNewlines(raw)).trim();
+
+  if (text.length < MIN_DOCUMENT_TEXT_CHARS) {
+    return { ok: false, error: "document_too_short" };
+  }
+  if (text.length > MAX_DOCUMENT_TEXT_CHARS) {
+    return { ok: false, error: "document_too_long" };
+  }
+  return { ok: true, text };
+}
+
+// ─── buildDocumentDraftPrompt ────────────────────────────────────────────────
+
+const MAX_TITLE_CONTEXT_CHARS = 120;
+const MAX_IDEA_CONTEXT_CHARS = 500;
+
+/**
+ * Compose the input string handed to the existing idea-to-spec generation path
+ * (`generateIdeaToSpecDraft` takes an `idea` string). Deterministic — no LLM.
+ *
+ * The project title leads the string so the generation path's degraded
+ * mock-fallback (which derives a product name from the head of the input)
+ * still produces something meaningful.
+ */
+export function buildDocumentDraftPrompt(
+  text: string,
+  project: { title?: string; idea?: string } | null | undefined,
+): string {
+  const parts: string[] = [];
+  const title = project?.title?.trim().slice(0, MAX_TITLE_CONTEXT_CHARS);
+  const idea = project?.idea?.trim().slice(0, MAX_IDEA_CONTEXT_CHARS);
+  if (title) parts.push(`${title} — 업로드된 기획 문서 기반 제품`);
+  if (idea) parts.push(`기존 아이디어 메모: ${idea}`);
+  parts.push(
+    "아래는 사용자가 업로드한 기획 문서(PRD) 전문입니다. 이 문서 내용을 아이디어의 원천으로 삼아 제품 설명서 초안을 작성하세요.\n\n--- 문서 시작 ---\n" +
+      text +
+      "\n--- 문서 끝 ---",
+  );
+  return parts.join("\n\n");
+}

--- a/apps/central-plane/src/workspace/usage-events-db.ts
+++ b/apps/central-plane/src/workspace/usage-events-db.ts
@@ -8,6 +8,7 @@ import type { Env } from "../env.js";
 
 export type UsageEventType =
   | "workspace_idea_to_spec_generated"
+  | "workspace_document_spec_draft_generated"
   | "workspace_check_draft_run"
   | "workspace_fix_suggestion_generated"
   | "workspace_builder_pack_exported"

--- a/apps/central-plane/test/workspace-document-intake.test.mjs
+++ b/apps/central-plane/test/workspace-document-intake.test.mjs
@@ -1,0 +1,365 @@
+/**
+ * workspace-document-intake.test.mjs — Stage 265
+ *
+ * Document intake → spec draft:
+ * POST /workspace/projects/:id/sources/:sourceId/spec-draft
+ *
+ * Route tests use mock D1 + mock R2 (same conventions as
+ * workspace-sources.test.mjs). Generation is exercised through the same seam
+ * as the existing idea-to-spec tests: no ANTHROPIC_API_KEY in env → the
+ * shared generateIdeaToSpecDraft path returns its deterministic
+ * mock-fallback, so nothing hits the network.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { createApp } = await import("../dist/router.js");
+const {
+  extractDocumentText,
+  buildDocumentDraftPrompt,
+  MIN_DOCUMENT_TEXT_CHARS,
+  MAX_DOCUMENT_TEXT_CHARS,
+} = await import("../dist/workspace/document-intake.js");
+
+const USER = "uk_owner";
+const OTHER = "uk_intruder";
+const PROJECT = "proj_doc";
+
+const PRD_TEXT = [
+  "# 골프장 컨디션 앱 PRD",
+  "",
+  "골프장 잔디/그린 상태를 회원들이 사진과 함께 공유하고,",
+  "예약 전에 최신 코스 컨디션을 확인할 수 있는 모바일 웹 서비스.",
+  "관리자는 공지와 코스 상태 등급을 직접 갱신할 수 있어야 한다.",
+].join("\n");
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+function makeDb({ projects = new Map(), sources = [], rateCount = 0 } = {}) {
+  const state = { sources, rateInserts: 0, usageEvents: [], projectWrites: 0 };
+  return {
+    _state: state,
+    prepare(sql) {
+      function handler(args) {
+        return {
+          async run() {
+            if (/INSERT INTO workspace_rate_limit/i.test(sql)) {
+              state.rateInserts += 1;
+              return { meta: { changes: 1 } };
+            }
+            if (/INSERT INTO workspace_usage_events/i.test(sql)) {
+              state.usageEvents.push(args);
+              return { meta: { changes: 1 } };
+            }
+            if (/(INSERT INTO|UPDATE)\s+workspace_projects/i.test(sql)) {
+              state.projectWrites += 1;
+              return { meta: { changes: 1 } };
+            }
+            return { meta: { changes: 0 } };
+          },
+          async first() {
+            if (sql.includes("FROM workspace_projects WHERE id = ?")) {
+              return projects.get(args[0]) ?? null;
+            }
+            if (sql.includes("FROM project_sources") && sql.includes("WHERE id = ?")) {
+              return sources.find((s) => s.id === args[0]) ?? null;
+            }
+            if (sql.includes("FROM workspace_rate_limit")) {
+              return { count: rateCount };
+            }
+            return null;
+          },
+          async all() {
+            return { results: [] };
+          },
+        };
+      }
+      return {
+        bind(...args) { return handler(args); },
+        run() { return handler([]).run(); },
+        first() { return handler([]).first(); },
+        all() { return handler([]).all(); },
+      };
+    },
+  };
+}
+
+function makeProjectRow(id, userKey) {
+  return {
+    id,
+    user_key: userKey,
+    title: "골프장 컨디션 앱",
+    idea: "골프장 상태 공유 서비스",
+    understood_json: "{}",
+    product_spec_json: "{}",
+    items_json: "[]",
+    created_at: "2026-07-02T00:00:00.000Z",
+    updated_at: "2026-07-02T00:00:00.000Z",
+  };
+}
+
+function makeSourceRow({
+  id = "psrc_doc1",
+  projectId = PROJECT,
+  userKey = USER,
+  type = "document",
+  reference = `docs/${USER}/${PROJECT}/psrc_doc1/prd.md`,
+  label = "PRD v1",
+  contentType = "text/markdown",
+} = {}) {
+  return {
+    id,
+    project_id: projectId,
+    user_key: userKey,
+    type,
+    reference,
+    label,
+    content_type: contentType,
+    size_bytes: 1234,
+    created_at: "2026-07-02T00:00:00.000Z",
+  };
+}
+
+function makeR2(entries = {}) {
+  const store = new Map(Object.entries(entries));
+  return {
+    _store: store,
+    async put(key, value) { store.set(key, value); },
+    async get(key) {
+      const hit = store.get(key);
+      if (hit === undefined) return null;
+      const bytes = typeof hit === "string" ? new TextEncoder().encode(hit) : hit;
+      return {
+        body: bytes,
+        async arrayBuffer() {
+          return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+        },
+      };
+    },
+    async delete(key) { store.delete(key); },
+  };
+}
+
+function makeEnv({ withR2 = true, sources, r2Entries, rateCount = 0, limit } = {}) {
+  const src = sources ?? [makeSourceRow()];
+  const env = {
+    ENVIRONMENT: "test",
+    // No ANTHROPIC_API_KEY on purpose — generation degrades to mock-fallback.
+    DB: makeDb({
+      projects: new Map([[PROJECT, makeProjectRow(PROJECT, USER)]]),
+      sources: src,
+      rateCount,
+    }),
+  };
+  if (limit !== undefined) env.WORKSPACE_GENERATION_LIMIT_PER_HOUR = limit;
+  if (withR2) {
+    env.EVIDENCE = makeR2(
+      r2Entries ?? { [`docs/${USER}/${PROJECT}/psrc_doc1/prd.md`]: PRD_TEXT },
+    );
+  }
+  return env;
+}
+
+async function specDraft(env, { projectId = PROJECT, sourceId = "psrc_doc1", body } = {}) {
+  const app = createApp();
+  const res = await app.fetch(
+    new Request(`http://localhost/workspace/projects/${projectId}/sources/${sourceId}/spec-draft`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body ?? { userKey: USER }),
+    }),
+    env,
+  );
+  return { status: res.status, json: await res.json() };
+}
+
+// ─── extractDocumentText unit tests ──────────────────────────────────────────
+
+test("extractDocumentText: strips BOM, normalizes CRLF, strips control chars", () => {
+  const body = "# PRD\r\ncol1\tcol2\r줄1" + String.fromCharCode(0x00, 0x08, 0x1f, 0x7f) + "끝 " + "x".repeat(60);
+  const bytes = new TextEncoder().encode(String.fromCharCode(0xfeff) + body);
+  const result = extractDocumentText(bytes, "text/markdown");
+  assert.equal(result.ok, true);
+  assert.ok(result.text.charCodeAt(0) !== 0xfeff);
+  assert.ok(!result.text.includes("\r"));
+  assert.ok(result.text.includes("# PRD\ncol1\tcol2\n줄1끝"), `got: ${JSON.stringify(result.text)}`);
+  assert.ok(![...result.text].some((ch) => { const c = ch.charCodeAt(0); return (c <= 0x1f && c !== 0x0a && c !== 0x09) || c === 0x7f; }));
+});
+
+test("extractDocumentText: too short / too long guards", () => {
+  const short = extractDocumentText(new TextEncoder().encode("   too short   "), "text/plain");
+  assert.deepEqual(short, { ok: false, error: "document_too_short" });
+  assert.ok(MIN_DOCUMENT_TEXT_CHARS === 50);
+
+  const long = extractDocumentText(
+    new TextEncoder().encode("a".repeat(MAX_DOCUMENT_TEXT_CHARS + 1)),
+    "text/plain",
+  );
+  assert.deepEqual(long, { ok: false, error: "document_too_long" });
+});
+
+test("extractDocumentText: pdf unsupported; unknown content type rejected", () => {
+  const pdf = extractDocumentText(new TextEncoder().encode("%PDF-1.7"), "application/pdf");
+  assert.deepEqual(pdf, { ok: false, error: "pdf_text_extraction_unsupported" });
+
+  const odd = extractDocumentText(new TextEncoder().encode("x".repeat(100)), "image/png");
+  assert.deepEqual(odd, { ok: false, error: "unsupported_content_type" });
+
+  // charset parameter is tolerated
+  const withCharset = extractDocumentText(
+    new TextEncoder().encode("y".repeat(100)),
+    "text/plain; charset=utf-8",
+  );
+  assert.equal(withCharset.ok, true);
+});
+
+test("buildDocumentDraftPrompt: leads with project title, embeds idea + document text", () => {
+  const prompt = buildDocumentDraftPrompt(PRD_TEXT, { title: "골프장 컨디션 앱", idea: "골프장 상태 공유" });
+  assert.ok(prompt.startsWith("골프장 컨디션 앱"));
+  assert.ok(prompt.includes("기존 아이디어 메모: 골프장 상태 공유"));
+  assert.ok(prompt.includes(PRD_TEXT));
+
+  const bare = buildDocumentDraftPrompt("doc body", null);
+  assert.ok(bare.includes("doc body"));
+  assert.ok(!bare.includes("기존 아이디어 메모"));
+});
+
+// ─── Route tests ──────────────────────────────────────────────────────────────
+
+test("happy path: md document → 200 draft (mock-fallback, same shape as idea-to-spec) + source info; project row untouched", async () => {
+  const env = makeEnv();
+  const { status, json } = await specDraft(env);
+  assert.equal(status, 200);
+  assert.equal(json.ok, true);
+  // draft = same shape idea-to-spec-draft returns (minus top-level ok)
+  assert.equal(json.draft.source, "mock-fallback"); // no ANTHROPIC_API_KEY → degrade preserved
+  assert.ok(typeof json.draft.understood.summary === "string");
+  assert.ok(Array.isArray(json.draft.questions));
+  assert.ok(typeof json.draft.productSpec.productName === "string");
+  assert.ok(Array.isArray(json.draft.items) && json.draft.items.length >= 3);
+  json.draft.items.forEach((item) => assert.equal(item.status, "not_started"));
+  assert.deepEqual(json.source, { id: "psrc_doc1", label: "PRD v1" });
+  // DRAFT ONLY — no write to workspace_projects
+  assert.equal(env.DB._state.projectWrites, 0);
+  // rate-limit counter incremented + usage event recorded
+  assert.equal(env.DB._state.rateInserts, 1);
+  assert.equal(env.DB._state.usageEvents.length, 1);
+});
+
+test("ownership: other userKey 403 (project and source); unknown project 404", async () => {
+  const env = makeEnv();
+  const forbidden = await specDraft(env, { body: { userKey: OTHER } });
+  assert.equal(forbidden.status, 403);
+  assert.equal(forbidden.json.error, "forbidden");
+
+  const missing = await specDraft(env, { projectId: "proj_nope" });
+  assert.equal(missing.status, 404);
+  assert.equal(missing.json.error, "project_not_found");
+
+  // source owned by someone else (but project owned by caller)
+  const env2 = makeEnv({ sources: [makeSourceRow({ userKey: OTHER })] });
+  const srcForbidden = await specDraft(env2);
+  assert.equal(srcForbidden.status, 403);
+});
+
+test("source not found / belongs to another project → 404", async () => {
+  const env = makeEnv();
+  const nope = await specDraft(env, { sourceId: "psrc_nope" });
+  assert.equal(nope.status, 404);
+  assert.equal(nope.json.error, "source_not_found");
+
+  const env2 = makeEnv({ sources: [makeSourceRow({ projectId: "proj_other" })] });
+  const wrongProject = await specDraft(env2);
+  assert.equal(wrongProject.status, 404);
+  assert.equal(wrongProject.json.error, "source_not_found");
+});
+
+test("non-document source (website) → 400 source_not_document", async () => {
+  const env = makeEnv({
+    sources: [makeSourceRow({ type: "website", reference: "https://x.dev/", contentType: null })],
+  });
+  const { status, json } = await specDraft(env);
+  assert.equal(status, 400);
+  assert.equal(json.error, "source_not_document");
+});
+
+test("pdf document → 400 pdf_text_extraction_unsupported (honest v1 limitation)", async () => {
+  const key = `docs/${USER}/${PROJECT}/psrc_doc1/prd.pdf`;
+  const env = makeEnv({
+    sources: [makeSourceRow({ reference: key, contentType: "application/pdf" })],
+    r2Entries: { [key]: "%PDF-1.7 fake" },
+  });
+  const { status, json } = await specDraft(env);
+  assert.equal(status, 400);
+  assert.equal(json.error, "pdf_text_extraction_unsupported");
+  assert.ok(typeof json.message === "string" && json.message.length > 0);
+});
+
+test("too-short and too-long documents → 400", async () => {
+  const key = `docs/${USER}/${PROJECT}/psrc_doc1/prd.md`;
+  const short = makeEnv({ r2Entries: { [key]: "짧음" } });
+  const shortRes = await specDraft(short);
+  assert.equal(shortRes.status, 400);
+  assert.equal(shortRes.json.error, "document_too_short");
+
+  const long = makeEnv({ r2Entries: { [key]: "a".repeat(MAX_DOCUMENT_TEXT_CHARS + 10) } });
+  const longRes = await specDraft(long);
+  assert.equal(longRes.status, 400);
+  assert.equal(longRes.json.error, "document_too_long");
+});
+
+test("no EVIDENCE R2 binding → 503 evidence_storage_unconfigured", async () => {
+  const env = makeEnv({ withR2: false });
+  const { status, json } = await specDraft(env);
+  assert.equal(status, 503);
+  assert.equal(json.error, "evidence_storage_unconfigured");
+});
+
+test("R2 object missing (or reference still pending) → 404 document_not_found", async () => {
+  const env = makeEnv({ r2Entries: {} });
+  const { status, json } = await specDraft(env);
+  assert.equal(status, 404);
+  assert.equal(json.error, "document_not_found");
+
+  const pending = makeEnv({ sources: [makeSourceRow({ reference: "pending" })] });
+  const pendingRes = await specDraft(pending);
+  assert.equal(pendingRes.status, 404);
+  assert.equal(pendingRes.json.error, "document_not_found");
+});
+
+test("rate limit: shares the hourly workspace bucket → 429 with retryAfterSeconds, no counter increment", async () => {
+  const env = makeEnv({ rateCount: 1, limit: "1" });
+  const { status, json } = await specDraft(env);
+  assert.equal(status, 429);
+  assert.equal(json.error, "rate_limited");
+  assert.ok(json.retryAfterSeconds >= 60);
+  assert.equal(env.DB._state.rateInserts, 0);
+});
+
+test("bad input: invalid JSON body → 400; missing userKey → 400", async () => {
+  const env = makeEnv();
+  const app = createApp();
+  const res = await app.fetch(
+    new Request(`http://localhost/workspace/projects/${PROJECT}/sources/psrc_doc1/spec-draft`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    }),
+    env,
+  );
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, "invalid_json");
+
+  const noKey = await specDraft(env, { body: {} });
+  assert.equal(noKey.status, 400);
+  assert.equal(noKey.json.error, "userKey_required");
+});
+
+test("locale=en passes through to the shared generation path (draft still valid shape)", async () => {
+  const env = makeEnv();
+  const { status, json } = await specDraft(env, { body: { userKey: USER, locale: "en" } });
+  assert.equal(status, 200);
+  assert.equal(json.ok, true);
+  assert.equal(json.draft.source, "mock-fallback");
+  assert.ok(Array.isArray(json.draft.items) && json.draft.items.length >= 3);
+});


### PR DESCRIPTION
## Summary

Phase 3.5 entry point: a Korean non-developer uploads a PRD/기획서 (Stage 261 document source, R2-stored md/txt) and gets a DRAFT product spec + acceptance items for their project — no persistence, the dashboard confirm flow saves via the existing `POST /workspace/projects`.

**New endpoint:** `POST /workspace/projects/:id/sources/:sourceId/spec-draft`

- Body `{ userKey, locale? }` — ownership enforced server-side (project + source must belong to userKey; source.type must be `document`).
- Document fetched from R2 (`EVIDENCE` binding; 503 `evidence_storage_unconfigured` without it).
- Deterministic pre-processing in pure `src/workspace/document-intake.ts`: UTF-8 decode, BOM strip, CRLF normalize, control-char strip, 50..100,000-char guards.
- **PDF is an honest v1 limitation**: 400 `pdf_text_extraction_unsupported` with a Korean user-facing message — no pdf parsing dependency added.
- Generation reuses the EXACT same path as `POST /workspace/idea-to-spec-draft` (`generateIdeaToSpecDraft`), feeding `buildDocumentDraftPrompt(text, {title, idea})` as the input. Missing `ANTHROPIC_API_KEY` degrades to the same deterministic mock-fallback (covered by tests).
- Shares the SAME hourly per-IP rate-limit counter as idea-to-spec-draft (`workspace::` bucket, `WORKSPACE_GENERATION_LIMIT_PER_HOUR`, 429 + `retry-after`).
- Usage event `workspace_document_spec_draft_generated` recorded (non-fatal).

## Files

- `apps/central-plane/src/workspace/document-intake.ts` — pure `extractDocumentText` + `buildDocumentDraftPrompt` (new)
- `apps/central-plane/src/routes/workspace-document-intake.ts` — route module (new)
- `apps/central-plane/src/router.ts` — wire-in
- `apps/central-plane/src/workspace/usage-events-db.ts` — additive event type
- `apps/central-plane/test/workspace-document-intake.test.mjs` — 15 tests (new)

## Tests

- 15 new tests: extractDocumentText units (BOM/CRLF/control chars, length guards, pdf/unknown type), prompt builder, ownership 403/404, non-document 400, pdf 400, too-short/too-long 400, R2-missing 503/404, happy path (mock-fallback seam, draft shape + project row untouched + counter increment), rate-limit 429, invalid JSON / missing userKey.
- Full central-plane suite: **1344/1344** (1329 existing + 15 new). `turbo build` + `typecheck` green.

## Notes for Stage 267 dashboard wiring

Response (200): `{ ok: true, draft: { source: "llm"|"mock-fallback", understood, questions, productSpec, items, warnings? }, source: { id, label } }` — `draft` is byte-for-byte the idea-to-spec-draft shape minus the top-level `ok`. Errors: 400 `invalid_json|userKey_required|source_not_document|pdf_text_extraction_unsupported|unsupported_content_type|document_too_short|document_too_long`, 403 `forbidden`, 404 `project_not_found|source_not_found|document_not_found`, 429 `rate_limited` (+`retryAfterSeconds`), 503 `evidence_storage_unconfigured`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)