### PR TITLE
Stage 270 — Auto-repair execution (worker agent applies fixes)

### DIFF
--- a/apps/central-plane/container/Dockerfile
+++ b/apps/central-plane/container/Dockerfile
@@ -49,10 +49,24 @@ COPY packages packages
 # helpers). Both files must be in the same dir for the relative import.
 COPY apps/central-plane/container/server.mjs ./server.mjs
 COPY apps/central-plane/container/coerce-result.mjs ./coerce-result.mjs
+# Stage 270 — canonical repair-brief module (inspector-container pattern):
+# compile the SAME source the Worker builds so container logic stays
+# lock-step with dist/workspace/repair-brief.js. Compiled after pnpm
+# install (tsc comes from the workspace root devDependencies).
+COPY apps/central-plane/src/workspace/repair-brief.ts ./container-src/repair-brief.ts
 
 # Install deps + build the cli + its workspace dependencies. Using
 # --frozen-lockfile to catch lockfile drift early (would block deploy).
 RUN pnpm install --frozen-lockfile
+
+# Stage 270 — emit ESM into ./container-dist (its own {"type":"module"}
+# marker: the workspace root package.json has no type field, so without it
+# the .js output would be treated as CJS and the dynamic import in
+# server.mjs runRepairJob would fail).
+RUN npx tsc container-src/repair-brief.ts \
+    --outDir container-dist --module es2022 --moduleResolution bundler \
+    --target es2022 --strict --skipLibCheck \
+ && echo '{"type":"module"}' > container-dist/package.json
 
 # Build the packages the container actually invokes at runtime: cli +
 # all of its workspace dependencies. Skip apps/* and packages we don't

