### PR TITLE
Flow STEP 2: 3-step routing skeleton + progress-map sidebar (lock/auto-check)

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/idea/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/idea/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import { getProject } from "@/lib/mock-data";
 import { getLocalProject } from "@/lib/workflow-store";
 import { useI18n } from "@/i18n/I18nProvider";
+import { StepNextButton } from "@/components/StepNextButton";
 
 export default function IdeaPage() {
   const { id } = useParams<{ id: string }>();
@@ -53,6 +54,7 @@ export default function IdeaPage() {
           ))}
         </ul>
       </div>
+      <StepNextButton />
     </div>
   );
 }

--- a/apps/dashboard/src/app/projects/[id]/items/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/items/page.tsx
@@ -6,6 +6,7 @@ import { getLocalProject } from "@/lib/workflow-store";
 import { ACCEPTANCE_CRITERIA } from "@/lib/mock-generators";
 import { StatusBadge } from "@/components/StatusBadge";
 import { useI18n } from "@/i18n/I18nProvider";
+import { StepNextButton } from "@/components/StepNextButton";
 
 export default function ItemsPage() {
   const { id } = useParams<{ id: string }>();
@@ -64,6 +65,7 @@ export default function ItemsPage() {
           {t.items.ctaButton} →
         </a>
       </div>
+      <StepNextButton />
     </div>
   );
 }

--- a/apps/dashboard/src/app/projects/[id]/spec/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/spec/page.tsx
@@ -5,6 +5,7 @@ import { getProject } from "@/lib/mock-data";
 import { getLocalProject } from "@/lib/workflow-store";
 import { SpecCompleteness } from "@/components/SpecCompleteness";
 import { useI18n } from "@/i18n/I18nProvider";
+import { StepNextButton } from "@/components/StepNextButton";
 
 export default function SpecPage() {
   const { id } = useParams<{ id: string }>();
@@ -64,6 +65,7 @@ export default function SpecPage() {
           </Section>
         )}
       </div>
+      <StepNextButton />
     </div>
   );
 }

--- a/apps/dashboard/src/components/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar.tsx
@@ -7,6 +7,8 @@ import { useI18n } from "@/i18n/I18nProvider";
 import { loadLocalProjects, getUserKey } from "@/lib/workflow-store";
 import { MOCK_PROJECTS, type Project } from "@/lib/mock-data";
 import { buildBetaFeedbackMailto } from "@/lib/beta-feedback.mjs";
+import { computeProjectSteps } from "@/lib/project-steps.mjs";
+import { fetchProjectRepo, listProjectReviewHistory } from "@/lib/workspace-github-api";
 
 const MOCK_IDS = new Set(MOCK_PROJECTS.map((p) => p.id));
 
