### PR TITLE
Flow STEP 1: single entry + branch chooser (fills entry_path)

### DIFF
--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -50,6 +50,9 @@ export default function NewProjectPage() {
   // builtWith — which AI tool(s) built this app (per-agent moat tag).
   const [builtWithTools, setBuiltWithTools] = useState<string[]>([]);
   const [builtWithOther, setBuiltWithOther] = useState("");
+  // Single entry → adaptive branch. The chosen branch fills the P1 entry_path.
+  // Until a branch is picked the chooser shows; then the step flow proceeds.
+  const [entryPath, setEntryPath] = useState<"idea" | "code" | "spec" | null>(null);
 
   function toggleBuiltWith(tool: string) {
     setBuiltWithTools((prev) => (prev.includes(tool) ? prev.filter((x) => x !== tool) : [...prev, tool]));
@@ -141,9 +144,8 @@ export default function NewProjectPage() {
         builtWithTools.length || builtWithOther.trim()
           ? { tools: builtWithTools, other: builtWithOther.trim() || undefined }
           : undefined,
-      // This flow starts from an idea (the only entry today). The single-entry
-      // / 3-branch UI is a separate track; entry_path fills in per branch later.
-      entryPath: "idea",
+      // The branch the user chose at the single entry (idea/code/spec).
+      entryPath: entryPath ?? "idea",
     }).catch(() => undefined);
     router.push(`/projects/${id}`);
   }
@@ -158,8 +160,35 @@ export default function NewProjectPage() {
 
       <main className="flex flex-1 justify-center px-4 py-12">
         <div className="w-full max-w-2xl">
+          {/* Step 0: single entry → "what do you have?" branch chooser.
+              Asks the user's situation, not a "type" — no jargon. The choice
+              sets entry_path (idea/code/spec) which persists to the P1 envelope. */}
+          {entryPath === null && (
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight text-gray-900">{t.branch.title}</h1>
+              <p className="mb-8 mt-2 text-sm text-gray-500">{t.branch.subtitle}</p>
+              <div className="space-y-3">
+                {([
+                  ["idea", t.branch.ideaTitle, t.branch.ideaDesc],
+                  ["code", t.branch.codeTitle, t.branch.codeDesc],
+                  ["spec", t.branch.specTitle, t.branch.specDesc],
+                ] as const).map(([id, title, desc]) => (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => { setEntryPath(id); setStep(1); }}
+                    className="card w-full p-5 text-left transition-colors hover:border-brand-300"
+                  >
+                    <span className="block text-sm font-semibold text-gray-900">{title}</span>
+                    <span className="mt-1 block text-xs text-gray-500">{desc}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* Step 1: idea */}
-          {step === 1 && (
+          {entryPath !== null && step === 1 && (
             <div>
               <h1 className="text-2xl font-semibold tracking-tight text-gray-900">{t.np.step1Title}</h1>
               <p className="mb-8 mt-2 text-sm text-gray-500">{t.np.step1Sub}</p>

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -188,6 +188,16 @@ export type Dictionary = {
       handCoded: string;
     };
   };
+  branch: {
+    title: string;
+    subtitle: string;
+    ideaTitle: string;
+    ideaDesc: string;
+    codeTitle: string;
+    codeDesc: string;
+    specTitle: string;
+    specDesc: string;
+  };
   overview: {
     specCompleteness: string;
     resultsSummary: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -242,6 +242,16 @@ const EN = {
       handCoded: "Hand-coded",
     },
   },
+  branch: {
+    title: "What do you have to start with?",
+    subtitle: "Pick whatever fits — you'll end up in the same place: your app, reviewed.",
+    ideaTitle: "💡 I just have an idea",
+    ideaDesc: "Describe what you want to build. We'll turn it into things to check.",
+    codeTitle: "🔗 I already built an app",
+    codeDesc: "Connect the code and review it right away.",
+    specTitle: "📄 I have a plan or spec",
+    specDesc: "Paste it in and we'll turn it into things to check.",
+  },
   overview: {
     specCompleteness: "Product brief completeness",
     resultsSummary: "Review summary",
@@ -2247,6 +2257,16 @@ const KO = {
       codex: "Codex",
       handCoded: "직접 코딩",
     },
+  },
+  branch: {
+    title: "무엇부터 시작할까요?",
+    subtitle: "지금 갖고 계신 걸 고르세요 — 어느 쪽이든 결국 '내 앱 검수'로 이어져요.",
+    ideaTitle: "💡 아이디어만 있어요",
+    ideaDesc: "만들고 싶은 걸 말하면 확인할 항목으로 정리해드려요.",
+    codeTitle: "🔗 이미 만든 앱이 있어요",
+    codeDesc: "코드를 연결하면 바로 검수해요.",
+    specTitle: "📄 기획서가 있어요",
+    specDesc: "붙여넣으면 확인할 항목으로 바꿔드려요.",
   },
   overview: {
     specCompleteness: "제품 설명서 완성도",


### PR DESCRIPTION
First step of the guided-flow track. One entry → **"무엇부터 시작할까요?"** branch chooser (idea/code/spec) whose choice fills the P1 `entry_path`. Non-breaking: idea branch uses the existing flow; code/spec specialized in STEP 3.

- Step-0 chooser on `/projects/new`: 3 cards asking the user's *situation* (no jargon). Picking sets `entryPath` → step flow.
- `handleSave` sends the chosen `entry_path` (was hardcoded "idea").
- `branch` i18n (EN+KO), design hygiene kept.

**entry_path 수집≠저장**: storage end proven by central-plane test "project built_with + entry_path reach the stored R2 record"; dashboard chooser→payload typechecked.

dashboard 383 pass, i18n parity 15, typecheck + lint + build green. 11 tabs preserved (hidden/regrouped, not deleted). code/spec temporarily route through idea flow until STEP 3 (never deployed in that state — deploy batched at open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)