### PR TITLE
Non-dev completeness: no raw error codes, no blank screens, review findings follow locale

### DIFF
--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -737,6 +737,8 @@ export function createWorkspaceGitHubRoutes(
     const b = body as Record<string, unknown>;
     const userKey = typeof b["userKey"] === "string" ? b["userKey"] : "";
     if (!userKey) return json({ ok: false, error: "userKey_required" }, 400, origin);
+    // Review findings (reason/evidence/nextAction) follow the user's UI language.
+    const reviewLocale: "en" | "ko" = b["locale"] === "en" ? "en" : "ko";
 
     // Ownership: the project must belong to the caller before anything else
     // (repo link, runs, and credits are all project-scoped).
@@ -921,6 +923,7 @@ export function createWorkspaceGitHubRoutes(
           items: itemsToReview,
           prMeta: prFilesResult.meta,
           prFiles: prFilesResult.files,
+          locale: reviewLocale,
         },
         c.env.ANTHROPIC_API_KEY,
         fetchImpl,

--- a/apps/central-plane/src/workspace/pr-review.ts
+++ b/apps/central-plane/src/workspace/pr-review.ts
@@ -72,7 +72,7 @@ ${diffSummary}
 
 중요한 규칙:
 - PR diff만으로 확인이 안 되면 "확인 부족"으로 표시 (억지로 통과/실패로 만들지 말 것)
-- 모든 사용자 대상 텍스트는 한국어로 작성
+- ${req.locale === "en" ? "Write all user-facing text (reason, evidence, nextAction) in ENGLISH" : "모든 사용자 대상 텍스트는 한국어로 작성"}
 - reason은 diff에서 관찰한 구체적인 내용을 1~2문장으로
 - evidence는 PR에서 관련 파일명이나 코드 변경 내용 (없으면 빈 배열)
 - nextAction은 사용자가 할 수 있는 다음 행동 1줄
@@ -134,12 +134,38 @@ async function callAnthropic(
 /** File extensions that strongly suggest code-level implementation. */
 const CODE_EXTENSIONS = /\.(ts|tsx|js|jsx|py|go|java|kt|swift|rb|rs|cs|cpp|c|php|vue|svelte)$/i;
 
+/** Localized copy for the heuristic fallback (no API key / LLM failure path). */
+const HEURISTIC_COPY = {
+  ko: {
+    excludedReason: "이 항목은 이번 버전의 제외 범위에 있는 기능과 관련됩니다.",
+    excludedNext: "제품 설명서의 포함/제외 범위를 다시 확인하거나, 이번 버전에서 제외하세요.",
+    openReason: "이 항목은 아직 결정되지 않은 제품 방향과 연결됩니다.",
+    openNext: "제품 설명서의 결정 필요 항목을 먼저 확정하고 다시 확인하세요.",
+    passReason: "PR의 변경 파일이 이 항목과 관련된 것으로 보이며, 완성 기준이 충분합니다.",
+    passNext: "변경 내용을 직접 검토해 기준이 모두 충족됐는지 확인하세요.",
+    incReason: "PR diff만으로는 이 항목의 구현 여부를 확인하기 어렵습니다.",
+    incNext: "변경된 파일 목록을 직접 확인하거나, 담당 개발자에게 어떤 파일에서 구현했는지 확인하세요.",
+  },
+  en: {
+    excludedReason: "This item relates to a feature marked out of scope for this version.",
+    excludedNext: "Re-check the in/out-of-scope list in your product spec, or leave it out of this version.",
+    openReason: "This item is tied to a product decision that hasn't been made yet.",
+    openNext: "Settle the open decision in your product spec first, then re-check.",
+    passReason: "The PR's changed files appear related to this item and the acceptance criteria look sufficient.",
+    passNext: "Review the changes yourself to confirm every criterion is met.",
+    incReason: "The PR diff alone isn't enough to confirm whether this item is implemented.",
+    incNext: "Check the changed files yourself, or ask the developer which file implements it.",
+  },
+} as const;
+
 function reviewItemHeuristic(
   item: CheckableItem,
   spec: ProductSpecForCheck,
   files: PullRequestFile[],
+  locale: "ko" | "en" = "ko",
 ): Omit<CheckResultItem, "title"> {
   const titleLower = item.title.toLowerCase();
+  const c = HEURISTIC_COPY[locale];
 
   // Check excluded features
   const conflictsExcluded = spec.excluded.some((ex) => {
@@ -154,11 +180,11 @@ function reviewItemHeuristic(
       itemId: item.id,
       status: "failed",
       userLabel: "안 맞음",
-      reason: "이 항목은 이번 버전의 제외 범위에 있는 기능과 관련됩니다.",
+      reason: c.excludedReason,
       evidence: spec.excluded.filter((ex) =>
         ex.split(/[\s,·]+/).some((w) => w.length > 1 && titleLower.includes(w.toLowerCase())),
       ),
-      nextAction: "제품 설명서의 포함/제외 범위를 다시 확인하거나, 이번 버전에서 제외하세요.",
+      nextAction: c.excludedNext,
     };
   }
 
@@ -175,11 +201,11 @@ function reviewItemHeuristic(
       itemId: item.id,
       status: "needs_decision",
       userLabel: "결정 필요",
-      reason: "이 항목은 아직 결정되지 않은 제품 방향과 연결됩니다.",
+      reason: c.openReason,
       evidence: spec.openQuestions.filter((q) =>
         q.split(/[\s,·]+/).some((w) => w.length > 1 && titleLower.includes(w.toLowerCase())),
       ),
-      nextAction: "제품 설명서의 결정 필요 항목을 먼저 확정하고 다시 확인하세요.",
+      nextAction: c.openNext,
     };
   }
 
@@ -195,9 +221,9 @@ function reviewItemHeuristic(
       itemId: item.id,
       status: "passed",
       userLabel: "통과",
-      reason: "PR의 변경 파일이 이 항목과 관련된 것으로 보이며, 완성 기준이 충분합니다.",
+      reason: c.passReason,
       evidence: matchingFiles.slice(0, 3).map((f) => f.filename),
-      nextAction: "변경 내용을 직접 검토해 기준이 모두 충족됐는지 확인하세요.",
+      nextAction: c.passNext,
     };
   }
 
@@ -206,15 +232,16 @@ function reviewItemHeuristic(
     itemId: item.id,
     status: "inconclusive",
     userLabel: "확인 부족",
-    reason: "PR diff만으로는 이 항목의 구현 여부를 확인하기 어렵습니다.",
+    reason: c.incReason,
     evidence: [],
-    nextAction: "변경된 파일 목록을 직접 확인하거나, 담당 개발자에게 어떤 파일에서 구현했는지 확인하세요.",
+    nextAction: c.incNext,
   };
 }
 
 function buildMockFallback(req: PRReviewRequest): PRReviewResponse {
+  const locale = req.locale === "en" ? "en" : "ko";
   const results: CheckResultItem[] = req.items.map((item) => ({
-    ...reviewItemHeuristic(item, req.productSpec, req.prFiles),
+    ...reviewItemHeuristic(item, req.productSpec, req.prFiles, locale),
     title: item.title,
   }));
 

--- a/apps/central-plane/test/workspace-pr-review.test.mjs
+++ b/apps/central-plane/test/workspace-pr-review.test.mjs
@@ -263,6 +263,20 @@ describe("reviewPRAgainstItems: mock fallback", () => {
     }, undefined);
     assert.equal(res.results[0].status, "failed");
     assert.equal(res.results[0].userLabel, "안 맞음");
+    // Default (no locale) → Korean reason text.
+    assert.match(res.results[0].reason, /제외 범위/);
+  });
+
+  it("heuristic fallback follows locale: en → English reason text", async () => {
+    const res = await reviewPRAgainstItems({
+      productSpec: MOCK_SPEC, items: [MOCK_ITEMS[1]],
+      prMeta: MOCK_PR_META, prFiles: MOCK_PR_FILES,
+      locale: "en",
+    }, undefined);
+    assert.equal(res.results[0].status, "failed");
+    assert.match(res.results[0].reason, /out of scope/i);
+    // No Korean characters leak into the English reason.
+    assert.ok(!/[가-힣]/.test(res.results[0].reason), "English reason must not contain Hangul");
   });
 
   it("marks items in openQuestions as needs_decision", async () => {

--- a/apps/dashboard/src/app/projects/[id]/credits/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/credits/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/workspace-credits-api";
 import { useI18n } from "@/i18n/I18nProvider";
 import type { Dictionary } from "@/i18n/dictionary.mjs";
+import { errorText } from "@/i18n/error-text.mjs";
 
 const STATUS_COLORS: Record<string, string> = {
   requested: "text-amber-600 bg-amber-50 border-amber-200",
@@ -131,11 +132,19 @@ export default function CreditsPage() {
           <h2 className="font-semibold text-gray-700 text-sm">{t.creditsPage.balanceTitle}</h2>
         </div>
         <div className="p-5">
-          {creditsPhase === "loading" && (
+          {(creditsPhase === "loading" || (creditsPhase === "idle" && userKey)) && (
             <p className="text-sm text-gray-400">{t.creditsPage.loading}</p>
           )}
+          {creditsPhase === "idle" && !userKey && (
+            <p className="text-sm text-gray-400">{t.creditsPage.signInToView}</p>
+          )}
           {creditsPhase === "error" && (
-            <p className="text-sm text-red-500">{creditsError}</p>
+            <div className="space-y-2">
+              <p className="text-sm text-red-500">{errorText(t, creditsError, "loadFailed")}</p>
+              <button onClick={() => void loadCredits()} className="btn btn-sm btn-secondary">
+                {t.common.retry}
+              </button>
+            </div>
           )}
           {creditsPhase === "done" && credits && (
             <div className="space-y-4">
@@ -243,7 +252,7 @@ export default function CreditsPage() {
               </div>
 
               {submitPhase === "error" && (
-                <p className="text-sm text-red-500">{submitError}</p>
+                <p className="text-sm text-red-500">{errorText(t, submitError, "saveFailed")}</p>
               )}
 
               <button
@@ -272,6 +281,14 @@ export default function CreditsPage() {
         <div className="p-5">
           {requestsPhase === "loading" && (
             <p className="text-sm text-gray-400">{t.creditsPage.loading}</p>
+          )}
+          {requestsPhase === "error" && (
+            <div className="space-y-2">
+              <p className="text-sm text-red-500">{t.errors.loadFailed}</p>
+              <button onClick={() => void loadRequests()} className="btn btn-sm btn-secondary">
+                {t.common.retry}
+              </button>
+            </div>
           )}
           {requestsPhase === "done" && requests.length === 0 && (
             <p className="text-sm text-gray-400">{t.creditsPage.noRequests}</p>

--- a/apps/dashboard/src/app/projects/[id]/github/history/[runId]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/history/[runId]/page.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/lib/review-run-comparison.mjs";
 import type { ReviewRunComparison, ReviewRunComparisonItem } from "@/lib/review-run-comparison.mjs";
 import { useI18n } from "@/i18n/I18nProvider";
+import { errorText } from "@/i18n/error-text.mjs";
 import { statusLabel } from "@/i18n/dictionary.mjs";
 import type { Dictionary, Locale } from "@/i18n/dictionary.mjs";
 
@@ -859,7 +860,7 @@ function ReviewItemSelectionPanel({
 function RerunPanel({
   projectId, prNumber, runId, userKey, selectedItemIds,
 }: { projectId: string; prNumber: number; runId: string; userKey: string; selectedItemIds: string[] }) {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const [phase, setPhase] = useState<"idle" | "running" | "done" | "error">("idle");
   const [newRunId, setNewRunId] = useState<string | null>(null);
   const [comparison, setComparison] = useState<SpecificRunComparison | null>(null);
@@ -881,9 +882,10 @@ function RerunPanel({
       rerunOfReviewRunId: runId,
       selectedItemIds,
       idempotencyKey,
+      locale,
     });
     if (!res.ok) {
-      setErrorMsg(res.error ?? t.runDetail.reviewFailed);
+      setErrorMsg(errorText(t, res.error, "generic"));
       setPhase("error");
       return;
     }

--- a/apps/dashboard/src/app/projects/[id]/github/history/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/history/page.tsx
@@ -81,6 +81,7 @@ function QuickRerun({
   userKey: string;
 }) {
   const router = useRouter();
+  const { locale } = useI18n();
   const [phase, setPhase] = useState<"idle" | "running" | "error">("idle");
 
   const enabled = (rerunAction?.recommendedItemCount ?? 0) > 0;
@@ -96,6 +97,7 @@ function QuickRerun({
       selectedItemIds: recommendedItemIds,
       rerunOfReviewRunId: runId,
       idempotencyKey,
+      locale,
     });
     if (!res.ok) {
       setPhase("error");

--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -35,6 +35,7 @@ import { StatusBadge } from "@/components/StatusBadge";
 import { StatusText } from "@/components/StatusText";
 import { useI18n } from "@/i18n/I18nProvider";
 import { statusLabel } from "@/i18n/dictionary.mjs";
+import { errorText } from "@/i18n/error-text.mjs";
 import type { Dictionary } from "@/i18n/dictionary.mjs";
 import type { ItemStatus } from "@/lib/labels";
 
@@ -172,6 +173,7 @@ export default function GitHubPage() {
       items,
       productSpec,
       idempotencyKey,
+      locale,
     });
     if (res.ok) {
       setReviewRuns((prev) => ({ ...prev, [lp.number]: res.run }));
@@ -665,7 +667,7 @@ function PRCommentPanel({
       setPreviewPhase("done");
     } else {
       setPreviewPhase("error");
-      setErrorMsg(res.message ?? res.error ?? t.comment.previewError);
+      setErrorMsg(res.message ?? errorText(t, res.error, "generic"));
     }
   }
 
@@ -690,7 +692,7 @@ function PRCommentPanel({
       if (res.error === "github_scope_required") {
         setScopeError(true);
       }
-      setErrorMsg(res.message ?? res.error ?? t.comment.postError);
+      setErrorMsg(res.message ?? errorText(t, res.error, "generic"));
     }
   }
 
@@ -1049,7 +1051,7 @@ function FixBriefPanel({
 
       {/* Error */}
       {phase === "error" && result && !result.ok && (
-        <p className="text-xs text-red-500">{result.error}</p>
+        <p className="text-xs text-red-500">{errorText(t, result.error, "generic")}</p>
       )}
 
       {/* Result */}

--- a/apps/dashboard/src/app/projects/[id]/settings/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/settings/page.tsx
@@ -61,7 +61,7 @@ export default function SettingsPage() {
   const [tgTestPhase, setTgTestPhase] = useState<"idle" | "sending" | "sent" | "error">("idle");
   const [tgTestError, setTgTestError] = useState("");
   const [notifications, setNotifications] = useState<NotificationRecord[]>([]);
-  const [notifPhase, setNotifPhase] = useState<"idle" | "loading" | "done">("idle");
+  const [notifPhase, setNotifPhase] = useState<"idle" | "loading" | "done" | "error">("idle");
 
   // Email notification state (simple default alternative to Telegram)
   const [emSettings, setEmSettings] = useState<NotificationSettings | null>(null);
@@ -105,8 +105,12 @@ export default function SettingsPage() {
   const loadNotifications = useCallback(async () => {
     setNotifPhase("loading");
     const res = await fetchNotifications(userKey);
-    if (res.ok) setNotifications(res.notifications);
-    setNotifPhase("done");
+    if (res.ok) {
+      setNotifications(res.notifications);
+      setNotifPhase("done");
+    } else {
+      setNotifPhase("error");
+    }
   }, [userKey]);
 
   async function handleSaveTgSettings() {
@@ -417,7 +421,7 @@ export default function SettingsPage() {
                   {linkedRepo.fullName}
                 </a>
                 {linkedRepo.private && (
-                  <span className="rounded bg-gray-200 px-1.5 py-0.5 text-xs text-gray-400">private</span>
+                  <span className="rounded bg-gray-200 px-1.5 py-0.5 text-xs text-gray-400">{t.github.statePrivate}</span>
                 )}
                 {linkedRepo.defaultBranch && (
                   <span className="text-xs text-gray-400">→ {linkedRepo.defaultBranch}</span>
@@ -693,6 +697,15 @@ export default function SettingsPage() {
         </div>
 
         {notifPhase === "loading" && <p className="text-xs text-gray-400">{t.common.loading}</p>}
+
+        {notifPhase === "error" && (
+          <div className="flex items-center gap-3">
+            <p className="text-xs text-red-500">{t.errors.loadFailed}</p>
+            <button onClick={() => void loadNotifications()} className="btn btn-sm btn-secondary">
+              {t.common.retry}
+            </button>
+          </div>
+        )}
 
         {notifPhase === "done" && notifications.length === 0 && (
           <p className="text-xs text-gray-400">{t.telegram.noHistory}</p>

--- a/apps/dashboard/src/app/projects/page.tsx
+++ b/apps/dashboard/src/app/projects/page.tsx
@@ -12,9 +12,14 @@ import type { Dictionary } from "@/i18n/dictionary.mjs";
 export default function ProjectsPage() {
   const { t } = useI18n();
   const [localProjects, setLocalProjects] = useState<Project[]>([]);
+  // Guard the one-frame empty-state flash: localProjects starts [] and only
+  // fills after this effect runs, so a returning user would briefly see the
+  // "no projects yet" card before their projects hydrate in.
+  const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
     setLocalProjects(loadLocalProjects());
+    setHydrated(true);
   }, []);
 
   return (
@@ -24,7 +29,13 @@ export default function ProjectsPage() {
         <p className="mt-1 text-sm text-gray-500">{t.projects.homeSubtitle}</p>
       </div>
 
-      {localProjects.length === 0 ? (
+      {!hydrated ? (
+        <div className="grid gap-4">
+          {[0, 1].map((i) => (
+            <div key={i} className="h-28 animate-pulse rounded-xl border border-gray-100 bg-gray-50" />
+          ))}
+        </div>
+      ) : localProjects.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 bg-white px-6 py-16 text-center">
           <h2 className="text-base font-semibold text-gray-900">{t.projects.emptyTitle}</h2>
           <p className="mx-auto mt-2 max-w-md text-sm text-gray-500">{t.projects.emptyBody}</p>

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -157,6 +157,21 @@ export type Dictionary = {
     more: string;
     rateLimited: string;
   };
+  errors: {
+    generic: string;
+    network: string;
+    timeout: string;
+    server: string;
+    unauthorized: string;
+    notFound: string;
+    rateLimited: string;
+    insufficientCredits: string;
+    githubScopeRequired: string;
+    prNotFound: string;
+    deliveryFailed: string;
+    saveFailed: string;
+    loadFailed: string;
+  };
   overview: {
     specCompleteness: string;
     resultsSummary: string;
@@ -309,6 +324,7 @@ export type Dictionary = {
     footer: string;
     unknownError: string;
     requestFailed: string;
+    signInToView: string;
     statusRequested: string;
     statusFulfilled: string;
     statusRejected: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -208,6 +208,24 @@ const EN = {
     more: "more",
     rateLimited: "Too many requests. Please wait a moment and try again.",
   },
+  // Friendly, localized messages for backend error codes. Non-developers must
+  // never see a raw code like "db_error" or "HTTP 500". Map at the render site
+  // via errorText(t, code); unknown codes fall back to `generic`.
+  errors: {
+    generic: "Something went wrong. Please try again.",
+    network: "Couldn't reach the server. Check your connection and try again.",
+    timeout: "This is taking longer than expected. Please try again.",
+    server: "The server had a problem. Please try again in a moment.",
+    unauthorized: "Please sign in again to continue.",
+    notFound: "We couldn't find what you were looking for.",
+    rateLimited: "Too many requests. Please wait a moment and try again.",
+    insufficientCredits: "You've used your free reviews for this month. Add credits to keep going.",
+    githubScopeRequired: "We need permission to post to GitHub. Reconnect GitHub and try again.",
+    prNotFound: "We couldn't find that pull request. It may have been closed or renamed.",
+    deliveryFailed: "Delivery failed. Please check the settings and try again.",
+    saveFailed: "Couldn't save. Please try again.",
+    loadFailed: "Couldn't load this. Please try again.",
+  },
   overview: {
     specCompleteness: "Product brief completeness",
     resultsSummary: "Review summary",
@@ -369,6 +387,7 @@ const EN = {
     footer: "After you request a top-up, an admin reviews and grants it. During beta, this is handled manually with no payment.",
     unknownError: "Unknown error",
     requestFailed: "Request failed",
+    signInToView: "Sign in to view your balance.",
     statusRequested: "Requested",
     statusFulfilled: "Granted",
     statusRejected: "Rejected",
@@ -1452,10 +1471,6 @@ const EN = {
     timelineOpen: "Open",
     timelineTruncated: "Timeline truncated",
   },
-  errors: {
-    generic: "Something went wrong. Please try again.",
-    loadFailed: "Could not load. Please try again.",
-  },
   // Stage 159 — MCP handoff/intake destination (the page the MCP handoff link opens).
   intake: {
     handoff: {
@@ -2171,6 +2186,21 @@ const KO = {
     more: "개 더",
     rateLimited: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
   },
+  errors: {
+    generic: "문제가 발생했어요. 잠시 후 다시 시도해주세요.",
+    network: "서버에 연결하지 못했어요. 인터넷 연결을 확인하고 다시 시도해주세요.",
+    timeout: "시간이 조금 오래 걸리고 있어요. 다시 시도해주세요.",
+    server: "서버에 문제가 있었어요. 잠시 후 다시 시도해주세요.",
+    unauthorized: "계속하려면 다시 로그인해주세요.",
+    notFound: "찾으시는 항목을 찾을 수 없었어요.",
+    rateLimited: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
+    insufficientCredits: "이번 달 무료 확인 횟수를 모두 사용했어요. 크레딧을 충전하면 계속 이용할 수 있어요.",
+    githubScopeRequired: "GitHub에 게시하려면 권한이 필요해요. GitHub를 다시 연결하고 시도해주세요.",
+    prNotFound: "해당 PR을 찾을 수 없었어요. 닫혔거나 이름이 바뀌었을 수 있어요.",
+    deliveryFailed: "전송에 실패했어요. 설정을 확인하고 다시 시도해주세요.",
+    saveFailed: "저장하지 못했어요. 다시 시도해주세요.",
+    loadFailed: "불러오지 못했어요. 다시 시도해주세요.",
+  },
   overview: {
     specCompleteness: "제품 설명서 완성도",
     resultsSummary: "확인 결과 요약",
@@ -2332,6 +2362,7 @@ const KO = {
     footer: "크레딧 충전 요청 후 관리자가 확인하면 지급됩니다. 현재는 결제 없이 관리자가 수동으로 처리합니다.",
     unknownError: "알 수 없는 오류",
     requestFailed: "요청 실패",
+    signInToView: "잔액을 보려면 로그인해주세요.",
     statusRequested: "요청됨",
     statusFulfilled: "지급됨",
     statusRejected: "거절됨",
@@ -3407,10 +3438,6 @@ const KO = {
     timelineImpactInconclusive: "영향 판단 불가",
     timelineOpen: "열기",
     timelineTruncated: "타임라인이 일부만 표시됩니다",
-  },
-  errors: {
-    generic: "문제가 발생했어요. 다시 시도해주세요.",
-    loadFailed: "불러오지 못했어요. 다시 시도해주세요.",
   },
   // Stage 159 — MCP 핸드오프/인테이크 도착 화면. Product term은 영어 유지 + 한국어 보조.
   intake: {

--- a/apps/dashboard/src/i18n/error-text.d.mts
+++ b/apps/dashboard/src/i18n/error-text.d.mts
@@ -1,0 +1,11 @@
+import type { Dictionary } from "./dictionary.d.mts";
+
+/**
+ * Map a raw backend error code / message to a friendly localized string.
+ * Unknown codes fall back to `t.errors[fallbackKey]` (default "generic").
+ */
+export function errorText(
+  t: Dictionary,
+  codeOrMessage: string | null | undefined,
+  fallbackKey?: keyof Dictionary["errors"],
+): string;

--- a/apps/dashboard/src/i18n/error-text.mjs
+++ b/apps/dashboard/src/i18n/error-text.mjs
@@ -1,0 +1,72 @@
+/**
+ * error-text.mjs — map a raw backend error code / message to a friendly,
+ * localized string. Non-developers must never read "db_error", "HTTP 500",
+ * "fetch_failed", or a raw exception. Call at the render site:
+ *
+ *   {creditsError && <p>{errorText(t, creditsError)}</p>}
+ *
+ * Unknown codes fall back to `t.errors.generic` (or an explicit fallback key),
+ * so a new server code degrades gracefully instead of leaking.
+ */
+
+/**
+ * Known backend error codes → t.errors.* key. Keep the codes lowercase; the
+ * matcher lowercases the input. HTTP status shapes (HTTP 5xx / 4xx) and
+ * timeouts are handled heuristically below.
+ */
+const CODE_TO_KEY = {
+  rate_limited: "rateLimited",
+  ratelimited: "rateLimited",
+  insufficient_credits: "insufficientCredits",
+  github_scope_required: "githubScopeRequired",
+  pr_not_found: "prNotFound",
+  not_found: "notFound",
+  project_not_found: "notFound",
+  unauthorized: "unauthorized",
+  unauthenticated: "unauthorized",
+  userkey_required: "unauthorized",
+  db_error: "server",
+  server_error: "server",
+  internal_error: "server",
+  fetch_failed: "network",
+  network: "network",
+  timeout: "timeout",
+  timed_out: "timeout",
+  invalid_email: "saveFailed",
+};
+
+/**
+ * @param {import("./dictionary.d.mts").Dictionary} t
+ * @param {string | null | undefined} codeOrMessage
+ * @param {keyof import("./dictionary.d.mts").Dictionary["errors"]} [fallbackKey]
+ * @returns {string}
+ */
+export function errorText(t, codeOrMessage, fallbackKey = "generic") {
+  const errors = t?.errors ?? {};
+  const fallback = errors[fallbackKey] ?? errors.generic ?? "Something went wrong.";
+  if (!codeOrMessage || typeof codeOrMessage !== "string") return fallback;
+
+  const raw = codeOrMessage.trim();
+  const lower = raw.toLowerCase();
+
+  // Exact known code.
+  if (CODE_TO_KEY[lower] && errors[CODE_TO_KEY[lower]]) return errors[CODE_TO_KEY[lower]];
+
+  // HTTP status shapes: "HTTP 500", "500", "http_502".
+  const httpMatch = lower.match(/\b(?:http[ _-]?)?(\d{3})\b/);
+  if (httpMatch) {
+    const status = Number(httpMatch[1]);
+    if (status === 401 || status === 403) return errors.unauthorized ?? fallback;
+    if (status === 404) return errors.notFound ?? fallback;
+    if (status === 408) return errors.timeout ?? fallback;
+    if (status === 429) return errors.rateLimited ?? fallback;
+    if (status >= 500) return errors.server ?? fallback;
+    if (status >= 400) return fallback;
+  }
+
+  // Substring hints for free-form messages / AbortError.
+  if (lower.includes("abort") || lower.includes("timeout")) return errors.timeout ?? fallback;
+  if (lower.includes("failed to fetch") || lower.includes("network")) return errors.network ?? fallback;
+
+  return fallback;
+}

--- a/apps/dashboard/src/lib/workspace-credits-api.ts
+++ b/apps/dashboard/src/lib/workspace-credits-api.ts
@@ -77,6 +77,7 @@ export async function fetchWorkspaceCredits(
 ): Promise<WorkspaceCreditsResponse> {
   const res = await fetch(
     `${BASE_URL}/workspace/credits?userKey=${encodeURIComponent(userKey)}`,
+    { signal: AbortSignal.timeout(8000) },
   );
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
@@ -92,6 +93,7 @@ export async function createTopUpRequest(
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(input),
+    signal: AbortSignal.timeout(15000),
   });
   const body = await res.json();
   if (!res.ok) {
@@ -109,6 +111,7 @@ export async function fetchTopUpRequests(
 ): Promise<TopUpRequest[]> {
   const res = await fetch(
     `${BASE_URL}/workspace/credits/top-up-requests?userKey=${encodeURIComponent(userKey)}`,
+    { signal: AbortSignal.timeout(8000) },
   );
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));

--- a/apps/dashboard/src/lib/workspace-github-api.ts
+++ b/apps/dashboard/src/lib/workspace-github-api.ts
@@ -433,6 +433,7 @@ export async function startPRReview(
     productSpec?: ProductSpec;
     idempotencyKey?: string;
     rerunOfReviewRunId?: string;
+    locale?: "en" | "ko";
   },
 ): Promise<StartReviewResponse> {
   try {

--- a/apps/dashboard/test/error-text.test.mjs
+++ b/apps/dashboard/test/error-text.test.mjs
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { errorText } from "../src/i18n/error-text.mjs";
+import { DICTIONARIES } from "../src/i18n/dictionary.mjs";
+
+const en = DICTIONARIES.en;
+const ko = DICTIONARIES.ko;
+
+test("maps known codes to localized copy (never the raw code)", () => {
+  assert.equal(errorText(en, "insufficient_credits"), en.errors.insufficientCredits);
+  assert.equal(errorText(ko, "insufficient_credits"), ko.errors.insufficientCredits);
+  assert.equal(errorText(en, "rate_limited"), en.errors.rateLimited);
+  assert.equal(errorText(en, "github_scope_required"), en.errors.githubScopeRequired);
+  assert.equal(errorText(en, "db_error"), en.errors.server);
+  assert.equal(errorText(en, "fetch_failed"), en.errors.network);
+});
+
+test("maps HTTP status shapes", () => {
+  assert.equal(errorText(en, "HTTP 500"), en.errors.server);
+  assert.equal(errorText(en, "HTTP 404"), en.errors.notFound);
+  assert.equal(errorText(en, "HTTP 401"), en.errors.unauthorized);
+  assert.equal(errorText(en, "429"), en.errors.rateLimited);
+});
+
+test("timeout / abort / network hints", () => {
+  assert.equal(errorText(en, "The operation was aborted"), en.errors.timeout);
+  assert.equal(errorText(en, "Failed to fetch"), en.errors.network);
+});
+
+test("unknown code falls back to generic (or explicit fallback)", () => {
+  assert.equal(errorText(en, "some_unknown_code"), en.errors.generic);
+  assert.equal(errorText(en, "some_unknown_code", "loadFailed"), en.errors.loadFailed);
+  assert.equal(errorText(en, "some_unknown_code", "saveFailed"), en.errors.saveFailed);
+});
+
+test("empty / non-string input → fallback, never throws", () => {
+  assert.equal(errorText(en, null), en.errors.generic);
+  assert.equal(errorText(en, undefined), en.errors.generic);
+  assert.equal(errorText(en, ""), en.errors.generic);
+  assert.equal(errorText(en, 500), en.errors.generic);
+});
+
+test("never returns the raw code for a known code", () => {
+  for (const code of ["insufficient_credits", "db_error", "HTTP 500", "fetch_failed"]) {
+    const out = errorText(ko, code);
+    assert.ok(!out.includes(code), `output must not contain raw code ${code}`);
+  }
+});


### PR DESCRIPTION
## Why

A proactive 3-pass audit (i18n coverage, broken/dead-end flows, empty/loading/error states) converged on one launch theme for the **Korean non-developer** audience: a non-dev must never see (a) a raw error code, (b) an English answer while the UI is in Korean, or (c) a blank "is it broken?" screen. This PR closes the launch-blocking instances of all three.

## What

**Error surface — raw codes → friendly localized copy**
- New `t.errors.*` namespace (EN+KO) + `errorText(t, code)` helper (`.mjs`/`.d.mts`, unit-tested): maps `insufficient_credits` / `db_error` / `HTTP 500` / `fetch_failed` / `github_scope_required` / … to friendly copy; unknown codes fall back to generic (never leak). Merged the two pre-existing sparse `errors` blocks in.
- Applied at every raw-error render site: credits (balance + top-up), github fix-brief, github comment preview/post, run-detail re-check.

**State handling — "error rendered as empty" / infinite spinner**
- Credits: request-history + balance get error branches with retry; neutral "sign in to view" for missing userKey; 8s/15s fetch timeouts on the credits API (was: hang forever on a stalled request).
- Settings notifications: added an error phase (was: a failed load rendered "no notifications yet").
- Projects list: hydration guard removes the one-frame empty-state flash returning users saw.

**Review findings follow the user's language** (the biggest content gap)
- `buildReviewPrompt` output directive + the heuristic fallback (`HEURISTIC_COPY` EN/KO) are now locale-aware; the review endpoint parses `locale`; `startPRReview` sends it from all 3 call sites. `reason` / `evidence` / `nextAction` now return in EN or KO to match the UI (previously always Korean).

**i18n quick win**: settings "private" badge → `t.github.statePrivate`.

## Verification
- central-plane **1522** pass, dashboard **383** pass (+7 new: errorText 6, review-locale 1).
- typecheck + i18n parity + lint green.

## Deferred (documented follow-up — the remaining content-localization gate)
- The **deterministic content builders** — fix-brief body + intake preview region (`packages/workspace-preview/intake-*.mjs`) and the intake enum label-maps — are still English-only regardless of locale.
- The silent project DB-save fallback (localStorage-only on sync failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
