### PR TITLE
Stage 268 — Visual check repair loop (fix PR dispatch)

### DIFF
--- a/apps/central-plane/container/coerce-result.mjs
+++ b/apps/central-plane/container/coerce-result.mjs
@@ -68,6 +68,113 @@ export function extractHeaderEnv(headers) {
   return out;
 }
 
+/**
+ * Stage 268 — simsa_repair job payload validation. A repair job carries the
+ * user's OAuth token + the visual check's deterministic agent fix prompt; the
+ * container creates a repair branch + draft PR on the user's repo.
+ */
+const REQUIRED_REPAIR_FIELDS = [
+  "jobId",
+  "repo",
+  "githubToken",
+  "branch",
+  "agentPrompt",
+  "callbackUrl",
+  "callbackToken",
+];
+
+export function validateRepairPayload(payload) {
+  if (!payload || typeof payload !== "object") {
+    return { ok: false, missing: REQUIRED_REPAIR_FIELDS };
+  }
+  const missing = REQUIRED_REPAIR_FIELDS.filter(
+    (k) => payload[k] === undefined || payload[k] === null || payload[k] === "",
+  );
+  if (missing.length > 0) return { ok: false, missing };
+  return { ok: true };
+}
+
+/**
+ * Stage 268 — strip a secret from a message before it travels anywhere
+ * (callback body, logs). Pure; no-op when the secret is empty.
+ */
+export function redactSecret(message, secret) {
+  const text = String(message ?? "");
+  if (typeof secret !== "string" || secret.length === 0) return text;
+  return text.split(secret).join("[REDACTED]");
+}
+
+/**
+ * Stage 268 — deterministic repair-PR content (no LLM). The v1 repair job
+ * does NOT auto-apply code changes: it commits the agent fix prompt as
+ * SIMSA-FIX-BRIEF.md on a repair branch and opens a DRAFT PR so any agent or
+ * human can execute the brief. The PR body says so explicitly — honest
+ * boundaries over pretended fixes.
+ *
+ * Returns { title, body, briefFileName, briefContent } — all strings, all
+ * derived only from the payload (never from env/secrets).
+ */
+export function buildRepairPrContent(payload) {
+  const intent = typeof payload?.intent === "string" && payload.intent.trim()
+    ? payload.intent.trim()
+    : "핵심 기능 점검";
+  const shortIntent = intent.length > 60 ? `${intent.slice(0, 57)}...` : intent;
+  const decision = typeof payload?.decision === "string" && payload.decision ? payload.decision : "Not Judged";
+  const targetUrl = typeof payload?.targetUrl === "string" ? payload.targetUrl : "";
+  const visualCheckId = typeof payload?.visualCheckId === "string" ? payload.visualCheckId : "";
+  const agentPrompt = String(payload?.agentPrompt ?? "");
+  const envCause = payload?.envCause === true;
+
+  const title = `Simsa 수리 시작점: ${shortIntent}`;
+
+  const bodyLines = [
+    "## Simsa 시각 검수 수리 브리프",
+    "",
+    "Simsa가 실제 브라우저로 앱을 열어 확인한 결과 문제가 발견되어, 수리 시작점 브랜치를 만들었습니다.",
+    "",
+    `- 검수 대상: ${targetUrl || "(기록 없음)"}`,
+    `- 판정: ${decision}`,
+    ...(visualCheckId ? [`- 검사 ID: \`${visualCheckId}\``] : []),
+    "",
+    "> **주의: 이 PR에는 자동 적용된 코드 수정이 없습니다.**",
+    "> 아래 수리 지시서(SIMSA-FIX-BRIEF.md와 동일)를 개발 에이전트나 개발자가 이 브랜치에서 실행해 주세요.",
+    "",
+  ];
+  if (envCause) {
+    bodyLines.push(
+      "> **환경 원인 가능성:** 증거에 백엔드 주소가 응답하지 않는 패턴(DNS/연결 실패)이 포함되어 있습니다.",
+      "> 코드 수정만으로 완전히 해결되지 않을 수 있어요 — 환경 변수(백엔드 주소 등) 설정도 함께 확인하세요.",
+      "",
+    );
+  }
+  bodyLines.push("### 수리 지시서", "", "```", agentPrompt, "```", "");
+
+  const briefContent = [
+    "# SIMSA-FIX-BRIEF",
+    "",
+    "이 파일은 Simsa 시각 검수가 생성한 수리 지시서입니다.",
+    "이 브랜치에서 아래 지시서를 그대로 실행한 뒤, 이 파일은 삭제해도 됩니다.",
+    "",
+    ...(envCause
+      ? [
+          "> 환경 원인 가능성: 코드 수정만으로 완전히 해결되지 않을 수 있어요 — 환경 변수 설정도 확인하세요.",
+          "",
+        ]
+      : []),
+    "---",
+    "",
+    agentPrompt,
+    "",
+  ].join("\n");
+
+  return {
+    title,
+    body: bodyLines.join("\n"),
+    briefFileName: "SIMSA-FIX-BRIEF.md",
+    briefContent,
+  };
+}
+
 const VERDICT_FROM_STATUS = Object.freeze({
   approved: "approve",
   merged: "approve",

--- a/apps/central-plane/container/server.mjs
+++ b/apps/central-plane/container/server.mjs
@@ -26,8 +26,11 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import {
+  buildRepairPrContent,
   coerceResult,
   extractHeaderEnv,
+  redactSecret,
+  validateRepairPayload,
   validateRunPayload,
 } from "./coerce-result.mjs";
 
@@ -65,6 +68,36 @@ const server = createServer(async (req, res) => {
   } catch (err) {
     res.writeHead(400, { "content-type": "application/json" });
     res.end(JSON.stringify({ error: "invalid JSON body", detail: err.message }));
+    return;
+  }
+
+  // Stage 268 — job-type switch. A `simsa_repair` job (visual-check repair
+  // loop) reuses this same container + /run endpoint but takes a different
+  // payload (user OAuth token + agent fix prompt, no PR yet) and a different
+  // execution path (repair branch + draft PR instead of runAutofix).
+  if (payload.jobType === "simsa_repair") {
+    const repairValidation = validateRepairPayload(payload);
+    if (!repairValidation.ok) {
+      res.writeHead(400, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: `missing fields: ${repairValidation.missing.join(", ")}` }));
+      return;
+    }
+    res.writeHead(202, { "content-type": "application/json" });
+    res.end(JSON.stringify({ jobId: payload.jobId, status: "accepted" }));
+
+    inFlightJobs.set(payload.jobId, payload);
+    runRepairJob(payload)
+      .catch(async (err) => {
+        console.error(`[repair ${payload.jobId}] crashed:`, redactSecret(err?.message ?? String(err), payload.githubToken));
+        await postCallback(payload.callbackUrl, payload.callbackToken, {
+          jobId: payload.jobId,
+          ok: false,
+          error: redactSecret(err?.message ?? String(err), payload.githubToken),
+        }).catch((cbErr) => {
+          console.error(`[repair ${payload.jobId}] callback also failed:`, cbErr);
+        });
+      })
+      .finally(() => inFlightJobs.delete(payload.jobId));
     return;
   }
 
@@ -132,13 +165,25 @@ async function gracefulShutdown(sig) {
   shuttingDown = true;
   console.log(`received ${sig} — draining ${inFlightJobs.size} in-flight job(s)`);
   const drains = Array.from(inFlightJobs.values()).map((p) =>
-    postCallback(p.callbackUrl, p.callbackToken, {
-      jobId: p.jobId,
-      repo: p.repo,
-      prNumber: p.prNumber,
-      status: "errored",
-      error: `container was killed by ${sig} mid-run (deploy rollout or sleepAfter)`,
-    }).catch((cbErr) => {
+    postCallback(
+      p.callbackUrl,
+      p.callbackToken,
+      // Stage 268 — repair jobs use the /internal/repair-done payload shape
+      // ({jobId, ok, error}); autofix jobs keep the /internal/job-done shape.
+      p.jobType === "simsa_repair"
+        ? {
+            jobId: p.jobId,
+            ok: false,
+            error: `container was killed by ${sig} mid-run (deploy rollout or sleepAfter)`,
+          }
+        : {
+            jobId: p.jobId,
+            repo: p.repo,
+            prNumber: p.prNumber,
+            status: "errored",
+            error: `container was killed by ${sig} mid-run (deploy rollout or sleepAfter)`,
+          },
+    ).catch((cbErr) => {
       console.error(`[shutdown] callback failed for ${p.jobId}:`, cbErr);
     }),
   );
@@ -343,6 +388,162 @@ async function runJob(payload) {
       console.error(`[job ${jobId}] cleanup failed:`, cleanupErr);
     }
   }
+}
+
+// --- Stage 268: simsa_repair job runner ------------------------------------
+
+/**
+ * Run a single visual-check repair job.
+ *
+ * v1 behavior (HONEST FALLBACK, chosen deliberately): runAutofix's input
+ * contract is PR-shaped (it reviews an EXISTING PR via `conclave review --pr N`
+ * and applies council-blocker patches) — it cannot cleanly consume a
+ * free-form agent fix prompt with no PR. Instead of pretending, the repair
+ * job:
+ *
+ *   1. Shallow-clones the repo with the user's OAuth token (public_repo)
+ *   2. Creates the repair branch (fix/simsa-{runId})
+ *   3. Commits SIMSA-FIX-BRIEF.md containing the deterministic agent fix
+ *      prompt (Stage 260B output)
+ *   4. Opens a DRAFT PR titled "Simsa 수리 시작점: ..." whose body carries the
+ *      prompt AND states explicitly that code changes were not auto-applied
+ *   5. Reports {jobId, ok, prUrl, prNumber, branch, envCause} to
+ *      /internal/repair-done
+ *
+ * The token lives only in memory (clone URL + API Authorization header) and
+ * is redacted from every error message before it leaves this process.
+ */
+async function runRepairJob(payload) {
+  const {
+    jobId,
+    repo, // "owner/name"
+    githubToken,
+    branch,
+    callbackUrl,
+    callbackToken,
+    runningUrl,
+    envCause = false,
+  } = payload;
+
+  const start = Date.now();
+  console.log(`[repair ${jobId}] start: ${repo} branch=${branch} envCause=${envCause}`);
+
+  // Ack running (best effort — the Worker treats queued/running the same for
+  // the 409 guard; a lost ack only affects dashboard status granularity).
+  if (runningUrl) {
+    await postCallback(runningUrl, callbackToken, { jobId }).catch((err) => {
+      console.error(`[repair ${jobId}] running ack failed:`, err?.message ?? err);
+    });
+  }
+
+  const workDir = await fs.mkdtemp(path.join(WORK_ROOT, `repair-${jobId}-`));
+  try {
+    // 1. Shallow clone with the user's OAuth token.
+    const cloneUrl = `https://x-access-token:${githubToken}@github.com/${repo}.git`;
+    await execFileP("git", ["clone", "--depth", "1", cloneUrl, workDir], { timeout: 90_000 });
+
+    // Base branch = whatever the clone checked out (the repo default).
+    const baseBranch = (
+      await execFileP("git", ["-C", workDir, "rev-parse", "--abbrev-ref", "HEAD"], { timeout: 10_000 })
+    ).stdout.trim();
+
+    // 2. Repair branch. Deterministic name per run — a retry after a failed
+    //    earlier attempt force-pushes the same branch instead of erroring.
+    await execFileP("git", ["-C", workDir, "checkout", "-b", branch], { timeout: 10_000 });
+
+    // 3. Commit the fix brief.
+    const content = buildRepairPrContent(payload);
+    await fs.writeFile(path.join(workDir, content.briefFileName), content.briefContent, "utf8");
+    await execFileP("git", ["-C", workDir, "config", "user.name", "simsa-repair[bot]"]);
+    await execFileP("git", ["-C", workDir, "config", "user.email", "simsa-repair@trysimsa.com"]);
+    await execFileP("git", ["-C", workDir, "add", content.briefFileName], { timeout: 10_000 });
+    await execFileP("git", ["-C", workDir, "commit", "-m", content.title], { timeout: 10_000 });
+    await execFileP("git", ["-C", workDir, "push", "--force", "origin", `HEAD:${branch}`], { timeout: 60_000 });
+    console.log(`[repair ${jobId}] pushed ${branch} (base ${baseBranch})`);
+
+    // 4. Draft PR via the REST API. If a PR for this head already exists
+    //    (retry path), reuse it instead of failing on the 422.
+    const pr = await createOrReuseRepairPr({
+      repo,
+      token: githubToken,
+      head: branch,
+      base: baseBranch,
+      title: content.title,
+      body: content.body,
+    });
+    console.log(`[repair ${jobId}] PR ready: #${pr.number} ${pr.html_url}`);
+
+    // 5. Report done.
+    await postCallback(callbackUrl, callbackToken, {
+      jobId,
+      ok: true,
+      prUrl: pr.html_url,
+      prNumber: pr.number,
+      branch,
+      envCause: envCause === true,
+      durationMs: Date.now() - start,
+    });
+  } catch (err) {
+    const message = redactSecret(err?.message ?? String(err), githubToken);
+    console.error(`[repair ${jobId}] failed:`, message);
+    await postCallback(callbackUrl, callbackToken, {
+      jobId,
+      ok: false,
+      error: message.slice(0, 500),
+      durationMs: Date.now() - start,
+    });
+  } finally {
+    try {
+      await fs.rm(workDir, { recursive: true, force: true });
+    } catch (cleanupErr) {
+      console.error(`[repair ${jobId}] cleanup failed:`, cleanupErr);
+    }
+  }
+}
+
+/**
+ * Create the draft repair PR, falling back gracefully:
+ *   - 422 "already exists" → look up + return the existing open PR for the head
+ *   - 422 mentioning draft (plan doesn't support draft PRs) → retry non-draft
+ */
+async function createOrReuseRepairPr({ repo, token, head, base, title, body }) {
+  const apiHeaders = {
+    authorization: `Bearer ${token}`,
+    accept: "application/vnd.github+json",
+    "content-type": "application/json",
+    "x-github-api-version": "2022-11-28",
+    "user-agent": "simsa-repair",
+  };
+  const owner = repo.split("/")[0];
+
+  const create = async (draft) => {
+    const r = await fetch(`https://api.github.com/repos/${repo}/pulls`, {
+      method: "POST",
+      headers: apiHeaders,
+      body: JSON.stringify({ title, head, base, body, draft }),
+    });
+    return { status: r.status, json: await r.json().catch(() => ({})) };
+  };
+
+  let res = await create(true);
+  if (res.status === 422) {
+    const detail = JSON.stringify(res.json.errors ?? res.json.message ?? "");
+    if (/already exists/i.test(detail)) {
+      const list = await fetch(
+        `https://api.github.com/repos/${repo}/pulls?head=${encodeURIComponent(`${owner}:${head}`)}&state=open`,
+        { headers: apiHeaders },
+      );
+      const pulls = list.ok ? await list.json().catch(() => []) : [];
+      if (Array.isArray(pulls) && pulls[0]?.html_url) return pulls[0];
+    }
+    if (/draft/i.test(detail)) {
+      res = await create(false);
+    }
+  }
+  if (res.status !== 201) {
+    throw new Error(`PR create failed: ${res.status} ${JSON.stringify(res.json.message ?? res.json).slice(0, 300)}`);
+  }
+  return res.json;
 }
 
 /**

--- a/apps/central-plane/migrations/0051_workspace_repair_jobs.sql
+++ b/apps/central-plane/migrations/0051_workspace_repair_jobs.sql
@@ -1,0 +1,35 @@
+-- Stage 268 — Simsa visual-check repair jobs (ADDITIVE).
+--
+-- One row per "[고치기]" click on a failed visual check. The Worker dispatches
+-- the check's stored agent_prompt (Stage 260B deterministic fix prompt) into
+-- the ConclaveSandbox container as a `simsa_repair` job; the container creates
+-- a repair branch + draft PR on the user's connected GitHub repo and reports
+-- back via /internal/repair-done (Bearer INTERNAL_CALLBACK_TOKEN).
+--
+-- env_cause: 1 when the check's evidence points at a dead-backend/env-var root
+-- cause (ERR_NAME_NOT_RESOLVED / ENOTFOUND / connection-refused patterns).
+-- The repair still runs (fallback-style code fixes are legitimate — golf-now
+-- PR #38) but the UI must warn that a code change alone may not fully fix it.
+--
+-- Safety: CREATE TABLE/INDEX IF NOT EXISTS only. No ALTER, no data mutation.
+
+CREATE TABLE IF NOT EXISTS workspace_repair_jobs (
+  id              TEXT NOT NULL PRIMARY KEY,
+  project_id      TEXT NOT NULL,
+  user_key        TEXT NOT NULL,
+  visual_check_id TEXT NOT NULL,
+  repo_full_name  TEXT NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'queued'
+                  CHECK (status IN ('queued', 'running', 'done', 'failed')),
+  branch_name     TEXT,
+  pr_url          TEXT,
+  pr_number       INTEGER,
+  env_cause       INTEGER NOT NULL DEFAULT 0,
+  error           TEXT,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_repair_jobs_check ON workspace_repair_jobs (visual_check_id);
+CREATE INDEX IF NOT EXISTS idx_workspace_repair_jobs_project ON workspace_repair_jobs (project_id);
+CREATE INDEX IF NOT EXISTS idx_workspace_repair_jobs_user ON workspace_repair_jobs (user_key);

--- a/apps/central-plane/src/index.ts
+++ b/apps/central-plane/src/index.ts
@@ -2,7 +2,7 @@ import { createApp } from "./router.js";
 import type { Env } from "./env.js";
 import { assertPreflight } from "./preflight.js";
 import { selfHealWebhook } from "./webhook-heal.js";
-import { cleanupStuckJobs, cleanupStuckVisualChecks } from "./stuck-cleanup.js";
+import { cleanupStuckJobs, cleanupStuckVisualChecks, cleanupStuckRepairJobs } from "./stuck-cleanup.js";
 import { refreshAllSources } from "./external-references.js";
 import { retryPendingFeedback } from "./routes/feedback.js";
 import { promoteSeedsPass } from "./seed-promoter.js";
@@ -59,6 +59,14 @@ export default {
         console.log(JSON.stringify({ cron: "stuck-cleanup-visual-checks", cronExpression: event.cron, ...result }));
       } catch (err) {
         console.error("[stuck-cleanup-visual-checks] crashed:", err);
+      }
+      // Stage 268 — same tick also sweeps repair jobs stuck in queued|running
+      // (ConclaveSandbox repair job killed / dispatch lost).
+      try {
+        const result = await cleanupStuckRepairJobs(env);
+        console.log(JSON.stringify({ cron: "stuck-cleanup-repair-jobs", cronExpression: event.cron, ...result }));
+      } catch (err) {
+        console.error("[stuck-cleanup-repair-jobs] crashed:", err);
       }
       return;
     }

--- a/apps/central-plane/src/router.ts
+++ b/apps/central-plane/src/router.ts
@@ -40,6 +40,7 @@ import { createWorkspaceSourcesRoutes } from "./routes/workspace-sources.js";
 import { createWorkspaceDocumentIntakeRoutes } from "./routes/workspace-document-intake.js";
 import { createWorkspaceVisualChecksRoutes } from "./routes/workspace-visual-checks.js";
 import { createWorkspaceVisualCheckRunRoutes } from "./routes/workspace-visual-check-runs.js";
+import { createWorkspaceRepairJobRoutes } from "./routes/workspace-repair-jobs.js";
 import { createWorkspaceExperimentRoutes } from "./routes/workspace-experiment.js";
 import { createWorkspaceAgentWorkflowRoutes } from "./routes/workspace-agent-workflow.js";
 import { createWorkspaceMembershipRoutes } from "./routes/workspace-membership.js";
@@ -164,6 +165,11 @@ export function createApp(opts: { fetch?: FetchLike } = {}): Hono<{ Bindings: En
   // SimsaInspector container job; /internal/visual-check-{running,done} are
   // the container's callbacks (Bearer INTERNAL_CALLBACK_TOKEN).
   app.route("/", createWorkspaceVisualCheckRunRoutes());
+  // Stage 268 — repair loop: POST .../visual-checks/:runId/repair dispatches a
+  // simsa_repair job into the ConclaveSandbox container (repair branch + draft
+  // PR from the run's agent_prompt); /internal/repair-{running,done} are the
+  // container's callbacks (Bearer INTERNAL_CALLBACK_TOKEN).
+  app.route("/", createWorkspaceRepairJobRoutes());
   // Stage 72 — Persisted Manual Multi-Agent Experiments.
   app.route("/", createWorkspaceExperimentRoutes());
   // Stage 112 — Persisted Agent Workflow Records (intake snapshot save/list/read).

--- a/apps/central-plane/src/routes/workspace-repair-jobs.ts
+++ b/apps/central-plane/src/routes/workspace-repair-jobs.ts
@@ -1,0 +1,417 @@
+/**
+ * workspace-repair-jobs.ts — Stage 268
+ *
+ * Repair loop backend: "[고치기]" on a failed Simsa visual check turns the
+ * check's stored deterministic agent fix prompt (Stage 260B, `agent_prompt`
+ * on the run) into a repair branch + draft PR on the user's connected GitHub
+ * repo, executed inside the EXISTING ConclaveSandbox container as a new
+ * `simsa_repair` job type (no third container).
+ *
+ *   POST /workspace/projects/:id/visual-checks/:runId/repair — queue + dispatch
+ *   GET  /workspace/projects/:id/visual-checks/:runId/repair — latest job (polling)
+ *   POST /internal/repair-running                            — container ack
+ *   POST /internal/repair-done                               — container result
+ *
+ * SECURITY:
+ *   - Ownership chain enforced twice: project → userKey AND run → project+userKey.
+ *   - The user's OAuth token (AES-GCM encrypted at rest, CONCLAVE_TOKEN_KEK)
+ *     is decrypted ONLY here, passed to the container in the job payload, and
+ *     never persisted anywhere else or echoed in any response.
+ *   - /internal/* endpoints require Bearer INTERNAL_CALLBACK_TOKEN (same gate
+ *     as /internal/visual-check-* and /internal/job-done).
+ *
+ * HONEST BOUNDARIES (env-cause): when the run's evidence points at a
+ * dead-backend/env-var root cause (ERR_NAME_NOT_RESOLVED / ENOTFOUND /
+ * connection-refused), the repair still dispatches — fallback-style code
+ * fixes are legitimate (golf-now PR #38 was exactly this) — but env_cause=1
+ * is stored so the UI can warn "코드 수정만으로 완전히 해결되지 않을 수
+ * 있어요".
+ *
+ * Fail-fast (Stage 263.1 semantics): when the SANDBOX binding / callback
+ * token is absent or the container refuses the job, the row is created and
+ * immediately marked failed with dispatched:false + note — nothing consumes
+ * queued rows later, and a wedged queued row would block the 409 guard for
+ * 30 min until the stuck sweep.
+ */
+import { Hono } from "hono";
+import { corsMiddleware } from "./cors.js";
+import type { Env } from "../env.js";
+import { getProject } from "../workspace/db.js";
+import { getVisualCheckById, type DbVisualCheck } from "../workspace/visual-check-db.js";
+import { getProjectRepo, getGitHubConnectionByUserKey } from "../workspace/github-db.js";
+import { listProjectSources } from "../workspace/project-sources-db.js";
+import { decryptToken } from "../crypto.js";
+import {
+  findActiveRepairJobForRun,
+  getLatestRepairJobForRun,
+  getRepairJobById,
+  insertQueuedRepairJob,
+  markRepairJobDone,
+  markRepairJobFailed,
+  markRepairJobRunning,
+  type DbRepairJob,
+} from "../workspace/repair-job-db.js";
+
+const MAX_ERROR_CHARS = 500;
+
+/**
+ * Env-cause pre-check (pure, tested). True when the check's evidence
+ * (agent_prompt + report_json snapshots the browser observations verbatim)
+ * contains dead-backend / unresolvable-host patterns — the classic "the env
+ * var points at a deleted backend" failure. DNS-level failures
+ * (ERR_NAME_NOT_RESOLVED, ENOTFOUND, getaddrinfo) and connection-refused
+ * (ERR_CONNECTION_REFUSED, ECONNREFUSED) both mean no code change alone can
+ * revive the host.
+ */
+const ENV_CAUSE_PATTERN =
+  /ERR_NAME_NOT_RESOLVED|ENOTFOUND|getaddrinfo|ERR_CONNECTION_REFUSED|ECONNREFUSED/i;
+
+export function detectEnvCause(agentPrompt: string, reportJson: string): boolean {
+  return ENV_CAUSE_PATTERN.test(`${agentPrompt ?? ""} ${reportJson ?? ""}`);
+}
+
+/** done + not-working + fix prompt present — the only repairable shape. */
+export function isRunRepairable(run: Pick<DbVisualCheck, "status" | "works" | "agentPrompt">): boolean {
+  return run.status === "done" && run.works !== true && typeof run.agentPrompt === "string" && run.agentPrompt.length > 0;
+}
+
+/**
+ * Normalize a project_sources github_repo reference into "owner/repo".
+ * Accepts bare "owner/repo" and https://github.com/owner/repo(.git) URLs.
+ */
+export function normalizeRepoReference(reference: string): string | null {
+  let ref = (reference ?? "").trim();
+  ref = ref.replace(/^https?:\/\/(www\.)?github\.com\//i, "");
+  ref = ref.replace(/\.git$/i, "").replace(/\/+$/, "");
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(ref) ? ref : null;
+}
+
+function requireInternalToken(c: {
+  env: Env;
+  req: { header: (name: string) => string | undefined };
+}): { ok: true } | { ok: false; status: 401 | 503; error: string } {
+  const expected = c.env.INTERNAL_CALLBACK_TOKEN;
+  if (!expected) return { ok: false, status: 503, error: "callback_disabled" };
+  const auth = c.req.header("authorization") ?? c.req.header("Authorization") ?? "";
+  const m = /^Bearer\s+(.+)$/i.exec(auth);
+  if (!m || m[1] !== expected) return { ok: false, status: 401, error: "unauthorized" };
+  return { ok: true };
+}
+
+function repairJobView(job: DbRepairJob) {
+  return {
+    id: job.id,
+    visualCheckId: job.visualCheckId,
+    repoFullName: job.repoFullName,
+    status: job.status,
+    branchName: job.branchName ?? null,
+    prUrl: job.prUrl ?? null,
+    prNumber: job.prNumber ?? null,
+    envCause: job.envCause,
+    error: job.error ?? null,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+  };
+}
+
+/**
+ * Dispatch the queued repair into the ConclaveSandbox container DO as a
+ * `simsa_repair` job. Mirrors spawnSandbox/dispatchInspection: fire-and-forget
+ * — the container acks 202 and reports back via /internal/repair-*.
+ * The GitHub token travels only in the job payload (memory → container env),
+ * never in a D1 row or response body.
+ */
+export async function dispatchRepairJob(
+  env: Env,
+  args: {
+    jobId: string;
+    projectId: string;
+    userKey: string;
+    visualCheckId: string;
+    repo: string;
+    githubToken: string;
+    branch: string;
+    agentPrompt: string;
+    intent: string;
+    targetUrl: string;
+    decision: string;
+    envCause: boolean;
+    publicBaseUrl: string;
+  },
+): Promise<{ dispatched: boolean; note?: string }> {
+  if (!env.SANDBOX) {
+    return { dispatched: false, note: "sandbox_unavailable" };
+  }
+  if (!env.INTERNAL_CALLBACK_TOKEN) {
+    return { dispatched: false, note: "callback_token_missing" };
+  }
+  const base = args.publicBaseUrl.replace(/\/+$/, "");
+  const payload = {
+    jobType: "simsa_repair",
+    jobId: args.jobId,
+    projectId: args.projectId,
+    visualCheckId: args.visualCheckId,
+    repo: args.repo,
+    githubToken: args.githubToken,
+    branch: args.branch,
+    agentPrompt: args.agentPrompt,
+    intent: args.intent,
+    targetUrl: args.targetUrl,
+    decision: args.decision,
+    envCause: args.envCause,
+    callbackUrl: `${base}/internal/repair-done`,
+    runningUrl: `${base}/internal/repair-running`,
+    callbackToken: env.INTERNAL_CALLBACK_TOKEN,
+  };
+  try {
+    const id = env.SANDBOX.idFromName(`repair-${args.jobId}`);
+    const stub = env.SANDBOX.get(id);
+    const r = await stub.fetch("http://sandbox/run", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!r.ok) {
+      const tail = await r.text();
+      return { dispatched: false, note: `container returned ${r.status}: ${tail.slice(0, 200)}` };
+    }
+    return { dispatched: true };
+  } catch (err) {
+    return { dispatched: false, note: `container fetch failed: ${(err as Error).message.slice(0, 200)}` };
+  }
+}
+
+export function createWorkspaceRepairJobRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("/workspace/*", corsMiddleware);
+
+  // ── POST /workspace/projects/:id/visual-checks/:runId/repair ───────────────
+  app.post("/workspace/projects/:id/visual-checks/:runId/repair", async (c) => {
+    const projectId = c.req.param("id");
+    const runId = c.req.param("runId");
+
+    let body: { userKey?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ ok: false, error: "invalid_json" }, 400);
+    }
+    const userKey = typeof body.userKey === "string" ? body.userKey : "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    // Ownership chain: project → userKey, run → project + userKey.
+    const project = await getProject(c.env, projectId);
+    if (!project) return c.json({ ok: false, error: "project_not_found" }, 404);
+    if (project.userKey !== userKey) return c.json({ ok: false, error: "forbidden" }, 403);
+
+    const run = await getVisualCheckById(c.env, runId);
+    if (!run || run.projectId !== projectId || run.userKey !== userKey) {
+      return c.json({ ok: false, error: "run_not_found" }, 404);
+    }
+
+    // Repairable gate: only a finished check that did NOT verify as working
+    // and that carries the deterministic fix prompt can be repaired.
+    const agentPrompt = run.agentPrompt ?? "";
+    if (!isRunRepairable(run) || !agentPrompt) {
+      return c.json(
+        {
+          ok: false,
+          error: "run_not_repairable",
+          message: "이 검사 결과로는 고치기를 시작할 수 없어요. 검사가 끝났고 문제가 발견된 경우에만 고칠 수 있어요.",
+        },
+        400,
+      );
+    }
+
+    // Resolve the repo. Prefer the explicit workspace-github connection (it
+    // has the token); fall back to a project_sources github_repo row.
+    let repoFullName: string | null = null;
+    const projectRepo = await getProjectRepo(c.env, projectId).catch(() => null);
+    if (projectRepo) {
+      repoFullName = projectRepo.repoFullName;
+    } else {
+      const sources = await listProjectSources(c.env, projectId).catch(() => []);
+      for (const s of sources) {
+        if (s.type !== "github_repo") continue;
+        const normalized = normalizeRepoReference(s.reference);
+        if (normalized) {
+          repoFullName = normalized;
+          break;
+        }
+      }
+    }
+    if (!repoFullName) {
+      return c.json(
+        {
+          ok: false,
+          error: "github_repo_required",
+          message: "연결된 GitHub 저장소가 없어요. 프로젝트 설정에서 저장소를 먼저 연결해 주세요.",
+        },
+        400,
+      );
+    }
+
+    // Resolve + decrypt the user's OAuth token (public_repo scope).
+    const tokenRequired = {
+      ok: false,
+      error: "github_token_required",
+      message: "GitHub 계정 연결이 필요해요. 설정에서 GitHub을 다시 연결해 주세요.",
+    };
+    const conn = await getGitHubConnectionByUserKey(c.env, userKey).catch(() => null);
+    if (!conn || !conn.accessTokenEnc || !c.env.CONCLAVE_TOKEN_KEK) {
+      return c.json(tokenRequired, 400);
+    }
+    let githubToken: string;
+    try {
+      githubToken = await decryptToken(conn.accessTokenEnc, c.env.CONCLAVE_TOKEN_KEK);
+    } catch {
+      return c.json(tokenRequired, 400);
+    }
+
+    // One active repair per run.
+    const active = await findActiveRepairJobForRun(c.env, runId);
+    if (active) {
+      return c.json({ ok: false, error: "repair_already_active", activeJobId: active.id }, 409);
+    }
+
+    // Honest boundary: env-cause evidence still dispatches (fallback-style
+    // code fixes are legitimate) but flags the row so the UI can warn.
+    const envCause = detectEnvCause(agentPrompt, run.reportJson ?? "");
+    const branch = `fix/simsa-${runId}`;
+
+    let job;
+    try {
+      job = await insertQueuedRepairJob(c.env, {
+        projectId,
+        userKey,
+        visualCheckId: runId,
+        repoFullName,
+        branchName: branch,
+        envCause,
+      });
+    } catch (err) {
+      console.error("[repair-jobs POST] insert failed:", err);
+      return c.json({ ok: false, error: "save_failed" }, 500);
+    }
+
+    const publicBaseUrl = c.env.PUBLIC_BASE_URL ?? new URL(c.req.url).origin;
+    const dispatch = await dispatchRepairJob(c.env, {
+      jobId: job.id,
+      projectId,
+      userKey,
+      visualCheckId: runId,
+      repo: repoFullName,
+      githubToken,
+      branch,
+      agentPrompt,
+      intent: run.intent,
+      targetUrl: run.targetUrl,
+      decision: run.decision,
+      envCause,
+      publicBaseUrl,
+    });
+
+    // Fail fast on undispatched jobs (Stage 263.1 semantics): a queued row
+    // nothing will ever pick up would wedge the 409 guard until the sweep.
+    let status = job.status;
+    if (!dispatch.dispatched) {
+      try {
+        await markRepairJobFailed(c.env, job.id, dispatch.note ?? "dispatch_failed");
+        status = "failed";
+      } catch (err) {
+        console.error("[repair-jobs POST] fail-fast mark failed:", err);
+      }
+    }
+
+    return c.json(
+      {
+        ok: true,
+        repair: { ...repairJobView(job), status },
+        dispatched: dispatch.dispatched,
+        ...(dispatch.note ? { note: dispatch.note } : {}),
+      },
+      202,
+    );
+  });
+
+  // ── GET /workspace/projects/:id/visual-checks/:runId/repair?userKey=... ────
+  // Latest repair job for the run — dashboard polling.
+  app.get("/workspace/projects/:id/visual-checks/:runId/repair", async (c) => {
+    const projectId = c.req.param("id");
+    const runId = c.req.param("runId");
+    const userKey = c.req.query("userKey") ?? "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    const project = await getProject(c.env, projectId);
+    if (!project) return c.json({ ok: false, error: "project_not_found" }, 404);
+    if (project.userKey !== userKey) return c.json({ ok: false, error: "forbidden" }, 403);
+
+    const run = await getVisualCheckById(c.env, runId);
+    if (!run || run.projectId !== projectId || run.userKey !== userKey) {
+      return c.json({ ok: false, error: "run_not_found" }, 404);
+    }
+
+    const job = await getLatestRepairJobForRun(c.env, runId);
+    return c.json({ ok: true, repair: job ? repairJobView(job) : null });
+  });
+
+  // ── POST /internal/repair-running ───────────────────────────────────────────
+  // Container ack: the repair actually started executing (queued → running).
+  app.post("/internal/repair-running", async (c) => {
+    const auth = requireInternalToken(c);
+    if (!auth.ok) return c.json({ error: auth.error }, auth.status);
+
+    const body = (await c.req.json().catch(() => null)) as { jobId?: string } | null;
+    if (!body || typeof body.jobId !== "string" || !body.jobId) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+    const job = await getRepairJobById(c.env, body.jobId);
+    if (!job) return c.json({ error: "not_found" }, 404);
+
+    const transitioned = await markRepairJobRunning(c.env, body.jobId);
+    return c.json({ ok: true, transitioned });
+  });
+
+  // ── POST /internal/repair-done ──────────────────────────────────────────────
+  // Container result callback: → done (branch + PR created) | failed.
+  app.post("/internal/repair-done", async (c) => {
+    const auth = requireInternalToken(c);
+    if (!auth.ok) return c.json({ error: auth.error }, auth.status);
+
+    const body = (await c.req.json().catch(() => null)) as
+      | {
+          jobId?: string;
+          ok?: boolean;
+          prUrl?: string;
+          prNumber?: number;
+          branch?: string;
+          envCause?: boolean;
+          error?: string;
+        }
+      | null;
+    if (!body || typeof body.jobId !== "string" || !body.jobId || typeof body.ok !== "boolean") {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+
+    const job = await getRepairJobById(c.env, body.jobId);
+    if (!job) return c.json({ error: "not_found" }, 404);
+
+    if (!body.ok) {
+      const error = typeof body.error === "string" && body.error ? body.error : "repair failed";
+      await markRepairJobFailed(c.env, body.jobId, error.slice(0, MAX_ERROR_CHARS));
+      return c.json({ ok: true, status: "failed" });
+    }
+
+    await markRepairJobDone(c.env, body.jobId, {
+      prUrl: typeof body.prUrl === "string" && body.prUrl ? body.prUrl : undefined,
+      prNumber: typeof body.prNumber === "number" && Number.isInteger(body.prNumber) && body.prNumber > 0
+        ? body.prNumber
+        : undefined,
+      branchName: typeof body.branch === "string" && body.branch ? body.branch : undefined,
+      envCause: body.envCause === true,
+    });
+    return c.json({ ok: true, status: "done" });
+  });
+
+  return app;
+}

--- a/apps/central-plane/src/stuck-cleanup.ts
+++ b/apps/central-plane/src/stuck-cleanup.ts
@@ -16,6 +16,7 @@ import type { Env } from "./env.js";
 import { findInstallationByRepoSlug } from "./db/saas.js";
 import { postPrComment } from "./gh-app.js";
 import { listStuckVisualChecks, markVisualCheckFailed } from "./workspace/visual-check-db.js";
+import { listStuckRepairJobs, markRepairJobFailed } from "./workspace/repair-job-db.js";
 
 const STUCK_AFTER_MS = 30 * 60 * 1000; // 30 minutes
 const SWEEP_LIMIT = 50; // safety cap; never touch more than 50 rows in a single tick
@@ -110,6 +111,42 @@ export async function cleanupStuckVisualChecks(
     } catch (err) {
       errors += 1;
       console.error(`[stuck-cleanup] visual-check ${r.id} failed:`, err);
+    }
+  }
+  return { swept: rows.length, errors };
+}
+
+/**
+ * Stage 268 — sweep Simsa repair jobs stuck in queued|running >30 min.
+ *
+ * Same failure modes as the other sweeps: the ConclaveSandbox container was
+ * killed mid-repair (deploy rollout, OOM, wall-clock timeout) or the dispatch
+ * was lost, so no /internal/repair-done callback will ever arrive. Uses
+ * updated_at as the staleness clock (touched on queue + on the running ack).
+ * Runs on the same `*\/5 * * * *` cron tick.
+ */
+export async function cleanupStuckRepairJobs(
+  env: Env,
+): Promise<{ swept: number; errors: number }> {
+  const cutoff = new Date(Date.now() - STUCK_AFTER_MS).toISOString();
+  let rows: Array<{ id: string; status: string }>;
+  try {
+    rows = await listStuckRepairJobs(env, cutoff, SWEEP_LIMIT);
+  } catch (err) {
+    // Table may not exist yet on a fresh D1 (migration 0051 unapplied) —
+    // don't let the repair sweep break the other sweeps sharing this cron.
+    console.error("[stuck-cleanup] repair-job query failed:", err);
+    return { swept: 0, errors: 1 };
+  }
+  let errors = 0;
+  const reason =
+    "repair container did not report a result within 30 minutes — likely killed by a deploy rollout. Start the repair again.";
+  for (const r of rows) {
+    try {
+      await markRepairJobFailed(env, r.id, reason);
+    } catch (err) {
+      errors += 1;
+      console.error(`[stuck-cleanup] repair-job ${r.id} failed:`, err);
     }
   }
   return { swept: rows.length, errors };

--- a/apps/central-plane/src/workspace/repair-job-db.ts
+++ b/apps/central-plane/src/workspace/repair-job-db.ts
@@ -1,0 +1,227 @@
+/**
+ * workspace/repair-job-db.ts — Stage 268
+ *
+ * D1 persistence for Simsa repair jobs: one row per "[고치기]" click on a
+ * failed visual check. Mirrors visual-check-db.ts operationally (queued →
+ * running → done|failed, updated_at as the staleness clock for the stuck
+ * sweep). The repo/branch/PR fields are filled in by the container's
+ * /internal/repair-done callback.
+ */
+import type { Env } from "../env.js";
+
+export const REPAIR_JOB_STATUSES = ["queued", "running", "done", "failed"] as const;
+export type RepairJobStatus = (typeof REPAIR_JOB_STATUSES)[number];
+
+export type DbRepairJob = {
+  id: string;
+  projectId: string;
+  userKey: string;
+  visualCheckId: string;
+  repoFullName: string;
+  status: RepairJobStatus;
+  branchName?: string;
+  prUrl?: string;
+  prNumber?: number;
+  envCause: boolean;
+  error?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type RawRow = {
+  id: string;
+  project_id: string;
+  user_key: string;
+  visual_check_id: string;
+  repo_full_name: string;
+  status: RepairJobStatus;
+  branch_name: string | null;
+  pr_url: string | null;
+  pr_number: number | null;
+  env_cause: number;
+  error: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+const SELECT_COLS =
+  `id, project_id, user_key, visual_check_id, repo_full_name, status,
+   branch_name, pr_url, pr_number, env_cause, error, created_at, updated_at`;
+
+function randId(): string {
+  const ts = Date.now().toString(36).slice(-6);
+  const r = Math.random().toString(36).slice(2, 6);
+  return `wrj_${ts}${r}`;
+}
+
+function fromRow(row: RawRow): DbRepairJob {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    userKey: row.user_key,
+    visualCheckId: row.visual_check_id,
+    repoFullName: row.repo_full_name,
+    status: row.status,
+    branchName: row.branch_name ?? undefined,
+    prUrl: row.pr_url ?? undefined,
+    prNumber: row.pr_number ?? undefined,
+    envCause: row.env_cause === 1,
+    error: row.error ?? undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function insertQueuedRepairJob(
+  env: Env,
+  input: {
+    projectId: string;
+    userKey: string;
+    visualCheckId: string;
+    repoFullName: string;
+    branchName: string;
+    envCause: boolean;
+    now?: string;
+  },
+): Promise<DbRepairJob> {
+  const id = randId();
+  const now = input.now ?? new Date().toISOString();
+  await env.DB.prepare(
+    `INSERT INTO workspace_repair_jobs
+       (id, project_id, user_key, visual_check_id, repo_full_name,
+        status, branch_name, pr_url, pr_number, env_cause, error, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, 'queued', ?, NULL, NULL, ?, NULL, ?, ?)`,
+  )
+    .bind(
+      id,
+      input.projectId,
+      input.userKey,
+      input.visualCheckId,
+      input.repoFullName,
+      input.branchName,
+      input.envCause ? 1 : 0,
+      now,
+      now,
+    )
+    .run();
+  return {
+    id,
+    projectId: input.projectId,
+    userKey: input.userKey,
+    visualCheckId: input.visualCheckId,
+    repoFullName: input.repoFullName,
+    status: "queued",
+    branchName: input.branchName,
+    envCause: input.envCause,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export async function getRepairJobById(env: Env, id: string): Promise<DbRepairJob | null> {
+  const row = (await env.DB.prepare(
+    `SELECT ${SELECT_COLS} FROM workspace_repair_jobs WHERE id = ?`,
+  )
+    .bind(id)
+    .first()) as RawRow | null;
+  return row ? fromRow(row) : null;
+}
+
+/** One active (queued|running) repair per visual check — 409 guard. */
+export async function findActiveRepairJobForRun(
+  env: Env,
+  visualCheckId: string,
+): Promise<{ id: string; status: RepairJobStatus } | null> {
+  const row = (await env.DB.prepare(
+    `SELECT id, status FROM workspace_repair_jobs
+      WHERE visual_check_id = ? AND status IN ('queued', 'running')
+      ORDER BY created_at DESC
+      LIMIT 1`,
+  )
+    .bind(visualCheckId)
+    .first()) as { id: string; status: RepairJobStatus } | null;
+  return row ?? null;
+}
+
+/** Latest repair job for a run (dashboard polling). */
+export async function getLatestRepairJobForRun(
+  env: Env,
+  visualCheckId: string,
+): Promise<DbRepairJob | null> {
+  const row = (await env.DB.prepare(
+    `SELECT ${SELECT_COLS} FROM workspace_repair_jobs
+      WHERE visual_check_id = ?
+      ORDER BY created_at DESC
+      LIMIT 1`,
+  )
+    .bind(visualCheckId)
+    .first()) as RawRow | null;
+  return row ? fromRow(row) : null;
+}
+
+/** queued → running (only from an in-flight state; done/failed are final). */
+export async function markRepairJobRunning(env: Env, id: string): Promise<boolean> {
+  const res = await env.DB.prepare(
+    `UPDATE workspace_repair_jobs
+        SET status = 'running', updated_at = ?
+      WHERE id = ? AND status IN ('queued', 'running')`,
+  )
+    .bind(new Date().toISOString(), id)
+    .run();
+  return (res.meta?.changes ?? 0) > 0;
+}
+
+/** Terminal success: repair branch + PR exist on the user's repo. */
+export async function markRepairJobDone(
+  env: Env,
+  id: string,
+  input: { prUrl?: string; prNumber?: number; branchName?: string; envCause?: boolean },
+): Promise<void> {
+  await env.DB.prepare(
+    `UPDATE workspace_repair_jobs
+        SET status = 'done',
+            pr_url = COALESCE(?, pr_url),
+            pr_number = COALESCE(?, pr_number),
+            branch_name = COALESCE(?, branch_name),
+            env_cause = CASE WHEN ? = 1 THEN 1 ELSE env_cause END,
+            updated_at = ?
+      WHERE id = ?`,
+  )
+    .bind(
+      input.prUrl ?? null,
+      input.prNumber ?? null,
+      input.branchName ?? null,
+      input.envCause === true ? 1 : 0,
+      new Date().toISOString(),
+      id,
+    )
+    .run();
+}
+
+/** Terminal failure — stores a truncated error for the dashboard. */
+export async function markRepairJobFailed(env: Env, id: string, error: string): Promise<void> {
+  await env.DB.prepare(
+    `UPDATE workspace_repair_jobs
+        SET status = 'failed', error = ?, updated_at = ?
+      WHERE id = ?`,
+  )
+    .bind(error.slice(0, 500), new Date().toISOString(), id)
+    .run();
+}
+
+/** Repair jobs stuck in queued|running past the cutoff (stuck sweep). */
+export async function listStuckRepairJobs(
+  env: Env,
+  cutoffIso: string,
+  limit: number,
+): Promise<Array<{ id: string; status: RepairJobStatus }>> {
+  const rs = await env.DB.prepare(
+    `SELECT id, status FROM workspace_repair_jobs
+      WHERE status IN ('queued', 'running') AND updated_at < ?
+      ORDER BY updated_at ASC
+      LIMIT ?`,
+  )
+    .bind(cutoffIso, limit)
+    .all<{ id: string; status: RepairJobStatus }>();
+  return rs.results ?? [];
+}

--- a/apps/central-plane/test/workspace-repair-jobs.test.mjs
+++ b/apps/central-plane/test/workspace-repair-jobs.test.mjs
@@ -1,0 +1,620 @@
+/**
+ * workspace-repair-jobs.test.mjs — Stage 268
+ *
+ * "[고치기]" repair loop for failed Simsa visual checks:
+ *   - POST /workspace/projects/:id/visual-checks/:runId/repair — ownership
+ *     chain, repairable gating (done + works!==true + agent_prompt), repo/token
+ *     resolution errors, env-cause pre-check, 409 guard, SANDBOX dispatch
+ *     payload, fail-fast without the binding (263.1 semantics).
+ *   - GET  .../repair — latest job for dashboard polling.
+ *   - POST /internal/repair-{running,done} — bearer gate + transitions.
+ *   - cleanupStuckRepairJobs — 30-min stuck sweep.
+ *   - container pure helpers (validateRepairPayload / redactSecret /
+ *     buildRepairPrContent) — token never leaks into PR title/body/brief.
+ *
+ * Mocks at the seam: fake D1, stub DurableObjectNamespace, REAL AES-GCM crypto
+ * (a generated KEK encrypts the stored OAuth token so the route's decrypt path
+ * is exercised for real). No network, no containers.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+
+const { createApp } = await import("../dist/router.js");
+const { cleanupStuckRepairJobs } = await import("../dist/stuck-cleanup.js");
+const { detectEnvCause, isRunRepairable, normalizeRepoReference } = await import(
+  "../dist/routes/workspace-repair-jobs.js"
+);
+const { encryptToken } = await import("../dist/crypto.js");
+const { validateRepairPayload, redactSecret, buildRepairPrContent } = await import(
+  "../container/coerce-result.mjs"
+);
+
+const USER = "uk_owner";
+const OTHER = "uk_intruder";
+const PROJECT = "proj_repair";
+const OTHER_PROJECT = "proj_other";
+const RUN = "wvc_fixme1";
+const TOKEN = "tok_internal_secret";
+const GH_TOKEN = "gho_userOauthToken12345";
+const KEK = randomBytes(32).toString("base64");
+const GH_TOKEN_ENC = await encryptToken(GH_TOKEN, KEK);
+
+const AGENT_PROMPT =
+  "당신은 이 프로젝트의 코드를 수정하는 개발 에이전트입니다.\n[고칠 문제] 버튼 클릭 후 목록이 비어 있음";
+const ENV_PROMPT =
+  AGENT_PROMPT + "\n증거: GET https://dead.supabase.co/rest/v1/x (net::ERR_NAME_NOT_RESOLVED)";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+function makeDb({ projects = new Map(), checks = [], repos = [], connections = [], sources = [], jobs = [] } = {}) {
+  return {
+    _jobs: jobs,
+    prepare(sql) {
+      function handler(args) {
+        return {
+          async run() {
+            if (sql.includes("INSERT INTO workspace_repair_jobs")) {
+              const [id, project_id, user_key, visual_check_id, repo_full_name, branch_name, env_cause, created_at, updated_at] = args;
+              jobs.push({
+                id, project_id, user_key, visual_check_id, repo_full_name,
+                status: "queued", branch_name, pr_url: null, pr_number: null,
+                env_cause, error: null, created_at, updated_at,
+              });
+              return { meta: { changes: 1 } };
+            }
+            if (sql.includes("workspace_repair_jobs") && sql.includes("SET status = 'running'")) {
+              const [updated_at, id] = args;
+              const row = jobs.find((r) => r.id === id && (r.status === "queued" || r.status === "running"));
+              if (row) { row.status = "running"; row.updated_at = updated_at; }
+              return { meta: { changes: row ? 1 : 0 } };
+            }
+            if (sql.includes("workspace_repair_jobs") && sql.includes("SET status = 'done'")) {
+              const [pr_url, pr_number, branch_name, env_flag, updated_at, id] = args;
+              const row = jobs.find((r) => r.id === id);
+              if (row) {
+                row.status = "done";
+                row.pr_url = pr_url ?? row.pr_url;
+                row.pr_number = pr_number ?? row.pr_number;
+                row.branch_name = branch_name ?? row.branch_name;
+                if (env_flag === 1) row.env_cause = 1;
+                row.updated_at = updated_at;
+              }
+              return { meta: { changes: row ? 1 : 0 } };
+            }
+            if (sql.includes("workspace_repair_jobs") && sql.includes("SET status = 'failed'")) {
+              const [error, updated_at, id] = args;
+              const row = jobs.find((r) => r.id === id);
+              if (row) { row.status = "failed"; row.error = error; row.updated_at = updated_at; }
+              return { meta: { changes: row ? 1 : 0 } };
+            }
+            return { meta: { changes: 0 } };
+          },
+          async first() {
+            if (sql.includes("FROM workspace_projects WHERE id = ?")) {
+              return projects.get(args[0]) ?? null;
+            }
+            if (sql.includes("FROM workspace_visual_checks") && sql.includes("WHERE id = ?")) {
+              return checks.find((r) => r.id === args[0]) ?? null;
+            }
+            if (sql.includes("FROM workspace_project_repos WHERE project_id = ?")) {
+              return repos.find((r) => r.project_id === args[0]) ?? null;
+            }
+            if (sql.includes("FROM workspace_github_connections WHERE user_key = ?")) {
+              return connections.find((r) => r.user_key === args[0]) ?? null;
+            }
+            if (sql.includes("FROM workspace_repair_jobs") && sql.includes("WHERE id = ?")) {
+              return jobs.find((r) => r.id === args[0]) ?? null;
+            }
+            if (sql.includes("FROM workspace_repair_jobs") && sql.includes("status IN ('queued', 'running')")) {
+              return jobs.find((r) => r.visual_check_id === args[0] && (r.status === "queued" || r.status === "running")) ?? null;
+            }
+            if (sql.includes("FROM workspace_repair_jobs") && sql.includes("WHERE visual_check_id = ?")) {
+              const list = jobs
+                .filter((r) => r.visual_check_id === args[0])
+                .sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+              return list[0] ?? null;
+            }
+            return null;
+          },
+          async all() {
+            if (sql.includes("FROM project_sources") && sql.includes("WHERE project_id = ?")) {
+              return { results: sources.filter((s) => s.project_id === args[0]) };
+            }
+            if (sql.includes("FROM workspace_repair_jobs") && sql.includes("updated_at < ?")) {
+              const [cutoff, limit] = args;
+              return {
+                results: jobs
+                  .filter((r) => (r.status === "queued" || r.status === "running") && r.updated_at < cutoff)
+                  .slice(0, limit)
+                  .map((r) => ({ id: r.id, status: r.status })),
+              };
+            }
+            return { results: [] };
+          },
+        };
+      }
+      return {
+        bind(...args) { return handler(args); },
+        run() { return handler([]).run(); },
+        first() { return handler([]).first(); },
+        all() { return handler([]).all(); },
+      };
+    },
+  };
+}
+
+function makeProjectRow(id, userKey) {
+  return {
+    id, user_key: userKey, title: "t", idea: "i",
+    understood_json: "{}", product_spec_json: "{}", items_json: "[]",
+    created_at: "2026-07-02T00:00:00.000Z", updated_at: "2026-07-02T00:00:00.000Z",
+  };
+}
+
+function makeCheck(over = {}) {
+  return {
+    id: RUN, project_id: PROJECT, user_key: USER,
+    target_url: "https://golf-now.example.app/", intent: "골퍼가 코스 목록을 볼 수 있어야 한다",
+    decision: "Needs Fix", works: 0, status: "done", executor: "container",
+    report_json: JSON.stringify({ verdict: "작동 안 해요" }), agent_prompt: AGENT_PROMPT,
+    evidence_keys_json: "[]",
+    created_at: "2026-07-02T00:00:00.000Z", updated_at: "2026-07-02T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function makeRepoRow(over = {}) {
+  return {
+    id: "wpr_1", project_id: PROJECT, user_key: USER, github_connection_id: "wgc_1",
+    repo_id: "1", repo_full_name: "acme/golf-now", repo_owner: "acme", repo_name: "golf-now",
+    default_branch: "main", private: 0, html_url: "https://github.com/acme/golf-now",
+    created_at: "2026-07-02T00:00:00.000Z", updated_at: "2026-07-02T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function makeConnection(over = {}) {
+  return {
+    id: "wgc_1", user_key: USER, github_user_id: "77", github_login: "acme-user",
+    github_name: null, avatar_url: null, access_token_enc: GH_TOKEN_ENC, scopes: "read:user public_repo",
+    created_at: "2026-07-02T00:00:00.000Z", updated_at: "2026-07-02T00:00:00.000Z",
+    ...over,
+  };
+}
+
+/** Stub SANDBOX DurableObjectNamespace recording idFromName + fetch payloads. */
+function makeSandbox(recorder, { status = 202 } = {}) {
+  return {
+    idFromName(name) {
+      recorder.names.push(name);
+      return { name };
+    },
+    get() {
+      return {
+        async fetch(url, init) {
+          recorder.calls.push({ url, body: JSON.parse(init.body) });
+          return new Response(JSON.stringify({ status: "accepted" }), { status });
+        },
+      };
+    },
+  };
+}
+
+function makeEnv({
+  checks = [makeCheck()],
+  repos = [makeRepoRow()],
+  connections = [makeConnection()],
+  sources = [],
+  jobs = [],
+  sandbox,
+  token = TOKEN,
+  kek = KEK,
+} = {}) {
+  const env = {
+    ENVIRONMENT: "test",
+    DB: makeDb({
+      projects: new Map([
+        [PROJECT, makeProjectRow(PROJECT, USER)],
+        [OTHER_PROJECT, makeProjectRow(OTHER_PROJECT, OTHER)],
+      ]),
+      checks, repos, connections, sources, jobs,
+    }),
+  };
+  if (sandbox) env.SANDBOX = sandbox;
+  if (token) env.INTERNAL_CALLBACK_TOKEN = token;
+  if (kek) env.CONCLAVE_TOKEN_KEK = kek;
+  return env;
+}
+
+async function req(env, method, path, body, headers = {}) {
+  const app = createApp();
+  const init = { method, headers: { "content-type": "application/json", ...headers } };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  const res = await app.fetch(new Request(`http://localhost${path}`, init), env);
+  let json = null;
+  try { json = await res.clone().json(); } catch { /* non-json */ }
+  return { status: res.status, json };
+}
+
+const REPAIR_PATH = `/workspace/projects/${PROJECT}/visual-checks/${RUN}/repair`;
+
+// ─── ownership chain ──────────────────────────────────────────────────────────
+
+test("repair: unknown project 404 / wrong userKey 403 / missing userKey 400", async () => {
+  const env = makeEnv();
+  const nope = await req(env, "POST", `/workspace/projects/proj_nope/visual-checks/${RUN}/repair`, { userKey: USER });
+  assert.equal(nope.status, 404);
+  assert.equal(nope.json.error, "project_not_found");
+
+  const forbidden = await req(env, "POST", REPAIR_PATH, { userKey: OTHER });
+  assert.equal(forbidden.status, 403);
+  assert.equal(forbidden.json.error, "forbidden");
+
+  const missing = await req(env, "POST", REPAIR_PATH, {});
+  assert.equal(missing.status, 400);
+  assert.equal(missing.json.error, "userKey_required");
+});
+
+test("repair: run belonging to another project/user → 404 run_not_found", async () => {
+  const env = makeEnv({ checks: [makeCheck({ project_id: OTHER_PROJECT, user_key: OTHER })] });
+  const r = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 404);
+  assert.equal(r.json.error, "run_not_found");
+
+  const unknown = await req(env, "POST", `/workspace/projects/${PROJECT}/visual-checks/wvc_nope/repair`, { userKey: USER });
+  assert.equal(unknown.status, 404);
+});
+
+// ─── repairable gating: done + works!==true + agent_prompt ───────────────────
+
+test("repair: run still running / failed → 400 run_not_repairable", async () => {
+  for (const status of ["queued", "running", "failed", "uploaded"]) {
+    const env = makeEnv({ checks: [makeCheck({ status })] });
+    const r = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+    assert.equal(r.status, 400, `status=${status}`);
+    assert.equal(r.json.error, "run_not_repairable");
+    assert.match(r.json.message, /고치기/);
+  }
+});
+
+test("repair: run that WORKS (works=true) → 400 run_not_repairable; works=null is repairable", async () => {
+  const works = makeEnv({ checks: [makeCheck({ works: 1 })] });
+  const r = await req(works, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 400);
+  assert.equal(r.json.error, "run_not_repairable");
+
+  // works=null (not verified) + prompt present → repairable (fail-fast path,
+  // no sandbox in this env, but gating passed: not run_not_repairable).
+  const nullWorks = makeEnv({ checks: [makeCheck({ works: null })] });
+  const r2 = await req(nullWorks, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r2.status, 202);
+});
+
+test("repair: missing agent_prompt → 400 run_not_repairable", async () => {
+  const env = makeEnv({ checks: [makeCheck({ agent_prompt: null })] });
+  const r = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 400);
+  assert.equal(r.json.error, "run_not_repairable");
+});
+
+// ─── repo + token resolution ──────────────────────────────────────────────────
+
+test("repair: no linked repo anywhere → 400 github_repo_required with Korean message", async () => {
+  const env = makeEnv({ repos: [], sources: [] });
+  const r = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 400);
+  assert.equal(r.json.error, "github_repo_required");
+  assert.match(r.json.message, /저장소/);
+});
+
+test("repair: falls back to project_sources github_repo when no workspace repo link", async () => {
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({
+    repos: [],
+    sources: [
+      { id: "psrc_w", project_id: PROJECT, user_key: USER, type: "website", reference: "https://x.app/", label: null, content_type: null, size_bytes: null, created_at: "2026-07-02T00:00:00.000Z" },
+      { id: "psrc_gh", project_id: PROJECT, user_key: USER, type: "github_repo", reference: "https://github.com/acme/golf-now.git", label: null, content_type: null, size_bytes: null, created_at: "2026-07-02T00:00:00.000Z" },
+    ],
+    sandbox: makeSandbox(recorder),
+  });
+  const r = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.repair.repoFullName, "acme/golf-now");
+  assert.equal(recorder.calls[0].body.repo, "acme/golf-now");
+});
+
+test("repair: token missing (no connection / no KEK / bad ciphertext) → 400 github_token_required", async () => {
+  const noConn = makeEnv({ connections: [] });
+  const r1 = await req(noConn, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r1.status, 400);
+  assert.equal(r1.json.error, "github_token_required");
+  assert.match(r1.json.message, /GitHub/);
+
+  const noKek = makeEnv({ kek: null });
+  const r2 = await req(noKek, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r2.status, 400);
+  assert.equal(r2.json.error, "github_token_required");
+
+  const tampered = makeEnv({ connections: [makeConnection({ access_token_enc: "not-a-ciphertext" })] });
+  const r3 = await req(tampered, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r3.status, 400);
+  assert.equal(r3.json.error, "github_token_required");
+});
+
+// ─── env-cause pre-check (pure) ───────────────────────────────────────────────
+
+test("detectEnvCause: DNS / connection-refused evidence → true; clean evidence → false", () => {
+  assert.equal(detectEnvCause(ENV_PROMPT, "{}"), true);
+  assert.equal(detectEnvCause("", JSON.stringify({ findings: [{ evidence: "getaddrinfo ENOTFOUND dead.host" }] })), true);
+  assert.equal(detectEnvCause("연결 실패: net::ERR_CONNECTION_REFUSED", "{}"), true);
+  assert.equal(detectEnvCause("fetch failed: ECONNREFUSED 127.0.0.1:5432", "{}"), true);
+  assert.equal(detectEnvCause(AGENT_PROMPT, JSON.stringify({ verdict: "버튼이 반응 없음" })), false);
+  assert.equal(detectEnvCause("", ""), false);
+});
+
+test("repair: env-cause run still dispatches but flags envCause on row + payload", async () => {
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({ checks: [makeCheck({ agent_prompt: ENV_PROMPT })], sandbox: makeSandbox(recorder) });
+  const r = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.dispatched, true, "env-cause must NOT block the repair");
+  assert.equal(r.json.repair.envCause, true);
+  assert.equal(env.DB._jobs[0].env_cause, 1);
+  assert.equal(recorder.calls[0].body.envCause, true);
+});
+
+// ─── dispatch + fail-fast + 409 ───────────────────────────────────────────────
+
+test("repair: SANDBOX present → dispatched:true, DO named repair-<jobId>, payload carries job contract (+ decrypted token, never in response)", async () => {
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({ sandbox: makeSandbox(recorder) });
+  const r = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.ok, true);
+  assert.equal(r.json.dispatched, true);
+  assert.equal(r.json.repair.status, "queued");
+  assert.equal(r.json.repair.branchName, `fix/simsa-${RUN}`);
+
+  const jobId = r.json.repair.id;
+  assert.deepEqual(recorder.names, [`repair-${jobId}`]);
+  const payload = recorder.calls[0].body;
+  assert.equal(payload.jobType, "simsa_repair");
+  assert.equal(payload.jobId, jobId);
+  assert.equal(payload.repo, "acme/golf-now");
+  assert.equal(payload.githubToken, GH_TOKEN, "container receives the DECRYPTED OAuth token");
+  assert.equal(payload.branch, `fix/simsa-${RUN}`);
+  assert.equal(payload.agentPrompt, AGENT_PROMPT);
+  assert.equal(payload.visualCheckId, RUN);
+  assert.equal(payload.callbackToken, TOKEN);
+  assert.match(payload.callbackUrl, /\/internal\/repair-done$/);
+  assert.match(payload.runningUrl, /\/internal\/repair-running$/);
+
+  // The token must never leak into the HTTP response or the D1 row.
+  assert.ok(!JSON.stringify(r.json).includes(GH_TOKEN), "response must not leak the GitHub token");
+  assert.ok(!JSON.stringify(env.DB._jobs).includes(GH_TOKEN), "D1 rows must not contain the token");
+});
+
+test("repair: SANDBOX absent → row created then FAIL-FAST (dispatched:false, retry not wedged)", async () => {
+  const env = makeEnv(); // no sandbox binding
+  const r = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.dispatched, false);
+  assert.equal(r.json.note, "sandbox_unavailable");
+  assert.equal(r.json.repair.status, "failed");
+  assert.equal(env.DB._jobs[0].status, "failed");
+
+  // and the user can retry immediately (no repair_already_active wedge)
+  const retry = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(retry.status, 202);
+});
+
+test("repair: container refuses (500) / callback token missing → fail-fast with note", async () => {
+  const recorder = { names: [], calls: [] };
+  const refuse = makeEnv({ sandbox: makeSandbox(recorder, { status: 500 }) });
+  const r = await req(refuse, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.dispatched, false);
+  assert.match(r.json.note, /container returned 500/);
+  assert.equal(refuse.DB._jobs[0].status, "failed");
+
+  const noCb = makeEnv({ sandbox: makeSandbox({ names: [], calls: [] }), token: null });
+  const r2 = await req(noCb, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r2.json.dispatched, false);
+  assert.equal(r2.json.note, "callback_token_missing");
+  assert.equal(noCb.DB._jobs[0].status, "failed");
+});
+
+test("repair: one active repair per run → 409 repair_already_active", async () => {
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({ sandbox: makeSandbox(recorder) }); // successful dispatch keeps row queued
+  const first = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(first.status, 202);
+
+  const second = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(second.status, 409);
+  assert.equal(second.json.error, "repair_already_active");
+  assert.equal(second.json.activeJobId, first.json.repair.id);
+
+  // running (not just queued) also blocks
+  env.DB._jobs[0].status = "running";
+  const third = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(third.status, 409);
+});
+
+// ─── /internal/repair-running + /internal/repair-done ────────────────────────
+
+test("internal repair callbacks: 503 when token unset, 401 on wrong/missing bearer", async () => {
+  const noToken = makeEnv({ token: null });
+  const disabled = await req(noToken, "POST", "/internal/repair-running", { jobId: "x" });
+  assert.equal(disabled.status, 503);
+
+  const env = makeEnv();
+  for (const path of ["/internal/repair-running", "/internal/repair-done"]) {
+    const wrong = await req(env, "POST", path, { jobId: "x", ok: true }, { authorization: "Bearer nope" });
+    assert.equal(wrong.status, 401, path);
+    const missing = await req(env, "POST", path, { jobId: "x", ok: true });
+    assert.equal(missing.status, 401, path);
+  }
+});
+
+test("internal repair-running: queued → running; unknown jobId 404", async () => {
+  const env = makeEnv({ sandbox: makeSandbox({ names: [], calls: [] }) });
+  const created = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  const jobId = created.json.repair.id;
+
+  const r = await req(env, "POST", "/internal/repair-running", { jobId }, { authorization: `Bearer ${TOKEN}` });
+  assert.equal(r.status, 200);
+  assert.equal(r.json.transitioned, true);
+  assert.equal(env.DB._jobs[0].status, "running");
+
+  const unknown = await req(env, "POST", "/internal/repair-running", { jobId: "wrj_nope" }, { authorization: `Bearer ${TOKEN}` });
+  assert.equal(unknown.status, 404);
+});
+
+test("internal repair-done: ok:true stores PR url/number/branch → status done", async () => {
+  const env = makeEnv({ sandbox: makeSandbox({ names: [], calls: [] }) });
+  const created = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  const jobId = created.json.repair.id;
+
+  const r = await req(
+    env, "POST", "/internal/repair-done",
+    { jobId, ok: true, prUrl: "https://github.com/acme/golf-now/pull/38", prNumber: 38, branch: `fix/simsa-${RUN}` },
+    { authorization: `Bearer ${TOKEN}` },
+  );
+  assert.equal(r.status, 200);
+  assert.equal(r.json.status, "done");
+
+  const row = env.DB._jobs[0];
+  assert.equal(row.status, "done");
+  assert.equal(row.pr_url, "https://github.com/acme/golf-now/pull/38");
+  assert.equal(row.pr_number, 38);
+  assert.equal(row.branch_name, `fix/simsa-${RUN}`);
+});
+
+test("internal repair-done: ok:false stores truncated error → status failed; invalid body 400; unknown 404", async () => {
+  const env = makeEnv({ sandbox: makeSandbox({ names: [], calls: [] }) });
+  const created = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  const jobId = created.json.repair.id;
+
+  const r = await req(
+    env, "POST", "/internal/repair-done",
+    { jobId, ok: false, error: "clone failed " + "x".repeat(600) },
+    { authorization: `Bearer ${TOKEN}` },
+  );
+  assert.equal(r.status, 200);
+  assert.equal(r.json.status, "failed");
+  assert.equal(env.DB._jobs[0].status, "failed");
+  assert.match(env.DB._jobs[0].error, /clone failed/);
+  assert.ok(env.DB._jobs[0].error.length <= 500, "error must be truncated");
+
+  const invalid = await req(env, "POST", "/internal/repair-done", { jobId }, { authorization: `Bearer ${TOKEN}` });
+  assert.equal(invalid.status, 400);
+  const unknown = await req(env, "POST", "/internal/repair-done", { jobId: "wrj_nope", ok: true }, { authorization: `Bearer ${TOKEN}` });
+  assert.equal(unknown.status, 404);
+});
+
+// ─── GET latest repair job ────────────────────────────────────────────────────
+
+test("GET repair: latest job for the run (dashboard polling); null when none; ownership enforced", async () => {
+  const env = makeEnv({ sandbox: makeSandbox({ names: [], calls: [] }) });
+
+  const empty = await req(env, "GET", `${REPAIR_PATH}?userKey=${USER}`);
+  assert.equal(empty.status, 200);
+  assert.equal(empty.json.repair, null);
+
+  const created = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  const jobId = created.json.repair.id;
+  await req(env, "POST", "/internal/repair-done",
+    { jobId, ok: true, prUrl: "https://github.com/acme/golf-now/pull/38", prNumber: 38 },
+    { authorization: `Bearer ${TOKEN}` });
+
+  const got = await req(env, "GET", `${REPAIR_PATH}?userKey=${USER}`);
+  assert.equal(got.status, 200);
+  assert.equal(got.json.repair.id, jobId);
+  assert.equal(got.json.repair.status, "done");
+  assert.equal(got.json.repair.prUrl, "https://github.com/acme/golf-now/pull/38");
+  assert.equal(got.json.repair.prNumber, 38);
+
+  const forbidden = await req(env, "GET", `${REPAIR_PATH}?userKey=${OTHER}`);
+  assert.equal(forbidden.status, 403);
+  const noKey = await req(env, "GET", REPAIR_PATH);
+  assert.equal(noKey.status, 400);
+});
+
+// ─── stuck sweep ──────────────────────────────────────────────────────────────
+
+test("stuck sweep: repair jobs stuck in queued|running >30 min → failed; fresh untouched", async () => {
+  const old = new Date(Date.now() - 45 * 60 * 1000).toISOString();
+  const fresh = new Date().toISOString();
+  const jobs = [
+    { id: "wrj_old_q", project_id: PROJECT, user_key: USER, visual_check_id: RUN, repo_full_name: "acme/golf-now", status: "queued", branch_name: "b", pr_url: null, pr_number: null, env_cause: 0, error: null, created_at: old, updated_at: old },
+    { id: "wrj_old_r", project_id: PROJECT, user_key: USER, visual_check_id: "wvc_2", repo_full_name: "acme/golf-now", status: "running", branch_name: "b", pr_url: null, pr_number: null, env_cause: 0, error: null, created_at: old, updated_at: old },
+    { id: "wrj_fresh", project_id: PROJECT, user_key: USER, visual_check_id: "wvc_3", repo_full_name: "acme/golf-now", status: "queued", branch_name: "b", pr_url: null, pr_number: null, env_cause: 0, error: null, created_at: fresh, updated_at: fresh },
+    { id: "wrj_done", project_id: PROJECT, user_key: USER, visual_check_id: "wvc_4", repo_full_name: "acme/golf-now", status: "done", branch_name: "b", pr_url: "u", pr_number: 1, env_cause: 0, error: null, created_at: old, updated_at: old },
+  ];
+  const env = makeEnv({ jobs });
+
+  const result = await cleanupStuckRepairJobs(env);
+  assert.equal(result.swept, 2);
+  assert.equal(result.errors, 0);
+  assert.equal(jobs[0].status, "failed");
+  assert.match(jobs[0].error, /30 minutes/);
+  assert.equal(jobs[1].status, "failed");
+  assert.equal(jobs[2].status, "queued", "fresh job must not be swept");
+  assert.equal(jobs[3].status, "done", "terminal job must not be touched");
+});
+
+// ─── pure helpers ─────────────────────────────────────────────────────────────
+
+test("isRunRepairable / normalizeRepoReference pure cases", () => {
+  assert.equal(isRunRepairable({ status: "done", works: false, agentPrompt: "p" }), true);
+  assert.equal(isRunRepairable({ status: "done", works: null, agentPrompt: "p" }), true);
+  assert.equal(isRunRepairable({ status: "done", works: true, agentPrompt: "p" }), false);
+  assert.equal(isRunRepairable({ status: "running", works: false, agentPrompt: "p" }), false);
+  assert.equal(isRunRepairable({ status: "done", works: false, agentPrompt: undefined }), false);
+
+  assert.equal(normalizeRepoReference("acme/golf-now"), "acme/golf-now");
+  assert.equal(normalizeRepoReference("https://github.com/acme/golf-now.git"), "acme/golf-now");
+  assert.equal(normalizeRepoReference("https://github.com/acme/golf-now/"), "acme/golf-now");
+  assert.equal(normalizeRepoReference("not a repo"), null);
+  assert.equal(normalizeRepoReference("https://gitlab.com/acme/x"), null);
+});
+
+test("container helpers: validateRepairPayload + redactSecret", () => {
+  const full = {
+    jobId: "wrj_1", repo: "acme/golf-now", githubToken: GH_TOKEN, branch: "fix/simsa-x",
+    agentPrompt: AGENT_PROMPT, callbackUrl: "https://w/internal/repair-done", callbackToken: TOKEN,
+  };
+  assert.deepEqual(validateRepairPayload(full), { ok: true });
+  const missing = validateRepairPayload({ ...full, githubToken: "", agentPrompt: undefined });
+  assert.equal(missing.ok, false);
+  assert.deepEqual(missing.missing.sort(), ["agentPrompt", "githubToken"]);
+  assert.equal(validateRepairPayload(null).ok, false);
+
+  assert.equal(redactSecret(`clone https://x-access-token:${GH_TOKEN}@github.com failed`, GH_TOKEN),
+    "clone https://x-access-token:[REDACTED]@github.com failed");
+  assert.equal(redactSecret("plain error", ""), "plain error");
+});
+
+test("container helpers: buildRepairPrContent is honest (no auto-fix claim), carries prompt + env warning, never the token", () => {
+  const content = buildRepairPrContent({
+    intent: "골퍼가 코스 목록을 볼 수 있어야 한다", decision: "Needs Fix",
+    targetUrl: "https://golf-now.example.app/", visualCheckId: RUN,
+    agentPrompt: ENV_PROMPT, envCause: true, githubToken: GH_TOKEN,
+  });
+  assert.match(content.title, /^Simsa 수리 시작점: /);
+  assert.match(content.body, /자동 적용된 코드 수정이 없습니다/);
+  assert.match(content.body, /코드 수정만으로 완전히 해결되지 않을 수 있어요/);
+  assert.ok(content.body.includes(ENV_PROMPT), "PR body carries the full agent prompt");
+  assert.equal(content.briefFileName, "SIMSA-FIX-BRIEF.md");
+  assert.ok(content.briefContent.includes(ENV_PROMPT));
+  for (const text of [content.title, content.body, content.briefContent]) {
+    assert.ok(!text.includes(GH_TOKEN), "token must never appear in PR content");
+  }
+
+  // non-env-cause: no env warning; long intent truncated in title
+  const plain = buildRepairPrContent({ intent: "x".repeat(100), agentPrompt: AGENT_PROMPT, envCause: false });
+  assert.ok(!/완전히 해결되지 않을 수 있어요/.test(plain.body));
+  assert.ok(plain.title.length < 80);
+});


