### PR TITLE
Stage 271 — open public sign-up (AUTH_SIGNUP_MODE=open)

### DIFF
--- a/apps/central-plane/wrangler.toml
+++ b/apps/central-plane/wrangler.toml
@@ -13,6 +13,10 @@ database_id = "28be7ec4-9c46-4b78-8d07-11f344021dd0"
 
 [vars]
 ENVIRONMENT = "production"
+# Stage 271 — public sign-up OPEN (Bae approved 2026-07-02: "env 변경도 저건 승인할게").
+# Was fail-closed (unset → disabled) since Stage 241. Sign-in/session were never gated
+# by this policy; only POST /api/auth/sign-up/* is affected.
+AUTH_SIGNUP_MODE = "open"
 # Public GitHub OAuth App client_id. Register at https://github.com/settings/developers
 # (type: OAuth App, enable device flow). Leave the placeholder if OAuth is not
 # yet configured — /oauth/device/* endpoints will return 503 until this is real.


### PR DESCRIPTION
Bae-approved env change: sign-up policy fail-closed → open. Config-only (wrangler.toml vars); Stage 241 guard code unchanged. Effective on next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)