### PR TITLE
STEP 3: topic_tags + remaining dims + assistance + cost_meta

### DIFF
--- a/apps/central-plane/migrations/0056_project_topic_acquisition.sql
+++ b/apps/central-plane/migrations/0056_project_topic_acquisition.sql
@@ -1,0 +1,10 @@
+-- 0056 — P1 envelope collection on the project: topic_tags + acquisition.
+--
+-- topic_tags: structured market-map classification (domain/pattern/integrations/
+-- ai_feature), computed at project creation from the idea/spec (deterministic).
+-- acquisition: where/how the user arrived (source), captured at creation.
+-- Both are capture-time tags copied onto every training record's envelope.
+-- JSON columns, 'null' default until sourced.
+
+ALTER TABLE workspace_projects ADD COLUMN topic_tags_json TEXT NOT NULL DEFAULT 'null';
+ALTER TABLE workspace_projects ADD COLUMN acquisition_json TEXT NOT NULL DEFAULT 'null';

--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -51,8 +51,10 @@ import {
 import { fetchPRFiles } from "../workspace/github-pr.js";
 import { reviewPRAgainstItems, deriveRunStatus } from "../workspace/pr-review.js";
 import { captureTrainingRecord } from "../workspace/training-store.js";
+import type { TopicTags, AcquisitionTag } from "../workspace/training-store.js";
 import { normalizeBuiltWith } from "../workspace/built-with.js";
-import { getProject, getOwnedProject } from "../workspace/db.js";
+import { detectContentLang } from "../workspace/topic-tags.js";
+import { getProject, getOwnedProject, listProjectsByUser } from "../workspace/db.js";
 import { consumeUserHourlyLimit, hourlyLimitFromEnv } from "../workspace/rate-limit.js";
 import type { CheckableItem, ProductSpecForCheck } from "../workspace/check.js";
 import { normalizeProductSpec, normalizeCheckableItems } from "../workspace/check.js";
@@ -964,6 +966,14 @@ export function createWorkspaceGitHubRoutes(
       projForTag?.entryPath === "idea" || projForTag?.entryPath === "code" || projForTag?.entryPath === "spec"
         ? projForTag.entryPath
         : null;
+    // STEP 3 dims: content_lang (detected from spec text), topic_tags + acquisition
+    // (from project), user_context (project_seq → skill_signal), plan_tier (beta),
+    // assistance (wild — no guided feature yet), cost_meta (usage measurement).
+    const specText = (() => {
+      try { return JSON.stringify(productSpec); } catch { return ""; }
+    })();
+    const projectCount = await listProjectsByUser(c.env, userKey, 200).then((r) => r.length).catch(() => null);
+    const usage = reviewResult.usage;
     await captureTrainingRecord(c.env, {
       userKey,
       projectId,
@@ -980,8 +990,21 @@ export function createWorkspaceGitHubRoutes(
       envelope: {
         region: cfCountry,
         locale: reviewLocale,
+        contentLang: detectContentLang(specText),
         builtWith: normalizeBuiltWith(projForTag?.builtWith),
         entryPath: projEntryPath,
+        topicTags: (projForTag?.topicTags as TopicTags) ?? null,
+        acquisition: (projForTag?.acquisition as AcquisitionTag) ?? null,
+        userContext: {
+          skill_signal: projectCount === null ? null : projectCount <= 1 ? "first_project" : "returning",
+          session_seq: null,
+          project_seq: projectCount,
+        },
+        planTier: "free_beta", // managed beta review path — value at capture
+        assistance: { mode: "wild", guided_at: null, guided_scope: null },
+        costMeta: usage
+          ? { tokens_consumed: usage.tokens_consumed, model_used: usage.model_used, review_count_in_session: null }
+          : null,
       },
     }).catch(() => {});
 

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -15,6 +15,7 @@ import type { Env } from "../env.js";
 import { ALLOWED_ORIGINS } from "./cors.js";
 import { generateIdeaToSpecDraft, type IdeaToSpecDraftRequest } from "../workspace/generate.js";
 import { normalizeBuiltWith } from "../workspace/built-with.js";
+import { classifyTopics } from "../workspace/topic-tags.js";
 import {
   generateCheckDraft,
   type WorkspaceCheckDraftRequest,
@@ -269,17 +270,28 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
         b["entryPath"] === "idea" || b["entryPath"] === "code" || b["entryPath"] === "spec"
           ? (b["entryPath"] as string)
           : null;
+      // topic_tags — deterministic classification of idea + spec (no LLM, no raw
+      // text stored; only structured tags). acquisition — where the user arrived.
+      const ideaText = typeof b["idea"] === "string" ? b["idea"] : "";
+      const topicTags = classifyTopics(`${ideaText} ${JSON.stringify(b["productSpec"] ?? {})}`);
+      const acqSource =
+        b["acquisition"] && typeof b["acquisition"] === "object"
+          ? (b["acquisition"] as Record<string, unknown>)["source"]
+          : b["acquisitionSource"];
+      const acquisition = { source: typeof acqSource === "string" ? acqSource.slice(0, 40) : "direct" };
       const id = await upsertProject(c.env, {
         id: typeof b["id"] === "string" ? b["id"] : undefined,
         userKey: String(b["userKey"]),
         title: String(b["title"]),
-        idea: typeof b["idea"] === "string" ? b["idea"] : "",
+        idea: ideaText,
         understood: b["understood"] ?? {},
         productSpec: b["productSpec"] ?? {},
         items: b["items"] ?? [],
         // P1 envelope collection — normalized so unknown tools fall into `other`.
         builtWith: normalizeBuiltWith(b["builtWith"]),
         entryPath,
+        topicTags,
+        acquisition,
       });
       return new Response(JSON.stringify({ ok: true, id }), { status: 200, headers: { "content-type": "application/json", ...headers } });
     } catch (err) {

--- a/apps/central-plane/src/workspace/db.ts
+++ b/apps/central-plane/src/workspace/db.ts
@@ -25,6 +25,10 @@ export type DbProject = {
   builtWith: unknown;
   /** entry_path — which branch the project entered through ("idea"|"code"|"spec"). */
   entryPath: string | null;
+  /** topic_tags — structured market-map classification (domain/pattern/…). */
+  topicTags: unknown;
+  /** acquisition — where/how the user arrived ({ source, ... }). */
+  acquisition: unknown;
   createdAt: string;
   updatedAt: string;
 };
@@ -60,6 +64,8 @@ export async function upsertProject(
     items: unknown;
     builtWith?: unknown;
     entryPath?: string | null;
+    topicTags?: unknown;
+    acquisition?: unknown;
   },
 ): Promise<string> {
   const id = input.id ?? randId("wsp");
@@ -70,8 +76,8 @@ export async function upsertProject(
   // clause is defense-in-depth for any other caller of this helper.
   await env.DB.prepare(
     `INSERT INTO workspace_projects
-       (id, user_key, title, idea, understood_json, product_spec_json, items_json, built_with_json, entry_path, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       (id, user_key, title, idea, understood_json, product_spec_json, items_json, built_with_json, entry_path, topic_tags_json, acquisition_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT (id) DO UPDATE SET
        title = excluded.title,
        idea = excluded.idea,
@@ -80,6 +86,8 @@ export async function upsertProject(
        items_json = excluded.items_json,
        built_with_json = excluded.built_with_json,
        entry_path = excluded.entry_path,
+       topic_tags_json = excluded.topic_tags_json,
+       acquisition_json = excluded.acquisition_json,
        updated_at = excluded.updated_at
      WHERE workspace_projects.user_key = excluded.user_key`,
   )
@@ -93,6 +101,8 @@ export async function upsertProject(
       JSON.stringify(input.items),
       JSON.stringify(input.builtWith ?? null),
       input.entryPath ?? null,
+      JSON.stringify(input.topicTags ?? null),
+      JSON.stringify(input.acquisition ?? null),
       now,
       now,
     )
@@ -102,7 +112,7 @@ export async function upsertProject(
 
 export async function getProject(env: Env, id: string): Promise<DbProject | null> {
   const row = await env.DB.prepare(
-    `SELECT id, user_key, title, idea, understood_json, product_spec_json, items_json, built_with_json, entry_path, created_at, updated_at
+    `SELECT id, user_key, title, idea, understood_json, product_spec_json, items_json, built_with_json, entry_path, topic_tags_json, acquisition_json, created_at, updated_at
      FROM workspace_projects WHERE id = ?`,
   )
     .bind(id)
@@ -116,6 +126,8 @@ export async function getProject(env: Env, id: string): Promise<DbProject | null
       items_json: string;
       built_with_json: string | null;
       entry_path: string | null;
+      topic_tags_json: string | null;
+      acquisition_json: string | null;
       created_at: string;
       updated_at: string;
     }>();
@@ -130,6 +142,8 @@ export async function getProject(env: Env, id: string): Promise<DbProject | null
     items: safeJson(row.items_json),
     builtWith: safeJson(row.built_with_json ?? "null"),
     entryPath: row.entry_path ?? null,
+    topicTags: safeJson(row.topic_tags_json ?? "null"),
+    acquisition: safeJson(row.acquisition_json ?? "null"),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/apps/central-plane/src/workspace/pr-review.ts
+++ b/apps/central-plane/src/workspace/pr-review.ts
@@ -32,7 +32,12 @@ export type PRReviewResponse = {
   };
   results: CheckResultItem[];
   warnings?: string[];
+  /** Usage measurement (cost_meta) — tokens + model. null on the heuristic path. */
+  usage?: { tokens_consumed: number | null; model_used: string | null };
 };
+
+/** The review model — surfaced for cost_meta.model_used. */
+export const REVIEW_MODEL = "claude-haiku-4-5-20251001";
 
 // ─── Prompt ───────────────────────────────────────────────────────────────────
 
@@ -99,7 +104,7 @@ async function callAnthropic(
   prompt: string,
   timeoutMs = 25000,
   fetchImpl: FetchLike = fetch.bind(globalThis) as FetchLike,
-): Promise<string> {
+): Promise<{ text: string; tokens: number | null }> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
   let resp: Response;
@@ -113,7 +118,7 @@ async function callAnthropic(
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        model: "claude-haiku-4-5-20251001",
+        model: REVIEW_MODEL,
         max_tokens: 6000,
         messages: [{ role: "user", content: prompt }],
       }),
@@ -125,8 +130,14 @@ async function callAnthropic(
     const tail = await resp.text().catch(() => "");
     throw new Error(`Anthropic ${resp.status}: ${tail.slice(0, 200)}`);
   }
-  const data = (await resp.json()) as { content?: Array<{ type: string; text?: string }> };
-  return (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
+  const data = (await resp.json()) as {
+    content?: Array<{ type: string; text?: string }>;
+    usage?: { input_tokens?: number; output_tokens?: number };
+  };
+  const text = (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
+  const tokens =
+    (data.usage?.input_tokens ?? 0) + (data.usage?.output_tokens ?? 0) || null;
+  return { text, tokens };
 }
 
 // ─── Mock fallback heuristics ─────────────────────────────────────────────────
@@ -316,8 +327,11 @@ export async function reviewPRAgainstItems(
 
   const prompt = buildReviewPrompt(req);
   let rawText = "";
+  let tokensConsumed: number | null = null;
   try {
-    rawText = await callAnthropic(anthropicApiKey, prompt, 25000, fetchImpl);
+    const out = await callAnthropic(anthropicApiKey, prompt, 25000, fetchImpl);
+    rawText = out.text;
+    tokensConsumed = out.tokens;
   } catch (err) {
     console.error("[workspace/pr-review] LLM call failed:", err);
     return buildMockFallback(req);
@@ -349,5 +363,11 @@ export async function reviewPRAgainstItems(
     needsDecision: results.filter((r) => r.status === "needs_decision").length,
   };
 
-  return { ok: true, source: "llm", summary, results };
+  return {
+    ok: true,
+    source: "llm",
+    summary,
+    results,
+    usage: { tokens_consumed: tokensConsumed, model_used: REVIEW_MODEL },
+  };
 }

--- a/apps/central-plane/src/workspace/topic-tags.ts
+++ b/apps/central-plane/src/workspace/topic-tags.ts
@@ -1,0 +1,94 @@
+/**
+ * topic-tags.ts — classify a project's idea/spec into structured topic tags
+ * (domain / integrations / ai_feature / pattern) for the market-map axis.
+ *
+ * Deterministic, dictionary-based (KR + EN keywords) — NOT an LLM call, so it's
+ * free, hallucination-proof, and unit-testable. An LLM enrichment pass can be
+ * layered later (P2) without changing the tag shape. Raw free text is never
+ * stored here; only the structured tags come out.
+ */
+
+export type TopicTagsResult = {
+  domain: string | null;
+  pattern: string | null;
+  integrations: string[];
+  ai_feature: string | null;
+};
+
+/** domain → keyword signals (lowercased match against idea+spec text). */
+const DOMAIN_KEYWORDS: Record<string, string[]> = {
+  productivity: ["productivity", "todo", "task", "note", "meeting", "생산성", "할일", "업무", "노트", "회의", "일정"],
+  commerce: ["shop", "store", "commerce", "ecommerce", "checkout", "payment", "커머스", "쇼핑", "상점", "결제", "판매", "주문"],
+  social: ["social", "community", "chat", "feed", "follow", "소셜", "커뮤니티", "채팅", "피드", "친구"],
+  finance: ["finance", "invest", "budget", "expense", "accounting", "금융", "투자", "예산", "가계부", "회계", "송금"],
+  health: ["health", "fitness", "workout", "diet", "medical", "헬스", "건강", "운동", "다이어트", "의료", "병원"],
+  education: ["education", "learn", "course", "quiz", "study", "교육", "학습", "강의", "퀴즈", "공부"],
+  content: ["blog", "content", "video", "podcast", "newsletter", "블로그", "콘텐츠", "영상", "뉴스레터"],
+  travel: ["travel", "trip", "booking", "hotel", "flight", "여행", "예약", "호텔", "항공"],
+};
+
+/** Known external tools/integrations to detect by name. */
+const INTEGRATION_NAMES = [
+  "Linear", "Stripe", "Notion", "Slack", "GitHub", "Discord", "Telegram", "Supabase",
+  "Vercel", "Figma", "Airtable", "Zapier", "Twilio", "Sendgrid", "Resend", "OpenAI",
+  "Anthropic", "Google", "Gmail", "Calendar", "Shopify", "Kakao", "Toss", "Naver",
+];
+
+/** ai_feature → keyword signals. */
+const AI_FEATURE_KEYWORDS: Record<string, string[]> = {
+  summarization: ["summar", "요약", "정리"],
+  recommendation: ["recommend", "suggest", "추천"],
+  generation: ["generate", "write", "draft", "create content", "생성", "작성", "만들어"],
+  classification: ["classif", "categor", "tag", "분류", "카테고리", "태그"],
+  extraction: ["extract", "parse", "추출", "파싱"],
+  search: ["search", "semantic", "검색"],
+  translation: ["translat", "번역"],
+  transcription: ["transcri", "speech", "stt", "받아쓰", "음성"],
+};
+
+function includesAny(haystack: string, needles: string[]): boolean {
+  return needles.some((n) => haystack.includes(n.toLowerCase()));
+}
+
+/** Detect the input content language. Hangul → ko; otherwise en (coarse, extend later). */
+export function detectContentLang(text: string): string | null {
+  if (!text || !text.trim()) return null;
+  if (/[가-힣]/.test(text)) return "ko"; // Hangul syllables
+  if (/[A-Za-z]/.test(text)) return "en";
+  return null;
+}
+
+/**
+ * Classify idea + spec text into topic tags. Never throws; returns nulls/empties
+ * when nothing matches (no invention).
+ */
+export function classifyTopics(text: string): TopicTagsResult {
+  const lower = (text ?? "").toLowerCase();
+
+  let domain: string | null = null;
+  for (const [d, kws] of Object.entries(DOMAIN_KEYWORDS)) {
+    if (includesAny(lower, kws)) {
+      domain = d;
+      break;
+    }
+  }
+
+  const integrations = INTEGRATION_NAMES.filter((name) => lower.includes(name.toLowerCase()));
+
+  let ai_feature: string | null = null;
+  for (const [f, kws] of Object.entries(AI_FEATURE_KEYWORDS)) {
+    if (includesAny(lower, kws)) {
+      ai_feature = f;
+      break;
+    }
+  }
+
+  // pattern: a light heuristic — "upload → AI → export" style flows.
+  let pattern: string | null = null;
+  const hasUpload = includesAny(lower, ["upload", "파일", "이미지", "import"]);
+  const hasExport = includesAny(lower, ["export", "send", "내보내", "전송", "다운로드"]);
+  if (hasUpload && ai_feature && hasExport) pattern = "upload->ai->export";
+  else if (includesAny(lower, ["dashboard", "crud", "manage", "대시보드", "관리"])) pattern = "crud-dashboard";
+
+  return { domain, pattern, integrations, ai_feature };
+}

--- a/apps/central-plane/src/workspace/training-store.ts
+++ b/apps/central-plane/src/workspace/training-store.ts
@@ -67,6 +67,28 @@ export type UserContextTag = {
   project_seq?: number | null;
 } | null;
 
+/**
+ * Guided vs wild. Separates data that came from Simsa's steering (guided) from
+ * pure user-origin data (wild) — mixing them corrupts the moat's pure failure
+ * patterns. Slot only for now: no guided feature exists, so mode is always
+ * "wild"; guided_at / guided_scope stay null until a guided feature ships.
+ */
+export type AssistanceTag = {
+  mode?: "wild" | "guided";
+  guided_at?: "before_build" | "after_review" | null;
+  guided_scope?: unknown; // P3 slot
+} | null;
+
+/**
+ * Usage MEASUREMENT (not billing). Enables a future count→token pricing decision
+ * to be made from data. No debit / cap / enforcement is added — measure only.
+ */
+export type CostMeta = {
+  review_count_in_session?: number | null;
+  tokens_consumed?: number | null;
+  model_used?: string | null;
+} | null;
+
 /** Envelope tags captured at review time. All optional — null slot if no source yet. */
 export type EnvelopeInput = {
   /** sha256(workspaceId) — team/personal split. */
@@ -81,6 +103,10 @@ export type EnvelopeInput = {
   userContext?: UserContextTag;
   /** Tier AT CAPTURE — never join the current tier (would corrupt past rows). */
   planTier?: string | null;
+  /** Guided vs wild (STEP 3). Always "wild" today — slot for future guided feature. */
+  assistance?: AssistanceTag;
+  /** Usage measurement (STEP 3) — tokens/model/session count. Not billing. */
+  costMeta?: CostMeta;
 };
 
 /**
@@ -186,6 +212,10 @@ export type TrainingRecord = {
   user_context: UserContextTag;
   // ── commercial dimension (P1 — tier at capture, never joined) ──
   commercial: { plan_tier: string | null; plan_at_capture: unknown };
+  // ── assistance (guided vs wild — separate-storage tag; "wild" today) ──
+  assistance: { mode: "wild" | "guided"; guided_at: "before_build" | "after_review" | null; guided_scope: unknown };
+  // ── cost_meta (usage measurement, NOT billing) ──
+  cost_meta: CostMeta;
   // ── event body ──
   event_type: "pr_reviewed" | "pr_rechecked";
   payload_scrub_state: "clean" | "metadata_only" | "raw_pending";
@@ -204,7 +234,6 @@ export type TrainingRecord = {
   device_context: unknown;
   experiment_arm: string | null;
   quality_signals: unknown;
-  cost_meta: unknown;
 };
 
 /**
@@ -247,6 +276,14 @@ export function buildTrainingRecord(
     user_context: env.userContext ?? null,
     // commercial — plan_tier is the value AT CAPTURE (never re-joined)
     commercial: { plan_tier: env.planTier ?? null, plan_at_capture: null },
+    // assistance — guided vs wild. Always "wild" today (no guided feature yet).
+    assistance: {
+      mode: env.assistance?.mode ?? "wild",
+      guided_at: env.assistance?.guided_at ?? null,
+      guided_scope: env.assistance?.guided_scope ?? null,
+    },
+    // cost_meta — usage measurement (tokens/model/session count), NOT billing.
+    cost_meta: env.costMeta ?? null,
     // event body
     event_type: input.rerunOfReviewRunId ? "pr_rechecked" : "pr_reviewed",
     payload_scrub_state: "clean", // code-based review payload → redactSecrets applied
@@ -269,7 +306,6 @@ export function buildTrainingRecord(
     device_context: null,
     experiment_arm: null,
     quality_signals: null,
-    cost_meta: null,
   };
 }
 

--- a/apps/central-plane/test/topic-tags.test.mjs
+++ b/apps/central-plane/test/topic-tags.test.mjs
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyTopics, detectContentLang } from "../dist/workspace/topic-tags.js";
+
+test("classifies domain from KR + EN keywords", () => {
+  assert.equal(classifyTopics("회의 녹음을 요약하는 생산성 앱").domain, "productivity");
+  assert.equal(classifyTopics("an online store with checkout").domain, "commerce");
+  assert.equal(classifyTopics("가계부 예산 관리").domain, "finance");
+});
+
+test("detects integrations by name", () => {
+  const t = classifyTopics("send tasks to Linear and charge with Stripe");
+  assert.ok(t.integrations.includes("Linear"));
+  assert.ok(t.integrations.includes("Stripe"));
+});
+
+test("detects ai_feature", () => {
+  assert.equal(classifyTopics("자동으로 요약해주는 도구").ai_feature, "summarization");
+  assert.equal(classifyTopics("recommend products to users").ai_feature, "recommendation");
+});
+
+test("pattern heuristic: upload -> ai -> export", () => {
+  const t = classifyTopics("파일 업로드하면 요약해서 Linear로 전송");
+  assert.equal(t.pattern, "upload->ai->export");
+});
+
+test("no match → nulls / empty (no invention)", () => {
+  const t = classifyTopics("zxcv qwer asdf");
+  assert.equal(t.domain, null);
+  assert.equal(t.ai_feature, null);
+  assert.deepEqual(t.integrations, []);
+});
+
+test("detectContentLang: Hangul → ko, Latin → en, empty → null", () => {
+  assert.equal(detectContentLang("안녕하세요 앱 만들래요"), "ko");
+  assert.equal(detectContentLang("I want to build an app"), "en");
+  assert.equal(detectContentLang("   "), null);
+});

--- a/apps/central-plane/test/training-store.test.mjs
+++ b/apps/central-plane/test/training-store.test.mjs
@@ -106,8 +106,9 @@ test("STEP1 수집≠저장: stored R2 payload has ALL P1 envelope keys (null ok
     "event_id", "schema_version", "subject_hash", "workspace_hash", "consent_version",
     "region", "locale", "content_lang", "timezone",
     "entry_path", "built_with", "topic_tags", "acquisition", "user_context", "commercial",
+    "assistance", "cost_meta",
     "event_type", "payload_scrub_state", "outcome",
-    "device_context", "experiment_arm", "quality_signals", "cost_meta",
+    "device_context", "experiment_arm", "quality_signals",
   ]) {
     assert.ok(key in rec, `P1 envelope key "${key}" must exist in the stored R2 record`);
   }
@@ -115,6 +116,46 @@ test("STEP1 수집≠저장: stored R2 payload has ALL P1 envelope keys (null ok
   assert.equal(rec.event_type, "pr_reviewed");
   assert.equal(rec.payload_scrub_state, "clean");
   assert.ok("plan_tier" in rec.commercial, "commercial.plan_tier slot must exist");
+});
+
+test("STEP3 수집≠저장: assistance + cost_meta + topic_tags land in the stored R2 record", async () => {
+  const r2 = new FakeR2();
+  const env = { DB: dbWithConsent({ consented: true, version: TRAINING_CONSENT_VERSION }), EVIDENCE: r2 };
+  await captureTrainingRecord(env, {
+    ...baseInput(),
+    envelope: {
+      region: "KR", contentLang: "ko",
+      topicTags: { domain: "productivity", pattern: "upload->ai->export", integrations: ["Linear"], ai_feature: "summarization" },
+      acquisition: { source: "reddit" },
+      userContext: { skill_signal: "first_project", session_seq: null, project_seq: 1 },
+      planTier: "free_beta",
+      assistance: { mode: "wild", guided_at: null, guided_scope: null },
+      costMeta: { tokens_consumed: 14200, model_used: "claude-haiku-4-5-20251001", review_count_in_session: null },
+    },
+  });
+  const rec = JSON.parse(r2.puts[0].value);
+  // assistance always "wild" today (separate-storage tag)
+  assert.equal(rec.assistance.mode, "wild");
+  assert.equal(rec.assistance.guided_at, null);
+  // cost_meta is measurement (real token number), not billing
+  assert.equal(rec.cost_meta.tokens_consumed, 14200);
+  assert.equal(rec.cost_meta.model_used, "claude-haiku-4-5-20251001");
+  // topic + content + acquisition + user_context + plan_tier
+  assert.equal(rec.topic_tags.domain, "productivity");
+  assert.deepEqual(rec.topic_tags.integrations, ["Linear"]);
+  assert.equal(rec.content_lang, "ko");
+  assert.equal(rec.acquisition.source, "reddit");
+  assert.equal(rec.user_context.skill_signal, "first_project");
+  assert.equal(rec.commercial.plan_tier, "free_beta");
+});
+
+test("assistance defaults to wild + cost_meta null when envelope omits them", async () => {
+  const r2 = new FakeR2();
+  const env = { DB: dbWithConsent({ consented: true, version: TRAINING_CONSENT_VERSION }), EVIDENCE: r2 };
+  await captureTrainingRecord(env, baseInput());
+  const rec = JSON.parse(r2.puts[0].value);
+  assert.equal(rec.assistance.mode, "wild"); // never null — always tagged
+  assert.equal(rec.cost_meta, null);
 });
 
 test("STEP1: envelope values actually flow into the stored record", async () => {


### PR DESCRIPTION
## STEP 3 of 4 — topic_tags + remaining dims + assistance + cost_meta

Fills the rest of the P1 envelope with real values, plus the two added slots (`assistance` = guided-vs-wild separation, `cost_meta` = usage measurement).

## Topic + language (deterministic — no LLM, so free / hallucination-proof / testable)
- `topic-tags.ts`: `classifyTopics(idea+spec)` → `{ domain, pattern, integrations, ai_feature }` via a KR+EN keyword dictionary; `detectContentLang` (Hangul→ko). **Raw text is never stored — only structured tags.**
- **migration 0056**: `workspace_projects.topic_tags_json` + `acquisition_json`.
- `POST /workspace/projects`: computes `topic_tags` at creation, captures `acquisition`.

## Remaining dims wired at review capture
`content_lang` (from spec text), `topic_tags` + `acquisition` (from project), `user_context` `{ project_seq (count), skill_signal (first_project|returning), session_seq:null }`, `plan_tier` `"free_beta"` (value **at capture**, never joined).

## assistance (P1 slot — added instruction)
`{ mode:"wild", guided_at:null, guided_scope:null }`. Always `"wild"` today — no guided feature exists. The slot separates future *guided* data from *wild* so the moat's pure failure patterns stay uncontaminated. **No guided feature built** — slot only.

## cost_meta (measurement, NOT billing — added instruction)
`reviewPRAgainstItems` now returns usage; the record stores `{ tokens_consumed (real API usage), model_used, review_count_in_session:null }`. **No debit / cap / enforcement** — measurement only, to inform a future count→token pricing decision from data.

## 수집 ≠ 저장 — proven
`STEP3 수집≠저장` reads the **actual R2 payload** and asserts `assistance.mode="wild"`, `cost_meta.tokens_consumed=14200`, `topic_tags.domain`, `content_lang`, `acquisition.source`, `user_context`, `commercial.plan_tier`. Plus topic-classifier tests (KR+EN domain / integrations / ai_feature / pattern / lang).

## Verification
central-plane **1565** pass (1 known-flaky `progress-emit` timing test on first run, green on re-run), typecheck green. Consent-OFF no-op + secret-scrub regression intact. (Remote CI green on this SHA to be confirmed before merge.)

## Next
STEP 4 — outcome poll stub (fill `pending` on recheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