### PR DESCRIPTION
## What

Phase 4 repair loop backend: **[고치기]** on a failed Simsa visual check turns the run's stored deterministic agent fix prompt (Stage 260B `agent_prompt`) into a **repair branch + draft PR on the user's connected GitHub repo**, executed inside the **existing ConclaveSandbox container** as a new `simsa_repair` job type — no third container.

## Endpoint contracts (for Stage 269 dashboard wiring)

**`POST /workspace/projects/:id/visual-checks/:runId/repair`** — body `{userKey}` → `202 {ok:true, repair:{id, visualCheckId, repoFullName, status, branchName, prUrl, prNumber, envCause, error, createdAt, updatedAt}, dispatched, note?}`
Errors: `400 run_not_repairable` / `400 github_repo_required` / `400 github_token_required` (each with Korean `message`), `404 project_not_found|run_not_found`, `403 forbidden`, `409 repair_already_active {activeJobId}`. Undispatched jobs are fail-fast marked `failed` (263.1 semantics) with `dispatched:false`.

**`GET /workspace/projects/:id/visual-checks/:runId/repair?userKey=...`** → `200 {ok:true, repair: null | {…same view…}}` — latest job, for polling.

**`POST /internal/repair-running`** `{jobId}` + **`POST /internal/repair-done`** `{jobId, ok, prUrl?, prNumber?, branch?, envCause?, error?}` — Bearer `INTERNAL_CALLBACK_TOKEN`.

