### PR TITLE
STEP 1: P1 envelope schema in R2 training record (schema_version 2.0)

### DIFF
--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -954,6 +954,9 @@ export function createWorkspaceGitHubRoutes(
     // 9c. Capture the raw training triplet (diff + council verdict) for a future
     // fine-tune / distillation. Opt-in only: no-op without active consent or an
     // EVIDENCE bucket, and never throws (best-effort telemetry).
+    // region from the edge (Cloudflare adds request.cf.country — coarse, not PII);
+    // locale from the review request. Other envelope tags land in STEP 2/3.
+    const cfCountry = (c.req.raw as { cf?: { country?: string } }).cf?.country ?? null;
     await captureTrainingRecord(c.env, {
       userKey,
       projectId,
@@ -967,6 +970,10 @@ export function createWorkspaceGitHubRoutes(
       review: reviewResult,
       finalStatus,
       rerunOfReviewRunId,
+      envelope: {
+        region: cfCountry,
+        locale: reviewLocale,
+      },
     }).catch(() => {});
 
     // 10. Telegram notification (non-blocking: failure must not fail the review response)

--- a/apps/central-plane/src/workspace/training-store.ts
+++ b/apps/central-plane/src/workspace/training-store.ts
@@ -31,7 +31,57 @@ import { redactSecrets } from "@simsa/secret-guard";
 import { sha256Hex } from "../util.js";
 import { TRAINING_CONSENT_VERSION, hasActiveTrainingConsent } from "./training-consent-db.js";
 
-export const TRAINING_SCHEMA_VERSION = 1;
+// 2.0 — the P1 envelope (region/locale/entry_path/built_with/topic_tags/
+// acquisition/user_context/commercial + reserved P2/P3 slots). All new fields
+// are nullable; schema_version tracks when each began to be filled.
+export const TRAINING_SCHEMA_VERSION = "2.0";
+
+/** builtWith tag — which AI tool(s) produced the code (per-agent moat axis). */
+export type BuiltWithTag = {
+  tools?: string[];
+  primary?: string | null;
+  other?: string | null;
+  modelNote?: string | null; // P2
+  tool_versions?: unknown; // P3 slot
+} | null;
+
+/** LLM-classified topic tags (market map). */
+export type TopicTags = {
+  domain?: string | null;
+  pattern?: string | null;
+  integrations?: string[];
+  ai_feature?: string | null;
+} | null;
+
+/** Where the user came from + how (P1 source; campaign/referrer are P2). */
+export type AcquisitionTag = {
+  source?: string | null;
+  campaign?: string | null; // P2
+  referrer_hash?: string | null; // P2
+} | null;
+
+/** User-context signals for retention/skill analysis. */
+export type UserContextTag = {
+  skill_signal?: string | null; // "first_project" | "returning"
+  session_seq?: number | null;
+  project_seq?: number | null;
+} | null;
+
+/** Envelope tags captured at review time. All optional — null slot if no source yet. */
+export type EnvelopeInput = {
+  /** sha256(workspaceId) — team/personal split. */
+  workspaceHash?: string | null;
+  region?: string | null; // ISO-3166, IP-based
+  locale?: string | null; // BCP-47 UI language
+  contentLang?: string | null; // detected input language
+  entryPath?: "idea" | "code" | "spec" | null;
+  builtWith?: BuiltWithTag;
+  topicTags?: TopicTags;
+  acquisition?: AcquisitionTag;
+  userContext?: UserContextTag;
+  /** Tier AT CAPTURE — never join the current tier (would corrupt past rows). */
+  planTier?: string | null;
+};
 
 /**
  * Scrub secrets out of arbitrary free text before it is persisted. Non-dev
@@ -93,6 +143,8 @@ export type CaptureTrainingInput = {
   };
   finalStatus: string;
   rerunOfReviewRunId?: string;
+  /** P1 envelope tags (all optional; unsourced ones stored as null). */
+  envelope?: EnvelopeInput;
   /** Injected clock for tests; defaults to real time. */
   now?: string;
   /** Injected subject hash for tests; defaults to sha256(userKey). */
@@ -105,10 +157,12 @@ export type CaptureTrainingInput = {
  * OUTCOME (reward — pending until a later poll fills it).
  */
 export type TrainingRecord = {
-  schema_version: number;
+  // ── identity ──
+  event_id: string;
   captured_at: string;
-  // identity + provenance (no raw handle)
-  subject_hash: string;
+  schema_version: string;
+  subject_hash: string; // sha256(userKey) — no raw handle
+  workspace_hash: string | null; // sha256(workspaceId) — P1, null until sourced
   consent_version: string;
   project_id: string;
   review_run_id: string;
@@ -116,17 +170,41 @@ export type TrainingRecord = {
   repo_full_name: string;
   pr_number: number;
   head_sha: string;
-  // INPUT
+  // ── global dimension (P1; timezone P2) ──
+  region: string | null;
+  locale: string | null;
+  content_lang: string | null;
+  timezone: string | null;
+  // ── entry / tool dimension (P1) ──
+  entry_path: "idea" | "code" | "spec" | null;
+  built_with: BuiltWithTag;
+  // ── topic dimension (P1) ──
+  topic_tags: TopicTags;
+  // ── acquisition dimension (P1 source) ──
+  acquisition: AcquisitionTag;
+  // ── user-context dimension (P1) ──
+  user_context: UserContextTag;
+  // ── commercial dimension (P1 — tier at capture, never joined) ──
+  commercial: { plan_tier: string | null; plan_at_capture: unknown };
+  // ── event body ──
+  event_type: "pr_reviewed" | "pr_rechecked";
+  payload_scrub_state: "clean" | "metadata_only" | "raw_pending";
+  // ── INPUT (the crude oil, scrubbed) ──
   product_spec: unknown;
   acceptance_items: unknown[];
   pr_files: TrainingPrFile[];
-  // LABEL (council verdict)
+  // ── LABEL (council verdict) ──
   review_source: string;
   results: TrainingResultItem[];
   summary: { passed: number; failed: number; inconclusive: number; needsDecision: number };
   final_status: string;
-  // OUTCOME (reward signal)
-  outcome: "pending";
+  // ── OUTCOME (reward — pending until the STEP-4 poll fills it) ──
+  outcome: "pending" | "resolved" | "unresolved" | "merged" | "rejected";
+  // ── reserved future slots (P3; null now) ──
+  device_context: unknown;
+  experiment_arm: string | null;
+  quality_signals: unknown;
+  cost_meta: unknown;
 };
 
 /**
@@ -138,10 +216,14 @@ export function buildTrainingRecord(
   subjectHash: string,
   capturedAt: string,
 ): TrainingRecord {
+  const env = input.envelope ?? {};
   return {
-    schema_version: TRAINING_SCHEMA_VERSION,
+    // identity
+    event_id: input.reviewRunId,
     captured_at: capturedAt,
+    schema_version: TRAINING_SCHEMA_VERSION,
     subject_hash: subjectHash,
+    workspace_hash: env.workspaceHash ?? null,
     consent_version: TRAINING_CONSENT_VERSION,
     project_id: input.projectId,
     review_run_id: input.reviewRunId,
@@ -149,8 +231,26 @@ export function buildTrainingRecord(
     repo_full_name: input.repoFullName,
     pr_number: input.prNumber,
     head_sha: input.headSha ?? "",
-    // Secret-scrub every user-authored surface before it lands in R2. A
-    // vibe-coder's diff or spec routinely contains live keys / .env values.
+    // global
+    region: env.region ?? null,
+    locale: env.locale ?? null,
+    content_lang: env.contentLang ?? null,
+    timezone: null,
+    // entry / tool — built_with freetext scrubbed (the "other" field is arbitrary)
+    entry_path: env.entryPath ?? null,
+    built_with: (env.builtWith ? scrubJson(env.builtWith) : null) as BuiltWithTag,
+    // topic
+    topic_tags: env.topicTags ?? null,
+    // acquisition
+    acquisition: env.acquisition ?? null,
+    // user context
+    user_context: env.userContext ?? null,
+    // commercial — plan_tier is the value AT CAPTURE (never re-joined)
+    commercial: { plan_tier: env.planTier ?? null, plan_at_capture: null },
+    // event body
+    event_type: input.rerunOfReviewRunId ? "pr_rechecked" : "pr_reviewed",
+    payload_scrub_state: "clean", // code-based review payload → redactSecrets applied
+    // INPUT — secret-scrub every user-authored surface before it lands in R2.
     product_spec: scrubJson(input.productSpec),
     acceptance_items: Array.isArray(input.items)
       ? (scrubJson(input.items) as unknown[])
@@ -159,24 +259,31 @@ export function buildTrainingRecord(
       ...f,
       ...(f.patch ? { patch: scrubText(f.patch) } : {}),
     })),
+    // LABEL — the verdict reason could quote a secret line from the diff.
     review_source: input.review.source,
-    // The verdict text (reason) could quote a secret line from the diff.
-    // Scrubbing only rewrites exact key-shaped matches, so the label is
-    // otherwise untouched.
     results: scrubJson(input.review.results) as TrainingResultItem[],
     summary: input.review.summary,
     final_status: input.finalStatus,
     outcome: "pending",
+    // reserved P3 slots
+    device_context: null,
+    experiment_arm: null,
+    quality_signals: null,
+    cost_meta: null,
   };
 }
 
-/** R2 object key. Day-bucketed so the store is browsable and cheap to sweep. */
-export function trainingRecordKey(capturedAt: string, reviewRunId: string): string {
-  // capturedAt is an ISO string; slice the date without constructing a Date
-  // (keeps this pure and TZ-free).
+/**
+ * R2 object key. Region-partitioned then day-bucketed:
+ * `events/{region}/YYYY/MM/DD/<eventId>.json`. Region enables per-country
+ * analysis (the moat's global axis) without scanning; unknown region → "unknown".
+ */
+export function trainingRecordKey(capturedAt: string, eventId: string, region?: string | null): string {
   const day = capturedAt.slice(0, 10); // YYYY-MM-DD
   const [y, m, d] = day.split("-");
-  return `training/${y}/${m}/${d}/${reviewRunId}.json`;
+  const safeRegion = (region ?? "unknown").replace(/[^A-Za-z0-9_-]/g, "").slice(0, 12) || "unknown";
+  const safeEvent = eventId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 80);
+  return `events/${safeRegion}/${y}/${m}/${d}/${safeEvent}.json`;
 }
 
 export type CaptureResult =
@@ -201,7 +308,7 @@ export async function captureTrainingRecord(
     const capturedAt = input.now ?? new Date().toISOString();
     const subjectHash = input.subjectHash ?? (await sha256Hex(input.userKey));
     const record = buildTrainingRecord(input, subjectHash, capturedAt);
-    const key = trainingRecordKey(capturedAt, input.reviewRunId);
+    const key = trainingRecordKey(capturedAt, input.reviewRunId, input.envelope?.region);
     await env.EVIDENCE.put(key, JSON.stringify(record), {
       httpMetadata: { contentType: "application/json" },
     });

--- a/apps/central-plane/test/training-store.test.mjs
+++ b/apps/central-plane/test/training-store.test.mjs
@@ -85,11 +85,60 @@ test("buildTrainingRecord: stable shape, deterministic, pending outcome", () => 
   assert.deepEqual(rec.summary, { passed: 1, failed: 0, inconclusive: 0, needsDecision: 0 });
 });
 
-test("trainingRecordKey is day-bucketed", () => {
+test("trainingRecordKey is region-partitioned + day-bucketed", () => {
+  assert.equal(
+    trainingRecordKey("2026-07-03T12:34:56.000Z", "run_1", "KR"),
+    "events/KR/2026/07/03/run_1.json",
+  );
+  // no region → "unknown"
   assert.equal(
     trainingRecordKey("2026-07-03T12:34:56.000Z", "run_1"),
-    "training/2026/07/03/run_1.json",
+    "events/unknown/2026/07/03/run_1.json",
   );
+});
+
+test("STEP1 수집≠저장: stored R2 payload has ALL P1 envelope keys (null ok)", async () => {
+  const r2 = new FakeR2();
+  const env = { DB: dbWithConsent({ consented: true, version: TRAINING_CONSENT_VERSION }), EVIDENCE: r2 };
+  await captureTrainingRecord(env, baseInput());
+  const rec = JSON.parse(r2.puts[0].value); // the ACTUAL stored JSON, not the input
+  for (const key of [
+    "event_id", "schema_version", "subject_hash", "workspace_hash", "consent_version",
+    "region", "locale", "content_lang", "timezone",
+    "entry_path", "built_with", "topic_tags", "acquisition", "user_context", "commercial",
+    "event_type", "payload_scrub_state", "outcome",
+    "device_context", "experiment_arm", "quality_signals", "cost_meta",
+  ]) {
+    assert.ok(key in rec, `P1 envelope key "${key}" must exist in the stored R2 record`);
+  }
+  assert.equal(rec.schema_version, "2.0");
+  assert.equal(rec.event_type, "pr_reviewed");
+  assert.equal(rec.payload_scrub_state, "clean");
+  assert.ok("plan_tier" in rec.commercial, "commercial.plan_tier slot must exist");
+});
+
+test("STEP1: envelope values actually flow into the stored record", async () => {
+  const r2 = new FakeR2();
+  const env = { DB: dbWithConsent({ consented: true, version: TRAINING_CONSENT_VERSION }), EVIDENCE: r2 };
+  await captureTrainingRecord(env, {
+    ...baseInput(),
+    rerunOfReviewRunId: "prev_run",
+    envelope: {
+      region: "KR", locale: "ko", contentLang: "ko", entryPath: "code",
+      builtWith: { tools: ["cursor"], primary: "cursor" },
+      planTier: "free_beta",
+      userContext: { skill_signal: "first_project", session_seq: 3, project_seq: 1 },
+    },
+  });
+  assert.equal(r2.puts[0].key, "events/KR/2026/07/03/run_1.json");
+  const rec = JSON.parse(r2.puts[0].value);
+  assert.equal(rec.region, "KR");
+  assert.equal(rec.locale, "ko");
+  assert.equal(rec.entry_path, "code");
+  assert.deepEqual(rec.built_with, { tools: ["cursor"], primary: "cursor" });
+  assert.equal(rec.commercial.plan_tier, "free_beta");
+  assert.equal(rec.event_type, "pr_rechecked"); // rerun → rechecked
+  assert.equal(rec.user_context.session_seq, 3);
 });
 
 test("no consent row → no-op, bucket untouched", async () => {
@@ -120,7 +169,7 @@ test("consent + bucket → stores at day-bucketed key", async () => {
   const env = { DB: dbWithConsent({ consented: true, version: TRAINING_CONSENT_VERSION }), EVIDENCE: r2 };
   const res = await captureTrainingRecord(env, baseInput());
   assert.equal(res.stored, true);
-  assert.equal(res.key, "training/2026/07/03/run_1.json");
+  assert.equal(res.key, "events/unknown/2026/07/03/run_1.json");
   assert.equal(r2.puts.length, 1);
   assert.equal(r2.puts[0].opts.httpMetadata.contentType, "application/json");
 });


### PR DESCRIPTION
## STEP 1 of 4 — the convergent open-blocker

Per the data-skeleton spec, the P1 work converges to one thing: **the P1 envelope tags must be on the R2 JSON that `captureTrainingRecord` writes, at capture time** — they can't be backfilled. Everything else (D1 index, aggregation, dashboards) is rebuildable from that R2 raw later. This PR adds the full envelope; unsourced fields are `null` now and fill in STEP 2/3 with **no schema change**.

## What

- `schema_version` `1` → **`"2.0"`**.
- Envelope fields added to the stored record (all nullable): `event_id`, `workspace_hash`, `region`, `locale`, `content_lang`, `timezone`, `entry_path`, `built_with`, `topic_tags`, `acquisition`, `user_context`, `commercial.plan_tier`, `event_type`, `payload_scrub_state`, + reserved P3 slots (`device_context`, `experiment_arm`, `quality_signals`, `cost_meta`).
- `CaptureTrainingInput.envelope` (optional) — STEP 2/3 pass tags without touching the schema.
- R2 key repartitioned: **`events/{region}/YYYY/MM/DD/<eventId>.json`** (region → `unknown` if absent).
- Wired now (trivially available): **region** (Cloudflare `request.cf.country` — coarse, not PII) + **locale** (review request). `event_type` derives `pr_reviewed` vs `pr_rechecked` from rerun lineage. Rest null this STEP.
- `commercial.plan_tier` = value **AT CAPTURE** (documented never-join, so past rows aren't corrupted by later tier changes).

## 수집 ≠ 저장 — proven by test
`STEP1 수집≠저장` reads the **actual stored R2 JSON** (`r2.puts[0].value`), not the input, and asserts every P1 envelope key exists (null ok). A second test asserts values flow (`region`/`locale`/`entry_path`/`built_with`/`plan_tier` land in the stored record; rerun → `pr_rechecked`; `events/KR/...` key).

## Regression held
Consent-OFF still no-ops (bucket untouched), secret-scrub still applied to `pr_files`/spec/results, never-throws intact.

## Verification
central-plane **1545** pass, typecheck green. (Remote CI green on this commit SHA to be confirmed before merge — per the #198 rule.)

## Note on #202
#202 (builtWith + journey) is **superseded** by this envelope standard — please **do not merge #202**. Its builtWith collection (intake question, migration, db) folds into STEP 2, aligned to `built_with`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
