### PR TITLE
Deploy prep — auth base URL + dead-domain fix + simsa-landing EN/KO + trysimsa.com redirect

### DIFF
--- a/apps/central-plane/wrangler.toml
+++ b/apps/central-plane/wrangler.toml
@@ -17,6 +17,11 @@ ENVIRONMENT = "production"
 # Was fail-closed (unset → disabled) since Stage 241. Sign-in/session were never gated
 # by this policy; only POST /api/auth/sign-up/* is affected.
 AUTH_SIGNUP_MODE = "open"
+# Open-deploy batch (2026-07-05) — Better Auth canonical origin. Required for the
+# GitHub LOGIN OAuth app (#213): without it Better Auth derives the base URL from
+# the proxied request (workers.dev) and the GitHub callback becomes
+# redirect_uri_mismatch. Must match the login OAuth app's registered callback host.
+BETTER_AUTH_BASE_URL = "https://app.trysimsa.com"
 # Public GitHub OAuth App client_id. Register at https://github.com/settings/developers
 # (type: OAuth App, enable device flow). Leave the placeholder if OAuth is not
 # yet configured — /oauth/device/* endpoints will return 503 until this is real.
@@ -34,7 +39,9 @@ GITHUB_CLIENT_ID = "Ov23ctqhuNRdhunT36Y9"
 WORKSPACE_GH_CLIENT_ID = "Ov23ctqhuNRdhunT36Y9"
 WORKSPACE_GH_REDIRECT_URI = "https://conclave-ai.seunghunbae.workers.dev/workspace/github/oauth/callback"
 WORKSPACE_GH_SCOPES = "read:user public_repo"
-WORKSPACE_GH_DASHBOARD_URL = "https://dashboard.conclave-ai.dev"
+# 2026-07-05: dashboard.conclave-ai.dev is a DEAD domain (DNS gone) — post-connect
+# OAuth redirects were pointing at it. Live dashboard is app.trysimsa.com (Stage 92).
+WORKSPACE_GH_DASHBOARD_URL = "https://app.trysimsa.com"
 # Private-repo support — public install URL of the existing GitHub App
 # (e.g. "https://github.com/apps/<slug>/installations/new"). Shown to users
 # whose private repo needs the App installed. Empty = no install link surfaced.