## Design decisions

- **Container behavior (reported deviation): honest draft-PR brief, not runAutofix.** `runAutofix`'s input contract is PR-shaped (`{pr, cwd}` + `conclave review --pr N` subprocess + council-blocker patches) — it cannot cleanly consume a free-form fix prompt with no PR. The reliable v1: shallow-clone with the user's OAuth token → branch `fix/simsa-{runId}` → commit `SIMSA-FIX-BRIEF.md` (the prompt) → **draft** PR titled "Simsa 수리 시작점: …" whose body carries the prompt and states explicitly that code changes were NOT auto-applied. Retry-safe (force-push same branch, reuses existing open PR on 422).
- **Env-cause honesty**: ERR_NAME_NOT_RESOLVED / ENOTFOUND / getaddrinfo / ECONNREFUSED patterns in the evidence set `env_cause=1` (UI warns "코드 수정만으로 완전히 해결되지 않을 수 있어요") but do NOT block the repair — fallback-style code fixes are legitimate (golf-now PR #38).
- **Repo resolution**: workspace GitHub connection (`workspace_project_repos`) preferred since it owns the token; `project_sources` `github_repo` rows are the fallback.
- **Token safety**: AES-GCM decrypt happens only in the route; token travels only in the job payload → container memory; redacted from every error message; never in D1 rows or responses (asserted in tests).
- Stuck sweep (30 min) added to the same `*/5` cron tick as Stage 263.

## Tests

23 new in `apps/central-plane/test/workspace-repair-jobs.test.mjs` (real AES-GCM crypto seam, stub SANDBOX DO, fake D1): repairable gating, repo/token error codes, env-cause pure cases + dispatch flag, 409 guard, fail-fast (no binding / refused / no callback token), internal callback auth + done/failed transitions, GET latest + ownership, stuck sweep, container pure helpers (payload validation, token redaction, honest PR content). Full central-plane suite **1367/1367** green; turbo build + typecheck pass.

## Deploy notes

- **Migration 0051** (`workspace_repair_jobs`) — applied automatically by deploy-central-plane.yml (`migrate:apply`).
- **Container image rebuild required** — `container/server.mjs` + `container/coerce-result.mjs` changed; the ConclaveSandbox image must be rebuilt/pushed (deploy workflow does this on deploy).
- No new secrets; reuses SANDBOX binding + INTERNAL_CALLBACK_TOKEN + CONCLAVE_TOKEN_KEK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)