--- a/apps/central-plane/container/server.mjs
+++ b/apps/central-plane/container/server.mjs
@@ -82,11 +82,19 @@ const server = createServer(async (req, res) => {
       res.end(JSON.stringify({ error: `missing fields: ${repairValidation.missing.join(", ")}` }));
       return;
     }
+    // Stage 270 — the Worker forwards ANTHROPIC_API_KEY via the same
+    // x-anthropic-key header the autofix spawn uses. Scoped to this job
+    // (passed explicitly to the worker agent), NOT written to process.env.
+    // Absent key → Stage 268 brief-only behavior.
+    const anthropicApiKey =
+      typeof req.headers["x-anthropic-key"] === "string" && req.headers["x-anthropic-key"].length > 0
+        ? req.headers["x-anthropic-key"]
+        : undefined;
     res.writeHead(202, { "content-type": "application/json" });
     res.end(JSON.stringify({ jobId: payload.jobId, status: "accepted" }));
 
     inFlightJobs.set(payload.jobId, payload);
-    runRepairJob(payload)
+    runRepairJob(payload, anthropicApiKey)
       .catch(async (err) => {
         console.error(`[repair ${payload.jobId}] crashed:`, redactSecret(err?.message ?? String(err), payload.githubToken));
         await postCallback(payload.callbackUrl, payload.callbackToken, {
@@ -395,25 +403,34 @@ async function runJob(payload) {
 /**
  * Run a single visual-check repair job.
  *
- * v1 behavior (HONEST FALLBACK, chosen deliberately): runAutofix's input
- * contract is PR-shaped (it reviews an EXISTING PR via `conclave review --pr N`
- * and applies council-blocker patches) — it cannot cleanly consume a
- * free-form agent fix prompt with no PR. Instead of pretending, the repair
- * job:
+ * Stage 270 behavior (true auto-repair): when the Worker forwards an
+ * ANTHROPIC_API_KEY, the container drives the REAL worker agent
+ * (@conclave-ai/agent-worker ClaudeWorker.work) with the Simsa fix brief as
+ * the blocker input so actual code changes land on the repair branch:
  *
  *   1. Shallow-clones the repo with the user's OAuth token (public_repo)
  *   2. Creates the repair branch (fix/simsa-{runId})
- *   3. Commits SIMSA-FIX-BRIEF.md containing the deterministic agent fix
- *      prompt (Stage 260B output)
- *   4. Opens a DRAFT PR titled "Simsa 수리 시작점: ..." whose body carries the
- *      prompt AND states explicitly that code changes were not auto-applied
- *   5. Reports {jobId, ok, prUrl, prNumber, branch, envCause} to
- *      /internal/repair-done
+ *   3. Parses the fix brief (canonical src/workspace/repair-brief.ts,
+ *      compiled in-image) into WorkerContext reviews/blockers, feeds ranked
+ *      file-snapshot batches to ClaudeWorker — bounded at 3 iterations /
+ *      5 min wall clock — and applies sanitized full-file rewrites
+ *   4. Commits code changes + SIMSA-FIX-BRIEF.md, pushes, opens a NON-draft
+ *      PR "Simsa 자동 수리: ..." listing what changed per finding
+ *   5. Reports {jobId, ok, prUrl, prNumber, branch, envCause, mode,
+ *      changedFiles} to /internal/repair-done
  *
- * The token lives only in memory (clone URL + API Authorization header) and
- * is redacted from every error message before it leaves this process.
+ * HONEST FALLBACK (Stage 268 semantics preserved): no key, zero parsed
+ * findings, worker declines/errors, rewrites all rejected by the sanitizer,
+ * or the quick syntax check fails → the working tree is reset to a clean
+ * state and the job degrades to the brief-only DRAFT PR ("Simsa 수리
+ * 시작점: ...", mode "brief_only") — never a broken half-state.
+ *
+ * The tokens live only in memory (clone URL + API Authorization header +
+ * worker client); the GitHub token is redacted from every error message
+ * before it leaves this process, and the Anthropic key never reaches the
+ * repo, the PR, or the callback.
  */
-async function runRepairJob(payload) {
+async function runRepairJob(payload, anthropicApiKey) {
   const {
     jobId,
     repo, // "owner/name"
@@ -426,7 +443,7 @@ async function runRepairJob(payload) {
   } = payload;
 
   const start = Date.now();
-  console.log(`[repair ${jobId}] start: ${repo} branch=${branch} envCause=${envCause}`);
+  console.log(`[repair ${jobId}] start: ${repo} branch=${branch} envCause=${envCause} keyPresent=${Boolean(anthropicApiKey)}`);
 
   // Ack running (best effort — the Worker treats queued/running the same for
   // the 409 guard; a lost ack only affects dashboard status granularity).
@@ -451,29 +468,64 @@ async function runRepairJob(payload) {
     //    earlier attempt force-pushes the same branch instead of erroring.
     await execFileP("git", ["-C", workDir, "checkout", "-b", branch], { timeout: 10_000 });
 
-    // 3. Commit the fix brief.
-    const content = buildRepairPrContent(payload);
-    await fs.writeFile(path.join(workDir, content.briefFileName), content.briefContent, "utf8");
+    // 3. Stage 270 — attempt the real fix. Any failure inside resets the
+    //    tree and returns null → brief-only fallback below.
+    let autoFix = null;
+    if (anthropicApiKey) {
+      try {
+        autoFix = await attemptAutoFix({ workDir, payload, anthropicApiKey });
+      } catch (err) {
+        console.error(
+          `[repair ${jobId}] auto-fix crashed (falling back to brief-only):`,
+          redactSecret(err?.message ?? String(err), githubToken),
+        );
+        autoFix = null;
+      }
+      if (!autoFix) await resetWorkTree(workDir);
+    }
+    const mode = autoFix ? "auto_fix" : "brief_only";
+    const changedFiles = autoFix ? autoFix.changedFiles : [];
+    console.log(`[repair ${jobId}] mode=${mode} changedFiles=${changedFiles.length}`);
+
+    // 4. Commit. Both modes carry SIMSA-FIX-BRIEF.md (the repair's evidence
+    //    + instructions); auto_fix additionally commits the worker's changes.
+    const briefContent = buildRepairPrContent(payload);
+    let title = briefContent.title;
+    let body = briefContent.body;
+    let commitArgs = ["-m", briefContent.title];
+    if (autoFix) {
+      const prContent = autoFix.prContent;
+      title = prContent.title;
+      body = prContent.body;
+      commitArgs = ["-m", prContent.commitMessage, "-m", prContent.commitBody];
+    }
+    await fs.writeFile(path.join(workDir, briefContent.briefFileName), briefContent.briefContent, "utf8");
     await execFileP("git", ["-C", workDir, "config", "user.name", "simsa-repair[bot]"]);
     await execFileP("git", ["-C", workDir, "config", "user.email", "simsa-repair@trysimsa.com"]);
-    await execFileP("git", ["-C", workDir, "add", content.briefFileName], { timeout: 10_000 });
-    await execFileP("git", ["-C", workDir, "commit", "-m", content.title], { timeout: 10_000 });
+    await execFileP(
+      "git",
+      ["-C", workDir, "add", briefContent.briefFileName, ...changedFiles],
+      { timeout: 10_000 },
+    );
+    await execFileP("git", ["-C", workDir, "commit", ...commitArgs], { timeout: 10_000 });
     await execFileP("git", ["-C", workDir, "push", "--force", "origin", `HEAD:${branch}`], { timeout: 60_000 });
     console.log(`[repair ${jobId}] pushed ${branch} (base ${baseBranch})`);
 
-    // 4. Draft PR via the REST API. If a PR for this head already exists
-    //    (retry path), reuse it instead of failing on the 422.
+    // 5. PR via the REST API. auto_fix → NON-draft (real code changed);
+    //    brief_only → draft (Stage 268 semantics). If a PR for this head
+    //    already exists (retry path), reuse it + refresh title/body.
     const pr = await createOrReuseRepairPr({
       repo,
       token: githubToken,
       head: branch,
       base: baseBranch,
-      title: content.title,
-      body: content.body,
+      title,
+      body,
+      draft: mode !== "auto_fix",
     });
     console.log(`[repair ${jobId}] PR ready: #${pr.number} ${pr.html_url}`);
 
-    // 5. Report done.
+    // 6. Report done.
     await postCallback(callbackUrl, callbackToken, {
       jobId,
       ok: true,
@@ -481,6 +533,8 @@ async function runRepairJob(payload) {
       prNumber: pr.number,
       branch,
       envCause: envCause === true,
+      mode,
+      changedFiles: changedFiles.length,
       durationMs: Date.now() - start,
     });
   } catch (err) {
@@ -501,12 +555,194 @@ async function runRepairJob(payload) {
   }
 }
 
+// --- Stage 270: auto-fix executor -------------------------------------------
+
+/** Bounds for the worker-agent loop (Stage 270 spec). */
+const AUTO_FIX_MAX_ITERATIONS = 3;
+const AUTO_FIX_DEADLINE_MS = 5 * 60 * 1000;
+/** Per-snapshot read cap — anything bigger blows the worker prompt budget. */
+const AUTO_FIX_MAX_SNAPSHOT_BYTES = 200 * 1024;
+
+/** `git reset --hard && git clean -fd` — restore a pristine tree after any failed attempt. */
+async function resetWorkTree(workDir) {
+  await execFileP("git", ["-C", workDir, "reset", "--hard", "HEAD"], { timeout: 30_000 });
+  await execFileP("git", ["-C", workDir, "clean", "-fd"], { timeout: 30_000 });
+}
+
 /**
- * Create the draft repair PR, falling back gracefully:
- *   - 422 "already exists" → look up + return the existing open PR for the head
+ * Cheap post-apply sanity check: `node --check` on every changed plain-JS
+ * file. Deliberately NOT a universal CI — a fresh clone has no node_modules,
+ * so builds/tests can't run; a syntax-valid rewrite is the honest bar here.
+ * Non-JS files (ts/tsx/css/html/...) are skipped.
+ */
+async function quickSyntaxCheck(workDir, changedFiles) {
+  for (const rel of changedFiles) {
+    if (!/\.(js|mjs|cjs)$/i.test(rel)) continue;
+    try {
+      await execFileP(process.execPath, ["--check", path.join(workDir, rel)], { timeout: 15_000 });
+    } catch (err) {
+      return { ok: false, file: rel, detail: String(err?.stderr ?? err?.message ?? err).slice(0, 300) };
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Drive the REAL worker agent (ClaudeWorker.work) with the parsed Simsa fix
+ * brief. Contract (packages/agent-worker):
+ *
+ *   worker.work({ repo, pullNumber, newSha, reviews, fileSnapshots, ... })
+ *     → { rewrites: [{path, content}], message, appliedFiles, ... }
+ *
+ * The worker emits FULL-FILE rewrites (v0.14+ — no unified diffs), so
+ * "applying" is a sanitized overwrite; the legacy git-apply/GNU-patch fuzz
+ * path is not involved. Bounded: AUTO_FIX_MAX_ITERATIONS worker calls inside
+ * AUTO_FIX_DEADLINE_MS, each with the next ranked snapshot batch (the
+ * outcome does not surface the model's free-text file requests, so retries
+ * rotate the snapshot window instead).
+ *
+ * Returns { changedFiles, prContent } on success, or null when the brief /
+ * worker produced nothing applicable — callers reset the tree + fall back
+ * to brief-only. Never leaves a dirty tree on the null path.
+ */
+async function attemptAutoFix({ workDir, payload, anthropicApiKey }) {
+  const jobId = payload.jobId;
+  const deadline = Date.now() + AUTO_FIX_DEADLINE_MS;
+
+  // Canonical brief helpers — compiled in-image from
+  // apps/central-plane/src/workspace/repair-brief.ts (see Dockerfile).
+  const brief = await import(new URL("./container-dist/repair-brief.js", import.meta.url).href);
+  const parsed = brief.parseRepairBrief(payload.agentPrompt);
+  const decision = brief.decideRepairMode({
+    hasAnthropicKey: true,
+    findingsCount: parsed.findings.length,
+  });
+  if (decision.mode !== "auto_fix") {
+    console.log(`[repair ${jobId}] auto-fix skipped: ${decision.reason}`);
+    return null;
+  }
+
+  // Repo inventory + ranked snapshot candidates.
+  const lsFiles = await execFileP("git", ["-C", workDir, "ls-files"], {
+    timeout: 30_000,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  const repoFiles = lsFiles.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+  const ranked = brief.rankSnapshotCandidates(parsed, repoFiles);
+  if (ranked.length === 0) {
+    console.log(`[repair ${jobId}] auto-fix skipped: no snapshot candidates in repo`);
+    return null;
+  }
+
+  const headSha = (
+    await execFileP("git", ["-C", workDir, "rev-parse", "HEAD"], { timeout: 10_000 })
+  ).stdout.trim();
+  const review = brief.buildRepairReview(parsed, { repoFiles });
+
+  // The worker agent — same dist layout the autofix path uses for cli.
+  const { ClaudeWorker } = await import("file:///app/packages/agent-worker/dist/index.js");
+  const worker = new ClaudeWorker({ apiKey: anthropicApiKey });
+
+  for (let iteration = 0; iteration < AUTO_FIX_MAX_ITERATIONS; iteration++) {
+    if (Date.now() >= deadline) {
+      console.log(`[repair ${jobId}] auto-fix deadline reached at iteration ${iteration}`);
+      break;
+    }
+    const batch = brief.pickSnapshotBatch(ranked, iteration);
+    if (batch.length === 0) break;
+
+    const fileSnapshots = [];
+    const originals = {};
+    for (const rel of batch) {
+      try {
+        const stat = await fs.stat(path.join(workDir, rel));
+        if (stat.size > AUTO_FIX_MAX_SNAPSHOT_BYTES) continue;
+        const contents = await fs.readFile(path.join(workDir, rel), "utf8");
+        fileSnapshots.push({ path: rel, contents });
+        originals[rel] = contents;
+      } catch {
+        // unreadable file — skip it, the batch still proceeds
+      }
+    }
+    if (fileSnapshots.length === 0) continue;
+
+    let outcome;
+    try {
+      outcome = await worker.work({
+        repo: payload.repo,
+        pullNumber: 0, // repair runs pre-PR; prompt context only
+        newSha: headSha,
+        reviews: [review],
+        fileSnapshots,
+      });
+    } catch (err) {
+      console.error(`[repair ${jobId}] worker call failed (iter ${iteration}):`, err?.message ?? err);
+      continue;
+    }
+    if (!Array.isArray(outcome.rewrites) || outcome.rewrites.length === 0) {
+      console.log(`[repair ${jobId}] worker returned no rewrites (iter ${iteration})`);
+      continue;
+    }
+
+    const { accepted, rejected } = brief.sanitizeRewrites(outcome.rewrites, repoFiles, originals);
+    if (rejected.length > 0) {
+      console.log(
+        `[repair ${jobId}] sanitizer rejected ${rejected.length} rewrite(s): ` +
+          rejected.map((r) => `${r.path}:${r.reason}`).join(", "),
+      );
+    }
+    if (accepted.length === 0) continue;
+
+    for (const rw of accepted) {
+      await fs.writeFile(path.join(workDir, rw.path), rw.content, "utf8");
+    }
+
+    // Real-change gate: the worker may return byte-identical content.
+    const diff = await execFileP("git", ["-C", workDir, "diff", "--name-only"], {
+      timeout: 30_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    const changedFiles = diff.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+    if (changedFiles.length === 0) {
+      console.log(`[repair ${jobId}] rewrites were no-ops (iter ${iteration})`);
+      continue;
+    }
+
+    const verify = await quickSyntaxCheck(workDir, changedFiles);
+    if (!verify.ok) {
+      console.error(`[repair ${jobId}] syntax check failed on ${verify.file}: ${verify.detail}`);
+      await resetWorkTree(workDir);
+      continue;
+    }
+
+    const prContent = brief.buildAutoFixPrContent({
+      runId: payload.visualCheckId ?? jobId,
+      intent: payload.intent,
+      decision: payload.decision,
+      targetUrl: payload.targetUrl,
+      visualCheckId: payload.visualCheckId,
+      envCause: payload.envCause === true,
+      findings: parsed.findings,
+      changedFiles,
+      workerCommitMessage: outcome.message,
+    });
+    console.log(
+      `[repair ${jobId}] auto-fix applied: ${changedFiles.length} file(s) after ${iteration + 1} iteration(s)`,
+    );
+    return { changedFiles, prContent };
+  }
+  return null;
+}
+
+/**
+ * Create the repair PR (draft for brief-only, non-draft for auto-fix),
+ * falling back gracefully:
+ *   - 422 "already exists" → reuse the existing open PR for the head and
+ *     refresh its title/body (retry-safe on the same branch; a draft PR
+ *     stays draft — REST cannot un-draft)
  *   - 422 mentioning draft (plan doesn't support draft PRs) → retry non-draft
  */
-async function createOrReuseRepairPr({ repo, token, head, base, title, body }) {
+async function createOrReuseRepairPr({ repo, token, head, base, title, body, draft = true }) {
   const apiHeaders = {
     authorization: `Bearer ${token}`,
     accept: "application/vnd.github+json",
@@ -516,16 +752,16 @@ async function createOrReuseRepairPr({ repo, token, head, base, title, body }) {
   };
   const owner = repo.split("/")[0];
 
-  const create = async (draft) => {
+  const create = async (asDraft) => {
     const r = await fetch(`https://api.github.com/repos/${repo}/pulls`, {
       method: "POST",
       headers: apiHeaders,
-      body: JSON.stringify({ title, head, base, body, draft }),
+      body: JSON.stringify({ title, head, base, body, draft: asDraft }),
     });
     return { status: r.status, json: await r.json().catch(() => ({})) };
   };
 
-  let res = await create(true);
+  let res = await create(draft);
   if (res.status === 422) {
     const detail = JSON.stringify(res.json.errors ?? res.json.message ?? "");
     if (/already exists/i.test(detail)) {
@@ -534,7 +770,18 @@ async function createOrReuseRepairPr({ repo, token, head, base, title, body }) {
         { headers: apiHeaders },
       );
       const pulls = list.ok ? await list.json().catch(() => []) : [];
-      if (Array.isArray(pulls) && pulls[0]?.html_url) return pulls[0];
+      if (Array.isArray(pulls) && pulls[0]?.html_url) {
+        const existing = pulls[0];
+        // Refresh title/body so a retry (or brief-only → auto-fix upgrade)
+        // is reflected on the reused PR. Best effort — the PR itself is fine
+        // even if the PATCH fails.
+        await fetch(`https://api.github.com/repos/${repo}/pulls/${existing.number}`, {
+          method: "PATCH",
+          headers: apiHeaders,
+          body: JSON.stringify({ title, body }),
+        }).catch(() => {});
+        return existing;
+      }
     }
     if (/draft/i.test(detail)) {
       res = await create(false);

--- a/apps/central-plane/migrations/0052_repair_job_mode.sql
+++ b/apps/central-plane/migrations/0052_repair_job_mode.sql
@@ -1,0 +1,22 @@
+-- Stage 270 — Auto-repair execution result columns (ADDITIVE ALTERs).
+--
+-- The repair container can now run the worker agent against the Simsa fix
+-- brief and apply real code changes on the repair branch. The
+-- /internal/repair-done callback reports how the job concluded:
+--   mode          TEXT    — 'auto_fix' (worker applied code, non-draft PR)
+--                           | 'brief_only' (Stage 268 draft-PR fallback).
+--                           NULL on legacy rows and rows still in flight.
+--   changed_files INTEGER — number of code files the worker actually changed
+--                           (auto_fix only; NULL otherwise).
+--
+-- NOTE (0048 precedent): `ALTER TABLE ... ADD COLUMN` is additive but NOT
+-- idempotent in SQLite/D1 — re-running this file fails with "duplicate column
+-- name". Safe here because the deploy pipeline applies each migration exactly
+-- once via the d1_migrations ledger (`wrangler d1 migrations apply`). Do NOT
+-- apply this file manually with `d1 execute` on a database that already ran
+-- the migrations ledger.
+--
+-- No DROP, no data mutation, both columns NULLable — legacy rows unaffected.
+
+ALTER TABLE workspace_repair_jobs ADD COLUMN mode TEXT;
+ALTER TABLE workspace_repair_jobs ADD COLUMN changed_files INTEGER;

--- a/apps/central-plane/src/routes/workspace-repair-jobs.ts
+++ b/apps/central-plane/src/routes/workspace-repair-jobs.ts
@@ -108,6 +108,11 @@ function repairJobView(job: DbRepairJob) {
     prUrl: job.prUrl ?? null,
     prNumber: job.prNumber ?? null,
     envCause: job.envCause,
+    // Stage 270 — how the repair concluded: 'auto_fix' (worker agent applied
+    // real code changes, non-draft PR) vs 'brief_only' (Stage 268 draft-PR
+    // fallback). Null on legacy rows and while in flight.
+    mode: job.mode ?? null,
+    changedFiles: job.changedFiles ?? null,
     error: job.error ?? null,
     createdAt: job.createdAt,
     updatedAt: job.updatedAt,
@@ -163,12 +168,18 @@ export async function dispatchRepairJob(
     runningUrl: `${base}/internal/repair-running`,
     callbackToken: env.INTERNAL_CALLBACK_TOKEN,
   };
+  // Stage 270 — forward the worker-agent LLM key the same way the autofix
+  // spawn does (routes/saas.ts): via header, not body, so the key never
+  // shows up in anything that logs request bodies. Absent key → the
+  // container keeps the Stage 268 brief-only behavior (mode 'brief_only').
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (env.ANTHROPIC_API_KEY) headers["x-anthropic-key"] = env.ANTHROPIC_API_KEY;
   try {
     const id = env.SANDBOX.idFromName(`repair-${args.jobId}`);
     const stub = env.SANDBOX.get(id);
     const r = await stub.fetch("http://sandbox/run", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers,
       body: JSON.stringify(payload),
     });
     if (!r.ok) {
@@ -386,6 +397,8 @@ export function createWorkspaceRepairJobRoutes(): Hono<{ Bindings: Env }> {
           prNumber?: number;
           branch?: string;
           envCause?: boolean;
+          mode?: string;
+          changedFiles?: number;
           error?: string;
         }
       | null;
@@ -409,6 +422,13 @@ export function createWorkspaceRepairJobRoutes(): Hono<{ Bindings: Env }> {
         : undefined,
       branchName: typeof body.branch === "string" && body.branch ? body.branch : undefined,
       envCause: body.envCause === true,
+      // Stage 270 — additive: how the container concluded. Anything outside
+      // the enum is dropped (old containers send neither field).
+      mode: body.mode === "auto_fix" || body.mode === "brief_only" ? body.mode : undefined,
+      changedFiles:
+        typeof body.changedFiles === "number" && Number.isInteger(body.changedFiles) && body.changedFiles >= 0
+          ? body.changedFiles
+          : undefined,
     });
     return c.json({ ok: true, status: "done" });
   });

--- a/apps/central-plane/src/workspace/repair-brief.ts
+++ b/apps/central-plane/src/workspace/repair-brief.ts
@@ -1,0 +1,547 @@
+/**
+ * workspace/repair-brief.ts — Stage 270
+ *
+ * Pure, dependency-free helpers that turn a Simsa fix brief (the
+ * deterministic agent fix prompt built by nondev-report.ts
+ * `buildAgentFixPrompt`) into input for the Conclave worker agent
+ * (@conclave-ai/agent-worker `ClaudeWorker.work(WorkerContext)`), plus the
+ * safety rails around applying the worker's full-file rewrites inside the
+ * repair container.
+ *
+ * CANONICAL SOURCE — the sandbox container compiles THIS file in-image
+ * (container/Dockerfile, inspector-container Stage 263 pattern) so the
+ * Worker build (dist/workspace/repair-brief.js) and the container runtime
+ * always execute the same logic. Keep it free of imports: it must compile
+ * standalone with `tsc --module es2022`.
+ *
+ * Brief format being parsed (buildAgentFixPrompt output, lock-stepped by
+ * test/repair-brief.test.mjs):
+ *
+ *   [대상]
+ *   - URL: <url>
+ *   - 검수한 사용자 플로우: <flow>
+ *   - 판정: <decision> (<korean>)
+ *   [브라우저 관찰 사실]
+ *   - ... free-form observation lines
+ *   [고칠 문제 — 우선순위순]
+ *   1. [높음] <what>
+ *      - 원인 설명: <why>
+ *      - 수정 방향: <how>
+ *      - 증거: <evidence | 없음>
+ *   [작업 규칙]
+ *   - ...
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Severity enum matches @conclave-ai/core BlockerSchema. */
+export type RepairSeverity = "blocker" | "major" | "minor" | "nit";
+
+export interface RepairFinding {
+  /** Mapped to the core Blocker severity enum. */
+  severity: RepairSeverity;
+  /** Original Korean label from the brief (높음/중간/낮음/참고). */
+  severityLabel: string;
+  what: string;
+  why?: string;
+  how?: string;
+  evidence?: string;
+}
+
+export interface ParsedRepairBrief {
+  targetUrl?: string;
+  flow?: string;
+  decision?: string;
+  observations: string[];
+  findings: RepairFinding[];
+  /** True when the [고칠 문제] section was present in the brief. */
+  hasFindingsSection: boolean;
+}
+
+/** Structurally compatible with @conclave-ai/core ReviewResult. */
+export interface RepairReview {
+  agent: string;
+  verdict: "rework";
+  summary: string;
+  blockers: Array<{
+    severity: RepairSeverity;
+    category: string;
+    message: string;
+  }>;
+}
+
+export type RepairMode = "auto_fix" | "brief_only";
+
+// ─── Brief parsing ────────────────────────────────────────────────────────────
+
+const SEVERITY_FROM_KO: Record<string, RepairSeverity> = {
+  높음: "blocker",
+  중간: "major",
+  낮음: "minor",
+  참고: "nit",
+};
+
+export function mapFindingSeverity(koLabel: string): RepairSeverity {
+  return SEVERITY_FROM_KO[koLabel.trim()] ?? "major";
+}
+
+const NO_FINDINGS_LINE = "고칠 문제가 관찰되지 않았습니다";
+
+type Section = "none" | "target" | "observations" | "findings" | "rules";
+
+/**
+ * Parse a Simsa fix brief into structured parts. Tolerant of malformed
+ * input: missing sections yield empty arrays / undefined fields, never a
+ * throw — the caller falls back to brief-only mode when findings are empty.
+ */
+export function parseRepairBrief(brief: string): ParsedRepairBrief {
+  const out: ParsedRepairBrief = {
+    observations: [],
+    findings: [],
+    hasFindingsSection: false,
+  };
+  if (typeof brief !== "string" || brief.trim().length === 0) return out;
+
+  let section: Section = "none";
+  let current: RepairFinding | null = null;
+
+  const flush = () => {
+    if (current) out.findings.push(current);
+    current = null;
+  };
+
+  for (const raw of brief.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.startsWith("[대상]")) {
+      flush();
+      section = "target";
+      continue;
+    }
+    if (line.startsWith("[브라우저 관찰 사실]")) {
+      flush();
+      section = "observations";
+      continue;
+    }
+    if (line.startsWith("[고칠 문제")) {
+      flush();
+      section = "findings";
+      out.hasFindingsSection = true;
+      continue;
+    }
+    if (line.startsWith("[작업 규칙]")) {
+      flush();
+      section = "rules";
+      continue;
+    }
+    if (line.length === 0) continue;
+
+    if (section === "target") {
+      if (line.startsWith("- URL:")) {
+        out.targetUrl = line.slice("- URL:".length).trim() || undefined;
+      } else if (line.startsWith("- 검수한 사용자 플로우:")) {
+        out.flow = line.slice("- 검수한 사용자 플로우:".length).trim() || undefined;
+      } else if (line.startsWith("- 판정:")) {
+        const rest = line.slice("- 판정:".length).trim();
+        // "Needs Fix (수정 필요)" → keep the machine value before " ("
+        const parenAt = rest.indexOf(" (");
+        out.decision = (parenAt > 0 ? rest.slice(0, parenAt) : rest) || undefined;
+      }
+      continue;
+    }
+
+    if (section === "observations") {
+      out.observations.push(line);
+      continue;
+    }
+
+    if (section === "findings") {
+      if (line.includes(NO_FINDINGS_LINE)) continue;
+      const head = /^(\d+)\.\s*\[([^\]]+)\]\s*(.+)$/.exec(line);
+      if (head) {
+        flush();
+        const label = head[2] ?? "";
+        current = {
+          severity: mapFindingSeverity(label),
+          severityLabel: label,
+          what: (head[3] ?? "").trim(),
+        };
+        continue;
+      }
+      if (!current) continue;
+      const why = /^-\s*원인 설명:\s*(.*)$/.exec(line);
+      if (why) {
+        current.why = (why[1] ?? "").trim() || undefined;
+        continue;
+      }
+      const how = /^-\s*수정 방향:\s*(.*)$/.exec(line);
+      if (how) {
+        current.how = (how[1] ?? "").trim() || undefined;
+        continue;
+      }
+      const evidence = /^-\s*증거:\s*(.*)$/.exec(line);
+      if (evidence) {
+        const v = (evidence[1] ?? "").trim();
+        current.evidence = v && v !== "없음" ? v : undefined;
+        continue;
+      }
+      continue;
+    }
+  }
+  flush();
+  return out;
+}
+
+// ─── Mode decision ────────────────────────────────────────────────────────────
+
+/**
+ * Decide whether the repair job may attempt an actual worker-agent fix.
+ * Honest boundary: no key → brief-only (Stage 268 semantics unchanged);
+ * a brief with zero actionable findings gives the worker nothing to fix.
+ */
+export function decideRepairMode(input: {
+  hasAnthropicKey: boolean;
+  findingsCount: number;
+}): { mode: RepairMode; reason: string } {
+  if (!input.hasAnthropicKey) return { mode: "brief_only", reason: "no_anthropic_key" };
+  if (input.findingsCount <= 0) return { mode: "brief_only", reason: "no_findings" };
+  return { mode: "auto_fix", reason: "ready" };
+}
+
+// ─── Worker review input ──────────────────────────────────────────────────────
+
+const MAX_FILE_LIST_IN_SUMMARY = 400;
+
+/**
+ * Build the ReviewResult-shaped input the worker prompt consumes
+ * (buildWorkerPrompt renders reviews[i].summary + one line per blocker).
+ * Simsa findings carry NO file attribution (they're browser observations),
+ * so the summary carries the repo file list — the worker locates the cause
+ * inside the provided snapshots.
+ */
+export function buildRepairReview(
+  parsed: ParsedRepairBrief,
+  opts: { agent?: string; repoFiles?: readonly string[] } = {},
+): RepairReview {
+  const summaryLines: string[] = [
+    "Simsa가 실제 브라우저로 배포된 앱을 열어 관찰한 실패입니다. 아래 블로커는 브라우저 관찰 기반이라 파일 경로가 없습니다 — 제공된 파일 스냅샷 안에서 원인 코드를 찾아 수정하세요. 스냅샷에 원인 파일이 없으면 빈 rewrites 배열을 반환하세요.",
+  ];
+  if (parsed.targetUrl) summaryLines.push(`- 검수 대상 URL: ${parsed.targetUrl}`);
+  if (parsed.flow) summaryLines.push(`- 검수한 사용자 플로우: ${parsed.flow}`);
+  if (parsed.decision) summaryLines.push(`- 판정: ${parsed.decision}`);
+  if (parsed.observations.length > 0) {
+    summaryLines.push("", "브라우저 관찰 사실:");
+    for (const o of parsed.observations) summaryLines.push(`- ${o}`);
+  }
+  const files = (opts.repoFiles ?? []).slice(0, MAX_FILE_LIST_IN_SUMMARY);
+  if (files.length > 0) {
+    summaryLines.push("", `저장소 파일 목록 (${files.length}개${(opts.repoFiles?.length ?? 0) > files.length ? ", 일부" : ""}):`);
+    for (const f of files) summaryLines.push(f);
+  }
+
+  return {
+    agent: opts.agent ?? "simsa-inspector",
+    verdict: "rework",
+    summary: summaryLines.join("\n"),
+    blockers: parsed.findings.map((f) => {
+      const parts = [f.what];
+      if (f.why) parts.push(`원인 설명: ${f.why}`);
+      if (f.how) parts.push(`수정 방향: ${f.how}`);
+      if (f.evidence) parts.push(`증거: ${f.evidence}`);
+      return {
+        severity: f.severity,
+        category: "simsa-visual",
+        message: parts.join(" — "),
+      };
+    }),
+  };
+}
+
+// ─── Snapshot candidate ranking ───────────────────────────────────────────────
+
+export const REPAIR_SNAPSHOT_BATCH_SIZE = 8;
+
+const SNAPSHOT_EXTENSIONS = new Set([
+  "js", "mjs", "cjs", "ts", "tsx", "jsx", "vue", "svelte",
+  "html", "css", "scss", "json", "py", "go", "rb", "php", "java",
+]);
+
+const VENDOR_DIR_PATTERN =
+  /(^|\/)(node_modules|dist|build|out|coverage|vendor|\.next|\.git|\.svelte-kit|\.turbo)(\/|$)/;
+
+const LOCKFILE_PATTERN = /(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb?)$/i;
+
+function extOf(p: string): string {
+  const base = p.split("/").pop() ?? p;
+  const dot = base.lastIndexOf(".");
+  return dot >= 0 ? base.slice(dot + 1).toLowerCase() : "";
+}
+
+/** Is this repo file even a candidate for a worker snapshot? */
+export function isSnapshotCandidate(relPath: string): boolean {
+  const norm = relPath.replace(/\\/g, "/");
+  if (VENDOR_DIR_PATTERN.test(norm)) return false;
+  if (LOCKFILE_PATTERN.test(norm)) return false;
+  if (/\.min\.(js|css)$/i.test(norm)) return false;
+  if (isRepairFileDenied(norm)) return false;
+  return SNAPSHOT_EXTENSIONS.has(extOf(norm));
+}
+
+/**
+ * Extract search tokens from the brief's evidence/observations: URL path
+ * segments (e.g. "/rest/v1/todos" → rest, v1, todos) and referenced file
+ * names (e.g. "main.js:12" → main.js). Deterministic and lowercase.
+ */
+export function extractEvidenceTokens(parsed: ParsedRepairBrief): string[] {
+  const texts: string[] = [];
+  if (parsed.targetUrl) texts.push(parsed.targetUrl);
+  for (const o of parsed.observations) texts.push(o);
+  for (const f of parsed.findings) {
+    texts.push(f.what);
+    if (f.why) texts.push(f.why);
+    if (f.how) texts.push(f.how);
+    if (f.evidence) texts.push(f.evidence);
+  }
+
+  const tokens = new Set<string>();
+  for (const text of texts) {
+    // URL pathname segments
+    for (const m of text.matchAll(/https?:\/\/[^\s'"<>)\]]+/g)) {
+      const url = m[0];
+      const afterHost = url.replace(/^https?:\/\/[^/]+/, "");
+      const pathname = afterHost.split(/[?#]/)[0] ?? "";
+      for (const seg of pathname.split("/")) {
+        const s = seg.trim().toLowerCase();
+        if (s.length >= 2 && !/^\d+$/.test(s)) tokens.add(s);
+      }
+    }
+    // Explicit source-file references (console errors etc.)
+    for (const m of text.matchAll(/[\w./-]*\b([\w-]+\.(?:js|mjs|cjs|ts|tsx|jsx|vue|svelte|css|html|json|py))\b/gi)) {
+      const base = (m[1] ?? "").toLowerCase();
+      if (base) tokens.add(base);
+    }
+  }
+  return [...tokens];
+}
+
+/**
+ * Rank repo files by likely relevance to the brief. Returns the FULL
+ * ordered candidate list; the caller feeds batches of
+ * REPAIR_SNAPSHOT_BATCH_SIZE per worker iteration (bounded retries with a
+ * progressively different snapshot set instead of a file-request loop —
+ * WorkerOutcome does not surface the model's free-text summary).
+ */
+export function rankSnapshotCandidates(
+  parsed: ParsedRepairBrief,
+  repoFiles: readonly string[],
+): string[] {
+  const tokens = extractEvidenceTokens(parsed);
+  const scored: Array<{ path: string; score: number }> = [];
+
+  for (const raw of repoFiles) {
+    const p = raw.replace(/\\/g, "/");
+    if (!isSnapshotCandidate(p)) continue;
+    const lower = p.toLowerCase();
+    const base = lower.split("/").pop() ?? lower;
+    const baseNoExt = base.replace(/\.[^.]+$/, "");
+    let score = 0;
+    for (const t of tokens) {
+      if (base === t || baseNoExt === t) score += 5;
+      else if (base.includes(t)) score += 3;
+      else if (lower.includes(t)) score += 1;
+    }
+    if (/^(index|main|app|server|api)\./.test(base)) score += 2;
+    const top = lower.split("/")[0] ?? "";
+    if (["src", "app", "pages", "api", "lib", "components"].includes(top)) score += 1;
+    scored.push({ path: p, score });
+  }
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (a.path.length !== b.path.length) return a.path.length - b.path.length;
+    return a.path < b.path ? -1 : a.path > b.path ? 1 : 0;
+  });
+  return scored.map((s) => s.path);
+}
+
+/** Batch N of the ranked candidates for worker iteration `iteration` (0-based). */
+export function pickSnapshotBatch(
+  ranked: readonly string[],
+  iteration: number,
+  batchSize: number = REPAIR_SNAPSHOT_BATCH_SIZE,
+): string[] {
+  if (iteration < 0 || batchSize <= 0) return [];
+  return ranked.slice(iteration * batchSize, (iteration + 1) * batchSize);
+}
+
+// ─── Rewrite application safety ───────────────────────────────────────────────
+
+/** Mirror of @conclave-ai/core DEFAULT_AUTOFIX_DENY_PATTERNS (kept dependency-free). */
+const DENY_NAME_PATTERNS: readonly RegExp[] = [
+  /^\.env$/i,
+  /^\.env\..*$/i,
+  /\.env$/i,
+  /\.pem$/i,
+  /\.key$/i,
+  /secret/i,
+  /\.credentials/i,
+  /credentials\.json$/i,
+  /^id_rsa$/i,
+  /^id_ed25519$/i,
+];
+
+export function isRepairFileDenied(relPath: string): boolean {
+  const norm = relPath.replace(/\\/g, "/").toLowerCase();
+  const name = norm.split("/").pop() ?? norm;
+  return DENY_NAME_PATTERNS.some((re) => re.test(name));
+}
+
+/** Obvious credential shapes the worker must never INTRODUCE into a repo. */
+const SECRET_CONTENT_PATTERN =
+  /(sk-[A-Za-z0-9_-]{16,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----)/;
+
+export interface RejectedRewrite {
+  path: string;
+  reason:
+    | "unsafe_path"
+    | "denied_file"
+    | "not_existing_file"
+    | "empty_content"
+    | "introduces_secret"
+    | "duplicate_path";
+}
+
+/**
+ * Validate worker rewrites before anything touches the working tree.
+ *   - path must be repo-relative, no traversal, not deny-listed
+ *   - must target an EXISTING repo file (the worker's own system prompt
+ *     forbids creating files; enforce it here too)
+ *   - content must be non-empty (a full-file rewrite to nothing is a
+ *     deletion in disguise)
+ *   - content must not introduce credential-shaped strings that were not
+ *     already present in the original snapshot
+ */
+export function sanitizeRewrites(
+  rewrites: ReadonlyArray<{ path: string; content: string }>,
+  repoFiles: readonly string[],
+  originals: Readonly<Record<string, string>> = {},
+): { accepted: Array<{ path: string; content: string }>; rejected: RejectedRewrite[] } {
+  const repoSet = new Set(repoFiles.map((f) => f.replace(/\\/g, "/")));
+  const accepted: Array<{ path: string; content: string }> = [];
+  const rejected: RejectedRewrite[] = [];
+  const seen = new Set<string>();
+
+  for (const rw of rewrites) {
+    let p = String(rw.path ?? "").trim().replace(/\\/g, "/");
+    while (p.startsWith("./")) p = p.slice(2);
+    if (
+      p.length === 0 ||
+      p.startsWith("/") ||
+      /^[A-Za-z]:/.test(p) ||
+      p.split("/").includes("..")
+    ) {
+      rejected.push({ path: rw.path, reason: "unsafe_path" });
+      continue;
+    }
+    if (seen.has(p)) {
+      rejected.push({ path: p, reason: "duplicate_path" });
+      continue;
+    }
+    if (isRepairFileDenied(p)) {
+      rejected.push({ path: p, reason: "denied_file" });
+      continue;
+    }
+    if (!repoSet.has(p)) {
+      rejected.push({ path: p, reason: "not_existing_file" });
+      continue;
+    }
+    const content = String(rw.content ?? "");
+    if (content.trim().length === 0) {
+      rejected.push({ path: p, reason: "empty_content" });
+      continue;
+    }
+    if (SECRET_CONTENT_PATTERN.test(content) && !SECRET_CONTENT_PATTERN.test(originals[p] ?? "")) {
+      rejected.push({ path: p, reason: "introduces_secret" });
+      continue;
+    }
+    seen.add(p);
+    accepted.push({ path: p, content });
+  }
+  return { accepted, rejected };
+}
+
+// ─── Auto-fix PR content ──────────────────────────────────────────────────────
+
+const SEVERITY_KO_LABEL: Record<RepairSeverity, string> = {
+  blocker: "높음",
+  major: "중간",
+  minor: "낮음",
+  nit: "참고",
+};
+
+/**
+ * Deterministic PR + commit content for the auto_fix path (no LLM output in
+ * titles; the worker's own commit summary is quoted in the body). The PR is
+ * NON-draft — real code changed — with an honest review-before-merge note.
+ * Never receives tokens/keys; derived only from the parsed brief + git facts.
+ */
+export function buildAutoFixPrContent(input: {
+  runId: string;
+  intent?: string;
+  decision?: string;
+  targetUrl?: string;
+  visualCheckId?: string;
+  envCause?: boolean;
+  findings: readonly RepairFinding[];
+  changedFiles: readonly string[];
+  workerCommitMessage?: string;
+}): { title: string; commitMessage: string; commitBody: string; body: string } {
+  const intent = (input.intent ?? "").trim() || "핵심 기능 점검";
+  const shortIntent = intent.length > 60 ? `${intent.slice(0, 57)}...` : intent;
+  const title = `Simsa 자동 수리: ${shortIntent}`;
+  const commitMessage = `fix(simsa): apply repair for ${input.runId}`;
+  const commitBody = [
+    "Simsa 시각 검수에서 발견된 문제를 워커 에이전트가 자동 수정한 커밋입니다.",
+    "수리 근거: 같은 브랜치의 SIMSA-FIX-BRIEF.md 참고.",
+    ...(input.workerCommitMessage ? [`워커 요약: ${input.workerCommitMessage}`] : []),
+  ].join("\n");
+
+  const lines: string[] = [
+    "## Simsa 자동 수리 결과",
+    "",
+    "Simsa가 실제 브라우저로 앱을 검수해 발견한 문제를, 워커 에이전트가 이 브랜치의 코드에 직접 수정했습니다.",
+    "",
+    `- 검수 대상: ${input.targetUrl || "(기록 없음)"}`,
+    `- 판정: ${input.decision || "Not Judged"}`,
+    ...(input.visualCheckId ? [`- 검사 ID: \`${input.visualCheckId}\``] : []),
+    `- 변경 파일 ${input.changedFiles.length}개:`,
+    ...input.changedFiles.map((f) => `  - \`${f}\``),
+    "",
+    "### 발견된 문제와 조치",
+  ];
+  if (input.findings.length > 0) {
+    input.findings.forEach((f, i) => {
+      lines.push(`${i + 1}. [${SEVERITY_KO_LABEL[f.severity]}] ${f.what}`);
+      if (f.how) lines.push(`   - 수정 방향: ${f.how}`);
+    });
+  } else {
+    lines.push("- (브리프에 개별 문제 항목이 없습니다)");
+  }
+  if (input.workerCommitMessage) {
+    lines.push("", `워커 커밋 요약: ${input.workerCommitMessage}`);
+  }
+  lines.push(
+    "",
+    "> **주의: 자동 생성된 수정입니다.** 머지 전에 반드시 코드 리뷰와 실제 동작 확인을 해주세요.",
+    "> 수리 근거(검수 증거 + 지시서)는 이 브랜치의 `SIMSA-FIX-BRIEF.md`에 있습니다.",
+    "",
+  );
+  if (input.envCause === true) {
+    lines.push(
+      "> **환경 원인 가능성:** 증거에 백엔드 주소가 응답하지 않는 패턴(DNS/연결 실패)이 포함되어 있습니다.",
+      "> 코드 수정만으로 완전히 해결되지 않을 수 있어요 — 환경 변수(백엔드 주소 등) 설정도 함께 확인하세요.",
+      "",
+    );
+  }
+
+  return { title, commitMessage, commitBody, body: lines.join("\n") };
+}

--- a/apps/central-plane/src/workspace/repair-job-db.ts
+++ b/apps/central-plane/src/workspace/repair-job-db.ts
@@ -12,6 +12,10 @@ import type { Env } from "../env.js";
 export const REPAIR_JOB_STATUSES = ["queued", "running", "done", "failed"] as const;
 export type RepairJobStatus = (typeof REPAIR_JOB_STATUSES)[number];
 
+/** Stage 270 — how the container concluded a done repair. */
+export const REPAIR_JOB_MODES = ["auto_fix", "brief_only"] as const;
+export type RepairJobMode = (typeof REPAIR_JOB_MODES)[number];
+
 export type DbRepairJob = {
   id: string;
   projectId: string;
@@ -23,6 +27,10 @@ export type DbRepairJob = {
   prUrl?: string;
   prNumber?: number;
   envCause: boolean;
+  /** Stage 270 — 'auto_fix' (worker applied code) | 'brief_only' (Stage 268 fallback). Unset on legacy/in-flight rows. */
+  mode?: RepairJobMode;
+  /** Stage 270 — number of code files the worker actually changed (auto_fix). */
+  changedFiles?: number;
   error?: string;
   createdAt: string;
   updatedAt: string;
@@ -39,6 +47,8 @@ type RawRow = {
   pr_url: string | null;
   pr_number: number | null;
   env_cause: number;
+  mode: string | null;
+  changed_files: number | null;
   error: string | null;
   created_at: string;
   updated_at: string;
@@ -46,7 +56,7 @@ type RawRow = {
 
 const SELECT_COLS =
   `id, project_id, user_key, visual_check_id, repo_full_name, status,
-   branch_name, pr_url, pr_number, env_cause, error, created_at, updated_at`;
+   branch_name, pr_url, pr_number, env_cause, mode, changed_files, error, created_at, updated_at`;
 
 function randId(): string {
   const ts = Date.now().toString(36).slice(-6);
@@ -66,6 +76,8 @@ function fromRow(row: RawRow): DbRepairJob {
     prUrl: row.pr_url ?? undefined,
     prNumber: row.pr_number ?? undefined,
     envCause: row.env_cause === 1,
+    mode: row.mode === "auto_fix" || row.mode === "brief_only" ? row.mode : undefined,
+    changedFiles: typeof row.changed_files === "number" ? row.changed_files : undefined,
     error: row.error ?? undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -175,7 +187,14 @@ export async function markRepairJobRunning(env: Env, id: string): Promise<boolea
 export async function markRepairJobDone(
   env: Env,
   id: string,
-  input: { prUrl?: string; prNumber?: number; branchName?: string; envCause?: boolean },
+  input: {
+    prUrl?: string;
+    prNumber?: number;
+    branchName?: string;
+    envCause?: boolean;
+    mode?: RepairJobMode;
+    changedFiles?: number;
+  },
 ): Promise<void> {
   await env.DB.prepare(
     `UPDATE workspace_repair_jobs
@@ -184,6 +203,8 @@ export async function markRepairJobDone(
             pr_number = COALESCE(?, pr_number),
             branch_name = COALESCE(?, branch_name),
             env_cause = CASE WHEN ? = 1 THEN 1 ELSE env_cause END,
+            mode = COALESCE(?, mode),
+            changed_files = COALESCE(?, changed_files),
             updated_at = ?
       WHERE id = ?`,
   )
@@ -192,6 +213,10 @@ export async function markRepairJobDone(
       input.prNumber ?? null,
       input.branchName ?? null,
       input.envCause === true ? 1 : 0,
+      input.mode ?? null,
+      typeof input.changedFiles === "number" && Number.isInteger(input.changedFiles) && input.changedFiles >= 0
+        ? input.changedFiles
+        : null,
       new Date().toISOString(),
       id,
     )

--- a/apps/central-plane/test/container-invariants.test.mjs
+++ b/apps/central-plane/test/container-invariants.test.mjs
@@ -120,3 +120,55 @@ test("Dockerfile copies coerce-result.mjs alongside server.mjs", () => {
     "Dockerfile must COPY container/coerce-result.mjs",
   );
 });
+
+// ---- Stage 270: auto-repair lock-step invariants -------------------------
+
+test("Stage 270: Dockerfile compiles the CANONICAL repair-brief.ts the Worker builds (lock-step)", () => {
+  // The container must run the exact same brief-parsing logic as
+  // dist/workspace/repair-brief.js. The Dockerfile COPYs the canonical
+  // source and compiles it in-image (inspector-container Stage 263
+  // pattern) — never a hand-duplicated .mjs.
+  assert.match(
+    dockerfile,
+    /COPY\s+apps\/central-plane\/src\/workspace\/repair-brief\.ts/,
+    "Dockerfile must COPY src/workspace/repair-brief.ts (canonical source)",
+  );
+  assert.match(
+    dockerfile,
+    /tsc\s+container-src\/repair-brief\.ts/,
+    "Dockerfile must compile repair-brief.ts with tsc",
+  );
+  assert.match(
+    dockerfile,
+    /container-dist\/package\.json/,
+    "Dockerfile must write container-dist/package.json ({\"type\":\"module\"}) or the ESM output won't load",
+  );
+});
+
+test("Stage 270: server.mjs drives the worker seam against the compiled brief module", () => {
+  assert.match(
+    serverMjs,
+    /container-dist\/repair-brief\.js/,
+    "server.mjs must import the in-image compiled repair-brief module",
+  );
+  assert.match(
+    serverMjs,
+    /packages\/agent-worker\/dist\/index\.js/,
+    "server.mjs must lazy-import ClaudeWorker from the agent-worker dist",
+  );
+  assert.match(serverMjs, /x-anthropic-key/, "server.mjs must read the forwarded LLM key header for repair jobs");
+  assert.match(serverMjs, /brief_only/, "server.mjs must report the brief_only fallback mode");
+  assert.match(serverMjs, /auto_fix/, "server.mjs must report the auto_fix mode");
+});
+
+test("Stage 270: Dockerfile still builds @conclave-ai/cli (whose dep graph provides agent-worker dist)", () => {
+  // ClaudeWorker is imported from /app/packages/agent-worker/dist —
+  // produced transitively because turbo's build dependsOn ^build and cli
+  // depends on agent-worker. If the cli filter disappears, the repair
+  // job's worker import breaks at runtime.
+  assert.match(
+    dockerfile,
+    /--filter @conclave-ai\/cli/,
+    "Dockerfile must keep building @conclave-ai/cli",
+  );
+});

--- a/apps/central-plane/test/repair-brief.test.mjs
+++ b/apps/central-plane/test/repair-brief.test.mjs
@@ -1,0 +1,291 @@
+/**
+ * repair-brief.test.mjs — Stage 270
+ *
+ * Pure helpers that turn a Simsa fix brief into worker-agent input
+ * (src/workspace/repair-brief.ts — the SAME source the sandbox container
+ * compiles in-image, see container/Dockerfile):
+ *   - parseRepairBrief — incl. LOCK-STEP against buildAgentFixPrompt output
+ *     (nondev-report.ts): if the brief format drifts, this file fails.
+ *   - malformed-brief tolerance (no throws, safe fallbacks)
+ *   - decideRepairMode — auto_fix vs brief_only decisions
+ *   - buildRepairReview — ReviewResult-shaped worker input
+ *   - snapshot candidate ranking + batching
+ *   - sanitizeRewrites — path traversal / deny-list / new-file / secret rails
+ *   - buildAutoFixPrContent — non-draft PR + commit content, honest notes
+ *
+ * No network, no LLM, no filesystem beyond imports.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  parseRepairBrief,
+  mapFindingSeverity,
+  decideRepairMode,
+  buildRepairReview,
+  extractEvidenceTokens,
+  rankSnapshotCandidates,
+  pickSnapshotBatch,
+  REPAIR_SNAPSHOT_BATCH_SIZE,
+  isSnapshotCandidate,
+  isRepairFileDenied,
+  sanitizeRewrites,
+  buildAutoFixPrContent,
+} = await import("../dist/workspace/repair-brief.js");
+const { buildAgentFixPrompt } = await import("../dist/nondev-report.js");
+
+/** Realistic check input — produces DNS-failure + console-error + failed-step findings. */
+const CHECK_INPUT = {
+  targetUrl: "https://golf-now.example.app/courses",
+  intentAnchor: "골퍼가 코스 목록을 볼 수 있어야 한다",
+  loadStatus: 200,
+  primaryActionFound: true,
+  interacted: true,
+  routeAfterClick: "/courses",
+  routeChanged: false,
+  consoleErrors: ["TypeError: Cannot read properties of undefined (reading 'map') at courses.js:41"],
+  networkFailures: ["GET https://dead.supabase.co/rest/v1/courses net::ERR_NAME_NOT_RESOLVED"],
+  decision: "Needs Fix",
+  steps: [{ label: "코스 목록 확인", ok: false, note: "목록이 비어 있음" }],
+};
+
+// ─── parseRepairBrief: lock-step with buildAgentFixPrompt ─────────────────────
+
+test("parseRepairBrief: parses a REAL buildAgentFixPrompt brief (lock-step)", () => {
+  const brief = buildAgentFixPrompt(CHECK_INPUT);
+  const parsed = parseRepairBrief(brief);
+
+  assert.equal(parsed.targetUrl, CHECK_INPUT.targetUrl);
+  assert.equal(parsed.flow, CHECK_INPUT.intentAnchor);
+  assert.equal(parsed.decision, "Needs Fix");
+  assert.equal(parsed.hasFindingsSection, true);
+  assert.ok(parsed.observations.length >= 4, "observation lines captured");
+  assert.ok(
+    parsed.observations.some((o) => o.includes("ERR_NAME_NOT_RESOLVED")),
+    "network failure evidence appears in observations",
+  );
+
+  // classifyFindings on this input: DNS(high) + console(medium) + failed step(medium)
+  assert.equal(parsed.findings.length, 3);
+  const dns = parsed.findings[0];
+  assert.equal(dns.severity, "blocker", "높음 → blocker");
+  assert.equal(dns.severityLabel, "높음");
+  assert.match(dns.what, /서버 주소를 찾지 못했어요/);
+  assert.ok(dns.why && dns.why.length > 0, "원인 설명 captured");
+  assert.ok(dns.how && dns.how.length > 0, "수정 방향 captured");
+  assert.match(dns.evidence ?? "", /ERR_NAME_NOT_RESOLVED/);
+
+  const step = parsed.findings[2];
+  assert.equal(step.severity, "major", "중간 → major");
+  assert.match(step.what, /코스 목록 확인/);
+});
+
+test("parseRepairBrief: '증거: 없음' → evidence undefined; no-findings brief → empty findings", () => {
+  const clean = buildAgentFixPrompt({
+    ...CHECK_INPUT,
+    consoleErrors: [],
+    networkFailures: [],
+    steps: [],
+    decision: "Ready",
+  });
+  const parsed = parseRepairBrief(clean);
+  assert.equal(parsed.hasFindingsSection, true);
+  assert.equal(parsed.findings.length, 0, "'고칠 문제가 관찰되지 않았습니다' line yields zero findings");
+
+  const manual = [
+    "[고칠 문제 — 우선순위순]",
+    "1. [중간] 화면에서 코드 오류가 났어요.",
+    "   - 원인 설명: 자바스크립트 실행 중 문제가 생겼어요.",
+    "   - 수정 방향: 콘솔 오류를 참고해 고치세요.",
+    "   - 증거: 없음",
+  ].join("\n");
+  const p2 = parseRepairBrief(manual);
+  assert.equal(p2.findings.length, 1);
+  assert.equal(p2.findings[0].evidence, undefined, "'없음' must not become evidence text");
+});
+
+test("parseRepairBrief: malformed briefs never throw — empty / non-brief text / headless bullets", () => {
+  for (const bad of ["", "   \n  ", "그냥 아무 텍스트", "- 원인 설명: 고아 서브라인\n2. 번호만"]) {
+    const parsed = parseRepairBrief(bad);
+    assert.deepEqual(parsed.findings, [], `findings empty for ${JSON.stringify(bad.slice(0, 20))}`);
+    assert.equal(parsed.hasFindingsSection, false);
+  }
+  // sub-lines before any numbered head are dropped, not attached to a ghost finding
+  const orphan = parseRepairBrief("[고칠 문제 — 우선순위순]\n   - 수정 방향: 고아 라인\n1. [높음] 진짜 문제");
+  assert.equal(orphan.findings.length, 1);
+  assert.equal(orphan.findings[0].what, "진짜 문제");
+  assert.equal(orphan.findings[0].how, undefined);
+});
+
+test("mapFindingSeverity: 높음/중간/낮음/참고 map to core enum; unknown → major", () => {
+  assert.equal(mapFindingSeverity("높음"), "blocker");
+  assert.equal(mapFindingSeverity("중간"), "major");
+  assert.equal(mapFindingSeverity("낮음"), "minor");
+  assert.equal(mapFindingSeverity("참고"), "nit");
+  assert.equal(mapFindingSeverity("치명"), "major");
+});
+
+// ─── mode decision ────────────────────────────────────────────────────────────
+
+test("decideRepairMode: no key → brief_only; key + findings → auto_fix; key + zero findings → brief_only", () => {
+  assert.deepEqual(decideRepairMode({ hasAnthropicKey: false, findingsCount: 3 }), {
+    mode: "brief_only",
+    reason: "no_anthropic_key",
+  });
+  assert.deepEqual(decideRepairMode({ hasAnthropicKey: true, findingsCount: 0 }), {
+    mode: "brief_only",
+    reason: "no_findings",
+  });
+  assert.deepEqual(decideRepairMode({ hasAnthropicKey: true, findingsCount: 2 }), {
+    mode: "auto_fix",
+    reason: "ready",
+  });
+});
+
+// ─── worker review input ──────────────────────────────────────────────────────
+
+test("buildRepairReview: ReviewResult-shaped input — verdict rework, one blocker per finding, summary carries context + file list", () => {
+  const parsed = parseRepairBrief(buildAgentFixPrompt(CHECK_INPUT));
+  const review = buildRepairReview(parsed, { repoFiles: ["src/app.js", "src/courses.js"] });
+
+  assert.equal(review.verdict, "rework");
+  assert.equal(review.agent, "simsa-inspector");
+  assert.equal(review.blockers.length, parsed.findings.length);
+  for (const b of review.blockers) {
+    assert.ok(["blocker", "major", "minor", "nit"].includes(b.severity));
+    assert.equal(b.category, "simsa-visual");
+    assert.ok(b.message.length > 0);
+  }
+  assert.match(review.blockers[0].message, /수정 방향:/, "blocker message carries the fix direction");
+  assert.ok(review.summary.includes(CHECK_INPUT.targetUrl));
+  assert.ok(review.summary.includes("src/courses.js"), "repo file list included for file location");
+  assert.match(review.summary, /파일 경로가 없습니다/, "explains why blockers carry no file field");
+});
+
+// ─── snapshot ranking + batching ──────────────────────────────────────────────
+
+test("rankSnapshotCandidates: evidence-token files rank first; vendor/lockfiles/secrets excluded", () => {
+  const parsed = parseRepairBrief(buildAgentFixPrompt(CHECK_INPUT));
+  const tokens = extractEvidenceTokens(parsed);
+  assert.ok(tokens.includes("courses"), "URL path segment extracted");
+  assert.ok(tokens.includes("courses.js"), "console-error file reference extracted");
+
+  const ranked = rankSnapshotCandidates(parsed, [
+    "README.md",
+    "node_modules/react/index.js",
+    "dist/bundle.js",
+    "package-lock.json",
+    ".env",
+    "secrets.js",
+    "src/utils/format.js",
+    "src/courses.js",
+    "src/main.js",
+  ]);
+  assert.equal(ranked[0], "src/courses.js", "token-matched file first");
+  assert.ok(!ranked.includes("node_modules/react/index.js"), "vendor excluded");
+  assert.ok(!ranked.includes("dist/bundle.js"), "build output excluded");
+  assert.ok(!ranked.includes("package-lock.json"), "lockfile excluded");
+  assert.ok(!ranked.includes(".env"), "deny-listed excluded");
+  assert.ok(!ranked.includes("secrets.js"), "secret-named file excluded");
+  assert.ok(!ranked.includes("README.md"), "non-code extension excluded");
+  assert.ok(ranked.includes("src/utils/format.js"), "unmatched code files stay as later candidates");
+
+  assert.equal(isSnapshotCandidate("src/app.ts"), true);
+  assert.equal(isSnapshotCandidate("assets/logo.png"), false);
+  assert.equal(isRepairFileDenied("config/service.credentials.json"), true);
+});
+
+test("pickSnapshotBatch: rotates non-overlapping windows per iteration", () => {
+  const ranked = Array.from({ length: 20 }, (_, i) => `f${i}.js`);
+  const b0 = pickSnapshotBatch(ranked, 0);
+  const b1 = pickSnapshotBatch(ranked, 1);
+  assert.equal(b0.length, REPAIR_SNAPSHOT_BATCH_SIZE);
+  assert.equal(b0[0], "f0.js");
+  assert.equal(b1[0], `f${REPAIR_SNAPSHOT_BATCH_SIZE}.js`);
+  assert.ok(b0.every((f) => !b1.includes(f)), "batches must not overlap");
+  assert.deepEqual(pickSnapshotBatch(ranked, 3), [], "past the end → empty (loop terminates)");
+  assert.deepEqual(pickSnapshotBatch(ranked, -1), []);
+});
+
+// ─── rewrite application safety ───────────────────────────────────────────────
+
+test("sanitizeRewrites: accepts normalized existing-file rewrites; rejects traversal/absolute/denied/new/empty/duplicate", () => {
+  const repoFiles = ["src/app.js", "src/courses.js", ".env"];
+  const { accepted, rejected } = sanitizeRewrites(
+    [
+      { path: "./src/app.js", content: "console.log('fixed');\n" },
+      { path: "../outside.js", content: "x" },
+      { path: "/etc/passwd", content: "x" },
+      { path: "C:/windows/x.js", content: "x" },
+      { path: ".env", content: "API=1" },
+      { path: "src/new-file.js", content: "x" },
+      { path: "src/courses.js", content: "   \n  " },
+      { path: "src/app.js", content: "duplicate" },
+    ],
+    repoFiles,
+  );
+  assert.equal(accepted.length, 1);
+  assert.equal(accepted[0].path, "src/app.js", "leading ./ normalized");
+  const reasons = Object.fromEntries(rejected.map((r) => [r.path, r.reason]));
+  assert.equal(reasons["../outside.js"], "unsafe_path");
+  assert.equal(reasons["/etc/passwd"], "unsafe_path");
+  assert.equal(reasons["C:/windows/x.js"], "unsafe_path");
+  assert.equal(reasons[".env"], "denied_file");
+  assert.equal(reasons["src/new-file.js"], "not_existing_file", "worker must not create files");
+  assert.equal(reasons["src/courses.js"], "empty_content", "full-file rewrite to nothing is a deletion in disguise");
+  assert.equal(reasons["src/app.js"], "duplicate_path");
+});
+
+test("sanitizeRewrites: rejects rewrites that INTRODUCE credential-shaped strings, allows pre-existing ones", () => {
+  const repoFiles = ["src/config.js", "src/legacy.js"];
+  const originals = {
+    "src/legacy.js": "const key = 'ghp_abcdefghijklmnopqrstuv123456';\n",
+  };
+  const { accepted, rejected } = sanitizeRewrites(
+    [
+      { path: "src/config.js", content: "const key = 'sk-ant-abcdefghijklmnop1234';\n" },
+      { path: "src/legacy.js", content: "// touched\nconst key = 'ghp_abcdefghijklmnopqrstuv123456';\n" },
+    ],
+    repoFiles,
+    originals,
+  );
+  assert.deepEqual(rejected.map((r) => [r.path, r.reason]), [["src/config.js", "introduces_secret"]]);
+  assert.equal(accepted.length, 1);
+  assert.equal(accepted[0].path, "src/legacy.js", "secret already in the original snapshot → not the worker's doing");
+});
+
+// ─── auto-fix PR content ──────────────────────────────────────────────────────
+
+test("buildAutoFixPrContent: non-draft repair PR content — per-finding list, changed files, honest review note, brief reference", () => {
+  const parsed = parseRepairBrief(buildAgentFixPrompt(CHECK_INPUT));
+  const out = buildAutoFixPrContent({
+    runId: "wvc_fixme1",
+    intent: CHECK_INPUT.intentAnchor,
+    decision: "Needs Fix",
+    targetUrl: CHECK_INPUT.targetUrl,
+    visualCheckId: "wvc_fixme1",
+    envCause: true,
+    findings: parsed.findings,
+    changedFiles: ["src/courses.js", "src/api.js"],
+    workerCommitMessage: "fix: guard courses map against undefined payload",
+  });
+
+  assert.equal(out.title, `Simsa 자동 수리: ${CHECK_INPUT.intentAnchor}`);
+  assert.equal(out.commitMessage, "fix(simsa): apply repair for wvc_fixme1");
+  assert.match(out.commitBody, /SIMSA-FIX-BRIEF\.md/, "commit references the brief");
+  assert.match(out.body, /변경 파일 2개/);
+  assert.ok(out.body.includes("`src/courses.js`"));
+  assert.match(out.body, /1\. \[높음\]/, "findings listed with severity labels");
+  assert.match(out.body, /머지 전에 반드시 코드 리뷰/, "honest review-before-merge note");
+  assert.match(out.body, /SIMSA-FIX-BRIEF\.md/);
+  assert.match(out.body, /환경 원인 가능성/, "env-cause warning preserved");
+  assert.ok(out.body.includes("fix: guard courses map against undefined payload"), "worker summary quoted");
+  assert.ok(!/자동 적용된 코드 수정이 없습니다/.test(out.body), "must NOT carry the brief-only disclaimer");
+
+  // long intent truncated in title; empty intent falls back
+  const long = buildAutoFixPrContent({ runId: "r", intent: "긴".repeat(100), findings: [], changedFiles: [] });
+  assert.ok(long.title.length < 80);
+  const fallback = buildAutoFixPrContent({ runId: "r", findings: [], changedFiles: [] });
+  assert.match(fallback.title, /핵심 기능 점검/);
+  assert.ok(!/환경 원인/.test(fallback.body), "no env warning without envCause");
+});

--- a/apps/central-plane/test/workspace-repair-jobs.test.mjs
+++ b/apps/central-plane/test/workspace-repair-jobs.test.mjs
@@ -70,7 +70,8 @@ function makeDb({ projects = new Map(), checks = [], repos = [], connections = [
               return { meta: { changes: row ? 1 : 0 } };
             }
             if (sql.includes("workspace_repair_jobs") && sql.includes("SET status = 'done'")) {
-              const [pr_url, pr_number, branch_name, env_flag, updated_at, id] = args;
+              // Stage 270 — markRepairJobDone also binds mode + changed_files.
+              const [pr_url, pr_number, branch_name, env_flag, mode, changed_files, updated_at, id] = args;
               const row = jobs.find((r) => r.id === id);
               if (row) {
                 row.status = "done";
@@ -78,6 +79,8 @@ function makeDb({ projects = new Map(), checks = [], repos = [], connections = [
                 row.pr_number = pr_number ?? row.pr_number;
                 row.branch_name = branch_name ?? row.branch_name;
                 if (env_flag === 1) row.env_cause = 1;
+                row.mode = mode ?? row.mode ?? null;
+                row.changed_files = changed_files ?? row.changed_files ?? null;
                 row.updated_at = updated_at;
               }
               return { meta: { changes: row ? 1 : 0 } };
@@ -193,7 +196,7 @@ function makeSandbox(recorder, { status = 202 } = {}) {
     get() {
       return {
         async fetch(url, init) {
-          recorder.calls.push({ url, body: JSON.parse(init.body) });
+          recorder.calls.push({ url, body: JSON.parse(init.body), headers: init.headers ?? {} });
           return new Response(JSON.stringify({ status: "accepted" }), { status });
         },
       };
@@ -617,4 +620,93 @@ test("container helpers: buildRepairPrContent is honest (no auto-fix claim), car
   const plain = buildRepairPrContent({ intent: "x".repeat(100), agentPrompt: AGENT_PROMPT, envCause: false });
   assert.ok(!/완전히 해결되지 않을 수 있어요/.test(plain.body));
   assert.ok(plain.title.length < 80);
+});
+
+// ─── Stage 270: auto-repair execution (mode + changed_files + key forwarding) ─
+
+test("Stage 270 dispatch: ANTHROPIC_API_KEY forwarded via x-anthropic-key HEADER, never in the payload body", async () => {
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({ sandbox: makeSandbox(recorder) });
+  env.ANTHROPIC_API_KEY = "sk-ant-testkey-abcdefghijklmnop";
+  const r = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 202);
+  assert.equal(r.json.dispatched, true);
+
+  const call = recorder.calls[0];
+  assert.equal(call.headers["x-anthropic-key"], env.ANTHROPIC_API_KEY);
+  assert.ok(
+    !JSON.stringify(call.body).includes(env.ANTHROPIC_API_KEY),
+    "LLM key must travel in the header, never in the job payload body",
+  );
+  assert.ok(!JSON.stringify(r.json).includes(env.ANTHROPIC_API_KEY), "key never echoes in the response");
+});
+
+test("Stage 270 dispatch: no ANTHROPIC_API_KEY → no x-anthropic-key header (container stays brief-only)", async () => {
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({ sandbox: makeSandbox(recorder) });
+  const r = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 202);
+  assert.equal(recorder.calls[0].headers["x-anthropic-key"], undefined);
+});
+
+test("Stage 270 repair-done: mode auto_fix + changedFiles persisted; GET view exposes both", async () => {
+  const env = makeEnv({ sandbox: makeSandbox({ names: [], calls: [] }) });
+  const created = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  const jobId = created.json.repair.id;
+
+  const r = await req(
+    env, "POST", "/internal/repair-done",
+    {
+      jobId, ok: true, prUrl: "https://github.com/acme/golf-now/pull/39", prNumber: 39,
+      branch: `fix/simsa-${RUN}`, mode: "auto_fix", changedFiles: 2,
+    },
+    { authorization: `Bearer ${TOKEN}` },
+  );
+  assert.equal(r.status, 200);
+  assert.equal(r.json.status, "done");
+
+  const row = env.DB._jobs[0];
+  assert.equal(row.mode, "auto_fix");
+  assert.equal(row.changed_files, 2);
+
+  const got = await req(env, "GET", `${REPAIR_PATH}?userKey=${USER}`);
+  assert.equal(got.status, 200);
+  assert.equal(got.json.repair.mode, "auto_fix");
+  assert.equal(got.json.repair.changedFiles, 2);
+});
+
+test("Stage 270 repair-done: brief_only fallback persists mode with changedFiles 0", async () => {
+  const env = makeEnv({ sandbox: makeSandbox({ names: [], calls: [] }) });
+  const created = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  const jobId = created.json.repair.id;
+
+  const r = await req(
+    env, "POST", "/internal/repair-done",
+    { jobId, ok: true, prUrl: "https://github.com/acme/golf-now/pull/40", prNumber: 40, mode: "brief_only", changedFiles: 0 },
+    { authorization: `Bearer ${TOKEN}` },
+  );
+  assert.equal(r.status, 200);
+  assert.equal(env.DB._jobs[0].mode, "brief_only");
+  assert.equal(env.DB._jobs[0].changed_files, 0);
+});
+
+test("Stage 270 repair-done: invalid mode / negative or non-int changedFiles are dropped; legacy callback (no fields) stays null", async () => {
+  const env = makeEnv({ sandbox: makeSandbox({ names: [], calls: [] }) });
+  const created = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  const jobId = created.json.repair.id;
+
+  const r = await req(
+    env, "POST", "/internal/repair-done",
+    { jobId, ok: true, prUrl: "u", prNumber: 1, mode: "hax", changedFiles: -3 },
+    { authorization: `Bearer ${TOKEN}` },
+  );
+  assert.equal(r.status, 200);
+  assert.equal(env.DB._jobs[0].status, "done");
+  assert.equal(env.DB._jobs[0].mode, null, "unknown mode must not be stored");
+  assert.equal(env.DB._jobs[0].changed_files, null, "negative count must not be stored");
+
+  // legacy container (Stage 268) sends neither field → view shows nulls
+  const got = await req(env, "GET", `${REPAIR_PATH}?userKey=${USER}`);
+  assert.equal(got.json.repair.mode, null);
+  assert.equal(got.json.repair.changedFiles, null);
 });


### PR DESCRIPTION
## What

Stage 268 shipped the `simsa_repair` container job as an honest brief-only loop: clone → `fix/simsa-{runId}` branch → commit `SIMSA-FIX-BRIEF.md` → DRAFT PR ("no code auto-applied"). Stage 270 upgrades it to **true auto-repair**: the container runs the real worker agent against the fix brief so actual code changes land on the branch, and the PR reflects the fixes.

## Worker seam used (exact contract)

`ClaudeWorker.work(ctx: WorkerContext) → WorkerOutcome` from `packages/agent-worker` — the same lower-level seam `runAutofix` drives per blocker (`packages/cli/src/lib/autofix-worker.ts`):

- **in**: `{ repo, pullNumber, newSha, reviews: ReviewResult[], fileSnapshots: {path, contents}[] }` — the brief becomes one `ReviewResult` (`verdict: "rework"`, one blocker per `[고칠 문제]` entry, severity 높음/중간/낮음/참고 → blocker/major/minor/nit, browser observations + repo file list in `summary`)
- **out**: `{ rewrites: FileRewrite[] ({path, content} FULL-FILE), message, appliedFiles }` — v0.14+ workers emit complete file rewrites, **not unified diffs**, so applying is a sanitized overwrite; the legacy `git apply`/GNU-patch fuzz path (`recountHunkHeaders`) is not involved on this path by design.

## How

1. **`src/workspace/repair-brief.ts`** (new, pure, dependency-free): `parseRepairBrief` / `decideRepairMode` / `buildRepairReview` / evidence-token snapshot ranking + batching / `sanitizeRewrites` / `buildAutoFixPrContent`. The container Dockerfile compiles this SAME source in-image (inspector-container Stage 263 pattern) — lock-step pinned by `container-invariants.test.mjs`, and parsing is lock-stepped against real `buildAgentFixPrompt` output in `repair-brief.test.mjs`.
2. **`container/server.mjs`**: when the Worker forwards `ANTHROPIC_API_KEY` (via `x-anthropic-key` header, same as the autofix spawn — key never in the payload body), `runRepairJob` runs `attemptAutoFix`: `git ls-files` → ranked snapshot batches (8 files/iter) → `worker.work()` → sanitizer (path traversal / deny-list / no new files / no introduced secrets / no empty rewrites) → `git diff --name-only` real-change gate → `node --check` on changed JS. **Bounded: max 3 worker iterations / 5-min wall clock.** Any failure → `git reset --hard && git clean -fd` → Stage 268 brief-only fallback (never a half-state).
3. **Commit/PR**: auto_fix → `fix(simsa): apply repair for {runId}` (+ brief reference in the body) and a **non-draft** PR "Simsa 자동 수리: …" listing findings + changed files + honest review-before-merge note; brief-only keeps Stage 268 draft semantics. Retry-safe: same-branch force-push + existing-PR reuse with title/body refresh.
4. **`/internal/repair-done` + D1**: additive `mode` (`auto_fix`|`brief_only`) and `changed_files` (INTEGER) — migration **0052** (`ALTER TABLE ADD COLUMN`, 0048 precedent: not idempotent, applied exactly once via the d1_migrations ledger). `repair-job-db.ts` + GET repair view expose both (dashboard consumes later).

## Tests

- 19 new: brief parsing (incl. real `buildAgentFixPrompt` lock-step + malformed briefs), severity mapping, mode-fallback decisions, worker-review shaping, snapshot ranking/batching, sanitizer rails (traversal/deny/new-file/empty/secret-introduction/duplicate), auto-fix PR content, key-header forwarding (never in body/response), done-callback `mode`/`changedFiles` round-trip + invalid-value drops + legacy-callback compat, container lock-step invariants.
- Central-plane suite: **1386/1386 pass** (was 1367). `pnpm typecheck` / `build` / `lint` green (pre-push hook verified).
- `packages/*` untouched.

## Deploy notes

- **Migration 0052** must apply (`wrangler d1 migrations apply` — deploy-central-plane.yml does this).
- **Sandbox container image rebuild required** (Dockerfile changed: compiles `repair-brief.ts` into `/app/container-dist`).
- `ANTHROPIC_API_KEY` Worker secret already exists (autofix uses it); no new secrets.

## Still requires live verification

- One real repair run end-to-end (worker call, rewrite quality, non-draft PR on a user repo) — deterministic logic is tested, the LLM round-trip is not.
- Image-build sanity that `npx tsc` resolves in the sandbox image (typescript is a workspace root devDependency; verified locally with the same flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)