### PR TITLE
STEP 4: outcome poll — fill pending reward on recheck (crown-jewel round-trip)

### DIFF
--- a/apps/central-plane/migrations/0057_review_run_training_key.sql
+++ b/apps/central-plane/migrations/0057_review_run_training_key.sql
@@ -1,0 +1,6 @@
+-- 0057 — STEP 4 outcome poll: remember where a review run's training record was
+-- written in R2, so a later recheck can find the PRIOR record and fill its
+-- outcome (pending → resolved/unresolved). Only set when a record was actually
+-- captured (consent on). Null otherwise.
+
+ALTER TABLE workspace_pr_review_runs ADD COLUMN training_r2_key TEXT;

--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -40,7 +40,7 @@ import { getRepoViaApp, resolveRepoAccessToken } from "../workspace/github-app-a
 import { upsertProjectPR, getLinkedPRs } from "../workspace/pr-db.js";
 import {
   insertReviewRun, updateReviewRun, getLatestReviewRun, getLatestTwoPrReviewRuns,
-  listPRReviewRuns, listProjectReviewRuns, getReviewRunById,
+  listPRReviewRuns, listProjectReviewRuns, getReviewRunById, setReviewRunTrainingKey,
 } from "../workspace/pr-review-db.js";
 import { loadPRReviewRunForAction } from "../workspace/pr-review-run-loader.js";
 import { normalizeSelectedItemIds, recommendedRerunItemIds } from "../workspace/selected-items.js";
@@ -50,7 +50,7 @@ import {
 } from "../workspace/pr-review-compare.js";
 import { fetchPRFiles } from "../workspace/github-pr.js";
 import { reviewPRAgainstItems, deriveRunStatus } from "../workspace/pr-review.js";
-import { captureTrainingRecord } from "../workspace/training-store.js";
+import { captureTrainingRecord, computeRecheckOutcome, updateTrainingRecordOutcome } from "../workspace/training-store.js";
 import type { TopicTags, AcquisitionTag } from "../workspace/training-store.js";
 import { normalizeBuiltWith } from "../workspace/built-with.js";
 import { detectContentLang } from "../workspace/topic-tags.js";
@@ -974,7 +974,7 @@ export function createWorkspaceGitHubRoutes(
     })();
     const projectCount = await listProjectsByUser(c.env, userKey, 200).then((r) => r.length).catch(() => null);
     const usage = reviewResult.usage;