@@ -27,6 +29,10 @@ export function AppSidebar() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [query, setQuery] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
+  // Progress-map facts. null = unknown (loading/failed) — the state machine
+  // fails OPEN on null: it never locks on an unconfirmed fact.
+  const [hasRepo, setHasRepo] = useState<boolean | null>(null);
+  const [hasReviewRun, setHasReviewRun] = useState<boolean | null>(null);
 
   useEffect(() => {
     try {
@@ -34,6 +40,23 @@ export function AppSidebar() {
     } catch {}
     setProjects([...loadLocalProjects(), ...MOCK_PROJECTS]);
   }, []);
+
+  // Observe repo-link + review-run facts for the progress map (best-effort;
+  // errors leave the fact unknown → fail-open, no false locks).
+  useEffect(() => {
+    if (!projectId) return;
+    let cancelled = false;
+    setHasRepo(null);
+    setHasReviewRun(null);
+    const uk = getUserKey();
+    fetchProjectRepo(projectId, uk)
+      .then((res) => { if (!cancelled) setHasRepo(res.ok ? Boolean(res.repo) : null); })
+      .catch(() => {});
+    listProjectReviewHistory(projectId, uk, { limit: 1 })
+      .then((res) => { if (!cancelled) setHasReviewRun(res.ok ? res.runs.length > 0 : null); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [projectId, pathname]);
 
   function toggleCollapse() {
     setCollapsed((c) => {
@@ -59,13 +82,30 @@ export function AppSidebar() {
       active ? "bg-gray-100 font-medium text-gray-900" : "text-gray-500 hover:bg-gray-50 hover:text-gray-900"
     }`;
 
-  // "Code repository" (settings) leads the Review group — it is the entry point
-  // of the review loop. Operator screens live under a collapsed Advanced group.
-  const groups = [
-    { label: t.nav.groupPlan, items: [["", t.nav.overview], ["idea", t.nav.idea], ["spec", t.nav.spec], ["items", t.nav.items]] },
-    { label: t.nav.groupReview, items: [["settings", t.nav.settings], ["github", t.nav.github], ["checks", t.nav.checks], ["visual-checks", t.nav.visualChecks]] },
-    { label: t.nav.groupDeliver, items: [["fixes", t.nav.fixes], ["export", t.nav.export]] },
-  ] as const;
+  // The left nav is a PROGRESS MAP, not a flat tab list: three steps
+  // (준비 → 검수 → 결과·수정) with derived done/current/locked states. The state
+  // machine (project-steps.mjs) locks only on CONFIRMED-unmet preconditions and
+  // auto-checks work already done — no wandering, no rework.
+  const hasItems = project ? project.requirements.length > 0 : null;
+  const steps = computeProjectSteps({ hasItems, hasRepo, hasReviewRun });
+  const stepMeta: Record<string, { label: string; items: ReadonlyArray<readonly [string, string]> }> = {
+    prepare: {
+      label: t.stepsNav.prepare,
+      items: [["idea", t.nav.idea], ["spec", t.nav.spec], ["items", t.nav.items]],
+    },
+    review: {
+      label: t.stepsNav.review,
+      items: [["settings", t.nav.settings], ["github", t.nav.github]],
+    },
+    results: {
+      label: t.stepsNav.results,
+      items: [["checks", t.nav.checks], ["visual-checks", t.nav.visualChecks], ["fixes", t.nav.fixes], ["export", t.nav.export]],
+    },
+  };
+  const lockHint = (reason: "need_items" | "need_code" | null) =>
+    reason === "need_code" ? t.stepsNav.lockNeedCode : reason === "need_items" ? t.stepsNav.lockNeedItems : "";
+  const statusGlyph = (status: string) =>
+    status === "done" ? "✓" : status === "current" ? "●" : "○";
   const advancedItems = [["experiment", t.nav.experiment], ["benchmark", t.nav.benchmark]] as const;
 
   // ── Collapsed rail ──────────────────────────────────────────────────────────
@@ -109,21 +149,56 @@ export function AppSidebar() {
               ← {t.nav.allProjects}
             </Link>
             <p className="truncate px-1.5 pb-2 text-xs font-medium text-gray-700">{project.name}</p>
-            {groups.map((g) => (
-              <div key={g.label} className="mb-4">
-                <p className="px-2.5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-300">{g.label}</p>
-                <ul className="space-y-0.5">
-                  {g.items.map(([slug, label]) => {
-                    const href = slug ? `${base}/${slug}` : base;
-                    return (
-                      <li key={slug || "overview"}>
-                        <Link href={href} className={itemClass(pathname === href)}>{label}</Link>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-            ))}
+
+            {/* Overview = the command center, above the steps */}
+            <ul className="mb-3">
+              <li>
+                <Link href={base} className={itemClass(pathname === base)}>{t.nav.overview}</Link>
+              </li>
+            </ul>
+
+            {/* 3-step progress map */}
+            {steps.map((step, i) => {
+              const meta = stepMeta[step.key]!;
+              const locked = step.status === "locked";
+              return (
+                <div key={step.key} className="mb-3">
+                  <p
+                    className={`flex items-center gap-2 px-2.5 pb-1 text-[11px] font-semibold tracking-wide ${
+                      locked ? "text-gray-300" : step.status === "current" ? "text-gray-900" : "text-gray-500"
+                    }`}
+                  >
+                    <span
+                      aria-hidden
+                      className={`inline-block w-3 text-center text-[10px] ${
+                        step.status === "done"
+                          ? "text-green-600"
+                          : step.status === "current"
+                            ? "text-brand-600"
+                            : "text-gray-300"
+                      }`}
+                    >
+                      {statusGlyph(step.status)}
+                    </span>
+                    {i + 1} · {meta.label}
+                  </p>
+                  {locked ? (
+                    <p className="px-2.5 pb-1 pl-[30px] text-[11px] text-gray-300">{lockHint(step.lockReason)}</p>
+                  ) : (
+                    <ul className="space-y-0.5 pl-[18px]">
+                      {meta.items.map(([slug, label]) => {
+                        const href = `${base}/${slug}`;
+                        return (
+                          <li key={slug}>
+                            <Link href={href} className={itemClass(pathname === href)}>{label}</Link>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+              );
+            })}
             <div className="mb-4">
               <button
                 type="button"

--- a/apps/dashboard/src/components/StepNextButton.tsx
+++ b/apps/dashboard/src/components/StepNextButton.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+/**
+ * StepNextButton — the bottom-of-screen "다음 →" that walks the user along the
+ * canonical flow (idea → spec → items → settings → github → checks → fixes) so
+ * finishing one screen never means scanning the sidebar for what's next.
+ * Renders nothing on screens without an obvious next (or outside a project).
+ */
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useI18n } from "@/i18n/I18nProvider";
+import { nextScreenSlug } from "@/lib/project-steps.mjs";
+
+export function StepNextButton() {
+  const { t } = useI18n();
+  const pathname = usePathname() ?? "";
+  const seg = pathname.split("/").filter(Boolean);
+  if (seg[0] !== "projects" || !seg[1] || seg[1] === "new") return null;
+  const slug = seg[2] ?? "";
+  const next = nextScreenSlug(slug);
+  if (!next) return null;
+
+  const labels: Record<string, string> = {
+    idea: t.nav.idea,
+    spec: t.nav.spec,
+    items: t.nav.items,
+    settings: t.nav.settings,
+    github: t.nav.github,
+    checks: t.nav.checks,
+    fixes: t.nav.fixes,
+  };
+
+  return (
+    <div className="mt-10 flex justify-end border-t border-gray-100 pt-4">
+      <Link
+        href={`/projects/${seg[1]}/${next}`}
+        className="btn btn-md btn-primary"
+      >
+        {t.stepsNav.next}: {labels[next] ?? next} →
+      </Link>
+    </div>
+  );
+}

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -188,6 +188,14 @@ export type Dictionary = {
       handCoded: string;
     };
   };
+  stepsNav: {
+    prepare: string;
+    review: string;
+    results: string;
+    lockNeedItems: string;
+    lockNeedCode: string;
+    next: string;
+  };
   branch: {
     title: string;
     subtitle: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -242,6 +242,14 @@ const EN = {
       handCoded: "Hand-coded",
     },
   },
+  stepsNav: {
+    prepare: "Prepare",
+    review: "Review",
+    results: "Results & fixes",
+    lockNeedItems: "Create your checklist first.",
+    lockNeedCode: "Connect your code first.",
+    next: "Next",
+  },
   branch: {
     title: "What do you have to start with?",
     subtitle: "Pick whatever fits — you'll end up in the same place: your app, reviewed.",
@@ -2257,6 +2265,14 @@ const KO = {
       codex: "Codex",
       handCoded: "직접 코딩",
     },
+  },
+  stepsNav: {
+    prepare: "준비",
+    review: "검수",
+    results: "결과·수정",
+    lockNeedItems: "확인 항목을 먼저 만드세요.",
+    lockNeedCode: "코드를 먼저 연결하세요.",
+    next: "다음",
   },
   branch: {
     title: "무엇부터 시작할까요?",

--- a/apps/dashboard/src/lib/project-steps.d.mts
+++ b/apps/dashboard/src/lib/project-steps.d.mts
@@ -1,0 +1,15 @@
+export type StepStatus = "done" | "current" | "todo" | "locked";
+export type StepKey = "prepare" | "review" | "results";
+export type StepLockReason = "need_items" | "need_code" | null;
+
+export type ProjectStepFacts = {
+  hasItems: boolean | null;
+  hasRepo: boolean | null;
+  hasReviewRun: boolean | null;
+};
+
+export function computeProjectSteps(
+  facts: ProjectStepFacts,
+): Array<{ key: StepKey; status: StepStatus; lockReason: StepLockReason }>;
+
+export function nextScreenSlug(slug: string): string | null;

--- a/apps/dashboard/src/lib/project-steps.mjs
+++ b/apps/dashboard/src/lib/project-steps.mjs
@@ -1,0 +1,83 @@
+/**
+ * project-steps.mjs — the 3-step progress map's state machine (pure).
+ *
+ * The flow skeleton is 준비 → 검수 → 결과·수정. This computes each step's status
+ * from observed project facts so the sidebar can render checked / current /
+ * locked — the two invariants that kill wandering and rework:
+ *
+ *  - LOCKING: a step whose precondition is CONFIRMED unmet is locked (dimmed +
+ *    hint). Unknown facts (null — fetch pending or failed) NEVER lock: a wrong
+ *    lock blocks a user, a briefly-missing lock just shows plain nav (fail-open).
+ *  - AUTO-CHECK: done is DERIVED from data ("repo already connected" → step 2
+ *    partially satisfied), never from user ceremony — revisiting a done step
+ *    never demands rework.
+ *
+ * Pure + deterministic so both invariants are test-fixed.
+ */
+
+/** @typedef {"done" | "current" | "todo" | "locked"} StepStatus */
+
+/**
+ * @param {{ hasItems: boolean | null, hasRepo: boolean | null, hasReviewRun: boolean | null }} facts
+ *   null = unknown (loading or fetch failed) — treated as "not confirmed", never locks.
+ * @returns {Array<{ key: "prepare" | "review" | "results", status: StepStatus, lockReason: "need_items" | "need_code" | null }>}
+ */
+export function computeProjectSteps(facts) {
+  const f = facts ?? {};
+  const hasItems = f.hasItems === true;
+  const noItems = f.hasItems === false; // confirmed absent — only this locks
+  const hasRepo = f.hasRepo === true;
+  const noRepo = f.hasRepo === false;
+  const hasRun = f.hasReviewRun === true;
+
+  // Step 1 — 준비 (idea / spec / items). Always accessible.
+  const prepareDone = hasItems;
+
+  // Step 2 — 검수 (connect code / run review). Locked only when items are
+  // CONFIRMED missing. Done when the code is connected AND a review has run.
+  const reviewLocked = noItems;
+  const reviewDone = hasRepo && hasRun;
+
+  // Step 3 — 결과·수정 (results / fixes / re-check). Locked only when the code
+  // is CONFIRMED not connected ("코드를 먼저 연결하세요"). Never auto-"done" —
+  // it is the working loop, not a checkbox.
+  const resultsLocked = noRepo;
+
+  const prepare = { key: /** @type {const} */ ("prepare"), status: /** @type {StepStatus} */ (prepareDone ? "done" : "current"), lockReason: null };
+
+  let reviewStatus;
+  if (reviewLocked) reviewStatus = "locked";
+  else if (reviewDone) reviewStatus = "done";
+  else reviewStatus = prepareDone ? "current" : "todo";
+  const review = {
+    key: /** @type {const} */ ("review"),
+    status: /** @type {StepStatus} */ (reviewStatus),
+    lockReason: reviewLocked ? /** @type {const} */ ("need_items") : null,
+  };
+
+  let resultsStatus;
+  if (resultsLocked) resultsStatus = "locked";
+  else if (reviewDone) resultsStatus = "current";
+  else resultsStatus = "todo";
+  const results = {
+    key: /** @type {const} */ ("results"),
+    status: /** @type {StepStatus} */ (resultsStatus),
+    lockReason: resultsLocked ? /** @type {const} */ ("need_code") : null,
+  };
+
+  return [prepare, review, results];
+}
+
+/**
+ * The canonical screen order inside the flow, used by the bottom "다음 →"
+ * button so a user finishing one screen is walked to the next without
+ * scanning the sidebar. Pure lookup; unknown slugs return null.
+ * @param {string} slug current screen slug ("" = overview)
+ * @returns {string | null} next slug, or null when there is no obvious next
+ */
+export function nextScreenSlug(slug) {
+  const order = ["idea", "spec", "items", "settings", "github", "checks", "fixes"];
+  const i = order.indexOf(slug);
+  if (i === -1 || i === order.length - 1) return null;
+  return order[i + 1];
+}

--- a/apps/dashboard/test/project-steps.test.mjs
+++ b/apps/dashboard/test/project-steps.test.mjs
@@ -1,0 +1,68 @@
+/**
+ * project-steps.test.mjs — fixes the progress map's two load-bearing invariants:
+ *  1. LOCKING: steps with a CONFIRMED-unmet precondition are locked (with the
+ *     right hint); unknown facts NEVER lock (fail-open — a wrong lock blocks a
+ *     user, a missing lock just shows plain nav).
+ *  2. AUTO-CHECK: done is derived from data — already-connected/already-run work
+ *     is auto-checked, so revisiting never demands rework.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeProjectSteps, nextScreenSlug } from "../src/lib/project-steps.mjs";
+
+const byKey = (steps) => Object.fromEntries(steps.map((s) => [s.key, s]));
+
+test("fresh project (no items confirmed): step1 current, step2+3 locked with hints", () => {
+  const s = byKey(computeProjectSteps({ hasItems: false, hasRepo: false, hasReviewRun: false }));
+  assert.equal(s.prepare.status, "current");
+  assert.equal(s.review.status, "locked");
+  assert.equal(s.review.lockReason, "need_items");
+  assert.equal(s.results.status, "locked");
+  assert.equal(s.results.lockReason, "need_code"); // "코드를 먼저 연결하세요"
+});
+
+test("items done, no repo: step2 unlocks (current), step3 still locked on code", () => {
+  const s = byKey(computeProjectSteps({ hasItems: true, hasRepo: false, hasReviewRun: false }));
+  assert.equal(s.prepare.status, "done"); // auto-checked — no rework
+  assert.equal(s.review.status, "current");
+  assert.equal(s.results.status, "locked");
+  assert.equal(s.results.lockReason, "need_code");
+});
+
+test("items + repo, no run yet: step3 unlocked (todo), step2 still current", () => {
+  const s = byKey(computeProjectSteps({ hasItems: true, hasRepo: true, hasReviewRun: false }));
+  assert.equal(s.review.status, "current"); // connected but not yet run
+  assert.equal(s.results.status, "todo"); // reachable, not current yet
+  assert.equal(s.results.lockReason, null);
+});
+
+test("AUTO-CHECK: items + repo + run → step1/2 done, step3 current (no rework demanded)", () => {
+  const s = byKey(computeProjectSteps({ hasItems: true, hasRepo: true, hasReviewRun: true }));
+  assert.equal(s.prepare.status, "done");
+  assert.equal(s.review.status, "done"); // repo already connected + review already run → checked
+  assert.equal(s.results.status, "current");
+});
+
+test("FAIL-OPEN: unknown facts (null) never lock anything", () => {
+  const s = byKey(computeProjectSteps({ hasItems: null, hasRepo: null, hasReviewRun: null }));
+  assert.notEqual(s.review.status, "locked");
+  assert.notEqual(s.results.status, "locked");
+  // and nothing is falsely checked either
+  assert.notEqual(s.review.status, "done");
+});
+
+test("null input tolerated (never throws)", () => {
+  const s = computeProjectSteps(undefined);
+  assert.equal(s.length, 3);
+});
+
+test("nextScreenSlug walks the canonical order and ends cleanly", () => {
+  assert.equal(nextScreenSlug("idea"), "spec");
+  assert.equal(nextScreenSlug("spec"), "items");
+  assert.equal(nextScreenSlug("items"), "settings");
+  assert.equal(nextScreenSlug("settings"), "github");
+  assert.equal(nextScreenSlug("github"), "checks");
+  assert.equal(nextScreenSlug("checks"), "fixes");
+  assert.equal(nextScreenSlug("fixes"), null); // last — no forced next
+  assert.equal(nextScreenSlug("benchmark"), null); // advanced screens stay out of the walk
+});


### PR DESCRIPTION
The UX heart of the track: the left nav becomes a **progress map** (준비 → 검수 → 결과·수정) instead of 11 flat tabs.

**The two load-bearing invariants, test-fixed (pure state machine `project-steps.mjs`):**
- **LOCKING**: confirmed-unmet preconditions dim the step with a hint — step 2 locks on no-items, step 3 locks on no-code ("코드를 먼저 연결하세요"). No more empty-screen clicks.
- **FAIL-OPEN**: unknown facts (null) never lock — a wrong lock blocks a user, a missing one just shows plain nav.
- **AUTO-CHECK**: done is derived from data (repo connected + review run → auto-checked); revisiting never demands rework.

Also: Overview pinned as command center; `StepNextButton` ("다음 → …") wired into idea/spec/items; `stepsNav` i18n EN+KO; Advanced stays collapsed; **11 tabs preserved** (regrouped under steps, nothing deleted).

7 new tests (locks/hints/auto-check/fail-open/walk order). dashboard **390** pass, i18n parity, typecheck + lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)