### PR TITLE
Stage 272 — Overview inspection card + post-repair re-check flow

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/page.tsx
@@ -29,11 +29,26 @@ import {
   timelineLimitationLabelKey,
   timelineHasNoEvents,
 } from "@/lib/project-evolution-timeline.mjs";
-import type { Dictionary } from "@/i18n/dictionary.mjs";
+import {
+  listVisualChecks,
+  type VisualCheckListItem,
+} from "@/lib/workspace-visual-checks-api";
+import { overviewNextAction, relativeTimeLabel, verdictLabel } from "@/lib/visual-check-view.mjs";
+import type { VerdictTone } from "@/lib/visual-check-view.mjs";
+import type { Dictionary, Locale } from "@/i18n/dictionary.mjs";
+
+// Stage 272 — verdict/status chip tones on the overview inspection card
+// (same brand tokens as the visual-checks pages; colors carry meaning only).
+const VC_TONE_CLASS: Record<VerdictTone, string> = {
+  passed: "bg-green-50 text-green-700 border-green-200",
+  failed: "bg-red-50 text-red-700 border-red-200",
+  inconclusive: "bg-amber-50 text-amber-700 border-amber-200",
+};
+const VC_STATUS_SLATE_CLASS = "bg-slate-50 text-slate-600 border-slate-200";
 
 export default function ProjectOverviewPage() {
   const { id } = useParams<{ id: string }>();
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   // Locally-created projects live in localStorage (client-only); mock demos are
   // bundled. Read on the client so real projects resolve.
   const project = getLocalProject(id) ?? getProject(id);
@@ -56,6 +71,9 @@ export default function ProjectOverviewPage() {
         </div>
         <span className="flex-shrink-0 text-xs text-brand-700">{t.planMap.youAreHere} →</span>
       </Link>
+
+      {/* Stage 272 — inspection status at a glance + the single next action */}
+      <VisualChecksOverviewCard projectId={id} t={t} locale={locale} />
 
       <section className="mb-8">
         <div className="mb-2 flex items-center justify-between">
@@ -132,6 +150,129 @@ export default function ProjectOverviewPage() {
         <EvolutionTimelineCard projectId={id} t={t} />
       </section>
     </div>
+  );
+}
+
+// Stage 272 — the "시각 검수" overview card: latest run's verdict chip +
+// relative date + the single next action (run first / view progress / open
+// the report). Best-effort: the card stays hidden while loading, without a
+// userKey, or when the run list cannot be fetched.
+function VisualChecksOverviewCard({
+  projectId,
+  t,
+  locale,
+}: {
+  projectId: string;
+  t: Dictionary;
+  locale: Locale;
+}) {
+  const [checks, setChecks] = useState<VisualCheckListItem[] | null>(null);
+  const [userKey, setUserKey] = useState<string>("");
+
+  useEffect(() => {
+    setUserKey(getUserKey());
+  }, []);
+
+  useEffect(() => {
+    if (!userKey) return;
+    let cancelled = false;
+    listVisualChecks(projectId, userKey).then((res) => {
+      if (cancelled) return;
+      if (res.ok) {
+        setChecks(res.checks);
+      } else if (res.error === "project_not_found") {
+        // A project that only exists in this browser has no server-side runs
+        // yet — show the "run your first inspection" state.
+        setChecks([]);
+      }
+      // Any other failure keeps the card hidden (best-effort, never blocks).
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, userKey]);
+
+  if (checks === null) return null;
+
+  const action = overviewNextAction(checks);
+  const run =
+    action.kind === "runFirst" ? null : (checks.find((c) => c.id === action.runId) ?? null);
+
+  return (
+    <section className="mb-8">
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="section-title">{t.visualChecks.title}</h2>
+        <Link
+          href={`/projects/${projectId}/visual-checks`}
+          className="text-xs text-brand-700 hover:underline"
+        >
+          {t.common.viewAll} →
+        </Link>
+      </div>
+      <div className="card p-5">
+        {run === null ? (
+          <>
+            <p className="text-sm leading-relaxed text-gray-600">
+              {t.visualChecks.overview.emptyLead}
+            </p>
+            <Link
+              href={`/projects/${projectId}/visual-checks`}
+              className="btn btn-primary btn-sm mt-3"
+            >
+              {t.visualChecks.overview.runFirst}
+            </Link>
+          </>
+        ) : (
+          <>
+            <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">
+              {t.visualChecks.overview.latestLabel}
+            </p>
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
+              <div className="flex min-w-0 flex-wrap items-center gap-2.5">
+                <OverviewRunChip run={run} t={t} />
+                <span className="truncate text-sm text-gray-700">{run.targetUrl}</span>
+                <span className="flex-shrink-0 text-xs text-gray-400">
+                  {relativeTimeLabel(run.createdAt, locale)}
+                </span>
+              </div>
+              <Link
+                href={`/projects/${projectId}/visual-checks/${run.id}`}
+                className={`flex-shrink-0 ${
+                  action.kind === "viewReport" ? "btn btn-primary btn-sm" : "btn btn-secondary btn-sm"
+                }`}
+              >
+                {action.kind === "inProgress"
+                  ? t.visualChecks.overview.inProgress
+                  : t.visualChecks.overview.viewReport}
+              </Link>
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// Stage 272 — chip for the latest run: queued/running/failed statuses take
+// priority; a done (or legacy) run shows its verdict chip.
+function OverviewRunChip({ run, t }: { run: VisualCheckListItem; t: Dictionary }) {
+  let chip: { label: string; cls: string };
+  if (run.status === "queued") {
+    chip = { label: t.visualChecks.statusQueued, cls: VC_STATUS_SLATE_CLASS };
+  } else if (run.status === "running") {
+    chip = { label: t.visualChecks.statusRunning, cls: VC_STATUS_SLATE_CLASS };
+  } else if (run.status === "failed") {
+    chip = { label: t.visualChecks.statusFailed, cls: VC_TONE_CLASS.failed };
+  } else {
+    const verdict = verdictLabel(run.works, run.decision, t);
+    chip = { label: verdict.label, cls: VC_TONE_CLASS[verdict.tone] };
+  }
+  return (
+    <span
+      className={`inline-flex flex-shrink-0 items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${chip.cls}`}
+    >
+      {chip.label}
+    </span>
   );
 }
 

--- a/apps/dashboard/src/app/projects/[id]/visual-checks/[runId]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/visual-checks/[runId]/page.tsx
@@ -13,9 +13,12 @@
 // section: dispatches a Stage 268 repair job (draft PR carrying the fix
 // brief — code is NOT auto-applied), polls it every 5s, then links the
 // resulting GitHub PR ("수리 시작점 PR").
+// Stage 272 — the repair-done card explains that the live site only changes
+// after merge + deploy, and offers a one-click re-check (new Stage 264 run →
+// navigate to its detail, which auto-shows the Stage 266 comparison).
 
 import { useEffect, useRef, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { getProject } from "@/lib/mock-data";
 import { getLocalProject, getUserKey } from "@/lib/workflow-store";
@@ -24,6 +27,7 @@ import {
   listVisualChecks,
   requestRepair,
   getRepair,
+  runVisualCheck,
   CENTRAL_PLANE_URL,
   type VisualCheckDetail,
   type NonDevFinding,
@@ -39,7 +43,8 @@ import {
 import type { VerdictTone, SeverityTone } from "@/lib/visual-check-view.mjs";
 import { compareVisualChecks, pickPreviousDoneCheck } from "@/lib/visual-check-compare.mjs";
 import type { VisualCheckComparison, ComparedFinding } from "@/lib/visual-check-compare.mjs";
-import { isActiveStatus, RUN_POLL_INTERVAL_MS } from "@/lib/visual-check-run-state.mjs";
+import { isActiveStatus, mapRunError, RUN_POLL_INTERVAL_MS } from "@/lib/visual-check-run-state.mjs";
+import type { RunErrorKey } from "@/lib/visual-check-run-state.mjs";
 import {
   canRepair,
   isRepairActive,
@@ -274,6 +279,13 @@ function ComparisonSection({
   );
 }
 
+// Stage 272 — after the repair PR is ready, the done card carries an honest
+// explainer (the fix lives on a PR branch; the LIVE site only changes after
+// merge + deploy) and a one-click re-check that dispatches a new Stage 264
+// run and navigates to its detail page (which polls and auto-shows the
+// Stage 266 comparison once done).
+type RecheckNotice = { kind: "queuedOnly" } | { kind: "error"; errorKey: RunErrorKey };
+
 // Stage 269 — "[고치기]": dispatch a repair job for a done-but-not-working
 // run, poll it every 5s, and surface the resulting draft PR. Honest copy:
 // the PR carries the fix brief (SIMSA-FIX-BRIEF.md) — code changes are NOT
@@ -290,10 +302,14 @@ function RepairSection({
   t: Dictionary;
 }) {
   const s = t.visualChecks.repair;
+  const router = useRouter();
   // null = no repair job yet (show the button); otherwise render the job state.
   const [repair, setRepair] = useState<RepairJob | null>(null);
   const [phase, setPhase] = useState<"loading" | "ready" | "submitting">("loading");
   const [errorKey, setErrorKey] = useState<RepairErrorKey | null>(null);
+  // Stage 272 — post-repair re-check dispatch state.
+  const [recheckSubmitting, setRecheckSubmitting] = useState(false);
+  const [recheckNotice, setRecheckNotice] = useState<RecheckNotice | null>(null);
 
   // On mount, GET once — if a repair already exists, render its state
   // instead of the bare button (and resume polling when it is still active).
@@ -345,6 +361,27 @@ function RepairSection({
       setErrorKey(key);
     }
     setPhase("ready");
+  }
+
+  // Stage 272 — same POST run dispatch as the Stage 264 list page. On a
+  // dispatched run we navigate straight to its detail page; a queued-only
+  // (degraded runner) or error answer keeps the user here with a callout.
+  async function handleRecheck() {
+    if (recheckSubmitting) return;
+    setRecheckSubmitting(true);
+    setRecheckNotice(null);
+    const res = await runVisualCheck(projectId, { userKey });
+    if (res.ok && res.dispatched) {
+      // Keep the button disabled while the navigation happens.
+      router.push(`/projects/${projectId}/visual-checks/${res.check.id}`);
+      return;
+    }
+    if (res.ok) {
+      setRecheckNotice({ kind: "queuedOnly" });
+    } else {
+      setRecheckNotice({ kind: "error", errorKey: mapRunError(res.error) });
+    }
+    setRecheckSubmitting(false);
   }
 
   const isDone = repair !== null && repair.status === "done";
@@ -405,6 +442,33 @@ function RepairSection({
                   {repair.branchName}
                 </code>
               </span>
+            )}
+          </div>
+
+          {/* Stage 272 — honest merge+deploy explainer + one-click re-check */}
+          <div className="mt-3 border-t border-green-200 pt-3">
+            <p className="text-sm leading-relaxed text-green-700">{s.recheckExplainer}</p>
+            <button
+              onClick={handleRecheck}
+              disabled={recheckSubmitting}
+              className="btn btn-secondary btn-sm mt-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {recheckSubmitting ? t.visualChecks.runSubmitting : s.recheckButton}
+            </button>
+            {recheckNotice?.kind === "queuedOnly" && (
+              <div className="callout callout-info mt-2">{t.visualChecks.runQueuedOnly}</div>
+            )}
+            {recheckNotice?.kind === "error" && (
+              <div
+                className={`callout mt-2 ${
+                  recheckNotice.errorKey === "runAlreadyActive" ||
+                  recheckNotice.errorKey === "websiteSourceRequired"
+                    ? "callout-info"
+                    : "callout-error"
+                }`}
+              >
+                {t.visualChecks.runErrors[recheckNotice.errorKey]}
+              </div>
             )}
           </div>
         </div>

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -1493,6 +1493,8 @@ export type Dictionary = {
       envCauseWarning: string;
       failedTitle: string;
       failedBody: string;
+      recheckExplainer: string;
+      recheckButton: string;
       detailsLabel: string;
       goToRepo: string;
       goToGithubSettings: string;
@@ -1505,6 +1507,13 @@ export type Dictionary = {
         forbidden: string;
         generic: string;
       };
+    };
+    overview: {
+      emptyLead: string;
+      runFirst: string;
+      inProgress: string;
+      viewReport: string;
+      latestLabel: string;
     };
   };
   sources: {

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -1590,6 +1590,10 @@ const EN = {
       envCauseWarning: "The evidence points at an environment or configuration cause, so a code change alone may not fully resolve this.",
       failedTitle: "The repair could not be completed",
       failedBody: "Something went wrong while creating the repair PR. You can try again.",
+      // Stage 272 — post-repair re-check: honest merge+deploy explainer + one click.
+      recheckExplainer:
+        "The fix currently lives only on the PR branch, so your live site has not changed yet. After you merge the repair PR and your platform finishes deploying, re-inspect and we will show the result compared with before.",
+      recheckButton: "Re-inspect to verify the fix",
       detailsLabel: "Details (for developers)",
       goToRepo: "Connect a repository",
       goToGithubSettings: "Connect GitHub",
@@ -1602,6 +1606,16 @@ const EN = {
         forbidden: "You do not have access to this project.",
         generic: "Could not start the repair. Please try again.",
       },
+    },
+    // Stage 272 — project-overview inspection card: latest verdict at a glance
+    // plus the single next action.
+    overview: {
+      emptyLead:
+        "No inspections have run yet. Simsa opens your live app in a real browser and reports what works in plain language.",
+      runFirst: "Run your first inspection",
+      inProgress: "View the inspection in progress",
+      viewReport: "View the report",
+      latestLabel: "Latest inspection",
     },
   },
   // Stage 262 — project sources (연결): website, GitHub repo, uploaded documents.
@@ -3244,6 +3258,10 @@ const KO = {
       envCauseWarning: "원인에 환경설정 문제가 포함돼 있어 코드 수정만으로 완전히 해결되지 않을 수 있어요",
       failedTitle: "고치기를 마치지 못했어요",
       failedBody: "수리 PR을 만드는 중에 문제가 생겼어요. 다시 시도할 수 있어요.",
+      // Stage 272 — 수리 후 재검수: 머지+배포 전에는 라이브가 안 바뀐다는 정직한 안내 + 원클릭.
+      recheckExplainer:
+        "수리 내용은 아직 PR 브랜치에만 있어서 실제 사이트는 그대로예요. 수리 PR을 머지하고 배포가 끝난 뒤 다시 검수하면, 이전과 비교한 결과를 보여드려요.",
+      recheckButton: "수리 확인 재검수",
       detailsLabel: "개발자용 상세 정보",
       goToRepo: "저장소 연결하러 가기",
       goToGithubSettings: "GitHub 연결하러 가기",
@@ -3256,6 +3274,15 @@ const KO = {
         forbidden: "이 프로젝트에 접근할 수 없어요.",
         generic: "고치기를 시작하지 못했어요. 다시 시도해주세요.",
       },
+    },
+    // Stage 272 — 프로젝트 개요 검수 카드: 최근 결과와 다음 할 일 하나.
+    overview: {
+      emptyLead:
+        "아직 실행된 검수가 없어요. Simsa가 라이브 앱을 실제 브라우저로 열어 무엇이 작동하는지 쉬운 말로 알려드려요.",
+      runFirst: "첫 검수 실행하기",
+      inProgress: "진행 중인 검수 보기",
+      viewReport: "리포트 보기",
+      latestLabel: "최근 검수",
     },
   },
   // Stage 262 — 연결(프로젝트 소스): 웹사이트 · GitHub 저장소 · 문서 업로드.

--- a/apps/dashboard/src/lib/visual-check-view.d.mts
+++ b/apps/dashboard/src/lib/visual-check-view.d.mts
@@ -1,9 +1,18 @@
-// Type declarations for visual-check-view.mjs (Stage 262).
+// Type declarations for visual-check-view.mjs (Stage 262; Stage 272 adds the
+// project-overview next-action + relative-time helpers).
 import type { Dictionary } from "../i18n/dictionary.mjs";
 
 export type VerdictTone = "passed" | "failed" | "inconclusive";
 export type SeverityTone = "failed" | "inconclusive" | "decision";
 export type FindingSeverity = "high" | "medium" | "low" | "info";
+
+export type OverviewNextAction =
+  | { kind: "runFirst" }
+  | { kind: "inProgress" | "viewReport" | "viewLatest"; runId: string };
+
+export function overviewNextAction(checks: unknown): OverviewNextAction;
+
+export function relativeTimeLabel(iso: string, locale: string, now?: number): string;
 
 export function verdictLabel(
   works: boolean | null | undefined,

--- a/apps/dashboard/src/lib/visual-check-view.mjs
+++ b/apps/dashboard/src/lib/visual-check-view.mjs
@@ -1,8 +1,12 @@
 // Stage 262: pure view helpers for the Simsa visual-check (시각 검수) pages.
+// Stage 272 adds the project-overview helpers: overviewNextAction (the single
+// next action a non-developer should take) and relativeTimeLabel.
 //
 // PURE — no LLM, no network, no randomness, no token/userKey storage. All
 // user-facing labels come from the injected dictionary (t), so the output
 // follows the UI language. NO numeric scores anywhere (Simsa policy).
+
+import { isActiveStatus } from "./visual-check-run-state.mjs";
 
 /**
  * Map a run's works flag (true / false / null) to the localized verdict label
@@ -53,6 +57,59 @@ export function splitEvidenceKeys(keys) {
  * keeps its `/` path separator (the backend route is a wildcard) but each
  * segment — and every id + the userKey — is URI-encoded.
  */
+/**
+ * Stage 272 — the single next action the project-overview inspection card
+ * should offer, derived from the run list (any order; sorted here by
+ * createdAt, newest first). Returns exactly one of:
+ *
+ *   { kind: "runFirst" }                 — no runs yet → "첫 검수 실행하기"
+ *   { kind: "inProgress", runId }        — a queued/running run exists (the
+ *                                          most recent one wins) → "진행 중"
+ *   { kind: "viewReport", runId }        — the latest run needs attention:
+ *                                          status failed, works=false, or a
+ *                                          done run that could not verify
+ *                                          (works=null) → "리포트 보기"
+ *   { kind: "viewLatest", runId }        — the latest run verified working
+ *
+ * Defensive: non-array input and rows without a string id are dropped, so a
+ * partial/legacy list can never crash the overview card.
+ */
+export function overviewNextAction(checks) {
+  const list = Array.isArray(checks)
+    ? checks.filter((c) => c && typeof c === "object" && typeof c.id === "string")
+    : [];
+  if (list.length === 0) return { kind: "runFirst" };
+  const sorted = [...list].sort((a, b) =>
+    String(b.createdAt ?? "").localeCompare(String(a.createdAt ?? "")),
+  );
+  const active = sorted.find((c) => isActiveStatus(c.status));
+  if (active) return { kind: "inProgress", runId: active.id };
+  const latest = sorted[0];
+  if (latest.status === "failed" || latest.works !== true) {
+    return { kind: "viewReport", runId: latest.id };
+  }
+  return { kind: "viewLatest", runId: latest.id };
+}
+
+/**
+ * Stage 272 — localized "3 minutes ago"-style label for the overview card.
+ * `now` is injectable for deterministic tests. Unparseable dates return ""
+ * (the card simply omits the timestamp).
+ */
+export function relativeTimeLabel(iso, locale, now = Date.now()) {
+  const ts = Date.parse(String(iso ?? ""));
+  if (Number.isNaN(ts)) return "";
+  const rtf = new Intl.RelativeTimeFormat(locale === "ko" ? "ko" : "en", { numeric: "auto" });
+  const diffSec = Math.round((ts - now) / 1000);
+  const abs = Math.abs(diffSec);
+  if (abs < 60) return rtf.format(diffSec, "second");
+  if (abs < 3600) return rtf.format(Math.trunc(diffSec / 60), "minute");
+  if (abs < 86400) return rtf.format(Math.trunc(diffSec / 3600), "hour");
+  if (abs < 86400 * 30) return rtf.format(Math.trunc(diffSec / 86400), "day");
+  if (abs < 86400 * 365) return rtf.format(Math.trunc(diffSec / (86400 * 30)), "month");
+  return rtf.format(Math.trunc(diffSec / (86400 * 365)), "year");
+}
+
 export function buildEvidenceUrl(base, projectId, runId, name, userKey) {
   const trimmedBase = String(base ?? "").replace(/\/+$/, "");
   const encodedName = String(name ?? "")

--- a/apps/dashboard/test/visual-check-view.test.mjs
+++ b/apps/dashboard/test/visual-check-view.test.mjs
@@ -7,6 +7,8 @@ import {
   severityTone,
   splitEvidenceKeys,
   buildEvidenceUrl,
+  overviewNextAction,
+  relativeTimeLabel,
 } from "../src/lib/visual-check-view.mjs";
 import { getDictionary } from "../src/i18n/dictionary.mjs";
 
@@ -85,6 +87,90 @@ describe("visual-check-view: splitEvidenceKeys", () => {
     ]);
     assert.deepEqual(screenshots, ["screenshots/a.png"]);
     assert.equal(video, null);
+  });
+});
+
+// Stage 272 — project-overview next action.
+function check(id, { status = "done", works = null, createdAt = "2026-07-01T00:00:00Z" } = {}) {
+  return { id, targetUrl: "https://app.example.com", decision: "", works, status, executor: "container", evidenceCount: 0, createdAt };
+}
+
+describe("visual-check-view: overviewNextAction", () => {
+  it("empty or non-array input → runFirst", () => {
+    assert.deepEqual(overviewNextAction([]), { kind: "runFirst" });
+    assert.deepEqual(overviewNextAction(null), { kind: "runFirst" });
+    assert.deepEqual(overviewNextAction("nope"), { kind: "runFirst" });
+    // Rows without a string id are dropped defensively.
+    assert.deepEqual(overviewNextAction([{ status: "done" }]), { kind: "runFirst" });
+  });
+
+  it("an active (queued/running) run wins → inProgress with that run's id", () => {
+    const action = overviewNextAction([
+      check("done_new", { works: true, createdAt: "2026-07-02T10:00:00Z" }),
+      check("run_active", { status: "running", createdAt: "2026-07-02T09:00:00Z" }),
+    ]);
+    assert.deepEqual(action, { kind: "inProgress", runId: "run_active" });
+    const queued = overviewNextAction([check("q1", { status: "queued" })]);
+    assert.deepEqual(queued, { kind: "inProgress", runId: "q1" });
+  });
+
+  it("latest done run that works → viewLatest", () => {
+    const action = overviewNextAction([
+      check("older_broken", { works: false, createdAt: "2026-07-01T00:00:00Z" }),
+      check("latest_ok", { works: true, createdAt: "2026-07-02T00:00:00Z" }),
+    ]);
+    assert.deepEqual(action, { kind: "viewLatest", runId: "latest_ok" });
+  });
+
+  it("latest done run that does not work (works=false) → viewReport", () => {
+    const action = overviewNextAction([
+      check("older_ok", { works: true, createdAt: "2026-07-01T00:00:00Z" }),
+      check("latest_broken", { works: false, createdAt: "2026-07-02T00:00:00Z" }),
+    ]);
+    assert.deepEqual(action, { kind: "viewReport", runId: "latest_broken" });
+  });
+
+  it("latest done run that could not verify (works=null) → viewReport", () => {
+    const action = overviewNextAction([check("unclear", { works: null })]);
+    assert.deepEqual(action, { kind: "viewReport", runId: "unclear" });
+  });
+
+  it("latest failed run → viewReport, ordered by createdAt regardless of list order", () => {
+    // The failed run is newest but listed first/last in different orders —
+    // sorting by createdAt must pick it either way.
+    const rows = [
+      check("failed_new", { status: "failed", createdAt: "2026-07-03T00:00:00Z" }),
+      check("ok_old", { works: true, createdAt: "2026-07-01T00:00:00Z" }),
+    ];
+    assert.deepEqual(overviewNextAction(rows), { kind: "viewReport", runId: "failed_new" });
+    assert.deepEqual(overviewNextAction([...rows].reverse()), {
+      kind: "viewReport",
+      runId: "failed_new",
+    });
+  });
+
+  it("ordering by createdAt also drives the working case (unsorted input)", () => {
+    const action = overviewNextAction([
+      check("broken_old", { works: false, createdAt: "2026-06-30T00:00:00Z" }),
+      check("ok_new", { works: true, createdAt: "2026-07-02T00:00:00Z" }),
+      check("broken_older", { works: false, createdAt: "2026-06-29T00:00:00Z" }),
+    ]);
+    assert.deepEqual(action, { kind: "viewLatest", runId: "ok_new" });
+  });
+});
+
+describe("visual-check-view: relativeTimeLabel", () => {
+  const now = Date.parse("2026-07-02T12:00:00Z");
+
+  it("formats minutes/hours/days in the requested locale", () => {
+    assert.equal(relativeTimeLabel("2026-07-02T11:57:00Z", "en", now), "3 minutes ago");
+    assert.equal(relativeTimeLabel("2026-07-02T09:00:00Z", "ko", now), "3시간 전");
+    assert.equal(relativeTimeLabel("2026-06-30T12:00:00Z", "ko", now), "그저께");
+  });
+
+  it("returns an empty string for unparseable dates", () => {
+    assert.equal(relativeTimeLabel("not-a-date", "en", now), "");
+    assert.equal(relativeTimeLabel(null, "ko", now), "");
   });
 });
 


### PR DESCRIPTION
## Summary

Two small connected pieces, dashboard-only (`apps/dashboard`):

### 1. Repair → re-check guidance (visual-check detail page)
- The Stage 269 repair-done card now tells the honest truth: the fix lives only on the PR branch — the LIVE site changes only after the user merges the PR and their platform finishes deploying.
- New one-click **"수리 확인 재검수"** button: same POST run dispatch as Stage 264 (`runVisualCheck`), with the 409 (`runAlreadyActive`) / `websiteSourceRequired` info callouts and the degraded-runner `runQueuedOnly` callout reused via `mapRunError`.
- On a dispatched run it navigates straight to the new run's detail page, which polls every 5s and auto-shows the Stage 266 "이전 검수와 비교" section when done.

### 2. Project overview integration (`/projects/[id]`)
- New **"시각 검수"** card near the top of the overview: latest run's verdict/status chip + localized relative date + the single next action.
  - no runs → "첫 검수 실행하기" (links to the visual-checks page)
  - active run → "진행 중인 검수 보기" (links to the run detail)
  - latest failed / `works=false` / unverified → "리포트 보기" (primary)
  - latest working → "리포트 보기" (secondary)
- Best-effort: hidden while loading, without a userKey, or on any fetch error; `project_not_found` (browser-only project) renders the empty "run first" state.

### Pure helpers (`src/lib/visual-check-view.mjs`, extended)
- `overviewNextAction(checks)` → `{kind, runId?}` — createdAt ordering (unsorted input safe), active-run priority, defensive row filtering.
- `relativeTimeLabel(iso, locale, now?)` — `Intl.RelativeTimeFormat`, injectable `now` for deterministic tests.

### i18n
- `visualChecks.overview.*` + `visualChecks.repair.recheckExplainer/recheckButton` in EN and KO; key-structure parity test green. No emoji, no numeric scores, brand chip primitives reused.

## Tests
- 9 new tests (7 `overviewNextAction` cases: empty/non-array, active priority, done-working, done-broken, works=null, failed-run + createdAt ordering both directions; 2 `relativeTimeLabel`).
- Dashboard suite: **360/360 pass** (was 351). `turbo verify` (typecheck + build + lint) green via pre-push hook.

## Files
- `apps/dashboard/src/lib/visual-check-view.mjs` / `.d.mts`
- `apps/dashboard/src/app/projects/[id]/page.tsx`
- `apps/dashboard/src/app/projects/[id]/visual-checks/[runId]/page.tsx`
- `apps/dashboard/src/i18n/dictionary.mjs` / `.d.mts`
- `apps/dashboard/test/visual-check-view.test.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)