--- a/apps/simsa-landing/package.json
+++ b/apps/simsa-landing/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start --port 3005",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test test/*.test.mjs"
   },
   "dependencies": {
     "next": "15.5.16",

--- a/apps/simsa-landing/src/app/globals.css
+++ b/apps/simsa-landing/src/app/globals.css
@@ -85,6 +85,27 @@ a {
   max-width: 34rem;
 }
 
+/* EN/KO manual switch — quiet text button, top of the hero. */
+.lang-toggle-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.5rem;
+}
+
+.lang-toggle {
+  border: 1px solid var(--line, rgba(0, 0, 0, 0.12));
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.8rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.lang-toggle:hover {
+  color: var(--fg, inherit);
+}
+
 .cta {
   display: inline-flex;
   align-items: center;

--- a/apps/simsa-landing/src/app/layout.tsx
+++ b/apps/simsa-landing/src/app/layout.tsx
@@ -1,9 +1,13 @@
 import type { Metadata } from "next";
 import "./globals.css";
 
+// Static metadata is single-language; KO leads because the open-beta community
+// distribution is Korean-first (link previews on Threads/KakaoTalk). The page
+// itself detects browser language and offers a manual EN/KO toggle.
 export const metadata: Metadata = {
-  title: "Simsa — The acceptance layer for AI-built software.",
-  description: "Review, compare, and accept AI-built software with evidence.",
+  title: "Simsa — AI로 만든 앱, 제대로 작동하는지 확인하세요",
+  description:
+    "AI로 만든 결과물이 요청한 대로 됐는지 근거와 함께 확인하세요. 오픈 베타 — 베타 기간 무료. Built an app with AI? Make sure it actually works.",
 };
 
 export default function RootLayout({

--- a/apps/simsa-landing/src/app/page.tsx
+++ b/apps/simsa-landing/src/app/page.tsx
@@ -1,9 +1,14 @@
-// Simsa marketing entry for trysimsa.com.
-// Stage 93 hero · 95 trust/contact · 96 staged-acceptance positioning ·
-// PR B open-beta framing: the early-access gate became an open-beta invite —
-// free while in beta, community tone, no launch hype.
-// Static, host-agnostic, no new dependencies.
+"use client";
+
+// Simsa marketing entry — served on simsa.dev (trysimsa.com redirects here).
+// Open-beta framing (PR B) + EN/KO with browser-language detection and a
+// manual toggle (persisted). Copy uses the dashboard's non-developer language
+// (확인 / 코드 저장소 / 기획서 / 코드 변경(PR)) — see src/lib/dictionary.mjs.
+// SSR renders EN deterministically; a hydration effect switches to the stored
+// or browser-detected language (same pattern as the dashboard I18nProvider).
 import Link from "next/link";
+import { useEffect, useState } from "react";
+import { LANDING_DICT, LANG_STORAGE_KEY, resolveInitialLang } from "../lib/dictionary.mjs";
 
 const APP_URL = "https://app.trysimsa.com";
 // Real contact mailbox (operator-provided). No trysimsa.com mailbox is wired
@@ -24,48 +29,59 @@ const FEEDBACK_MAILTO = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
   FEEDBACK_SUBJECT,
 )}&body=${encodeURIComponent(FEEDBACK_BODY)}`;
 
-const INPUTS = [
-  "Idea",
-  "PRD / spec",
-  "Product URL",
-  "GitHub repo",
-  "Pull request",
-  "AI-built app",
-];
-
-const OUTPUTS = [
-  "Product understanding",
-  "Acceptance items",
-  "Stage plan",
-  "Review evidence",
-  "Accept / fix / rerun decisions",
-  "Release readiness",
-];
+type Lang = "en" | "ko";
 
 export default function Home() {
+  // Deterministic SSR default (en) — the effect below re-resolves after
+  // hydration so there is no server/client markup mismatch.
+  const [lang, setLang] = useState<Lang>("en");
+
+  useEffect(() => {
+    let stored: string | null = null;
+    try {
+      stored = window.localStorage.getItem(LANG_STORAGE_KEY);
+    } catch {
+      /* storage blocked — fall through to browser detection */
+    }
+    setLang(resolveInitialLang({ stored, navigatorLanguage: navigator.language }));
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = lang;
+  }, [lang]);
+
+  const toggleLang = () => {
+    const next: Lang = lang === "en" ? "ko" : "en";
+    setLang(next);
+    try {
+      window.localStorage.setItem(LANG_STORAGE_KEY, next);
+    } catch {
+      /* non-fatal */
+    }
+  };
+
+  const t = LANDING_DICT[lang];
+
   return (
     <main>
       <section className="hero">
         <div className="container">
-          <p className="wordmark">Simsa</p>
-          <h1 className="tagline">The acceptance layer for AI-built software.</h1>
-          <p className="subline">From fast AI-built drafts to accepted product work.</p>
-          <p className="lede">
-            AI coding agents can create a first draft fast. Simsa helps teams
-            review, compare, and decide what to accept, fix, or rerun — with
-            evidence.
-          </p>
-          <p className="beta-note">
-            Simsa is in open beta — everything is free while we build it out.
-            You&apos;d be one of the early members, and what you run shapes what
-            it becomes.
-          </p>
+          <div className="lang-toggle-row">
+            <button type="button" className="lang-toggle" onClick={toggleLang}>
+              {t.langToggle}
+            </button>
+          </div>
+          <p className="wordmark">{t.hero.wordmark}</p>
+          <h1 className="tagline">{t.hero.headline}</h1>
+          <p className="subline">{t.hero.subline}</p>
+          <p className="lede">{t.hero.lede}</p>
+          <p className="beta-note">{t.hero.betaNote}</p>
           <div className="hero-actions">
             <a className="cta" href={APP_URL}>
-              Start free — open beta
+              {t.hero.ctaStart}
             </a>
             <Link className="cta-secondary" href="/demo">
-              View demo
+              {t.hero.ctaDemo}
             </Link>
           </div>
         </div>
@@ -73,13 +89,10 @@ export default function Home() {
 
       <section className="section">
         <div className="container">
-          <h2>Start from anything</h2>
-          <p>
-            Bring an idea, a PRD, a product URL, a GitHub repo, a pull request,
-            or an AI-built app. Simsa turns it into a staged acceptance workflow.
-          </p>
+          <h2>{t.startAnything.title}</h2>
+          <p>{t.startAnything.body}</p>
           <div className="chips">
-            {INPUTS.map((input) => (
+            {t.startAnything.chips.map((input) => (
               <span className="chip" key={input}>
                 {input}
               </span>
@@ -90,13 +103,10 @@ export default function Home() {
 
       <section className="section">
         <div className="container">
-          <h2>What Simsa creates</h2>
-          <p>
-            Raw AI-built output becomes reviewable, comparable, acceptance-ready
-            product work.
-          </p>
+          <h2>{t.creates.title}</h2>
+          <p>{t.creates.body}</p>
           <ul className="outputs">
-            {OUTPUTS.map((output) => (
+            {t.creates.outputs.map((output) => (
               <li key={output}>{output}</li>
             ))}
           </ul>
@@ -105,42 +115,22 @@ export default function Home() {
 
       <section className="section">
         <div className="container">
-          <h2>How the workflow runs</h2>
+          <h2>{t.workflow.title}</h2>
           <ol className="steps">
-            <li>
-              Understand what exists.{" "}
-              <span>Idea, spec, repo, or AI-built draft.</span>
-            </li>
-            <li>
-              Turn it into acceptance items.{" "}
-              <span>The criteria a change has to meet.</span>
-            </li>
-            <li>
-              Review builds and agent outputs.{" "}
-              <span>Against those criteria, with evidence.</span>
-            </li>
-            <li>
-              Decide what to accept, fix, or rerun.{" "}
-              <span>Compare runs and choose.</span>
-            </li>
-            <li>
-              Keep evidence and release history.{" "}
-              <span>So decisions stay reviewable.</span>
-            </li>
+            {t.workflow.steps.map((step) => (
+              <li key={step.title}>
+                {step.title} <span>{step.sub}</span>
+              </li>
+            ))}
           </ol>
         </div>
       </section>
 
       <section className="section">
         <div className="container">
-          <h2>For teams building with AI coding agents</h2>
-          <p className="note">
-            Built for founders, product teams, and agencies. Simsa runs the
-            acceptance process on top of fast AI-built drafts — staged review,
-            evidence, and release decisions — so you can tell what is actually
-            ready to accept, fix, or rerun.
-          </p>
-          <p>For partnership inquiries, contact the team.</p>
+          <h2>{t.forWhom.title}</h2>
+          <p className="note">{t.forWhom.body}</p>
+          <p>{t.forWhom.contactLead}</p>
           <a className="contact-link" href={`mailto:${CONTACT_EMAIL}`}>
             {CONTACT_EMAIL}
           </a>
@@ -149,23 +139,15 @@ export default function Home() {
 
       <section className="section">
         <div className="container">
-          <h2>Join the open beta</h2>
-          <p>
-            No waitlist, no invite code — bring an idea, a PRD, a GitHub repo,
-            or an AI-built app and start checking it today. Everything is free
-            during the beta.
-          </p>
-          <p>
-            Being early matters here: the reviews beta members run are what
-            teach Simsa which failures actually happen in AI-built software.
-            If something feels off or missing, tell us — we read every note.
-          </p>
+          <h2>{t.joinBeta.title}</h2>
+          <p>{t.joinBeta.p1}</p>
+          <p>{t.joinBeta.p2}</p>
           <div className="hero-actions">
             <a className="cta" href={APP_URL}>
-              Start free — open beta
+              {t.joinBeta.ctaStart}
             </a>
             <a className="cta-secondary" href={FEEDBACK_MAILTO}>
-              Send beta feedback
+              {t.joinBeta.ctaFeedback}
             </a>
           </div>
         </div>
@@ -174,12 +156,12 @@ export default function Home() {
       <footer className="foot">
         <div className="container">
           <nav className="foot-links">
-            <Link href="/demo">Demo</Link>
-            <Link href="/privacy">Privacy</Link>
-            <Link href="/terms">Terms</Link>
-            <a href={`mailto:${CONTACT_EMAIL}`}>Contact</a>
+            <Link href="/demo">{t.footer.demo}</Link>
+            <Link href="/privacy">{t.footer.privacy}</Link>
+            <Link href="/terms">{t.footer.terms}</Link>
+            <a href={`mailto:${CONTACT_EMAIL}`}>{t.footer.contact}</a>
           </nav>
-          <p className="foot-tag">Built for AI-built software acceptance.</p>
+          <p className="foot-tag">{t.footer.tag}</p>
         </div>
       </footer>
     </main>

--- a/apps/simsa-landing/src/lib/dictionary.d.mts
+++ b/apps/simsa-landing/src/lib/dictionary.d.mts
@@ -1,0 +1,27 @@
+export declare const LANG_STORAGE_KEY: string;
+
+export declare function resolveInitialLang(input: {
+  stored?: string | null;
+  navigatorLanguage?: string | null;
+}): "en" | "ko";
+
+export interface LandingDict {
+  langToggle: string;
+  hero: {
+    wordmark: string;
+    headline: string;
+    subline: string;
+    lede: string;
+    betaNote: string;
+    ctaStart: string;
+    ctaDemo: string;
+  };
+  startAnything: { title: string; body: string; chips: string[] };
+  creates: { title: string; body: string; outputs: string[] };
+  workflow: { title: string; steps: { title: string; sub: string }[] };
+  forWhom: { title: string; body: string; contactLead: string };
+  joinBeta: { title: string; p1: string; p2: string; ctaStart: string; ctaFeedback: string };
+  footer: { demo: string; privacy: string; terms: string; contact: string; tag: string };
+}
+
+export declare const LANDING_DICT: { en: LandingDict; ko: LandingDict };

--- a/apps/simsa-landing/src/lib/dictionary.mjs
+++ b/apps/simsa-landing/src/lib/dictionary.mjs
@@ -1,0 +1,159 @@
+/**
+ * simsa-landing dictionary — EN + KO, same key shape (parity-tested).
+ *
+ * Non-developer language rules (same as the dashboard):
+ *   acceptance → 확인 · repo → 코드 저장소 · PRD → 기획서 · PR → 코드 변경(PR).
+ * Tone: open-beta invite — calm, early-member, no launch hype.
+ *
+ * Pure ESM (no React) so `node --test` can import it directly.
+ */
+
+/** localStorage key for the visitor's manual language choice. */
+export const LANG_STORAGE_KEY = "simsa:landing-lang";
+
+/**
+ * Resolve the language to show. Pure + deterministic:
+ *   stored choice ("en"|"ko") > browser language (ko* → ko) > "en".
+ * @param {{ stored?: string | null, navigatorLanguage?: string | null }} input
+ * @returns {"en" | "ko"}
+ */
+export function resolveInitialLang(input) {
+  const { stored, navigatorLanguage } = input ?? {};
+  if (stored === "en" || stored === "ko") return stored;
+  const nav = typeof navigatorLanguage === "string" ? navigatorLanguage.toLowerCase() : "";
+  if (nav === "ko" || nav.startsWith("ko-")) return "ko";
+  return "en";
+}
+
+export const LANDING_DICT = {
+  en: {
+    langToggle: "한국어",
+    hero: {
+      wordmark: "Simsa",
+      headline: "Built an app with AI? Make sure it actually works.",
+      subline: "From fast AI-built drafts to product work you can trust.",
+      lede:
+        "AI coding tools can build a first version fast. Simsa checks whether that result does what you asked — and helps you decide what to accept, fix, or run again, with evidence.",
+      betaNote:
+        "Simsa is in open beta — everything is free while we build it out. You'd be one of the early members, and what you run shapes what it becomes.",
+      ctaStart: "Start free — open beta",
+      ctaDemo: "View demo",
+    },
+    startAnything: {
+      title: "Start from anything",
+      body:
+        "Bring an idea, a product brief, a product link, a code home (GitHub), a submitted code change, or an AI-built app. Simsa turns it into a step-by-step checking flow.",
+      chips: ["Idea", "Product brief", "Product link", "Code home (GitHub)", "Code change (PR)", "AI-built app"],
+    },
+    creates: {
+      title: "What Simsa gives you",
+      body:
+        "Left alone, AI-built output stays at \"it seems to work.\" Simsa turns it into results you can check, compare, and stand behind.",
+      outputs: [
+        "A clear picture of your product",
+        "Checking items (what \"done\" means)",
+        "A step-by-step plan",
+        "Evidence for every check",
+        "Accept / fix / re-run decisions",
+        "Ready-to-ship status",
+      ],
+    },
+    workflow: {
+      title: "How a check runs",
+      steps: [
+        { title: "See what you have.", sub: "An idea, a brief, code, or an AI-built draft." },
+        { title: "Turn it into checking items.", sub: "The things the result has to get right." },
+        { title: "Check the result against them.", sub: "With evidence, not gut feeling." },
+        { title: "Decide: accept, fix, or run again.", sub: "Compare runs and choose." },
+        { title: "Keep the evidence and history.", sub: "So every decision stays reviewable." },
+      ],
+    },
+    forWhom: {
+      title: "For everyone building with AI",
+      body:
+        "You don't need to be a developer. Founders, planners, and teams use Simsa to put a checking layer on top of fast AI-built drafts — so you can tell what's actually ready.",
+      contactLead: "For partnership inquiries, contact the team.",
+    },
+    joinBeta: {
+      title: "Join the open beta",
+      p1:
+        "No waitlist, no invite code — bring an idea, a brief, or an AI-built app and start checking it today. Everything is free during the beta.",
+      p2:
+        "Being early matters here: the checks beta members run are what teach Simsa which failures actually happen in AI-built apps. If something feels off or missing, tell us — we read every note.",
+      ctaStart: "Start free — open beta",
+      ctaFeedback: "Send beta feedback",
+    },
+    footer: {
+      demo: "Demo",
+      privacy: "Privacy",
+      terms: "Terms",
+      contact: "Contact",
+      tag: "The checking layer for AI-built apps.",
+    },
+  },
+  ko: {
+    langToggle: "English",
+    hero: {
+      wordmark: "Simsa",
+      headline: "AI로 만든 앱, 제대로 작동하는지 확인하세요.",
+      subline: "빠르게 만든 초안을, 믿고 내보낼 수 있는 결과물로.",
+      lede:
+        "AI 코딩 도구는 첫 버전을 금방 만들어줘요. Simsa는 그 결과물이 요청한 대로 됐는지 확인하고 — 채택할지, 고칠지, 다시 돌릴지를 근거와 함께 결정하도록 도와줘요.",
+      betaNote:
+        "지금은 오픈 베타예요 — 만들어가는 동안 모든 기능이 무료입니다. 지금 시작하면 초기 멤버가 되고, 여러분이 돌린 확인이 Simsa의 방향을 만들어요.",
+      ctaStart: "무료로 시작하기 — 오픈 베타",
+      ctaDemo: "데모 보기",
+    },
+    startAnything: {
+      title: "무엇으로든 시작하세요",
+      body:
+        "아이디어, 기획서, 제품 링크, 코드 저장소(GitHub), 제출된 코드 변경, AI로 만든 앱 — 무엇이든 가져오면 Simsa가 단계별 확인 과정으로 바꿔줘요.",
+      chips: ["아이디어", "기획서", "제품 링크", "코드 저장소(GitHub)", "코드 변경(PR)", "AI로 만든 앱"],
+    },
+    creates: {
+      title: "Simsa가 만들어주는 것",
+      body:
+        "AI가 만든 결과물은 그대로 두면 \"되는 것 같은\" 상태에 머물러요. Simsa는 이를 확인하고, 비교하고, 자신 있게 내보낼 수 있는 결과로 바꿔줘요.",
+      outputs: [
+        "내 제품에 대한 명확한 정리",
+        "확인 항목 (\"완성\"의 기준)",
+        "단계별 진행 계획",
+        "확인마다 남는 근거",
+        "채택 · 수정 · 재확인 결정",
+        "내보낼 준비 상태",
+      ],
+    },
+    workflow: {
+      title: "확인은 이렇게 진행돼요",
+      steps: [
+        { title: "지금 있는 것을 파악해요.", sub: "아이디어, 기획서, 코드, AI가 만든 초안." },
+        { title: "확인 항목으로 바꿔요.", sub: "결과물이 반드시 맞춰야 할 기준." },
+        { title: "결과물을 기준에 맞춰 확인해요.", sub: "감이 아니라 근거로." },
+        { title: "채택할지, 고칠지, 다시 돌릴지 정해요.", sub: "실행 결과를 비교해서 선택해요." },
+        { title: "근거와 이력을 남겨요.", sub: "모든 결정을 언제든 다시 볼 수 있게." },
+      ],
+    },
+    forWhom: {
+      title: "AI로 만드는 모든 사람을 위해",
+      body:
+        "개발자가 아니어도 괜찮아요. 창업자, 기획자, 팀이 AI로 빠르게 만든 결과물 위에 확인 과정을 얹어 — 무엇이 정말 준비됐는지 알 수 있게 해줘요.",
+      contactLead: "제휴 문의는 팀에게 연락해주세요.",
+    },
+    joinBeta: {
+      title: "오픈 베타에 함께하세요",
+      p1:
+        "대기 명단도 초대 코드도 없어요 — 아이디어든, 기획서든, AI로 만든 앱이든 가져와서 오늘 바로 확인을 시작하세요. 베타 기간에는 전부 무료예요.",
+      p2:
+        "초기 멤버가 중요한 이유가 있어요: 베타 멤버가 돌린 확인이, AI로 만든 앱에서 실제로 어떤 문제가 생기는지 Simsa에게 가르쳐줘요. 이상하거나 아쉬운 게 있으면 알려주세요 — 모든 메모를 읽습니다.",
+      ctaStart: "무료로 시작하기 — 오픈 베타",
+      ctaFeedback: "베타 피드백 보내기",
+    },
+    footer: {
+      demo: "데모",
+      privacy: "개인정보 처리방침",
+      terms: "이용약관",
+      contact: "문의",
+      tag: "AI로 만든 앱을 위한 확인 레이어.",
+    },
+  },
+};

--- a/apps/simsa-landing/test/dictionary.test.mjs
+++ b/apps/simsa-landing/test/dictionary.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * simsa-landing dictionary — EN/KO parity + language resolution.
+ *
+ * Parity: both languages expose the exact same key tree (recursive), every
+ * leaf is a non-empty string, and array leaves have equal lengths.
+ * Jargon guard: KO copy must not leak developer jargon the dashboard bans
+ * (acceptance → 확인, repo → 코드 저장소, PRD → 기획서).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { LANDING_DICT, resolveInitialLang, LANG_STORAGE_KEY } = await import(
+  "../src/lib/dictionary.mjs"
+);
+
+function collectPaths(obj, prefix = "") {
+  const paths = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const p = prefix ? `${prefix}.${key}` : key;
+    if (Array.isArray(value)) {
+      paths.push(`${p}[len:${value.length}]`);
+      value.forEach((v, i) => {
+        if (typeof v === "object" && v !== null) paths.push(...collectPaths(v, `${p}[${i}]`));
+        else paths.push(`${p}[${i}]`);
+      });
+    } else if (typeof value === "object" && value !== null) {
+      paths.push(...collectPaths(value, p));
+    } else {
+      paths.push(p);
+    }
+  }
+  return paths.sort();
+}
+
+function collectLeafStrings(obj, out = []) {
+  for (const value of Object.values(obj)) {
+    if (Array.isArray(value)) value.forEach((v) => (typeof v === "object" ? collectLeafStrings(v, out) : out.push(v)));
+    else if (typeof value === "object" && value !== null) collectLeafStrings(value, out);
+    else out.push(value);
+  }
+  return out;
+}
+
+describe("landing dictionary parity", () => {
+  it("EN and KO have the identical key tree (including array lengths)", () => {
+    assert.deepEqual(collectPaths(LANDING_DICT.en), collectPaths(LANDING_DICT.ko));
+  });
+
+  it("every leaf is a non-empty string in both languages", () => {
+    for (const lang of ["en", "ko"]) {
+      for (const leaf of collectLeafStrings(LANDING_DICT[lang])) {
+        assert.equal(typeof leaf, "string", `${lang} leaf must be a string`);
+        assert.ok(leaf.trim().length > 0, `${lang} leaf must not be empty`);
+      }
+    }
+  });
+
+  it("KO copy avoids banned developer jargon", () => {
+    const koText = collectLeafStrings(LANDING_DICT.ko).join(" ");
+    for (const banned of ["acceptance", "PRD", "레포", "리포지토리", "pull request", "Pull request"]) {
+      assert.ok(!koText.includes(banned), `KO copy must not contain "${banned}"`);
+    }
+  });
+
+  it("KO actually renders in Korean (hangul present in every KO section title)", () => {
+    const hangul = /[가-힣]/;
+    assert.ok(hangul.test(LANDING_DICT.ko.hero.headline));
+    assert.ok(hangul.test(LANDING_DICT.ko.startAnything.title));
+    assert.ok(hangul.test(LANDING_DICT.ko.joinBeta.title));
+  });
+});
+
+describe("resolveInitialLang", () => {
+  it("stored manual choice wins", () => {
+    assert.equal(resolveInitialLang({ stored: "ko", navigatorLanguage: "en-US" }), "ko");
+    assert.equal(resolveInitialLang({ stored: "en", navigatorLanguage: "ko-KR" }), "en");
+  });
+
+  it("browser language ko / ko-KR → ko", () => {
+    assert.equal(resolveInitialLang({ navigatorLanguage: "ko" }), "ko");
+    assert.equal(resolveInitialLang({ navigatorLanguage: "ko-KR" }), "ko");
+    assert.equal(resolveInitialLang({ navigatorLanguage: "KO-kr" }), "ko");
+  });
+
+  it("everything else (and garbage) → en", () => {
+    assert.equal(resolveInitialLang({ navigatorLanguage: "en-US" }), "en");
+    assert.equal(resolveInitialLang({ navigatorLanguage: "ja-JP" }), "en");
+    assert.equal(resolveInitialLang({ stored: "fr", navigatorLanguage: null }), "en");
+    assert.equal(resolveInitialLang({}), "en");
+    assert.equal(resolveInitialLang(undefined), "en");
+  });
+
+  it("storage key is namespaced", () => {
+    assert.ok(LANG_STORAGE_KEY.startsWith("simsa:"));
+  });
+});

--- a/apps/simsa-landing/vercel.json
+++ b/apps/simsa-landing/vercel.json
@@ -1,4 +1,24 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "trysimsa.com" }],
+      "destination": "https://simsa.dev/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.trysimsa.com" }],
+      "destination": "https://simsa.dev/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.simsa.dev" }],
+      "destination": "https://simsa.dev/:path*",
+      "permanent": true
+    }
+  ]
 }


### PR DESCRIPTION
오픈 직전 배치 배포 전제 PR (config + simsa-landing만, conclave-ai.dev 불가침):

### 1. wrangler.toml [vars] 2건
- **BETTER_AUTH_BASE_URL = https://app.trysimsa.com** — 로그인용 OAuth 앱 콜백 호스트 일치 (없으면 workers.dev로 파생 → redirect_uri_mismatch)
- **WORKSPACE_GH_DASHBOARD_URL** — `dashboard.conclave-ai.dev`는 DNS 죽은 도메인 (repo 연결 OAuth 후 죽은 페이지로 리다이렉트되던 프로덕션 버그) → `app.trysimsa.com`

### 2. simsa-landing EN/KO + 도메인 재배치 준비
- simsa.dev(커뮤니티 배포 주소)에 현재 "Simsa for Developers · coming soon"이 떠 있음 → 이 PR + 배포로 simsa-landing이 인수
- **EN/KO**: 브라우저 언어 감지(ko* → KO) + 수동 토글(localStorage 영속) + `document.lang` 동기화. SSR은 EN 결정적 렌더 → hydration 후 전환(대시보드 I18nProvider 패턴)
- **비개발자 언어** (대시보드와 동일): acceptance→확인, repo→코드 저장소, PRD→기획서, PR→코드 변경(PR)
- **헤드라인**: "AI로 만든 앱, 제대로 작동하는지 확인하세요." / "Built an app with AI? Make sure it actually works."
- 오픈베타 초대 톤 유지, blur/emoji/반복카드 없음
- **vercel.json 호스트 리다이렉트**: trysimsa.com·www.trysimsa.com·www.simsa.dev → https://simsa.dev (308). app.trysimsa.com은 별도 프로젝트(dashboard) — 영향 없음
- 메타데이터 KO 우선 (Threads/카카오톡 링크 프리뷰)

### 3. 테스트 (8개 신규)
EN/KO 키트리 parity(배열 길이 포함) · 빈 문자열 금지 · KO 금지어(acceptance/PRD/레포/pull request) · 한글 실존 · resolveInitialLang 매트릭스(stored>navigator>en)

남김: demo 페이지는 EN 유지(후속), terms/privacy는 법적 문서라 EN 유지. 도메인 자체 이동(simsa.dev를 simsa-dev 프로젝트 → simsa-landing 프로젝트)은 머지 후 배포 단계에서 Vercel CLI로 실행 + 라이브 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)