-    await captureTrainingRecord(c.env, {
+    const captureRes = await captureTrainingRecord(c.env, {
       userKey,
       projectId,
       reviewRunId: run.id,
@@ -1008,7 +1008,26 @@ export function createWorkspaceGitHubRoutes(
         channel: "web", // this is the web review path; MCP is a future channel
         mcpClient: null,
       },
-    }).catch(() => {});
+    }).catch(() => ({ stored: false as const }));
+
+    // 9d. STEP 4 outcome poll. Remember where this record landed (so a future
+    // recheck can find it); and if THIS is a recheck, fill the PRIOR record's
+    // outcome (pending → resolved/unresolved) by comparing prior vs current. All
+    // best-effort, non-fatal, consent already implied by a stored key.
+    if (captureRes.stored) {
+      await setReviewRunTrainingKey(c.env, run.id, captureRes.key).catch(() => {});
+    }
+    if (rerunOfReviewRunId) {
+      const priorRun = await getReviewRunById(c.env, rerunOfReviewRunId).catch(() => null);
+      if (priorRun?.trainingR2Key) {
+        const priorResults = (() => {
+          try { return (JSON.parse(priorRun.resultJson ?? "{}").results ?? []) as Array<{ itemId?: string; status?: string }>; }
+          catch { return []; }
+        })();
+        const outcome = computeRecheckOutcome(priorResults, reviewResult.results);
+        await updateTrainingRecordOutcome(c.env, priorRun.trainingR2Key, outcome).catch(() => {});
+      }
+    }
 
     // 10. Telegram notification (non-blocking: failure must not fail the review response)
     await (async () => {

--- a/apps/central-plane/src/workspace/pr-review-db.ts
+++ b/apps/central-plane/src/workspace/pr-review-db.ts
@@ -20,6 +20,8 @@ export type DbReviewRun = {
   resultJson?: string;
   errorMessage?: string;
   rerunOfReviewRunId?: string;
+  /** R2 key of this run's training record, if one was captured (consent on). */
+  trainingR2Key?: string;
   createdAt: string;
   updatedAt: string;
 };
@@ -28,7 +30,7 @@ export type DbReviewRun = {
 
 const COLS = `id, project_id, user_key, repo_full_name, pr_number, linked_pr_id,
               selected_item_ids_json, status, result_json, error_message,
-              rerun_of_review_run_id, created_at, updated_at`;
+              rerun_of_review_run_id, training_r2_key, created_at, updated_at`;
 
 type RawRow = {
   id: string;
@@ -42,6 +44,7 @@ type RawRow = {
   result_json: string | null;
   error_message: string | null;
   rerun_of_review_run_id: string | null;
+  training_r2_key: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -59,9 +62,17 @@ function mapRow(row: RawRow): DbReviewRun {
     resultJson: row.result_json ?? undefined,
     errorMessage: row.error_message ?? undefined,
     rerunOfReviewRunId: row.rerun_of_review_run_id ?? undefined,
+    trainingR2Key: row.training_r2_key ?? undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+/** Remember where this run's training record landed in R2 (for the outcome poll). */
+export async function setReviewRunTrainingKey(env: Env, runId: string, key: string): Promise<void> {
+  await env.DB.prepare(
+    `UPDATE workspace_pr_review_runs SET training_r2_key = ? WHERE id = ?`,
+  ).bind(key, runId).run();
 }
 
 // ─── randId ───────────────────────────────────────────────────────────────────

--- a/apps/central-plane/src/workspace/training-store.ts
+++ b/apps/central-plane/src/workspace/training-store.ts
@@ -382,3 +382,54 @@ export async function captureTrainingRecord(
     return { stored: false, reason: "error" };
   }
 }
+
+// ─── STEP 4: outcome poll (fill the pending reward on recheck) ─────────────────
+
+type MinimalResult = { itemId?: string; status?: string };
+
+/**
+ * Compare a prior review's results to a recheck's results and decide the prior
+ * record's outcome. "resolved" = every item that wasn't passing before is now
+ * passing; "unresolved" = at least one previously-unresolved item is still not
+ * passing. Pure + deterministic. (merge/reject from GitHub is a later P2 signal.)
+ */
+export function computeRecheckOutcome(
+  priorResults: MinimalResult[],
+  currentResults: MinimalResult[],
+): "resolved" | "unresolved" {
+  const current = new Map<string, string>();
+  for (const r of currentResults) if (r.itemId) current.set(r.itemId, r.status ?? "");
+  const wasUnresolved = (priorResults ?? []).filter((r) => r.status && r.status !== "passed");
+  if (wasUnresolved.length === 0) return "resolved"; // nothing was open
+  for (const p of wasUnresolved) {
+    const now = p.itemId ? current.get(p.itemId) : undefined;
+    if (now !== "passed") return "unresolved"; // still open (or not re-checked)
+  }
+  return "resolved";
+}
+
+/**
+ * Update a PRIOR training record's outcome in place. Fetches the R2 object by
+ * key, rewrites only `outcome`, re-puts. Consent/bucket are already implied
+ * (the key only exists because the prior record was stored). Never throws.
+ */
+export async function updateTrainingRecordOutcome(
+  env: Env,
+  r2Key: string,
+  outcome: "resolved" | "unresolved" | "merged" | "rejected",
+): Promise<{ updated: boolean }> {
+  try {
+    if (!env.EVIDENCE || !r2Key) return { updated: false };
+    const obj = await env.EVIDENCE.get(r2Key);
+    if (!obj) return { updated: false };
+    const rec = JSON.parse(await obj.text()) as Record<string, unknown>;
+    rec["outcome"] = outcome;
+    await env.EVIDENCE.put(r2Key, JSON.stringify(rec), {
+      httpMetadata: { contentType: "application/json" },
+    });
+    return { updated: true };
+  } catch (err) {
+    console.warn("[training-store] outcome update failed (non-fatal):", err instanceof Error ? err.message : err);
+    return { updated: false };
+  }
+}

--- a/apps/central-plane/test/training-outcome-poll.test.mjs
+++ b/apps/central-plane/test/training-outcome-poll.test.mjs
@@ -1,0 +1,70 @@
+/**
+ * STEP 4 — outcome poll. computeRecheckOutcome (pure) + updateTrainingRecordOutcome
+ * (fetches the PRIOR R2 record and fills its outcome). The 수집≠저장 proof here is
+ * that the ACTUAL stored object's outcome flips pending → resolved/unresolved.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  computeRecheckOutcome,
+  updateTrainingRecordOutcome,
+  buildTrainingRecord,
+} from "../dist/workspace/training-store.js";
+
+test("computeRecheckOutcome: all previously-open items now pass → resolved", () => {
+  const prior = [{ itemId: "a", status: "failed" }, { itemId: "b", status: "passed" }];
+  const current = [{ itemId: "a", status: "passed" }];
+  assert.equal(computeRecheckOutcome(prior, current), "resolved");
+});
+
+test("computeRecheckOutcome: a previously-open item still not passing → unresolved", () => {
+  const prior = [{ itemId: "a", status: "failed" }, { itemId: "b", status: "inconclusive" }];
+  const current = [{ itemId: "a", status: "passed" }, { itemId: "b", status: "failed" }];
+  assert.equal(computeRecheckOutcome(prior, current), "unresolved");
+});
+
+test("computeRecheckOutcome: nothing was open → resolved", () => {
+  assert.equal(computeRecheckOutcome([{ itemId: "a", status: "passed" }], []), "resolved");
+});
+
+test("updateTrainingRecordOutcome: flips the STORED record's outcome (pending → resolved)", async () => {
+  // Seed a prior record (outcome pending) as it would sit in R2.
+  const prior = buildTrainingRecord(
+    {
+      userKey: "uk", projectId: "p", reviewRunId: "run_prev", repoFullName: "o/r", prNumber: 1,
+      productSpec: {}, items: [], prFiles: [],
+      review: { source: "llm", summary: { passed: 0, failed: 1, inconclusive: 0, needsDecision: 0 }, results: [] },
+      finalStatus: "failed",
+    },
+    "hash", "2026-07-04T00:00:00.000Z",
+  );
+  assert.equal(prior.outcome, "pending");
+
+  const store = new Map([["events/KR/2026/07/04/run_prev.json", JSON.stringify(prior)]]);
+  const env = {
+    EVIDENCE: {
+      async get(key) {
+        const v = store.get(key);
+        return v ? { async text() { return v; } } : null;
+      },
+      async put(key, value) { store.set(key, value); },
+    },
+  };
+
+  const res = await updateTrainingRecordOutcome(env, "events/KR/2026/07/04/run_prev.json", "resolved");
+  assert.equal(res.updated, true);
+  // The ACTUAL stored object now reads "resolved" — the reward half is filled.
+  const after = JSON.parse(store.get("events/KR/2026/07/04/run_prev.json"));
+  assert.equal(after.outcome, "resolved");
+  // everything else untouched
+  assert.equal(after.review_run_id, "run_prev");
+});
+
+test("updateTrainingRecordOutcome: missing object → no-op, never throws", async () => {
+  const env = { EVIDENCE: { async get() { return null; }, async put() { throw new Error("should not put"); } } };
+  assert.deepEqual(await updateTrainingRecordOutcome(env, "nope.json", "resolved"), { updated: false });
+});
+
+test("updateTrainingRecordOutcome: no bucket → no-op", async () => {
+  assert.deepEqual(await updateTrainingRecordOutcome({}, "k.json", "resolved"), { updated: false });
+});


### PR DESCRIPTION
## STEP 4 of 4 — outcome poll (the last "before open" gap)

`outcome` was permanently `"pending"`. Now a **recheck fills the PRIOR record's outcome**, so the crown-jewel `fix_brief → next-PR` round-trip (per agent) becomes a real reward signal — not a half.

## What
- `computeRecheckOutcome(prior, current)` — pure/deterministic: every previously non-passing item now passing → `"resolved"`; any still open → `"unresolved"`.
- `updateTrainingRecordOutcome(env, r2Key, outcome)` — fetches the **prior R2 object**, rewrites only `outcome`, re-puts. Never throws; no-op without bucket/object.
- **migration 0057**: `workspace_pr_review_runs.training_r2_key`. On capture we remember where the record landed (`setReviewRunTrainingKey`); on a recheck we load the prior run's key, compute the outcome from prior-vs-current results, and update the prior R2 record **in place**.
- Wired at the review handler: capture → store key; if rerun → fill prior outcome. Best-effort/non-fatal; consent implied by a stored key existing.

## 수집 ≠ 저장 — proven
`updateTrainingRecordOutcome flips the STORED record's outcome` seeds a prior record (`outcome:"pending"`) in a fake R2, runs the update, and asserts the **actual stored object** now reads `"resolved"` (rest untouched). Plus `computeRecheckOutcome` resolved / unresolved / nothing-open cases.

## Verification
central-plane **1572** pass, typecheck green. Consent-OFF no-op + secret-scrub regression intact. (Remote CI green on this SHA confirmed before merge.)

## This completes the "오픈 전 필수" data skeleton
P1 envelope (region / locale / content_lang / entry_path / built_with / topic_tags / acquisition / user_context / plan_tier) + assistance (wild) + cost_meta (measurement) + growth/channel slots + **outcome fill path** + consent aggregate clause. GitHub-webhook merge/reject stays P2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
