### PR TITLE
UX 글로벌 기준 배치 — 뒤로가기 URL화 + 모바일 셸 + WCAG 대비 + 위계 + 정직한 에러

### DIFF
--- a/apps/dashboard/src/app/account/page.tsx
+++ b/apps/dashboard/src/app/account/page.tsx
@@ -22,7 +22,7 @@ function Badge({ children, tone = "gray" }: { children: React.ReactNode; tone?: 
     tone === "gold"
       ? "bg-gold-100 text-gold-700"
       : tone === "muted"
-        ? "bg-gray-100 text-gray-400"
+        ? "bg-gray-100 text-gray-500"
         : "bg-gray-100 text-gray-600";
   return <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}>{children}</span>;
 }
@@ -124,12 +124,12 @@ export default function AccountPage() {
               maxLength={DISPLAY_NAME_MAX}
               onChange={(e) => onChange(e.target.value)}
               placeholder={a.profile.displayNamePlaceholder}
-              className="mt-1 w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-100"
+              className="mt-1 w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-500 focus:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-100"
             />
           </label>
         </div>
-        <p className="mt-2 text-xs text-gray-400">{a.profile.storedLocally}</p>
-        <p className="mt-1 text-xs text-gray-400">
+        <p className="mt-2 text-xs text-gray-500">{a.profile.storedLocally}</p>
+        <p className="mt-1 text-xs text-gray-500">
           {a.profile.emailRequiresSignIn} <Badge tone="muted">{a.badges.requiresSignIn}</Badge>
         </p>
         {!hydrated && <span className="sr-only">loading</span>}
@@ -142,7 +142,7 @@ export default function AccountPage() {
           <span className="text-sm text-gray-700">{a.preferences.language}</span>
           <LanguageToggle />
         </div>
-        <p className="mt-2 text-xs text-gray-400">{a.preferences.languageHelp}</p>
+        <p className="mt-2 text-xs text-gray-500">{a.preferences.languageHelp}</p>
       </section>
 
       {/* Authentication (controlled preview) */}
@@ -151,7 +151,7 @@ export default function AccountPage() {
           <p className="section-title">{a.auth.heading}</p>
           <Badge tone="muted">{a.badges.requiresSignIn}</Badge>
         </div>
-        <p className="mt-2 text-xs text-gray-400">{a.auth.controlledPreview}</p>
+        <p className="mt-2 text-xs text-gray-500">{a.auth.controlledPreview}</p>
         <div className="mt-3 flex items-center justify-between gap-3">
           <span className="text-sm text-gray-700">{a.auth.statusLabel}</span>
           <span className="text-sm text-gray-900">
@@ -206,7 +206,7 @@ export default function AccountPage() {
             )}
           </div>
         )}
-        <p className="mt-2 text-xs text-gray-400">{a.auth.keepsLocal}</p>
+        <p className="mt-2 text-xs text-gray-500">{a.auth.keepsLocal}</p>
       </section>
 
       {/* Connected accounts */}
@@ -215,13 +215,13 @@ export default function AccountPage() {
         <ul className="mt-3 space-y-2">
           <li className="flex items-center justify-between gap-3 text-sm">
             <span className="text-gray-700">{a.connectedAccounts.github}</span>
-            <span className="flex items-center gap-2 text-xs text-gray-400">
+            <span className="flex items-center gap-2 text-xs text-gray-500">
               {a.connectedAccounts.githubStatus} <Badge tone="muted">{a.badges.readOnly}</Badge>
             </span>
           </li>
           <li className="flex items-center justify-between gap-3 text-sm">
             <span className="text-gray-700">{a.connectedAccounts.vercel}</span>
-            <span className="flex items-center gap-2 text-xs text-gray-400">
+            <span className="flex items-center gap-2 text-xs text-gray-500">
               {a.connectedAccounts.vercelStatus} <Badge tone="muted">{a.badges.planned}</Badge>
             </span>
           </li>
@@ -235,15 +235,15 @@ export default function AccountPage() {
       <section className="card mt-6 p-5">
         <p className="section-title">{a.sections.data}</p>
         <p className="mt-3 text-sm text-gray-600">{a.data.projectExports}</p>
-        <p className="mt-1 text-xs text-gray-400">{a.data.accountExportPlanned}</p>
-        <p className="mt-1 text-xs text-gray-400">{a.data.importPlanned}</p>
+        <p className="mt-1 text-xs text-gray-500">{a.data.accountExportPlanned}</p>
+        <p className="mt-1 text-xs text-gray-500">{a.data.importPlanned}</p>
         <div className="mt-3 flex items-center gap-2">
           <button type="button" disabled className="btn btn-secondary btn-sm cursor-not-allowed opacity-50">
             {a.data.deleteAccount}
           </button>
           <Badge tone="muted">{a.badges.requiresSignIn}</Badge>
         </div>
-        <p className="mt-1 text-xs text-gray-400">{a.data.deleteRequiresSignIn}</p>
+        <p className="mt-1 text-xs text-gray-500">{a.data.deleteRequiresSignIn}</p>
       </section>
 
       {/* Workspace */}
@@ -252,10 +252,10 @@ export default function AccountPage() {
         <p className="mt-3 text-sm text-gray-700">
           {a.workspaceInfo.current}: <span className="text-gray-500">{a.workspaceInfo.localScoped}</span>
         </p>
-        <p className="mt-1 text-xs text-gray-400">
+        <p className="mt-1 text-xs text-gray-500">
           {a.workspaceInfo.teamPlanned} <Badge tone="muted">{a.badges.planned}</Badge>
         </p>
-        <p className="mt-1 text-xs text-gray-400">
+        <p className="mt-1 text-xs text-gray-500">
           {a.workspaceInfo.invitePlanned} <Badge tone="muted">{a.badges.planned}</Badge>
         </p>
       </section>

--- a/apps/dashboard/src/app/admin/credits/page.tsx
+++ b/apps/dashboard/src/app/admin/credits/page.tsx
@@ -115,7 +115,7 @@ function BalanceTable({ balances }: { balances: CreditBalance[] }) {
           <tr key={b.creditType} className="border-b last:border-0">
             <td className="py-1">{creditTypeLabel(t, b.creditType)}</td>
             <td className="py-1 text-right font-mono font-bold text-indigo-700">{b.balance}</td>
-            <td className="py-1 text-right text-gray-400">{b.updatedAt.slice(0, 10)}</td>
+            <td className="py-1 text-right text-gray-500">{b.updatedAt.slice(0, 10)}</td>
           </tr>
         ))}
       </tbody>
@@ -165,7 +165,7 @@ function LedgerTable({ entries }: { entries: LedgerEntry[] }) {
                     ? "text-red-500"
                     : e.status === "pending"
                     ? "text-amber-600"
-                    : "text-gray-400"
+                    : "text-gray-500"
                 }
               >
                 {statusLabelText(t, e.status)}
@@ -173,7 +173,7 @@ function LedgerTable({ entries }: { entries: LedgerEntry[] }) {
             </td>
             <td className="py-1 text-right font-mono">{e.amount}</td>
             <td className="py-1 pl-3 text-gray-600 max-w-xs truncate">{e.reason}</td>
-            <td className="py-1 text-right text-gray-400">{e.createdAt.slice(0, 10)}</td>
+            <td className="py-1 text-right text-gray-500">{e.createdAt.slice(0, 10)}</td>
           </tr>
         ))}
       </tbody>
@@ -286,7 +286,7 @@ function PendingCleanupTable({
                   </span>
                 </td>
                 <td className="py-1 pl-2 font-mono text-xs text-gray-500 max-w-xs truncate">{e.sourceEventId ?? "—"}</td>
-                <td className="py-1 pl-2 text-xs text-gray-400">{e.createdAt.slice(0, 16).replace("T", " ")}</td>
+                <td className="py-1 pl-2 text-xs text-gray-500">{e.createdAt.slice(0, 16).replace("T", " ")}</td>
                 <td className="py-1 pl-2">
                   <button
                     onClick={() => onMarkFailed(e.id)}
@@ -356,7 +356,7 @@ function RolloutChecklistSection({ data }: { data: AdminCreditRolloutChecklistRe
             <div key={s.id} className="border border-gray-200 rounded-lg px-3 py-2">
               <div className="flex items-center gap-2 mb-1">
                 <span className="text-sm font-medium text-gray-700">{s.label}</span>
-                <span className="text-xs text-gray-400">
+                <span className="text-xs text-gray-500">
                   debits={String(s.flags.actualDebitsEnabled)} · blocking={String(s.flags.blockingEnabled)}
                 </span>
               </div>
@@ -372,7 +372,7 @@ function RolloutChecklistSection({ data }: { data: AdminCreditRolloutChecklistRe
         <ul className="space-y-1">
           {productionEnableCriteria.map((criterion, i) => (
             <li key={i} className="flex gap-2 text-xs text-gray-600">
-              <span className="text-gray-400 shrink-0">{i + 1}.</span>
+              <span className="text-gray-500 shrink-0">{i + 1}.</span>
               <span>{criterion}</span>
             </li>
           ))}
@@ -446,7 +446,7 @@ function PreviewTable({ preview }: { preview: PreviewResult }) {
                       </span>
                     )
                   ) : (
-                    <span className="text-gray-400">—</span>
+                    <span className="text-gray-500">—</span>
                   )}
                 </td>
                 <td className="py-1 pl-3">
@@ -516,7 +516,7 @@ function MonthlyPreviewSection({ data }: { data: MonthlyCreditPreviewResult }) {
                     {u.wouldBlockCount > 0 ? (
                       <span className="text-xs bg-red-100 text-red-700 px-1.5 py-0.5 rounded">{t.adminCredits.countSuffix.replace("{n}", String(u.wouldBlockCount))}</span>
                     ) : (
-                      <span className="text-xs text-gray-400">0</span>
+                      <span className="text-xs text-gray-500">0</span>
                     )}
                   </td>
                 </tr>
@@ -989,13 +989,13 @@ export default function AdminCreditsPage() {
           </div>
           {balances !== null && (
             <div className="pt-2">
-              <p className="text-xs text-gray-400 mb-2">userKey: {userKey}</p>
+              <p className="text-xs text-gray-500 mb-2">userKey: {userKey}</p>
               <BalanceTable balances={balances} />
             </div>
           )}
           {ledger !== null && (
             <div className="pt-2">
-              <p className="text-xs text-gray-400 mb-2">userKey: {userKey} — {t.adminCredits.recentEntries.replace("{n}", "50")}</p>
+              <p className="text-xs text-gray-500 mb-2">userKey: {userKey} — {t.adminCredits.recentEntries.replace("{n}", "50")}</p>
               <LedgerTable entries={ledger} />
             </div>
           )}
@@ -1048,7 +1048,7 @@ export default function AdminCreditsPage() {
               {t.adminCredits.grant}
             </button>
           </div>
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-gray-500">
             {t.adminCredits.grantNotice}
           </p>
         </div>
@@ -1270,7 +1270,7 @@ export default function AdminCreditsPage() {
                         {req.adminNote && (
                           <p className="text-xs text-indigo-600 mt-0.5">{t.adminCredits.topUpAdminNoteLabel}{req.adminNote}</p>
                         )}
-                        <p className="text-xs text-gray-400 mt-1">
+                        <p className="text-xs text-gray-500 mt-1">
                           {t.adminCredits.topUpRequestedAt}{req.createdAt.slice(0, 10)}
                           {req.resolvedAt && `${t.adminCredits.topUpResolvedAt}${req.resolvedAt.slice(0, 10)}`}
                         </p>

--- a/apps/dashboard/src/app/admin/usage/page.tsx
+++ b/apps/dashboard/src/app/admin/usage/page.tsx
@@ -131,7 +131,7 @@ export default function AdminUsagePage() {
 
         {stats && (
           <>
-            <p className="text-xs text-gray-400 mb-4">
+            <p className="text-xs text-gray-500 mb-4">
               {t.adminUsage.basis
                 .replace("{range}", rangeLabel(t, stats.range))
                 .replace("{cutoff}", stats.cutoff.slice(0, 10))}
@@ -187,7 +187,7 @@ export default function AdminUsagePage() {
                   <div className="bg-white rounded-xl border border-gray-200 overflow-hidden mb-4">
                     <div className="px-5 py-4 border-b border-gray-100">
                       <h2 className="font-semibold text-gray-800">{t.adminUsage.billableTitle}</h2>
-                      <p className="text-xs text-gray-400 mt-0.5">{t.adminUsage.billableDesc}</p>
+                      <p className="text-xs text-gray-500 mt-0.5">{t.adminUsage.billableDesc}</p>
                     </div>
                     <BillingEventTable rows={billableRows} />
                   </div>
@@ -269,13 +269,13 @@ export default function AdminUsagePage() {
                 <h2 className="font-semibold text-gray-800">{t.adminUsage.byEventTitle}</h2>
               </div>
               {stats.byEventType.length === 0 ? (
-                <p className="px-5 py-4 text-sm text-gray-400">{t.adminUsage.noEvents}</p>
+                <p className="px-5 py-4 text-sm text-gray-500">{t.adminUsage.noEvents}</p>
               ) : (
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="bg-gray-50 text-gray-500 text-xs">
                       <th className="text-left px-5 py-2 font-medium">{t.adminUsage.colFeature}</th>
-                      <th className="text-left px-5 py-2 font-medium text-gray-400">{t.adminUsage.colEventType}</th>
+                      <th className="text-left px-5 py-2 font-medium text-gray-500">{t.adminUsage.colEventType}</th>
                       <th className="text-right px-5 py-2 font-medium">{t.adminUsage.colCount}</th>
                     </tr>
                   </thead>
@@ -283,7 +283,7 @@ export default function AdminUsagePage() {
                     {stats.byEventType.map((row) => (
                       <tr key={row.eventType} className="border-t border-gray-100 hover:bg-gray-50">
                         <td className="px-5 py-3 text-gray-900">{row.label}</td>
-                        <td className="px-5 py-3 text-gray-400 font-mono text-xs">{row.eventType}</td>
+                        <td className="px-5 py-3 text-gray-500 font-mono text-xs">{row.eventType}</td>
                         <td className="px-5 py-3 text-right font-medium text-gray-900">
                           {row.count.toLocaleString()}
                         </td>

--- a/apps/dashboard/src/app/admin/workflows/page.tsx
+++ b/apps/dashboard/src/app/admin/workflows/page.tsx
@@ -84,7 +84,7 @@ export default function AdminWorkflowsPage() {
         account authentication. Avoid exposing or copying sensitive workflow content.
       </p>
       {/* Stage 122 — usage boundary note */}
-      <p className="mt-1 text-xs text-gray-400">
+      <p className="mt-1 text-xs text-gray-500">
         {ADMIN_USAGE_BOUNDARY_NOTE} {ADMIN_COUNTS_SIGNAL_NOTE}
       </p>
 
@@ -177,7 +177,7 @@ export default function AdminWorkflowsPage() {
                     </span>
                   </div>
                   <p className="mt-1 text-xs text-gray-500">{r.sourceSummary}</p>
-                  <p className="mt-1 text-xs text-gray-400">
+                  <p className="mt-1 text-xs text-gray-500">
                     {r.id} · userKey {r.userKey} · created {r.createdAt} · updated {r.updatedAt}
                   </p>
                   <div className="mt-2 flex flex-wrap gap-2">

--- a/apps/dashboard/src/app/globals.css
+++ b/apps/dashboard/src/app/globals.css
@@ -35,7 +35,7 @@
 
   /* Buttons */
   .btn {
-    @apply inline-flex items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50;
+    @apply inline-flex items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300 focus-visible:ring-offset-1;
   }
   .btn-sm {
     @apply px-2.5 py-1.5 text-xs;
@@ -43,8 +43,10 @@
   .btn-md {
     @apply px-3.5 py-2;
   }
+  /* The ONE look-here action per screen: brand fill + shadow so it separates
+     from outlines and any dark neutral element at a glance. Reserve it. */
   .btn-primary {
-    @apply bg-brand-600 text-white hover:bg-brand-700;
+    @apply bg-brand-600 text-white shadow-sm hover:bg-brand-700;
   }
   .btn-secondary {
     @apply border border-gray-200 bg-white text-gray-700 hover:bg-gray-50;
@@ -72,15 +74,18 @@
     @apply rounded-lg border border-dashed border-gray-300 bg-white px-6 py-14 text-center;
   }
 
-  /* Page + section headers — consistent hierarchy */
+  /* Page + section headers — consistent hierarchy.
+     The type scale needs ≥2 real steps: page (2xl) > section (base) > body
+     (sm) > caption (xs). section-title at text-sm collapsed into body copy —
+     that was the "everything reads the same" failure. */
   .page-title {
-    @apply text-xl font-semibold tracking-tight text-gray-900;
+    @apply text-2xl font-semibold tracking-tight text-gray-900;
   }
   .page-subtitle {
     @apply mt-1 text-sm text-gray-500;
   }
   .section-title {
-    @apply text-sm font-semibold text-gray-800;
+    @apply text-base font-semibold tracking-tight text-gray-800;
   }
   .section-desc {
     @apply mt-0.5 text-xs text-gray-500;

--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           {/* App shell: slim left sidebar (like an AI-platform workspace) + spacious main */}
           <div className="flex min-h-screen">
             <AppSidebar />
-            <main className="relative min-w-0 flex-1">
+            <main className="relative min-w-0 flex-1 pt-12 md:pt-0">
               <div className="absolute right-4 top-3 z-20">
                 <LanguageToggle />
               </div>

--- a/apps/dashboard/src/app/login/page.tsx
+++ b/apps/dashboard/src/app/login/page.tsx
@@ -142,12 +142,12 @@ function LoginInner() {
         <button
           type="button"
           onClick={() => { setMode(mode === "signin" ? "signup" : "signin"); setErrorMsg(""); }}
-          className="mt-4 w-full text-center text-xs text-gray-400 underline hover:text-gray-600"
+          className="mt-4 w-full text-center text-xs text-gray-500 underline hover:text-gray-600"
         >
           {mode === "signin" ? t.login.toSignUp : t.login.toSignIn}
         </button>
 
-        <p className="mt-8 text-center text-xs text-gray-400">
+        <p className="mt-8 text-center text-xs text-gray-500">
           {t.login.keepsLocal}{" "}
           <Link href={nextPath} className="underline hover:text-gray-600">{t.login.skip}</Link>
         </p>

--- a/apps/dashboard/src/app/projects/[id]/benchmark/[benchmarkId]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/benchmark/[benchmarkId]/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useState, useEffect, Fragment } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
@@ -86,7 +88,7 @@ const MATRIX_BADGE: Record<string, string> = {
   failed: "border-red-200 bg-red-50 text-red-700",
   needs_decision: "border-slate-200 bg-slate-50 text-slate-700",
   inconclusive: "border-yellow-200 bg-yellow-50 text-yellow-700",
-  missing: "border-gray-200 bg-gray-50 text-gray-400",
+  missing: "border-gray-200 bg-gray-50 text-gray-500",
 };
 
 function matrixStatusLabel(t: Dictionary, status: string): string {
@@ -126,14 +128,14 @@ export default function BenchmarkDetailPage() {
     return () => { cancelled = true; };
   }, [id, benchmarkId, userKey]);
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   const backUrl = `/projects/${id}/benchmark`;
 
   if (phase === "loading") {
     return (
       <div className="max-w-3xl">
-        <div className="flex items-center gap-2 text-sm text-gray-400">
+        <div className="flex items-center gap-2 text-sm text-gray-500">
           <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-gray-200 border-t-gray-500" />
           {t.benchmark.detailLoading}
         </div>
@@ -143,7 +145,7 @@ export default function BenchmarkDetailPage() {
   if (phase === "not_found" || phase === "error" || !data) {
     return (
       <div className="max-w-3xl space-y-4">
-        <Link href={backUrl} className="text-xs text-gray-400 hover:text-indigo-600">{t.benchmark.detailBack}</Link>
+        <Link href={backUrl} className="text-xs text-gray-500 hover:text-indigo-600">{t.benchmark.detailBack}</Link>
         <div className="rounded-xl border border-gray-200 bg-white px-4 py-6 text-center text-sm text-gray-500">
           {phase === "not_found" ? t.benchmark.notFoundDetail : t.benchmark.loadErrorDetail}
         </div>
@@ -304,7 +306,7 @@ export default function BenchmarkDetailPage() {
     <div className="max-w-4xl space-y-6">
       {/* Header */}
       <div>
-        <Link href={backUrl} className="text-xs text-gray-400 hover:text-indigo-600">{t.benchmark.detailBack}</Link>
+        <Link href={backUrl} className="text-xs text-gray-500 hover:text-indigo-600">{t.benchmark.detailBack}</Link>
         <div className="mt-2 flex items-start justify-between gap-3">
           <div>
             <h2 className="text-lg font-semibold tracking-tight text-gray-900">{t.benchmark.detailTitle}</h2>
@@ -334,7 +336,7 @@ export default function BenchmarkDetailPage() {
       {/* Acceptance set alignment */}
       {alignment && (
         alignment.aligned ? (
-          <p className="text-xs text-gray-400">{t.benchmark.sameAcceptanceSet}</p>
+          <p className="text-xs text-gray-500">{t.benchmark.sameAcceptanceSet}</p>
         ) : (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800">
             {t.benchmark.acceptanceSetWarning}
@@ -399,12 +401,12 @@ export default function BenchmarkDetailPage() {
       <section className="overflow-hidden rounded-xl border border-gray-200 bg-white">
         <div className="border-b border-gray-100 px-5 py-3">
           <h3 className="text-sm font-semibold text-gray-800">{t.benchmark.candidateComparison}</h3>
-          <p className="mt-0.5 text-[11px] text-gray-400">{t.benchmark.scoreNote}</p>
+          <p className="mt-0.5 text-[11px] text-gray-500">{t.benchmark.scoreNote}</p>
         </div>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="bg-gray-50 text-[11px] uppercase tracking-wide text-gray-400">
+              <tr className="bg-gray-50 text-[11px] uppercase tracking-wide text-gray-500">
                 <th className="px-4 py-2 text-left font-medium">{t.benchmark.colCandidate}</th>
                 <th className="px-4 py-2 text-left font-medium">{t.benchmark.colMode}</th>
                 <th className="px-4 py-2 text-left font-medium">{t.benchmark.colSource}</th>
@@ -465,7 +467,7 @@ export default function BenchmarkDetailPage() {
       {itemBlockers !== undefined ? (
         <section className="rounded-xl border border-gray-200 bg-white p-5">
           <h3 className="text-sm font-semibold text-gray-800">{t.benchmark.blockerItemsTitle}</h3>
-          <p className="mt-0.5 text-xs text-gray-400">{t.benchmark.blockerItemsDesc}</p>
+          <p className="mt-0.5 text-xs text-gray-500">{t.benchmark.blockerItemsDesc}</p>
           {itemBlockers.length > 0 ? (
             <div className="mt-3 space-y-2">
               {itemBlockers.map((b, i) => (
@@ -477,12 +479,12 @@ export default function BenchmarkDetailPage() {
                     <span className="text-sm font-medium text-gray-800">{b.title}</span>
                   </div>
                   {b.evidence && <p className="mt-1 text-xs text-gray-500">{t.benchmark.evidence}: {b.evidence}</p>}
-                  <p className="mt-0.5 text-[11px] text-gray-400">{candidateLabelById(b.candidateId)}</p>
+                  <p className="mt-0.5 text-[11px] text-gray-500">{candidateLabelById(b.candidateId)}</p>
                 </div>
               ))}
             </div>
           ) : (
-            <p className="mt-2 text-xs text-gray-400">{t.benchmark.noBlockerItems}</p>
+            <p className="mt-2 text-xs text-gray-500">{t.benchmark.noBlockerItems}</p>
           )}
         </section>
       ) : (
@@ -501,9 +503,9 @@ export default function BenchmarkDetailPage() {
               )}
             </div>
           ) : (
-            <p className="mt-2 text-xs text-gray-400">{t.benchmark.noRemainingBlockers}</p>
+            <p className="mt-2 text-xs text-gray-500">{t.benchmark.noRemainingBlockers}</p>
           )}
-          <p className="mt-2 text-[11px] text-gray-400">{t.benchmark.oldBenchmarkBlockers}</p>
+          <p className="mt-2 text-[11px] text-gray-500">{t.benchmark.oldBenchmarkBlockers}</p>
         </section>
       )}
 
@@ -513,7 +515,7 @@ export default function BenchmarkDetailPage() {
       ) : (
         <section className="rounded-xl border border-gray-100 bg-gray-50 px-5 py-4">
           <p className="text-sm font-medium text-gray-700">{t.benchmark.matrixUnavailable}</p>
-          <p className="mt-0.5 text-xs text-gray-400">{t.benchmark.matrixUnavailableBody}</p>
+          <p className="mt-0.5 text-xs text-gray-500">{t.benchmark.matrixUnavailableBody}</p>
         </section>
       )}
 
@@ -585,7 +587,7 @@ export default function BenchmarkDetailPage() {
 function Stat({ label, value, strong = false }: { label: string; value: string; strong?: boolean }) {
   return (
     <div>
-      <p className="text-[11px] text-gray-400">{label}</p>
+      <p className="text-[11px] text-gray-500">{label}</p>
       <p className={`${strong ? "text-base font-bold text-gray-900" : "text-sm font-medium text-gray-700"}`}>{value}</p>
     </div>
   );
@@ -611,8 +613,8 @@ function MatrixSection({
         <div className="flex items-start justify-between gap-3">
           <div>
             <h3 className="text-sm font-semibold text-gray-800">{t.benchmark.matrixTitle}</h3>
-            <p className="mt-0.5 text-xs text-gray-400">{t.benchmark.matrixDesc}</p>
-            <div className="mt-1.5 flex flex-wrap gap-x-3 text-[11px] text-gray-400">
+            <p className="mt-0.5 text-xs text-gray-500">{t.benchmark.matrixDesc}</p>
+            <div className="mt-1.5 flex flex-wrap gap-x-3 text-[11px] text-gray-500">
               <span>{t.benchmark.matrixItemsCompared.replace("{n}", String(matrix.itemsCompared))}</span>
               {matrix.disagreementCount > 0 && (
                 <span className="text-amber-600">{t.benchmark.matrixDisagreements.replace("{n}", String(matrix.disagreementCount))}</span>
@@ -635,7 +637,7 @@ function MatrixSection({
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="bg-gray-50 text-[11px] uppercase tracking-wide text-gray-400">
+              <tr className="bg-gray-50 text-[11px] uppercase tracking-wide text-gray-500">
                 <th className="px-4 py-2 text-left font-medium" />
                 {candidates.map((c) => (
                   <th key={c.id} className="px-4 py-2 text-left font-medium">
@@ -691,7 +693,7 @@ function MatrixSection({
                                     {matrixStatusLabel(t, s)}
                                   </span>
                                 </div>
-                                <p className={`mt-0.5 text-xs ${ev ? "text-gray-600" : "text-gray-400"}`}>
+                                <p className={`mt-0.5 text-xs ${ev ? "text-gray-600" : "text-gray-500"}`}>
                                   {ev ?? t.benchmark.noEvidenceStored}
                                 </p>
                               </div>
@@ -709,7 +711,7 @@ function MatrixSection({
       ) : (
         <div className="px-5 py-6 text-center">
           <p className="text-sm font-medium text-gray-700">{t.benchmark.noDifferentResults}</p>
-          <p className="mt-0.5 text-xs text-gray-400">{t.benchmark.noDifferentResultsBody}</p>
+          <p className="mt-0.5 text-xs text-gray-500">{t.benchmark.noDifferentResultsBody}</p>
         </div>
       )}
     </section>

--- a/apps/dashboard/src/app/projects/[id]/benchmark/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/benchmark/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
@@ -135,7 +137,7 @@ export default function BenchmarkPage() {
     return () => { cancelled = true; };
   }, [id, userKey, loadSaved]);
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   const selectedIds = new Set(configs.map((c) => c.runId));
   const availableRuns = runs.filter((r) => !selectedIds.has(r.id));
@@ -217,13 +219,16 @@ export default function BenchmarkPage() {
       </div>
 
       {phase === "loading" && (
-        <div className="flex items-center gap-2 text-sm text-gray-400">
+        <div className="flex items-center gap-2 text-sm text-gray-500">
           <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-gray-200 border-t-gray-500" />
           {t.benchmark.loading}
         </div>
       )}
       {phase === "error" && (
-        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{t.benchmark.loadError}</div>
+        <div className="flex items-center justify-between rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <span>{t.benchmark.loadError}</span>
+          <button onClick={() => window.location.reload()} className="btn btn-sm btn-secondary">{t.common.retry}</button>
+        </div>
       )}
 
       {phase === "done" && (
@@ -231,21 +236,24 @@ export default function BenchmarkPage() {
           {/* Candidate selector */}
           <section className="rounded-xl border border-gray-200 bg-white p-5">
             <h3 className="text-sm font-semibold text-gray-800">{t.benchmark.selectorTitle}</h3>
-            <p className="mt-0.5 text-xs text-gray-400">{t.benchmark.selectorHint}</p>
+            <p className="mt-0.5 text-xs text-gray-500">{t.benchmark.selectorHint}</p>
 
             {runs.length === 0 ? (
               <div className="mt-4 rounded-lg border border-gray-100 bg-gray-50 px-4 py-6 text-center">
                 <p className="text-sm font-medium text-gray-700">{t.benchmark.emptyTitle}</p>
-                <p className="mt-0.5 text-xs text-gray-400">{t.benchmark.emptyBody}</p>
+                <p className="mt-0.5 text-xs text-gray-500">{t.benchmark.emptyBody}</p>
+                <a href={`/projects/${id}/github`} className="btn btn-md btn-primary mt-4">
+                  {t.checks.connectPr} →
+                </a>
               </div>
             ) : (
               <div className="mt-4 grid gap-4 sm:grid-cols-2">
                 {/* Available runs */}
                 <div>
-                  <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400">{t.benchmark.availableRuns}</p>
+                  <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">{t.benchmark.availableRuns}</p>
                   <div className="space-y-1.5">
                     {availableRuns.length === 0 && (
-                      <p className="text-xs text-gray-400">{t.benchmark.noRuns}</p>
+                      <p className="text-xs text-gray-500">{t.benchmark.noRuns}</p>
                     )}
                     {availableRuns.map((run) => (
                       <div key={run.id} className="flex items-center justify-between gap-2 rounded-lg border border-gray-100 px-3 py-2">
@@ -253,7 +261,7 @@ export default function BenchmarkPage() {
                           <p className="text-xs font-medium text-gray-700">
                             {t.benchmark.runMeta.replace("{pr}", String(run.prNumber)).replace("{date}", formatDate(run.createdAt, locale))}
                           </p>
-                          <p className="truncate text-[11px] text-gray-400">
+                          <p className="truncate text-[11px] text-gray-500">
                             {t.benchmark.runCounts
                               .replace("{passed}", String(run.summary?.passed ?? 0))
                               .replace("{failed}", String(run.summary?.failed ?? 0))
@@ -273,20 +281,20 @@ export default function BenchmarkPage() {
 
                 {/* Selected candidates */}
                 <div>
-                  <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400">{t.benchmark.selected}</p>
+                  <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">{t.benchmark.selected}</p>
                   <div className="space-y-2">
                     {configs.length === 0 && (
-                      <p className="text-xs text-gray-400">{t.benchmark.needMoreBody}</p>
+                      <p className="text-xs text-gray-500">{t.benchmark.needMoreBody}</p>
                     )}
                     {configs.map((c) => {
                       const run = runById.get(c.runId);
                       return (
                         <div key={c.runId} className="rounded-lg border border-gray-200 bg-gray-50 p-3">
                           <div className="mb-2 flex items-center justify-between">
-                            <span className="text-[11px] text-gray-400">
+                            <span className="text-[11px] text-gray-500">
                               {run ? t.benchmark.runMeta.replace("{pr}", String(run.prNumber)).replace("{date}", formatDate(run.createdAt, locale)) : c.runId}
                             </span>
-                            <button onClick={() => removeCandidate(c.runId)} className="text-[11px] text-gray-400 underline hover:text-gray-600">
+                            <button onClick={() => removeCandidate(c.runId)} className="text-[11px] text-gray-500 underline hover:text-gray-600">
                               {t.benchmark.remove}
                             </button>
                           </div>
@@ -331,7 +339,7 @@ export default function BenchmarkPage() {
           {runs.length > 0 && configs.length < 2 && (
             <div className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-6 text-center">
               <p className="text-sm font-medium text-gray-700">{t.benchmark.needMoreTitle}</p>
-              <p className="mt-0.5 text-xs text-gray-400">{t.benchmark.needMoreBody}</p>
+              <p className="mt-0.5 text-xs text-gray-500">{t.benchmark.needMoreBody}</p>
             </div>
           )}
 
@@ -356,7 +364,7 @@ export default function BenchmarkPage() {
                     >
                       <div className="mb-2 flex items-center justify-between">
                         <p className="text-sm font-semibold text-gray-800">{candidate.label}</p>
-                        <span className="text-[11px] text-gray-400">{modeLabel(t, candidate.mode)} · {sourceLabel(t, candidate.source)}</span>
+                        <span className="text-[11px] text-gray-500">{modeLabel(t, candidate.mode)} · {sourceLabel(t, candidate.source)}</span>
                       </div>
                       <div className="grid grid-cols-2 gap-2 text-xs">
                         <Stat label={t.benchmark.acceptancePassRate} value={pct(metrics.acceptancePassRate)} strong />
@@ -371,13 +379,13 @@ export default function BenchmarkPage() {
               </section>
 
               {/* Comparison table */}
-              <section className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+              <section className="overflow-x-auto rounded-xl border border-gray-200 bg-white">
                 <div className="border-b border-gray-100 px-5 py-3">
                   <h3 className="text-sm font-semibold text-gray-800">{t.benchmark.comparisonTitle}</h3>
                 </div>
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="bg-gray-50 text-[11px] uppercase tracking-wide text-gray-400">
+                    <tr className="bg-gray-50 text-[11px] uppercase tracking-wide text-gray-500">
                       <th className="px-4 py-2 text-left font-medium">{t.benchmark.colCandidate}</th>
                       <th className="px-4 py-2 text-right font-medium">{t.benchmark.colPassRate}</th>
                       <th className="px-4 py-2 text-right font-medium">{t.benchmark.colPassed}</th>
@@ -432,7 +440,7 @@ export default function BenchmarkPage() {
               {/* Remaining blockers */}
               <section className="rounded-xl border border-gray-200 bg-white p-5">
                 <h3 className="text-sm font-semibold text-gray-800">{t.benchmark.blockersTitle}</h3>
-                <p className="mt-0.5 text-xs text-gray-400">{t.benchmark.blockersSubtitle}</p>
+                <p className="mt-0.5 text-xs text-gray-500">{t.benchmark.blockersSubtitle}</p>
                 {result.recommendation && result.recommendation.blockers.length > 0 ? (
                   <ul className="mt-2 space-y-1">
                     {result.recommendation.blockers.map((b) => (
@@ -440,7 +448,7 @@ export default function BenchmarkPage() {
                     ))}
                   </ul>
                 ) : (
-                  <p className="mt-2 text-xs text-gray-400">{t.benchmark.noBlockers}</p>
+                  <p className="mt-2 text-xs text-gray-500">{t.benchmark.noBlockers}</p>
                 )}
               </section>
 
@@ -479,7 +487,7 @@ export default function BenchmarkPage() {
           <section className="rounded-xl border border-gray-200 bg-white p-5">
             <h3 className="text-sm font-semibold text-gray-800">{t.benchmark.savedBenchmarks}</h3>
             {saved.length === 0 ? (
-              <p className="mt-2 text-xs text-gray-400">{t.benchmark.noSavedBenchmarks}</p>
+              <p className="mt-2 text-xs text-gray-500">{t.benchmark.noSavedBenchmarks}</p>
             ) : (
               <ul className="mt-3 space-y-1.5">
                 {saved.map((b) => {
@@ -496,7 +504,7 @@ export default function BenchmarkPage() {
                     <li key={b.id} className="flex items-center justify-between gap-2 rounded-lg border border-gray-100 px-3 py-2">
                       <div className="min-w-0">
                         <p className="truncate text-xs font-medium text-gray-700">{b.title || t.benchmark.savedBenchmarks}</p>
-                        <p className="truncate text-[11px] text-gray-400">
+                        <p className="truncate text-[11px] text-gray-500">
                           {t.benchmark.savedAt.replace("{date}", formatDate(b.createdAt, locale))} · {winnerLabel}
                         </p>
                       </div>
@@ -521,7 +529,7 @@ export default function BenchmarkPage() {
 function Stat({ label, value, strong = false }: { label: string; value: string; strong?: boolean }) {
   return (
     <div>
-      <p className="text-[11px] text-gray-400">{label}</p>
+      <p className="text-[11px] text-gray-500">{label}</p>
       <p className={`${strong ? "text-base font-bold text-gray-900" : "text-sm font-medium text-gray-700"}`}>{value}</p>
     </div>
   );

--- a/apps/dashboard/src/app/projects/[id]/checks/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/checks/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
@@ -117,7 +119,7 @@ export default function ChecksPage() {
     saveExtendedProjectData(id, { checkResults: res });
   }, [id, project, results, t]);
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   const needsAction = results
     ? results.summary.failed + results.summary.inconclusive + results.summary.needsDecision
@@ -136,13 +138,17 @@ export default function ChecksPage() {
 
   return (
     <div className="max-w-3xl space-y-10">
+      <div>
+        <h1 className="page-title">{t.nav.checks}</h1>
+        <p className="page-subtitle">{t.checks.pageSubtitle}</p>
+      </div>
 
       {/* ─── Section 1: Draft review ─── */}
       <section>
         <div className="mb-1 flex items-center justify-between">
           <div>
             <h2 className="text-lg font-semibold tracking-tight text-gray-900">{t.checks.draftTitle}</h2>
-            <p className="mt-0.5 text-xs text-gray-400">{t.checks.draftDesc}</p>
+            <p className="mt-0.5 text-xs text-gray-500">{t.checks.draftDesc}</p>
           </div>
           {phase === "done" && (
             <button onClick={runCheck} className="flex-shrink-0 text-xs font-medium text-brand-700 hover:text-brand-800">
@@ -152,7 +158,7 @@ export default function ChecksPage() {
         </div>
 
         {phase === "loading" && (
-          <div className="my-4 flex items-center gap-2.5 text-sm text-gray-400">
+          <div className="my-4 flex items-center gap-2.5 text-sm text-gray-500">
             <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-brand-300 border-t-brand-600" />
             {t.checks.checking}
           </div>
@@ -186,7 +192,7 @@ export default function ChecksPage() {
         {phase === "idle" && !results && (
           <div className="card p-8 text-center">
             <p className="mb-1 text-sm font-medium text-gray-700">{t.checks.emptyTitle}</p>
-            <p className="mb-5 text-xs text-gray-400">{t.checks.emptyDesc}</p>
+            <p className="mb-5 text-xs text-gray-500">{t.checks.emptyDesc}</p>
             <button onClick={runCheck} className="btn btn-md btn-primary">{t.checks.runCheck}</button>
           </div>
         )}
@@ -221,11 +227,11 @@ export default function ChecksPage() {
       <section>
         <div className="mb-3">
           <h2 className="text-lg font-semibold tracking-tight text-gray-900">{t.checks.prTitle}</h2>
-          <p className="mt-0.5 text-xs text-gray-400">{t.checks.prDesc}</p>
+          <p className="mt-0.5 text-xs text-gray-500">{t.checks.prDesc}</p>
         </div>
 
         {prLoadPhase === "loading" && (
-          <div className="flex items-center gap-2 text-sm text-gray-400">
+          <div className="flex items-center gap-2 text-sm text-gray-500">
             <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-gray-200 border-t-gray-500" />
             {t.checks.prLoading}
           </div>
@@ -234,7 +240,7 @@ export default function ChecksPage() {
         {prLoadPhase === "done" && !latestPrReview && (
           <div className="card p-8 text-center">
             <p className="mb-1 text-sm text-gray-600">{t.checks.noPrReview}</p>
-            <p className="mb-4 text-xs text-gray-400">{t.checks.noPrReviewDesc}</p>
+            <p className="mb-4 text-xs text-gray-500">{t.checks.noPrReviewDesc}</p>
             <Link href={`/projects/${id}/github`} className="btn btn-md btn-primary">
               {t.checks.connectPr} →
             </Link>
@@ -250,12 +256,12 @@ export default function ChecksPage() {
             <div className="card p-4">
               <div className="mb-3 flex items-center gap-3">
                 <div className="flex-1">
-                  <p className="mb-0.5 text-xs text-gray-400">{t.checks.reviewedPr}</p>
+                  <p className="mb-0.5 text-xs text-gray-500">{t.checks.reviewedPr}</p>
                   <p className="text-sm font-medium text-gray-800">
                     {reviewedPR ? `#${reviewedPR.number} ${reviewedPR.title}` : `PR #${latestPrReview.prNumber}`}
                   </p>
                   {latestPrReview.repoFullName && (
-                    <p className="mt-0.5 font-mono text-xs text-gray-400">{latestPrReview.repoFullName}</p>
+                    <p className="mt-0.5 font-mono text-xs text-gray-500">{latestPrReview.repoFullName}</p>
                   )}
                 </div>
                 <PRReviewStatusBadge t={t} status={latestPrReview.status} />
@@ -270,8 +276,8 @@ export default function ChecksPage() {
                 </div>
               )}
 
-              <p className="text-xs text-gray-400">{t.review.basisNote}</p>
-              <p className="text-xs text-gray-400">{t.review.verifyLiveNote}</p>
+              <p className="text-xs text-gray-500">{t.review.basisNote}</p>
+              <p className="text-xs text-gray-500">{t.review.verifyLiveNote}</p>
             </div>
 
             {/* Per-item results (compact) */}
@@ -292,14 +298,14 @@ export default function ChecksPage() {
             {/* CTA */}
             <div className="flex flex-wrap items-center gap-3">
               {prNeedsAction > 0 && (
-                <Link href={`/projects/${id}/github`} className="text-sm font-medium text-brand-700 hover:text-brand-800">
+                <Link href={`/projects/${id}/github`} className="btn btn-md btn-primary">
                   {t.github.createFixInstructions} →
                 </Link>
               )}
               <Link href={`/projects/${id}/github`} className="text-sm font-medium text-brand-700 hover:text-brand-800">
                 {t.checks.viewComparison} →
               </Link>
-              <Link href={`/projects/${id}/github`} className="text-sm text-gray-400 hover:text-gray-600">
+              <Link href={`/projects/${id}/github`} className="text-sm text-gray-500 hover:text-gray-600">
                 {t.checks.toGithub} →
               </Link>
             </div>

--- a/apps/dashboard/src/app/projects/[id]/credits/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/credits/page.tsx
@@ -133,10 +133,10 @@ export default function CreditsPage() {
         </div>
         <div className="p-5">
           {(creditsPhase === "loading" || (creditsPhase === "idle" && userKey)) && (
-            <p className="text-sm text-gray-400">{t.creditsPage.loading}</p>
+            <p className="text-sm text-gray-500">{t.creditsPage.loading}</p>
           )}
           {creditsPhase === "idle" && !userKey && (
-            <p className="text-sm text-gray-400">{t.creditsPage.signInToView}</p>
+            <p className="text-sm text-gray-500">{t.creditsPage.signInToView}</p>
           )}
           {creditsPhase === "error" && (
             <div className="space-y-2">
@@ -280,7 +280,7 @@ export default function CreditsPage() {
         </div>
         <div className="p-5">
           {requestsPhase === "loading" && (
-            <p className="text-sm text-gray-400">{t.creditsPage.loading}</p>
+            <p className="text-sm text-gray-500">{t.creditsPage.loading}</p>
           )}
           {requestsPhase === "error" && (
             <div className="space-y-2">
@@ -291,7 +291,7 @@ export default function CreditsPage() {
             </div>
           )}
           {requestsPhase === "done" && requests.length === 0 && (
-            <p className="text-sm text-gray-400">{t.creditsPage.noRequests}</p>
+            <p className="text-sm text-gray-500">{t.creditsPage.noRequests}</p>
           )}
           {requestsPhase === "done" && requests.length > 0 && (
             <div className="space-y-3">
@@ -315,7 +315,7 @@ export default function CreditsPage() {
                   {req.adminNote && (
                     <p className="text-xs text-indigo-600 mt-1">{t.creditsPage.adminNote} {req.adminNote}</p>
                   )}
-                  <p className="text-xs text-gray-400 mt-1">
+                  <p className="text-xs text-gray-500 mt-1">
                     {req.createdAt.slice(0, 10)}
                     {req.resolvedAt && ` → ${req.resolvedAt.slice(0, 10)} ${t.creditsPage.resolved}`}
                   </p>
@@ -327,7 +327,7 @@ export default function CreditsPage() {
       </div>
 
       {/* Footer note */}
-      <p className="text-xs text-gray-400 text-center">{t.creditsPage.footer}</p>
+      <p className="text-xs text-gray-500 text-center">{t.creditsPage.footer}</p>
     </div>
   );
 }

--- a/apps/dashboard/src/app/projects/[id]/experiment/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/experiment/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
@@ -209,7 +211,7 @@ export default function ExperimentPage() {
     if (qp) void openExperiment(qp);
   }, [id, userKey, loadSaved, openExperiment]);
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   const ext = loadExtendedProjectData(id);
   const spec = ext?.productSpec as { oneLine?: string; problem?: string } | undefined;
@@ -349,7 +351,7 @@ export default function ExperimentPage() {
             <div className="mb-2 flex items-start justify-between gap-3">
               <div>
                 <p className="text-sm font-semibold text-gray-800">{c.label}</p>
-                <p className="mt-0.5 text-[11px] text-gray-400">
+                <p className="mt-0.5 text-[11px] text-gray-500">
                   {t.experiment.roleLabel}: {roleLabel(t, c.role)} · {t.experiment.suggestedAgentLabel}: {agentLabel(t, c.suggestedAgent)}
                 </p>
               </div>
@@ -370,7 +372,10 @@ export default function ExperimentPage() {
       {/* Save experiment */}
       <section className="rounded-xl border border-gray-200 bg-white p-5">
         <h3 className="text-sm font-semibold text-gray-800">{t.experiment.createExperiment}</h3>
-        <p className="mt-0.5 text-xs text-gray-400">{t.experiment.saveHint}</p>
+        <p className="mt-0.5 text-xs text-gray-500">
+          {t.experiment.saveHint}
+          {!titleInput.trim() && <span className="ml-1 text-amber-600">{t.experiment.titleRequired}</span>}
+        </p>
         <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
           <input
             value={titleInput}
@@ -395,14 +400,14 @@ export default function ExperimentPage() {
       <section className="rounded-xl border border-gray-200 bg-white p-5">
         <h3 className="text-sm font-semibold text-gray-800">{t.experiment.savedExperiments}</h3>
         {saved.length === 0 ? (
-          <p className="mt-2 text-xs text-gray-400">{t.experiment.noSavedExperiments}</p>
+          <p className="mt-2 text-xs text-gray-500">{t.experiment.noSavedExperiments}</p>
         ) : (
           <ul className="mt-3 space-y-1.5">
             {saved.map((e) => (
               <li key={e.id} className="flex items-center justify-between gap-2 rounded-lg border border-gray-100 px-3 py-2">
                 <div className="min-w-0">
                   <p className="truncate text-xs font-medium text-gray-700">{e.title}</p>
-                  <p className="truncate text-[11px] text-gray-400">{templateTitle(t, e.templateId)} · {e.candidateCount} · {expDate(e.createdAt, locale)}</p>
+                  <p className="truncate text-[11px] text-gray-500">{templateTitle(t, e.templateId)} · {e.candidateCount} · {expDate(e.createdAt, locale)}</p>
                 </div>
                 <button onClick={() => openExperiment(e.id)} className="flex-shrink-0 rounded-lg border border-gray-200 px-2.5 py-1 text-[11px] font-medium text-gray-700 transition-colors hover:bg-gray-50">
                   {t.experiment.open}
@@ -417,7 +422,7 @@ export default function ExperimentPage() {
       {openExp && (
         <section className="rounded-xl border border-indigo-200 bg-white p-5">
           <h3 className="text-sm font-semibold text-gray-800">{openExp.title}</h3>
-          <p className="mt-0.5 text-xs text-gray-400">{templateTitle(t, openExp.templateId)}</p>
+          <p className="mt-0.5 text-xs text-gray-500">{templateTitle(t, openExp.templateId)}</p>
           <div className="mt-3 space-y-3">
             {openExp.candidates.map((c) => (
               <CandidateLinkCard key={c.id} candidate={c} reviewRuns={reviewRuns} onPatch={handlePatchCandidate} t={t} locale={locale} />
@@ -431,7 +436,7 @@ export default function ExperimentPage() {
             return (
               <div className="mt-4 rounded-lg border border-gray-100 bg-gray-50 p-4">
                 <p className="text-sm font-semibold text-gray-800">{t.experiment.benchmarkHandoff}</p>
-                <p className="mt-0.5 text-xs text-gray-400">{t.experiment.benchmarkHandoffDesc}</p>
+                <p className="mt-0.5 text-xs text-gray-500">{t.experiment.benchmarkHandoffDesc}</p>
                 {linkedBenchmarkId ? (
                   <div className="mt-2">
                     <p className="text-xs text-green-600">{benchPhase === "done" ? t.experiment.benchmarkCreated : t.experiment.benchmarkLinked}</p>
@@ -495,7 +500,7 @@ export default function ExperimentPage() {
       {/* Benchmark link */}
       <section className="rounded-xl border border-gray-100 bg-gray-50 px-5 py-4">
         <p className="text-xs text-gray-500">{t.experiment.afterReview}</p>
-        <p className="mt-0.5 text-xs text-gray-400">{t.experiment.benchmarkHint}</p>
+        <p className="mt-0.5 text-xs text-gray-500">{t.experiment.benchmarkHint}</p>
         <Link
           href={`/projects/${id}/benchmark`}
           className="mt-2 inline-block rounded-lg bg-indigo-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-indigo-700"
@@ -571,8 +576,8 @@ function DecisionSection({
   return (
     <div className="mt-4 rounded-lg border border-gray-100 bg-gray-50 p-4">
       <p className="text-sm font-semibold text-gray-800">{t.experiment.decision}</p>
-      <p className="mt-0.5 text-xs text-gray-400">{t.experiment.decisionDesc}</p>
-      <p className={`mt-1 text-[11px] ${hasBenchmark ? "text-gray-400" : "text-amber-700"}`}>
+      <p className="mt-0.5 text-xs text-gray-500">{t.experiment.decisionDesc}</p>
+      <p className={`mt-1 text-[11px] ${hasBenchmark ? "text-gray-500" : "text-amber-700"}`}>
         {hasBenchmark ? t.experiment.useBenchmarkEvidence : t.experiment.createBenchmarkFirst}
       </p>
       <div className="mt-3 space-y-2">
@@ -999,9 +1004,9 @@ function OutcomeQualitySection({
   return (
     <div className="mt-4 rounded-lg border border-gray-100 bg-white p-4">
       <p className="text-sm font-semibold text-gray-800">{t.outcome.title}</p>
-      <p className="mt-0.5 text-xs text-gray-400">{t.outcome.desc}</p>
+      <p className="mt-0.5 text-xs text-gray-500">{t.outcome.desc}</p>
 
-      {loading && <p className="mt-3 text-xs text-gray-400">{t.outcome.loading}</p>}
+      {loading && <p className="mt-3 text-xs text-gray-500">{t.outcome.loading}</p>}
 
       {!loading && scorecard && (
         <>
@@ -1013,7 +1018,7 @@ function OutcomeQualitySection({
             >
               {outcomeText(t, gradeLabelKey(scorecard.quality.grade))}
             </span>
-            <span className="text-[11px] text-gray-400">
+            <span className="text-[11px] text-gray-500">
               {t.outcome.score}: {scorecard.quality.score}
             </span>
           </div>
@@ -1028,13 +1033,13 @@ function OutcomeQualitySection({
           </dl>
 
           <div className="mt-3 rounded-lg border border-gray-100 bg-gray-50 p-3">
-            <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.outcome.recommendedNext}</p>
+            <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.outcome.recommendedNext}</p>
             <p className="mt-0.5 text-sm font-semibold text-gray-800">
               {outcomeText(t, actionLabelKey(scorecard.nextEvolution.recommendedAction))}
             </p>
             {scorecard.nextEvolution.reasons.length > 0 && (
               <>
-                <p className="mt-2 text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.outcome.reasonsLabel}</p>
+                <p className="mt-2 text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.outcome.reasonsLabel}</p>
                 <ul className="mt-1 space-y-0.5 text-xs text-gray-600">
                   {scorecard.nextEvolution.reasons.map((r) => (
                     <li key={r} className="flex gap-1.5">
@@ -1049,7 +1054,7 @@ function OutcomeQualitySection({
 
           {scorecard.nextEvolution.suggestedFocusItemIds.length > 0 && (
             <div className="mt-3">
-              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.outcome.suggestedFocus}</p>
+              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.outcome.suggestedFocus}</p>
               <div className="mt-1 flex flex-wrap gap-1.5">
                 {scorecard.nextEvolution.suggestedFocusItemIds.map((itemId) => (
                   <span key={itemId} className="rounded-md border border-gray-200 bg-gray-50 px-2 py-0.5 text-[11px] font-mono text-gray-600">
@@ -1086,12 +1091,12 @@ function OutcomeQualitySection({
             </button>
           </div>
 
-          <p className="mt-3 text-[11px] leading-relaxed text-gray-400">{t.outcome.basis}</p>
+          <p className="mt-3 text-[11px] leading-relaxed text-gray-500">{t.outcome.basis}</p>
 
           {/* Evolution action pack (Stage 76 + Stage 77 persistence) */}
           <div className="mt-4 rounded-lg border border-gray-100 bg-gray-50 p-4">
             <p className="text-sm font-semibold text-gray-800">{t.evolution.title}</p>
-            <p className="mt-0.5 text-xs text-gray-400">{t.evolution.desc}</p>
+            <p className="mt-0.5 text-xs text-gray-500">{t.evolution.desc}</p>
 
             <div className="mt-3 flex flex-wrap items-center gap-2">
               <button
@@ -1140,7 +1145,7 @@ function OutcomeQualitySection({
                     {pack.title}
                   </span>
                   {pack.targetCandidateId && (
-                    <span className="text-gray-400">
+                    <span className="text-gray-500">
                       {t.evolution.targetCandidate}: {pack.targetCandidateId}
                     </span>
                   )}
@@ -1159,7 +1164,7 @@ function OutcomeQualitySection({
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div>
                   <p className="text-sm font-semibold text-gray-800">{t.evolution.summaryTitle}</p>
-                  <p className="mt-0.5 text-[11px] text-gray-400">{t.evolution.summaryDesc}</p>
+                  <p className="mt-0.5 text-[11px] text-gray-500">{t.evolution.summaryDesc}</p>
                 </div>
                 {summary && (
                   <span
@@ -1181,7 +1186,7 @@ function OutcomeQualitySection({
               </div>
 
               {summaryPhase === "loading" && (
-                <p className="mt-2 text-xs text-gray-400">{t.outcome.loading}</p>
+                <p className="mt-2 text-xs text-gray-500">{t.outcome.loading}</p>
               )}
 
               {summaryPhase === "ready" && summary && (
@@ -1196,44 +1201,44 @@ function OutcomeQualitySection({
                     <>
                       <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs sm:grid-cols-3">
                         <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-                          <dt className="text-gray-400">{t.evolution.summaryActionPacks}</dt>
+                          <dt className="text-gray-500">{t.evolution.summaryActionPacks}</dt>
                           <dd className="font-semibold text-gray-800">{summary.actionPackCount}</dd>
                         </div>
                         <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-                          <dt className="text-gray-400">{t.evolution.summaryFollowedPacks}</dt>
+                          <dt className="text-gray-500">{t.evolution.summaryFollowedPacks}</dt>
                           <dd className="font-semibold text-gray-800">{summary.followedPackCount}</dd>
                         </div>
                         <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-                          <dt className="text-gray-400">{t.evolution.summaryImprovedPacks}</dt>
+                          <dt className="text-gray-500">{t.evolution.summaryImprovedPacks}</dt>
                           <dd className="font-semibold text-emerald-700">{summary.verdictCounts.improved}</dd>
                         </div>
                         <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-                          <dt className="text-gray-400">{t.evolution.summaryRegressedPacks}</dt>
+                          <dt className="text-gray-500">{t.evolution.summaryRegressedPacks}</dt>
                           <dd className="font-semibold text-red-700">{summary.verdictCounts.regressed}</dd>
                         </div>
                         <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-                          <dt className="text-gray-400">{t.evolution.summaryUnchangedPacks}</dt>
+                          <dt className="text-gray-500">{t.evolution.summaryUnchangedPacks}</dt>
                           <dd className="font-semibold text-gray-700">{summary.verdictCounts.unchanged}</dd>
                         </div>
                         <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-                          <dt className="text-gray-400">{t.evolution.summaryInconclusivePacks}</dt>
+                          <dt className="text-gray-500">{t.evolution.summaryInconclusivePacks}</dt>
                           <dd className="font-semibold text-amber-700">{summary.verdictCounts.inconclusive}</dd>
                         </div>
                       </dl>
 
                       <div className="mt-3 rounded-md border border-gray-100 bg-gray-50 p-2">
-                        <p className="text-[10px] uppercase tracking-wide text-gray-400">{t.evolution.summaryAverageChange}</p>
+                        <p className="text-[10px] uppercase tracking-wide text-gray-500">{t.evolution.summaryAverageChange}</p>
                         <dl className="mt-1 grid grid-cols-2 gap-x-4 gap-y-0.5 text-[11px] sm:grid-cols-4">
-                          <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactPassRate}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaPercent(summary.averageDelta.passRateDelta)}</dd></div>
-                          <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactCritical}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(summary.averageDelta.criticalIssueDelta)}</dd></div>
-                          <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactNotVerified}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(summary.averageDelta.notVerifiedDelta)}</dd></div>
-                          <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactBlockers}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(summary.averageDelta.blockerDelta)}</dd></div>
+                          <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactPassRate}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaPercent(summary.averageDelta.passRateDelta)}</dd></div>
+                          <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactCritical}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(summary.averageDelta.criticalIssueDelta)}</dd></div>
+                          <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactNotVerified}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(summary.averageDelta.notVerifiedDelta)}</dd></div>
+                          <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactBlockers}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(summary.averageDelta.blockerDelta)}</dd></div>
                         </dl>
                       </div>
 
                       {summary.recommendedActionVerdicts.length > 0 && (
                         <div className="mt-3">
-                          <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.evolution.summaryActionBreakdown}</p>
+                          <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.evolution.summaryActionBreakdown}</p>
                           <ul className="mt-1 space-y-1 text-xs">
                             {summary.recommendedActionVerdicts.map((r) => (
                               <li
@@ -1254,7 +1259,7 @@ function OutcomeQualitySection({
 
                   {summary.reasons.length > 0 && (
                     <div className="mt-3">
-                      <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.evolution.summaryReasonsLabel}</p>
+                      <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.evolution.summaryReasonsLabel}</p>
                       <ul className="mt-1 space-y-0.5 text-xs text-gray-600">
                         {summary.reasons.map((r) => (
                           <li key={r} className="flex gap-1.5">
@@ -1268,7 +1273,7 @@ function OutcomeQualitySection({
 
                   {summary.limitations.length > 0 && (
                     <div className="mt-2">
-                      <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.evolution.summaryLimitationsLabel}</p>
+                      <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.evolution.summaryLimitationsLabel}</p>
                       <ul className="mt-1 flex flex-wrap gap-1.5">
                         {summary.limitations.map((l) => (
                           <li
@@ -1291,9 +1296,9 @@ function OutcomeQualitySection({
 
             {/* Stage 77: saved action packs list */}
             <div className="mt-4 border-t border-gray-100 pt-3">
-              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.evolution.saved}</p>
+              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.evolution.saved}</p>
               {savedPacks.length === 0 ? (
-                <p className="mt-1 text-xs text-gray-400">{t.evolution.noSaved}</p>
+                <p className="mt-1 text-xs text-gray-500">{t.evolution.noSaved}</p>
               ) : (
                 <ul className="mt-2 space-y-1.5">
                   {savedPacks.map((p) => (
@@ -1318,9 +1323,9 @@ function OutcomeQualitySection({
                             {t.evolution[followupStatusLabelKey(p.followupStatus) as keyof typeof t.evolution]}
                           </span>
                           {p.followupPullRequestNumber && (
-                            <span className="text-[10px] text-gray-400">PR #{p.followupPullRequestNumber}</span>
+                            <span className="text-[10px] text-gray-500">PR #{p.followupPullRequestNumber}</span>
                           )}
-                          <span className="text-[10px] text-gray-400">
+                          <span className="text-[10px] text-gray-500">
                             {t.evolution.createdAt}: {new Date(p.createdAt).toLocaleString()}
                           </span>
                         </div>
@@ -1344,7 +1349,7 @@ function OutcomeQualitySection({
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
                     <p className="text-xs font-semibold text-gray-800">{t.evolution.serverGenerated}</p>
-                    <p className="text-[11px] text-gray-400">{t.evolution.serverGeneratedDesc}</p>
+                    <p className="text-[11px] text-gray-500">{t.evolution.serverGeneratedDesc}</p>
                   </div>
                   <div className="flex flex-wrap items-center gap-2">
                     <button
@@ -1370,7 +1375,7 @@ function OutcomeQualitySection({
                     {openedPack.title}
                   </span>
                   {openedPack.pack.targetCandidateId && (
-                    <span className="text-gray-400">
+                    <span className="text-gray-500">
                       {t.evolution.targetCandidate}: {openedPack.pack.targetCandidateId}
                     </span>
                   )}
@@ -1389,7 +1394,7 @@ function OutcomeQualitySection({
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <div>
                       <p className="text-xs font-semibold text-gray-800">{t.evolution.followup}</p>
-                      <p className="text-[11px] text-gray-400">{t.evolution.followupDesc}</p>
+                      <p className="text-[11px] text-gray-500">{t.evolution.followupDesc}</p>
                     </div>
                     <span className="rounded-full border border-gray-200 bg-white px-2 py-0.5 text-[11px] font-medium text-gray-700">
                       {t.evolution[followupStatusLabelKey(openedPack.followup.status) as keyof typeof t.evolution]}
@@ -1468,7 +1473,7 @@ function OutcomeQualitySection({
                           : t.evolution.saveFollowup}
                     </button>
                     {openedPack.followup.followedAt && (
-                      <span className="text-[11px] text-gray-400">
+                      <span className="text-[11px] text-gray-500">
                         {t.evolution.followedAt}: {new Date(openedPack.followup.followedAt).toLocaleString()}
                       </span>
                     )}
@@ -1487,7 +1492,7 @@ function OutcomeQualitySection({
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <div>
                       <p className="text-xs font-semibold text-gray-800">{t.evolution.impact}</p>
-                      <p className="text-[11px] text-gray-400">{t.evolution.impactDesc}</p>
+                      <p className="text-[11px] text-gray-500">{t.evolution.impactDesc}</p>
                     </div>
                     {impact && (
                       <span
@@ -1507,7 +1512,7 @@ function OutcomeQualitySection({
                   </div>
 
                   {impactPhase === "loading" && (
-                    <p className="mt-2 text-xs text-gray-400">{t.outcome.loading}</p>
+                    <p className="mt-2 text-xs text-gray-500">{t.outcome.loading}</p>
                   )}
 
                   {impactPhase === "ready" && impact && (
@@ -1518,42 +1523,42 @@ function OutcomeQualitySection({
                         <>
                           <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
                             <div className="rounded-md border border-gray-100 bg-white p-2">
-                              <p className="text-[10px] uppercase tracking-wide text-gray-400">{t.evolution.impactBefore}</p>
+                              <p className="text-[10px] uppercase tracking-wide text-gray-500">{t.evolution.impactBefore}</p>
                               {impact.before ? (
                                 <dl className="mt-1 space-y-0.5 text-[11px]">
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactPassRate}</dt><dd className="font-semibold text-gray-700">{formatRate(impact.before.passRate)}</dd></div>
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactCritical}</dt><dd className="font-semibold text-gray-700">{impact.before.criticalIssueCount}</dd></div>
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactNotVerified}</dt><dd className="font-semibold text-gray-700">{impact.before.notVerifiedCount}</dd></div>
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactBlockers}</dt><dd className="font-semibold text-gray-700">{impact.before.blockerCount}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactPassRate}</dt><dd className="font-semibold text-gray-700">{formatRate(impact.before.passRate)}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactCritical}</dt><dd className="font-semibold text-gray-700">{impact.before.criticalIssueCount}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactNotVerified}</dt><dd className="font-semibold text-gray-700">{impact.before.notVerifiedCount}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactBlockers}</dt><dd className="font-semibold text-gray-700">{impact.before.blockerCount}</dd></div>
                                 </dl>
                               ) : (
-                                <p className="mt-1 text-[11px] text-gray-400">—</p>
+                                <p className="mt-1 text-[11px] text-gray-500">—</p>
                               )}
                             </div>
                             <div className="rounded-md border border-gray-100 bg-white p-2">
-                              <p className="text-[10px] uppercase tracking-wide text-gray-400">{t.evolution.impactAfter}</p>
+                              <p className="text-[10px] uppercase tracking-wide text-gray-500">{t.evolution.impactAfter}</p>
                               {impact.after ? (
                                 <dl className="mt-1 space-y-0.5 text-[11px]">
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactPassRate}</dt><dd className="font-semibold text-gray-700">{formatRate(impact.after.passRate)}</dd></div>
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactCritical}</dt><dd className="font-semibold text-gray-700">{impact.after.criticalIssueCount}</dd></div>
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactNotVerified}</dt><dd className="font-semibold text-gray-700">{impact.after.notVerifiedCount}</dd></div>
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactBlockers}</dt><dd className="font-semibold text-gray-700">{impact.after.blockerCount}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactPassRate}</dt><dd className="font-semibold text-gray-700">{formatRate(impact.after.passRate)}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactCritical}</dt><dd className="font-semibold text-gray-700">{impact.after.criticalIssueCount}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactNotVerified}</dt><dd className="font-semibold text-gray-700">{impact.after.notVerifiedCount}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactBlockers}</dt><dd className="font-semibold text-gray-700">{impact.after.blockerCount}</dd></div>
                                 </dl>
                               ) : (
-                                <p className="mt-1 text-[11px] text-gray-400">—</p>
+                                <p className="mt-1 text-[11px] text-gray-500">—</p>
                               )}
                             </div>
                             <div className="rounded-md border border-gray-100 bg-white p-2">
-                              <p className="text-[10px] uppercase tracking-wide text-gray-400">{t.evolution.impactDelta}</p>
+                              <p className="text-[10px] uppercase tracking-wide text-gray-500">{t.evolution.impactDelta}</p>
                               {impact.delta ? (
                                 <dl className="mt-1 space-y-0.5 text-[11px]">
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.deltaPassRate}</dt><dd className="font-semibold text-gray-700">{formatDeltaPercent(impact.delta.passRateDelta)}</dd></div>
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.deltaCritical}</dt><dd className="font-semibold text-gray-700">{formatDeltaInt(impact.delta.criticalIssueDelta)}</dd></div>
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.deltaNotVerified}</dt><dd className="font-semibold text-gray-700">{formatDeltaInt(impact.delta.notVerifiedDelta)}</dd></div>
-                                  <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.deltaBlockers}</dt><dd className="font-semibold text-gray-700">{formatDeltaInt(impact.delta.blockerDelta)}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.deltaPassRate}</dt><dd className="font-semibold text-gray-700">{formatDeltaPercent(impact.delta.passRateDelta)}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.deltaCritical}</dt><dd className="font-semibold text-gray-700">{formatDeltaInt(impact.delta.criticalIssueDelta)}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.deltaNotVerified}</dt><dd className="font-semibold text-gray-700">{formatDeltaInt(impact.delta.notVerifiedDelta)}</dd></div>
+                                  <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.deltaBlockers}</dt><dd className="font-semibold text-gray-700">{formatDeltaInt(impact.delta.blockerDelta)}</dd></div>
                                 </dl>
                               ) : (
-                                <p className="mt-1 text-[11px] text-gray-400">—</p>
+                                <p className="mt-1 text-[11px] text-gray-500">—</p>
                               )}
                             </div>
                           </div>
@@ -1564,7 +1569,7 @@ function OutcomeQualitySection({
 
                           {impact.reasons.length > 0 && (
                             <div className="mt-3">
-                              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.evolution.impactReasons}</p>
+                              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.evolution.impactReasons}</p>
                               <ul className="mt-1 flex flex-wrap gap-1.5">
                                 {impact.reasons.map((r) => (
                                   <li
@@ -1580,7 +1585,7 @@ function OutcomeQualitySection({
 
                           {impact.limitations.length > 0 && (
                             <div className="mt-2">
-                              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.evolution.impactLimitations}</p>
+                              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.evolution.impactLimitations}</p>
                               <ul className="mt-1 flex flex-wrap gap-1.5">
                                 {impact.limitations.map((l) => (
                                   <li
@@ -1609,7 +1614,7 @@ function OutcomeQualitySection({
       )}
 
       {!loading && !scorecard && (
-        <p className="mt-3 text-xs text-gray-400">{t.evolution.needScorecard}</p>
+        <p className="mt-3 text-xs text-gray-500">{t.evolution.needScorecard}</p>
       )}
     </div>
   );
@@ -1618,7 +1623,7 @@ function OutcomeQualitySection({
 function Metric({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-      <dt className="text-gray-400">{label}</dt>
+      <dt className="text-gray-500">{label}</dt>
       <dd className="font-semibold text-gray-800">{value}</dd>
     </div>
   );

--- a/apps/dashboard/src/app/projects/[id]/experiment/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/experiment/page.tsx
@@ -379,6 +379,7 @@ export default function ExperimentPage() {
         <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
           <input
             value={titleInput}
+            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleSaveExperiment(); } }}
             onChange={(e) => setTitleInput(e.target.value)}
             placeholder={t.experiment.titlePlaceholder}
             maxLength={120}
@@ -885,7 +886,12 @@ function OutcomeQualitySection({
 
   async function handleCopy() {
     try {
+      try {
       await navigator.clipboard.writeText(packText);
+    } catch {
+      window.prompt(t.github.copyManually, packText);
+      return;
+    }
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);
     } catch {
@@ -940,7 +946,12 @@ function OutcomeQualitySection({
   async function handleCopySaved() {
     if (!openedPack) return;
     try {
+      try {
       await navigator.clipboard.writeText(openedPack.text);
+    } catch {
+      window.prompt(t.github.copyManually, openedPack.text);
+      return;
+    }
       setCopiedSaved(true);
       window.setTimeout(() => setCopiedSaved(false), 1500);
     } catch {

--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import { getProject } from "@/lib/mock-data";
@@ -333,7 +335,7 @@ export default function ExportPage() {
     setOutcomeStatus(null);
   }
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   const currentFile = result?.bundle.files.find((f) => f.path === selectedFile);
 
@@ -349,7 +351,7 @@ export default function ExportPage() {
       <div className="bg-white rounded-xl border border-gray-200 p-5">
         <div className="flex flex-col sm:flex-row gap-4">
           <div className="flex-1">
-            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2">{t.exportPage.chooseAi}</p>
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">{t.exportPage.chooseAi}</p>
             <div className="flex gap-2">
               {TARGET_VALUES.map((value) => (
                 <button key={value} onClick={() => handleTargetChange(value)}
@@ -361,7 +363,7 @@ export default function ExportPage() {
             </div>
           </div>
           <div className="flex-1">
-            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2">{t.exportPage.scope}</p>
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">{t.exportPage.scope}</p>
             <div className="flex gap-2">
               {(["all", "selected"] as const).map((mode) => (
                 <button key={mode} onClick={() => setSelectionMode(mode)}
@@ -380,7 +382,7 @@ export default function ExportPage() {
           <div className="flex items-center justify-between mb-2">
             <p className="text-sm font-semibold text-gray-700">
               {t.exportPage.selectTitle}
-              <span className="ml-2 text-xs font-normal text-gray-400">
+              <span className="ml-2 text-xs font-normal text-gray-500">
                 {t.exportPage.selectedOfTotal
                   .replace("{sel}", String(selectedIds.size))
                   .replace("{total}", String(allItems.length))}
@@ -392,7 +394,7 @@ export default function ExportPage() {
             </button>
           </div>
           {problemItemCount > 0 && (
-            <p className="text-xs text-gray-400 mb-3">{t.exportPage.recommendHint}</p>
+            <p className="text-xs text-gray-500 mb-3">{t.exportPage.recommendHint}</p>
           )}
           {/* Status filter */}
           <div className="flex gap-1.5 flex-wrap mb-3">
@@ -418,7 +420,7 @@ export default function ExportPage() {
               </label>
             ))}
             {filteredItems.length === 0 && (
-              <p className="text-xs text-gray-400 py-4 text-center">{t.exportPage.noItemsForStatus}</p>
+              <p className="text-xs text-gray-500 py-4 text-center">{t.exportPage.noItemsForStatus}</p>
             )}
           </div>
           <div className="mt-4 flex items-center justify-end">
@@ -434,7 +436,7 @@ export default function ExportPage() {
       {phase === "loading" && (
         <div className="bg-white rounded-xl border border-gray-200 p-8 text-center">
           <div className="w-5 h-5 border-2 border-indigo-300 border-t-indigo-600 rounded-full animate-spin mx-auto mb-3" />
-          <p className="text-sm text-gray-400">{t.exportPage.generatingPack}</p>
+          <p className="text-sm text-gray-500">{t.exportPage.generatingPack}</p>
         </div>
       )}
       {phase === "error" && (
@@ -495,7 +497,7 @@ export default function ExportPage() {
           {/* File browser */}
           <div className="flex gap-4 h-[500px]">
             <div className="w-48 flex-shrink-0 bg-white rounded-xl border border-gray-200 overflow-y-auto">
-              <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide px-4 py-3 border-b border-gray-100">{t.exportPage.fileList}</p>
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3 border-b border-gray-100">{t.exportPage.fileList}</p>
               <ul className="py-1">
                 {result.bundle.files.map((f) => (
                   <li key={f.path}>
@@ -521,7 +523,7 @@ export default function ExportPage() {
                 </>
               ) : (
                 <div className="flex-1 flex items-center justify-center">
-                  <p className="text-sm text-gray-400">{t.exportPage.selectFile}</p>
+                  <p className="text-sm text-gray-500">{t.exportPage.selectFile}</p>
                 </div>
               )}
             </div>
@@ -637,13 +639,13 @@ function OutcomeHistory({
       <div className="space-y-2">
         {outcomes.slice(0, 10).map((oc) => (
           <div key={oc.id} className="flex items-start gap-3 text-xs text-gray-600 py-2 border-b border-gray-50 last:border-0">
-            <span className="text-gray-400 flex-shrink-0 w-32">{formatDate(oc.createdAt)}</span>
+            <span className="text-gray-500 flex-shrink-0 w-32">{formatDate(oc.createdAt)}</span>
             <span className="flex-shrink-0">{TARGET_LABEL[oc.target]}</span>
-            <span className="flex-shrink-0 text-gray-400">{t.exportPage.itemsCount.replace("{n}", String(oc.selectedItemIds.length))}</span>
-            <span className={`flex-shrink-0 font-medium ${oc.outcome === "worked" ? "text-green-600" : oc.outcome === "partial" ? "text-amber-600" : oc.outcome === "failed" ? "text-red-600" : "text-gray-400"}`}>
+            <span className="flex-shrink-0 text-gray-500">{t.exportPage.itemsCount.replace("{n}", String(oc.selectedItemIds.length))}</span>
+            <span className={`flex-shrink-0 font-medium ${oc.outcome === "worked" ? "text-green-600" : oc.outcome === "partial" ? "text-amber-600" : oc.outcome === "failed" ? "text-red-600" : "text-gray-500"}`}>
               {outcomeLabel(t, oc.outcome)}
             </span>
-            {oc.note && <span className="text-gray-400 truncate flex-1">{oc.note}</span>}
+            {oc.note && <span className="text-gray-500 truncate flex-1">{oc.note}</span>}
             <Link
               href={`/projects/${projectId}/checks`}
               title={t.exportPage.recheckTooltip}
@@ -654,7 +656,7 @@ function OutcomeHistory({
           </div>
         ))}
       </div>
-      <p className="text-xs text-gray-400 mt-3">{t.exportPage.historyNote}</p>
+      <p className="text-xs text-gray-500 mt-3">{t.exportPage.historyNote}</p>
     </div>
   );
 }

--- a/apps/dashboard/src/app/projects/[id]/fixes/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/fixes/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
@@ -96,7 +98,7 @@ export default function FixesPage() {
     }));
   }
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   if (!checkItems) {
     return (
@@ -200,12 +202,15 @@ function FixItemCard({
             </button>
           )}
           {fixState?.phase === "error" && (
-            <button
-              onClick={onFix}
-              className="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-medium text-red-600 transition-colors hover:bg-red-50"
-            >
-              {t.common.retry}
-            </button>
+            <span className="flex items-center gap-2">
+              <span className="text-xs text-red-600">{t.fixesScreen.generateError}</span>
+              <button
+                onClick={onFix}
+                className="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-medium text-red-600 transition-colors hover:bg-red-50"
+              >
+                {t.common.retry}
+              </button>
+            </span>
           )}
         </div>
       </div>
@@ -227,7 +232,7 @@ function FixSuggestionPanel({ t, suggestion }: { t: Dictionary; suggestion: FixS
       )}
 
       <div>
-        <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-400">{t.fixesScreen.summary}</p>
+        <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">{t.fixesScreen.summary}</p>
         <p className="text-sm leading-relaxed text-gray-700">{plainSummary}</p>
       </div>
 
@@ -239,7 +244,7 @@ function FixSuggestionPanel({ t, suggestion }: { t: Dictionary; suggestion: FixS
 
         {builderBrief.tasks.length > 0 && (
           <div>
-            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-400">{t.fixesScreen.tasks}</p>
+            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">{t.fixesScreen.tasks}</p>
             <ul className="space-y-1">
               {builderBrief.tasks.map((task, i) => (
                 <li key={i} className="flex gap-2 text-xs text-gray-700">
@@ -252,7 +257,7 @@ function FixSuggestionPanel({ t, suggestion }: { t: Dictionary; suggestion: FixS
 
         {builderBrief.doneWhen.length > 0 && (
           <div>
-            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-400">{t.fixesScreen.doneWhen}</p>
+            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">{t.fixesScreen.doneWhen}</p>
             <ul className="space-y-1">
               {builderBrief.doneWhen.map((d, i) => (
                 <li key={i} className="flex gap-2 text-xs text-gray-700">
@@ -265,7 +270,7 @@ function FixSuggestionPanel({ t, suggestion }: { t: Dictionary; suggestion: FixS
 
         {builderBrief.doNotDo.length > 0 && (
           <div>
-            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-400">{t.fixesScreen.doNotDo}</p>
+            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">{t.fixesScreen.doNotDo}</p>
             <ul className="space-y-1">
               {builderBrief.doNotDo.map((d, i) => (
                 <li key={i} className="flex gap-2 text-xs text-gray-500">

--- a/apps/dashboard/src/app/projects/[id]/github/history/[runId]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/history/[runId]/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
@@ -216,7 +218,7 @@ function FixPackPanel({
 
   if (phase === "loading") {
     return (
-      <div ref={containerRef} className="flex items-center gap-2 text-sm text-gray-400 py-2">
+      <div ref={containerRef} className="flex items-center gap-2 text-sm text-gray-500 py-2">
         <div className="w-4 h-4 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin flex-shrink-0" />
         {t.runDetail.fpCreating}
       </div>
@@ -286,7 +288,7 @@ function FixPackPanel({
       {/* File preview */}
       {selectedFile && (
         <div className="p-4 bg-white">
-          <p className="text-xs text-gray-400 mb-2 font-mono">{selectedFile.path}</p>
+          <p className="text-xs text-gray-500 mb-2 font-mono">{selectedFile.path}</p>
           <pre className="text-xs text-gray-700 whitespace-pre-wrap leading-relaxed max-h-64 overflow-y-auto">
             {selectedFile.content}
           </pre>
@@ -328,6 +330,7 @@ function CommentPanel({
 }) {
   const { t, locale } = useI18n();
   const [phase, setPhase] = useState<"idle" | "previewing" | "ready" | "posting" | "posted" | "error">("idle");
+  const [postError, setPostError] = useState<string | null>(null);
   const [preview, setPreview] = useState<CommentPreview | null>(null);
   const [warnings, setWarnings] = useState<string[]>([]);
   const [postResult, setPostResult] = useState<{ url?: string } | null>(null);
@@ -357,7 +360,10 @@ function CommentPanel({
 
   const post = useCallback(async () => {
     if (!preview) return;
+    // Publishes publicly on GitHub and can't be deleted from here.
+    if (!window.confirm(t.comment.postConfirm)) return;
     setPhase("posting");
+    setPostError(null);
     const res = await postPRComment(projectId, prNumber, {
       ...buildComparisonCommentInput({
         userKey, reviewRunId: runId, selectedItemIds: sharedSelected,
@@ -366,7 +372,12 @@ function CommentPanel({
       mode: "new",
       locale,
     });
-    if (!res.ok) { setPhase("ready"); return; }
+    if (!res.ok) {
+      // Never fail silently: the user must see WHY the public post didn't land.
+      setPostError(errorText(t, res.error, "generic"));
+      setPhase("ready");
+      return;
+    }
     setPostResult({ url: (res as { comment?: { githubCommentUrl?: string } }).comment?.githubCommentUrl });
     setPhase("posted");
   }, [projectId, prNumber, runId, userKey, preview, sharedSelected, includeRerunComparison, comparisonAvailable, locale]);
@@ -399,13 +410,13 @@ function CommentPanel({
             />
             <span>
               {t.runDetail.cmInclude}
-              <span className="block text-[11px] text-gray-400">
+              <span className="block text-[11px] text-gray-500">
                 {t.runDetail.cmIncludeHint}
               </span>
             </span>
           </label>
         ) : comparisonDisplayOnly ? (
-          <p className="text-[11px] text-gray-400">
+          <p className="text-[11px] text-gray-500">
             {t.runDetail.cmDisplayOnly}
           </p>
         ) : null}
@@ -421,7 +432,7 @@ function CommentPanel({
 
   if (phase === "previewing") {
     return (
-      <div className="flex items-center gap-2 text-sm text-gray-400 py-2">
+      <div className="flex items-center gap-2 text-sm text-gray-500 py-2">
         <div className="w-4 h-4 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin flex-shrink-0" />
         {t.runDetail.cmGenerating}
       </div>
@@ -470,6 +481,8 @@ function CommentPanel({
           </button>
         </div>
       </div>
+      <p className="border-b border-amber-100 bg-amber-50 px-4 py-2 text-xs text-amber-800">{t.comment.publicOnly}</p>
+      {postError && <p className="border-b border-red-100 bg-red-50 px-4 py-2 text-xs text-red-700">{postError}</p>}
 
       {warnings.length > 0 && (
         <div className="bg-amber-50 border-b border-amber-100 px-4 py-2">
@@ -523,7 +536,7 @@ function ComparisonPanel({ cmp, newRunId, projectId, selectedCount }: {
           {typeof selectedCount === "number" && selectedCount > 0 && (
             <p className="text-xs text-indigo-600 mt-0.5">{t.runDetail.rerunDoneCount.replace("{n}", String(selectedCount))}</p>
           )}
-          <p className="text-xs text-gray-400 mt-0.5">{cmp.summaryText}</p>
+          <p className="text-xs text-gray-500 mt-0.5">{cmp.summaryText}</p>
         </div>
         <Link
           href={`/projects/${projectId}/github/history/${newRunId}`}
@@ -539,9 +552,9 @@ function ComparisonPanel({ cmp, newRunId, projectId, selectedCount }: {
             {cmp.improved.map((item) => (
               <div key={item.itemId} className="text-xs text-gray-600 mb-1.5">
                 <span className="font-medium">{item.title}</span>
-                <span className="text-gray-400 mx-1">·</span>
+                <span className="text-gray-500 mx-1">·</span>
                 <span className={CMP_STATUS_COLORS[item.from] ?? ""}>{statusText(t, item.from)}</span>
-                <span className="text-gray-400 mx-1">→</span>
+                <span className="text-gray-500 mx-1">→</span>
                 <span className={CMP_STATUS_COLORS[item.to] ?? ""}>{statusText(t, item.to)}</span>
               </div>
             ))}
@@ -553,9 +566,9 @@ function ComparisonPanel({ cmp, newRunId, projectId, selectedCount }: {
             {cmp.newlyProblematic.map((item) => (
               <div key={item.itemId} className="text-xs text-gray-600 mb-1.5">
                 <span className="font-medium">{item.title}</span>
-                <span className="text-gray-400 mx-1">·</span>
+                <span className="text-gray-500 mx-1">·</span>
                 <span className={CMP_STATUS_COLORS[item.from] ?? ""}>{statusText(t, item.from)}</span>
-                <span className="text-gray-400 mx-1">→</span>
+                <span className="text-gray-500 mx-1">→</span>
                 <span className={CMP_STATUS_COLORS[item.to] ?? ""}>{statusText(t, item.to)}</span>
               </div>
             ))}
@@ -567,7 +580,7 @@ function ComparisonPanel({ cmp, newRunId, projectId, selectedCount }: {
             {cmp.stillOpen.map((item) => (
               <div key={item.itemId} className="text-xs text-gray-600 mb-1.5">
                 <span className="font-medium">{item.title}</span>
-                <span className="text-gray-400 mx-1">·</span>
+                <span className="text-gray-500 mx-1">·</span>
                 <span className={CMP_STATUS_COLORS[item.status] ?? ""}>{statusText(t, item.status)}</span>
               </div>
             ))}
@@ -583,7 +596,7 @@ function ComparisonPanel({ cmp, newRunId, projectId, selectedCount }: {
             ))}
           </div>
         )}
-        <div className="px-4 py-3 bg-gray-50 text-xs text-gray-400">
+        <div className="px-4 py-3 bg-gray-50 text-xs text-gray-500">
           {t.runDetail.cmpCaption}
         </div>
       </div>
@@ -621,7 +634,7 @@ function autoCompareErrorText(t: Dictionary, reason: string): string {
 // Stage 48: status-transition pill — previous status → current status.
 function TransitionPill({ item }: { item: ReviewRunComparisonItem }) {
   const { t } = useI18n();
-  const sourceColor = item.sourceStatus ? (CMP_STATUS_COLORS[item.sourceStatus] ?? "text-gray-500") : "text-gray-400";
+  const sourceColor = item.sourceStatus ? (CMP_STATUS_COLORS[item.sourceStatus] ?? "text-gray-500") : "text-gray-500";
   const currentColor = item.currentStatus ? (CMP_STATUS_COLORS[item.currentStatus] ?? "text-gray-500") : "text-gray-500";
   return (
     <span className="inline-flex items-center gap-1 text-[11px] border border-gray-200 rounded-full px-2 py-0.5 bg-white">
@@ -647,7 +660,7 @@ function AutoCompareGroup({ title, description, color, items }: {
   return (
     <div className="px-4 py-3">
       <p className={`text-xs font-medium ${color}`}>{title} ({items.length})</p>
-      <p className="text-[11px] text-gray-400 mb-2">{description}</p>
+      <p className="text-[11px] text-gray-500 mb-2">{description}</p>
       <div className="space-y-2">
         {items.map((item) => (
           <div key={item.itemId}>
@@ -656,7 +669,7 @@ function AutoCompareGroup({ title, description, color, items }: {
               <TransitionPill item={item} />
             </div>
             {item.currentEvidence && (
-              <p className="text-[11px] text-gray-400 mt-0.5 truncate">{t.runDetail.acCurrentEvidence}: {item.currentEvidence}</p>
+              <p className="text-[11px] text-gray-500 mt-0.5 truncate">{t.runDetail.acCurrentEvidence}: {item.currentEvidence}</p>
             )}
             {item.currentNextAction && (
               <p className="text-[11px] text-indigo-500 mt-0.5 truncate">{t.runDetail.acNextAction}: {item.currentNextAction}</p>
@@ -676,7 +689,7 @@ function AutoComparisonPanel({ state, hasLineage, onSendToComment }: {
   const { t, locale } = useI18n();
   if (state.phase === "loading") {
     return (
-      <div className="flex items-center gap-2 text-xs text-gray-400 py-1">
+      <div className="flex items-center gap-2 text-xs text-gray-500 py-1">
         <div className="w-3 h-3 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin flex-shrink-0" />
         {t.runDetail.acComparing}
       </div>
@@ -687,7 +700,7 @@ function AutoComparisonPanel({ state, hasLineage, onSendToComment }: {
     return (
       <div className="bg-gray-50 border border-gray-200 rounded-xl px-4 py-2.5">
         <p className="text-xs font-medium text-gray-600">{t.runDetail.acCannotCompare}</p>
-        <p className="text-[11px] text-gray-400 mt-0.5">{autoCompareErrorText(t, state.reason)}</p>
+        <p className="text-[11px] text-gray-500 mt-0.5">{autoCompareErrorText(t, state.reason)}</p>
       </div>
     );
   }
@@ -697,10 +710,10 @@ function AutoComparisonPanel({ state, hasLineage, onSendToComment }: {
     <div className="border border-gray-200 rounded-xl overflow-hidden">
       <div className="bg-gray-50 border-b border-gray-200 px-4 py-3">
         <p className="text-sm font-semibold text-gray-800">{t.runDetail.acTitle}</p>
-        <p className="text-xs text-gray-400 mt-0.5">
+        <p className="text-xs text-gray-500 mt-0.5">
           {t.runDetail.acCaption}
         </p>
-        <div className="flex flex-wrap gap-x-3 gap-y-0.5 mt-1.5 text-[11px] text-gray-400">
+        <div className="flex flex-wrap gap-x-3 gap-y-0.5 mt-1.5 text-[11px] text-gray-500">
           <span>{t.runDetail.acPrevious}: {formatDate(sourceCreatedAt, locale)}</span>
           <span>{t.runDetail.acCurrent}: {formatDate(currentCreatedAt, locale)}</span>
         </div>
@@ -744,7 +757,7 @@ function AutoComparisonPanel({ state, hasLineage, onSendToComment }: {
             {t.runDetail.acSendToComment}
           </button>
         ) : (
-          <p className="text-[11px] text-gray-400">
+          <p className="text-[11px] text-gray-500">
             {t.runDetail.acNeedLineage}
           </p>
         )}
@@ -775,7 +788,7 @@ function RerunItemRow({ item, checked, onToggle }: {
           </span>
           <span className="text-xs font-medium text-gray-800 truncate">{item.title}</span>
         </div>
-        {evidence && <p className="text-[11px] text-gray-400 mt-0.5 truncate">{evidence}</p>}
+        {evidence && <p className="text-[11px] text-gray-500 mt-0.5 truncate">{evidence}</p>}
         {item.status !== "passed" && item.nextAction && (
           <p className="text-[11px] text-indigo-500 mt-0.5 truncate">{t.runDetail.next}: {item.nextAction}</p>
         )}
@@ -801,7 +814,7 @@ function ReviewItemSelectionPanel({
     <div className="border border-gray-200 rounded-xl overflow-hidden">
       <div className="bg-gray-50 border-b border-gray-200 px-4 py-3">
         <p className="text-sm font-semibold text-gray-800">{t.runDetail.selTitle}</p>
-        <p className="text-xs text-gray-400 mt-0.5">
+        <p className="text-xs text-gray-500 mt-0.5">
           {t.runDetail.selDesc}
         </p>
         <div className="flex flex-wrap gap-1.5 mt-2.5">
@@ -851,7 +864,7 @@ function ReviewItemSelectionPanel({
             {t.runDetail.selHint}
           </p>
         )}
-        {storageNote && <span className="text-[11px] text-gray-400 flex-shrink-0">{storageNote}</span>}
+        {storageNote && <span className="text-[11px] text-gray-500 flex-shrink-0">{storageNote}</span>}
       </div>
     </div>
   );
@@ -896,7 +909,7 @@ function RerunPanel({
 
   if (phase === "running") {
     return (
-      <div className="flex items-center gap-2 text-sm text-gray-400 py-2">
+      <div className="flex items-center gap-2 text-sm text-gray-500 py-2">
         <div className="w-4 h-4 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin flex-shrink-0" />
         {t.runDetail.rerunRunning}
       </div>
@@ -1069,7 +1082,7 @@ export default function RunDetailPage() {
     return () => { cancelled = true; };
   }, [phase, detail, fromRunId, id, runId, userKey]);
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   const historyUrl = `/projects/${id}/github/history`;
   const prPageUrl = `/projects/${id}/github`;
@@ -1077,7 +1090,7 @@ export default function RunDetailPage() {
   if (phase === "loading") {
     return (
       <div className="max-w-3xl">
-        <div className="flex items-center gap-2 text-sm text-gray-400">
+        <div className="flex items-center gap-2 text-sm text-gray-500">
           <div className="w-4 h-4 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin flex-shrink-0" />
           {t.runDetail.loading}
         </div>
@@ -1088,12 +1101,12 @@ export default function RunDetailPage() {
   if (phase === "not_found") {
     return (
       <div className="max-w-3xl space-y-4">
-        <Link href={historyUrl} className="text-xs text-gray-400 hover:text-indigo-600 inline-block">
+        <Link href={historyUrl} className="text-xs text-gray-500 hover:text-indigo-600 inline-block">
           {t.runDetail.backToHistory}
         </Link>
         <div className="bg-white rounded-xl border border-gray-200 p-8 text-center">
           <p className="text-sm font-medium text-gray-700 mb-1">{t.runDetail.notFoundTitle}</p>
-          <p className="text-xs text-gray-400">{t.runDetail.notFoundDesc}</p>
+          <p className="text-xs text-gray-500">{t.runDetail.notFoundDesc}</p>
         </div>
       </div>
     );
@@ -1102,7 +1115,7 @@ export default function RunDetailPage() {
   if (phase === "error" || !detail) {
     return (
       <div className="max-w-3xl space-y-4">
-        <Link href={historyUrl} className="text-xs text-gray-400 hover:text-indigo-600 inline-block">
+        <Link href={historyUrl} className="text-xs text-gray-500 hover:text-indigo-600 inline-block">
           {t.runDetail.backToHistory}
         </Link>
         <div className="bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700">
@@ -1133,11 +1146,11 @@ export default function RunDetailPage() {
       {/* ── Header ── */}
       <div className="flex items-start justify-between gap-4">
         <div>
-          <Link href={historyUrl} className="text-xs text-gray-400 hover:text-indigo-600 mb-2 inline-block">
+          <Link href={historyUrl} className="text-xs text-gray-500 hover:text-indigo-600 mb-2 inline-block">
             {t.runDetail.backToHistory}
           </Link>
           <h2 className="text-lg font-bold text-gray-900">{t.runDetail.title}</h2>
-          <p className="text-xs text-gray-400 mt-0.5">{repoFullName} · PR #{prNumber}</p>
+          <p className="text-xs text-gray-500 mt-0.5">{repoFullName} · PR #{prNumber}</p>
         </div>
         <StatusBadge status={run.status} />
       </div>
@@ -1271,7 +1284,7 @@ export default function RunDetailPage() {
         </section>
       ) : (
         run.status !== "error" && run.status !== "queued" && (
-          <div className="bg-gray-50 rounded-xl border border-gray-200 px-4 py-6 text-center text-sm text-gray-400">
+          <div className="bg-gray-50 rounded-xl border border-gray-200 px-4 py-6 text-center text-sm text-gray-500">
             {t.runDetail.noItemResults}
           </div>
         )

--- a/apps/dashboard/src/app/projects/[id]/github/history/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/history/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
@@ -115,7 +117,7 @@ function QuickRerun({
 
   if (phase === "running") {
     return (
-      <div className="flex items-center gap-2 text-xs text-gray-400">
+      <div className="flex items-center gap-2 text-xs text-gray-500">
         <div className="h-3 w-3 flex-shrink-0 animate-spin rounded-full border-2 border-gray-200 border-t-gray-500" />
         {t.history.rerunning}
       </div>
@@ -144,7 +146,7 @@ function QuickRerun({
         {detailLink}
       </div>
       {!enabled && (
-        <p className="text-[11px] text-gray-400">
+        <p className="text-[11px] text-gray-500">
           {rerunAction?.disabledReason === "results_unavailable" ? t.history.rerunDisabledNoResults : t.history.rerunNoItems}
         </p>
       )}
@@ -207,7 +209,7 @@ export default function ReviewHistoryPage() {
     return () => { cancelled = true; };
   }, [id, userKey]);
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   // Group runs by PR number for display
   const byPr = new Map<number, ProjectReviewHistoryItem[]>();
@@ -223,7 +225,7 @@ export default function ReviewHistoryPage() {
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-lg font-semibold tracking-tight text-gray-900">{t.history.title}</h2>
-          <p className="mt-0.5 text-xs text-gray-400">{t.history.desc}</p>
+          <p className="mt-0.5 text-xs text-gray-500">{t.history.desc}</p>
         </div>
         <Link href={`/projects/${id}/github`} className="text-xs font-medium text-brand-700 hover:text-brand-800">
           ← {t.history.backToPr}
@@ -232,20 +234,25 @@ export default function ReviewHistoryPage() {
 
       {/* Loading */}
       {phase === "loading" && (
-        <div className="flex items-center gap-2 text-sm text-gray-400">
+        <div className="flex items-center gap-2 text-sm text-gray-500">
           <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-gray-200 border-t-gray-500" />
           {t.history.loading}
         </div>
       )}
 
       {/* Error */}
-      {phase === "error" && <div className="callout callout-error">{t.history.loadError}</div>}
+      {phase === "error" && (
+        <div className="callout callout-error flex items-center justify-between">
+          <span>{t.history.loadError}</span>
+          <button onClick={() => window.location.reload()} className="btn btn-sm btn-secondary">{t.common.retry}</button>
+        </div>
+      )}
 
       {/* Empty */}
       {phase === "done" && runs.length === 0 && (
         <div className="card p-10 text-center">
           <p className="mb-1 text-sm font-medium text-gray-600">{t.history.emptyTitle}</p>
-          <p className="mb-4 text-xs text-gray-400">{t.history.emptyBody}</p>
+          <p className="mb-4 text-xs text-gray-500">{t.history.emptyBody}</p>
           <Link href={`/projects/${id}/github`} className="btn btn-md btn-primary">
             {t.checks.connectPr} →
           </Link>
@@ -281,7 +288,7 @@ export default function ReviewHistoryPage() {
                     <span className="text-xs font-semibold text-gray-700 flex-shrink-0">
                       PR #{run.prNumber}
                     </span>
-                    <span className="text-xs text-gray-400 truncate">{run.repoFullName}</span>
+                    <span className="text-xs text-gray-500 truncate">{run.repoFullName}</span>
                   </div>
                   <RunStatusBadge t={t} status={run.status} />
                 </div>
@@ -289,11 +296,11 @@ export default function ReviewHistoryPage() {
                 {run.summary && <SummaryBar t={t} summary={run.summary} />}
 
                 {run.status === "error" && run.errorMessage && (
-                  <p className="mt-1 text-xs text-gray-400">{t.runStatus.error}: {run.errorMessage}</p>
+                  <p className="mt-1 text-xs text-gray-500">{t.runStatus.error}: {run.errorMessage}</p>
                 )}
 
                 <div className="mt-1.5 flex items-center justify-between">
-                  <span className="font-mono text-xs text-gray-400">{formatDate(run.createdAt, locale)}</span>
+                  <span className="font-mono text-xs text-gray-500">{formatDate(run.createdAt, locale)}</span>
                   <span className="text-xs text-gray-300">{run.selectedItemCount} {t.history.items}</span>
                 </div>
 
@@ -328,7 +335,7 @@ export default function ReviewHistoryPage() {
                     <span className="text-xs font-bold text-gray-700">PR #{prNum}</span>
                     {latest && <RunStatusBadge t={t} status={latest.status} />}
                   </div>
-                  <p className="text-xs text-gray-400">{prRuns.length} {t.history.totalRuns}</p>
+                  <p className="text-xs text-gray-500">{prRuns.length} {t.history.totalRuns}</p>
                 </div>
               );
             })}

--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
@@ -48,7 +50,7 @@ export default function GitHubPage() {
   const project = getLocalProject(id) ?? getProject(id);
   const userKey = getUserKey();
 
-  const [loadPhase, setLoadPhase] = useState<"loading" | "no_repo" | "ready">("loading");
+  const [loadPhase, setLoadPhase] = useState<"loading" | "no_repo" | "load_error" | "ready">("loading");
   const [repo, setRepo] = useState<LinkedRepo | null>(null);
   const [pulls, setPulls] = useState<GitHubPull[]>([]);
   const [pullsPhase, setPullsPhase] = useState<"idle" | "loading" | "done" | "error">("idle");
@@ -73,6 +75,8 @@ export default function GitHubPage() {
   const [creditDryRunByPr, setCreditDryRunByPr] = useState<Record<number, CreditEnforcementResult | CreditEnforcementDryRun>>({});
   // Comparison data: keyed by prNumber (loaded by ComparisonPanel, used by PRCommentPanel)
   const [comparisonDataByPr, setComparisonDataByPr] = useState<Record<number, PrReviewComparisonResponse>>({});
+  // Specific review-failure message per PR (rate limit / credits / network…).
+  const [reviewErrorByPr, setReviewErrorByPr] = useState<Record<number, string>>({});
 
   const ext = loadExtendedProjectData(id);
   const checkResultMap = new Map(
@@ -138,8 +142,13 @@ export default function GitHubPage() {
     if (repoRes.ok && repoRes.repo) {
       setRepo(repoRes.repo);
       setLoadPhase("ready");
-    } else {
+    } else if (repoRes.ok) {
+      // Confirmed: genuinely no repo linked.
       setLoadPhase("no_repo");
+    } else {
+      // Transient fetch failure ≠ "not connected" — a user WITH a linked repo
+      // must not be sent to settings to "connect" what is already connected.
+      setLoadPhase("load_error");
     }
     if (linkedRes.ok) {
       setLinkedPulls(linkedRes.pulls);
@@ -213,7 +222,10 @@ export default function GitHubPage() {
   }
 
   async function handleStartReview(lp: LinkedPull) {
+    // Double-click guard: two clicks in the same tick would start two runs.
+    if (reviewPhase[lp.number] === "running") return;
     setReviewPhase((prev) => ({ ...prev, [lp.number]: "running" }));
+    setReviewErrorByPr((prev) => ({ ...prev, [lp.number]: "" }));
     const ext2 = loadExtendedProjectData(id);
     const items = (project?.requirements ?? []).map((r) => ({
       id: r.id,
@@ -240,16 +252,41 @@ export default function GitHubPage() {
       } else if (res.creditDryRun) {
         setCreditDryRunByPr((prev) => ({ ...prev, [lp.number]: res.creditDryRun! }));
       }
-    } else {
+      return;
+    }
+    // HTTP 402: store enforcement info so CreditDryRunBanner can show the blocked state
+    if (res.error === "insufficient_credits" && res.creditEnforcement) {
+      setCreditDryRunByPr((prev) => ({ ...prev, [lp.number]: res.creditEnforcement! }));
       setReviewPhase((prev) => ({ ...prev, [lp.number]: "error" }));
-      // HTTP 402: store enforcement info so CreditDryRunBanner can show the blocked state
-      if (!res.ok && res.error === "insufficient_credits" && res.creditEnforcement) {
-        setCreditDryRunByPr((prev) => ({ ...prev, [lp.number]: res.creditEnforcement! }));
+      return;
+    }
+    // A slow-but-healthy review looks identical to a network failure here (the
+    // client request aborts at 40s while the server keeps working). Before
+    // declaring failure, poll the latest run for up to ~60s — if it lands, show
+    // the result instead of a false "review failed". Only poll on transport-ish
+    // failures; explicit server verdicts (rate limit, credits…) are final.
+    const finalServerCodes = new Set([
+      "rate_limited", "insufficient_credits", "no_repo_linked", "not_connected",
+      "no_selected_items", "not_found", "invalid_json", "userKey_required",
+    ]);
+    if (!finalServerCodes.has(res.error)) {
+      for (let attempt = 0; attempt < 6; attempt++) {
+        await new Promise((r) => setTimeout(r, 10_000));
+        const latest = await getLatestPRReview(id, lp.number, userKey).catch(() => null);
+        if (latest?.ok && latest.run && latest.run.status !== "running") {
+          setReviewRuns((prev) => ({ ...prev, [lp.number]: latest.run! }));
+          setReviewPhase((prev) => ({ ...prev, [lp.number]: "done" }));
+          return;
+        }
       }
     }
+    // Real failure — show a SPECIFIC message (rate_limited → daily-cap copy,
+    // not the generic "check your PR on GitHub" misdirection).
+    setReviewErrorByPr((prev) => ({ ...prev, [lp.number]: errorText(t, res.error, "generic") }));
+    setReviewPhase((prev) => ({ ...prev, [lp.number]: "error" }));
   }
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   return (
     <div className="max-w-3xl space-y-6">
@@ -260,7 +297,7 @@ export default function GitHubPage() {
         </div>
         <Link
           href={`/projects/${id}/github/history`}
-          className="mt-1 flex-shrink-0 text-xs font-medium text-gray-400 hover:text-brand-700"
+          className="mt-1 flex-shrink-0 text-xs font-medium text-gray-500 hover:text-brand-700"
         >
           {t.github.viewHistory} →
         </Link>
@@ -270,7 +307,7 @@ export default function GitHubPage() {
       {loadPhase === "loading" && (
         <div className="card p-6 text-center">
           <div className="mx-auto mb-2 h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
-          <p className="text-sm text-gray-400">{t.github.checkingConnection}</p>
+          <p className="text-sm text-gray-500">{t.github.checkingConnection}</p>
         </div>
       )}
 
@@ -284,13 +321,23 @@ export default function GitHubPage() {
         </div>
       )}
 
+      {/* Transient load failure — retry, don't misdirect to settings */}
+      {loadPhase === "load_error" && (
+        <div className="card p-8 text-center">
+          <p className="mb-4 text-sm text-gray-600">{t.github.connectionLoadError}</p>
+          <button onClick={() => void loadInitial()} className="btn btn-md btn-primary">
+            {t.common.retry}
+          </button>
+        </div>
+      )}
+
       {/* Ready */}
       {loadPhase === "ready" && repo && (
         <>
           {/* Repo info */}
           <div className="card flex items-center justify-between p-4">
             <div>
-              <p className="mb-0.5 text-xs text-gray-400">{t.github.connectedRepo}</p>
+              <p className="mb-0.5 text-xs text-gray-500">{t.github.connectedRepo}</p>
               <a
                 href={repo.htmlUrl ?? `https://github.com/${repo.fullName}`}
                 target="_blank"
@@ -299,9 +346,9 @@ export default function GitHubPage() {
               >
                 {repo.fullName}
               </a>
-              {repo.defaultBranch && <span className="ml-2 text-xs text-gray-400">→ {repo.defaultBranch}</span>}
+              {repo.defaultBranch && <span className="ml-2 text-xs text-gray-500">→ {repo.defaultBranch}</span>}
             </div>
-            <button onClick={handleLoadPulls} disabled={pullsPhase === "loading"} className="btn btn-md btn-secondary">
+            <button onClick={handleLoadPulls} disabled={pullsPhase === "loading"} className="btn btn-md btn-primary">
               {pullsPhase === "loading" ? t.common.loading : t.github.loadPulls}
             </button>
           </div>
@@ -329,10 +376,10 @@ export default function GitHubPage() {
                       className={`w-full px-5 py-4 text-left transition-colors hover:bg-gray-50 ${selectedPR?.number === pull.number ? "border-l-2 border-brand-500 bg-brand-50" : ""}`}
                     >
                       <div className="flex items-start gap-3">
-                        <span className="mt-0.5 flex-shrink-0 font-mono text-xs text-gray-400">#{pull.number}</span>
+                        <span className="mt-0.5 flex-shrink-0 font-mono text-xs text-gray-500">#{pull.number}</span>
                         <div className="min-w-0 flex-1">
                           <p className="truncate text-sm font-medium text-gray-800">{pull.title}</p>
-                          <p className="mt-0.5 font-mono text-xs text-gray-400">
+                          <p className="mt-0.5 font-mono text-xs text-gray-500">
                             {pull.headBranch} → {pull.baseBranch}
                             {pull.updatedAt && ` · ${new Date(pull.updatedAt).toLocaleDateString(locale === "ko" ? "ko-KR" : "en-US")}`}
                           </p>
@@ -352,7 +399,7 @@ export default function GitHubPage() {
               <p className="mb-1 text-sm font-semibold text-gray-800">
                 PR #{selectedPR.number}: {selectedPR.title}
               </p>
-              <p className="mb-4 text-xs text-gray-400">
+              <p className="mb-4 text-xs text-gray-500">
                 {t.github.selectItemsForPr} ({selectedItemIds.size} {t.github.selected})
               </p>
               {allItems.length === 0 ? (
@@ -406,6 +453,11 @@ export default function GitHubPage() {
             </div>
           )}
 
+          {/* Link success — rendered here because handleLink clears selectedPR */}
+          {linkPhase === "done" && (
+            <p className="text-sm text-green-600">✓ {t.github.linked}</p>
+          )}
+
           {/* Linked PRs list */}
           {linkedPulls.length > 0 && (
             <div className="card">
@@ -420,10 +472,10 @@ export default function GitHubPage() {
                     <div key={lp.id} className="px-5 py-4 space-y-3">
                       {/* PR header */}
                       <div className="flex items-start gap-3">
-                        <span className="text-xs text-gray-400 font-mono mt-0.5">#{lp.number}</span>
+                        <span className="text-xs text-gray-500 font-mono mt-0.5">#{lp.number}</span>
                         <div className="flex-1 min-w-0">
                           <p className="text-sm font-medium text-gray-800 truncate">{lp.title}</p>
-                          <p className="text-xs text-gray-400 mt-0.5">{lp.repoFullName}</p>
+                          <p className="text-xs text-gray-500 mt-0.5">{lp.repoFullName}</p>
                         </div>
                         <span className={`text-xs rounded-full px-2 py-0.5 flex-shrink-0 ${lp.state === "open" ? "text-green-600 bg-green-50 border border-green-200" : "text-gray-500 bg-gray-100 border border-gray-200"}`}>
                           {lp.state === "open" ? t.github.stateOpen : lp.state === "closed" ? t.github.stateClosed : lp.state}
@@ -448,7 +500,7 @@ export default function GitHubPage() {
                       <div className="ml-6">
                         {phase === "idle" && (
                           <div className="space-y-2">
-                            <p className="text-xs text-gray-400">{t.github.notReviewedYet}</p>
+                            <p className="text-xs text-gray-500">{t.github.notReviewedYet}</p>
                             <button onClick={() => handleStartReview(lp)} className="btn btn-md btn-primary">
                               {t.github.runReviewBtn}
                             </button>
@@ -456,9 +508,12 @@ export default function GitHubPage() {
                         )}
 
                         {phase === "running" && (
-                          <div className="flex items-center gap-2 text-sm text-gray-500">
-                            <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-gray-300 border-t-brand-600" />
-                            {t.github.reviewing}
+                          <div className="space-y-1">
+                            <div className="flex items-center gap-2 text-sm text-gray-500">
+                              <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-gray-300 border-t-brand-600" />
+                              {t.github.reviewing}
+                            </div>
+                            <p className="pl-6 text-xs text-gray-500">{t.github.reviewingHint}</p>
                           </div>
                         )}
 
@@ -467,7 +522,7 @@ export default function GitHubPage() {
                             {creditDryRunByPr[lp.number] && (creditDryRunByPr[lp.number] as CreditEnforcementResult).blocked ? (
                               <CreditDryRunBanner t={t} dryRun={creditDryRunByPr[lp.number]!} projectId={id} />
                             ) : (
-                              <p className="text-xs text-red-600">{t.github.reviewFailed}</p>
+                              <p className="text-xs text-red-600">{reviewErrorByPr[lp.number] || t.github.reviewFailed}</p>
                             )}
                             <button onClick={() => handleStartReview(lp)} className="btn btn-sm btn-secondary">
                               {t.common.retry}
@@ -571,7 +626,7 @@ function ComparisonPanel({
 
   if (!data.comparable) {
     return (
-      <p className="rounded-lg border border-gray-100 bg-gray-50 px-3 py-2.5 text-xs text-gray-400">
+      <p className="rounded-lg border border-gray-100 bg-gray-50 px-3 py-2.5 text-xs text-gray-500">
         {t.comparison.noComparison}
       </p>
     );
@@ -583,7 +638,7 @@ function ComparisonPanel({
 
   function DeltaBadge({ prev, latest }: { prev: number; latest: number }) {
     const delta = latest - prev;
-    if (delta === 0) return <span className="text-gray-400">{latest}</span>;
+    if (delta === 0) return <span className="text-gray-500">{latest}</span>;
     if (delta > 0) return <span className="text-green-600">{prev} → {latest} (+{delta})</span>;
     return <span className="text-red-600">{prev} → {latest} ({delta})</span>;
   }
@@ -592,7 +647,7 @@ function ComparisonPanel({
     <div className="space-y-3">
       <div>
         <p className="mb-0.5 text-sm font-semibold text-gray-800">{t.comparison.title}</p>
-        <p className="text-xs text-gray-400">{t.comparison.desc}</p>
+        <p className="text-xs text-gray-500">{t.comparison.desc}</p>
       </div>
 
       {/* Summary delta */}
@@ -677,7 +732,7 @@ function ComparisonPanel({
         </div>
       )}
 
-      <p className="text-xs text-gray-400 italic">{comparison.summaryText}</p>
+      <p className="text-xs text-gray-500 italic">{comparison.summaryText}</p>
     </div>
   );
 }
@@ -753,6 +808,10 @@ function PRCommentPanel({
   }
 
   async function handlePost() {
+    // Posting publishes a PUBLIC comment on the user's PR under their GitHub
+    // identity and it can't be deleted from here (only updated). Make that
+    // unmistakable at the moment of posting.
+    if (!window.confirm(t.comment.postConfirm)) return;
     setPostPhase("loading");
     setScopeError(false);
     setErrorMsg(null);
@@ -787,6 +846,14 @@ function PRCommentPanel({
     }
   }
 
+  // Duplicate-comment guard: detect an existing posted comment BEFORE the
+  // first post, so the update-vs-new choice is offered automatically instead
+  // of only after the user happens to expand "past comments".
+  useEffect(() => {
+    void loadPastComments();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   function handleRecheck() {
     setPostPhase("idle");
     setPreviewPhase("idle");
@@ -804,7 +871,7 @@ function PRCommentPanel({
     <div className="space-y-3">
       <div>
         <p className="text-sm font-semibold text-gray-800 mb-0.5">{t.comment.title}</p>
-        <p className="text-xs text-gray-400">{t.comment.desc}</p>
+        <p className="text-xs text-gray-500">{t.comment.desc}</p>
       </div>
 
       <p className="text-xs text-blue-600 bg-blue-50 border border-blue-100 rounded-lg px-3 py-2">
@@ -825,7 +892,7 @@ function PRCommentPanel({
           <span className="text-xs text-gray-700">{t.comment.includeComparison}</span>
         </label>
         {!comparable && (
-          <p className="text-xs text-gray-400 mt-1 ml-6">{t.comment.comparisonUnavailable}</p>
+          <p className="text-xs text-gray-500 mt-1 ml-6">{t.comment.comparisonUnavailable}</p>
         )}
       </div>
 
@@ -849,7 +916,7 @@ function PRCommentPanel({
       )}
 
       {/* Item selection */}
-      <p className="mb-1 text-xs text-gray-400">
+      <p className="mb-1 text-xs text-gray-500">
         {t.exportPage.selectedOfTotal
           .replace("{sel}", String(selectedIds.size))
           .replace("{total}", String(allResults.length))}
@@ -879,7 +946,7 @@ function PRCommentPanel({
         <button
           onClick={handlePreview}
           disabled={!canPost || previewPhase === "loading"}
-          className="text-sm px-4 py-2 rounded-xl font-medium border border-gray-200 text-gray-700 hover:bg-gray-50 disabled:opacity-40 transition-colors"
+          className="btn btn-md btn-secondary"
         >
           {previewPhase === "loading" ? t.comment.previewing : t.comment.preview}
         </button>
@@ -887,7 +954,7 @@ function PRCommentPanel({
           <button
             onClick={handlePost}
             disabled={postPhase === "loading"}
-            className="text-sm px-4 py-2 rounded-xl font-medium bg-gray-900 text-white hover:bg-gray-800 disabled:opacity-40 transition-colors"
+            className="btn btn-md btn-primary"
           >
             {postPhase === "loading"
               ? t.comment.posting
@@ -957,7 +1024,7 @@ function PRCommentPanel({
       {/* Past comments toggle */}
       <button
         onClick={loadPastComments}
-        className="text-xs text-gray-400 hover:text-gray-600 underline"
+        className="text-xs text-gray-500 hover:text-gray-600 underline"
       >
         {t.comment.showPast}
       </button>
@@ -966,7 +1033,7 @@ function PRCommentPanel({
         <div className="space-y-1.5">
           {latestPosted && (
             <p className="text-xs text-indigo-600 bg-indigo-50 border border-indigo-100 rounded-lg px-3 py-1.5">
-              {t.comment.latest} {latestPosted.updatedAt.slice(0, 10)}{" "}
+              {t.comment.latest} {new Date(latestPosted.updatedAt).toLocaleDateString(locale === "ko" ? "ko-KR" : "en-US")}{" "}
               {latestPosted.githubCommentUrl && (
                 <a href={latestPosted.githubCommentUrl} target="_blank" rel="noopener noreferrer" className="underline">{t.comment.viewOnGithub}</a>
               )}
@@ -989,7 +1056,7 @@ function PRCommentPanel({
       )}
 
       {pastLoaded && pastComments.length === 0 && (
-        <p className="text-xs text-gray-400">{t.comment.noPast}</p>
+        <p className="text-xs text-gray-500">{t.comment.noPast}</p>
       )}
     </div>
   );
@@ -1056,8 +1123,14 @@ function FixBriefPanel({
   }
 
   async function handleCopy(file: FixBriefFile) {
-    await navigator.clipboard.writeText(file.content).catch(() => {});
-    setCopyMsg(file.path);
+    try {
+      await navigator.clipboard.writeText(file.content);
+      setCopyMsg(file.path); // only claim "copied" when the copy succeeded
+    } catch {
+      setCopyMsg(null);
+      window.prompt(t.github.copyManually, file.content);
+      return;
+    }
     setTimeout(() => setCopyMsg(null), 2000);
   }
 
@@ -1081,11 +1154,11 @@ function FixBriefPanel({
     <div className="space-y-3">
       <div>
         <p className="text-sm font-semibold text-gray-800 mb-0.5">{t.fixBrief.title}</p>
-        <p className="text-xs text-gray-400">{t.fixBrief.desc}</p>
+        <p className="text-xs text-gray-500">{t.fixBrief.desc}</p>
       </div>
 
       {/* Item checkboxes */}
-      <p className="mb-1 text-xs text-gray-400">
+      <p className="mb-1 text-xs text-gray-500">
         {t.exportPage.selectedOfTotal
           .replace("{sel}", String(selectedIds.size))
           .replace("{total}", String(fixableItems.length))}
@@ -1124,7 +1197,7 @@ function FixBriefPanel({
         <button
           onClick={handleGenerate}
           disabled={selectedIds.size === 0 || phase === "loading"}
-          className="text-sm px-4 py-2 rounded-xl font-medium bg-gray-900 text-white hover:bg-gray-800 disabled:opacity-40 transition-colors"
+          className="btn btn-md btn-primary"
         >
           {phase === "loading" ? t.fixBrief.generating : t.fixBrief.generate}
         </button>
@@ -1166,11 +1239,11 @@ function FixBriefPanel({
                   <span className="text-xs font-mono text-indigo-700 flex-1 truncate">{f.path}</span>
                   <button
                     onClick={(e) => { e.stopPropagation(); handleCopy(f); }}
-                    className="text-xs text-gray-400 hover:text-gray-600 px-2 py-0.5 rounded border border-gray-200 bg-white flex-shrink-0"
+                    className="text-xs text-gray-500 hover:text-gray-600 px-2 py-0.5 rounded border border-gray-200 bg-white flex-shrink-0"
                   >
                     {t.fixBrief.copy}
                   </button>
-                  <span className="text-gray-400 text-xs flex-shrink-0">
+                  <span className="text-gray-500 text-xs flex-shrink-0">
                     {previewFile === f.path ? "▲" : "▼"}
                   </span>
                 </button>
@@ -1185,7 +1258,7 @@ function FixBriefPanel({
             ))}
           </div>
 
-          <p className="text-xs text-gray-400">{t.fixBrief.usageNote}</p>
+          <p className="text-xs text-gray-500">{t.fixBrief.usageNote}</p>
         </div>
       )}
     </div>
@@ -1223,22 +1296,22 @@ function ReviewResultPanel({ run, onRerun }: { run: ReviewRun; onRerun: () => vo
           {t.review.resultLabel}: {runLabel}
         </span>
         {run.summary && (
-          <span className="text-xs text-gray-400">
+          <span className="text-xs text-gray-500">
             {statusLabel(t, "passed")} {run.summary.passed} · {statusLabel(t, "failed")} {run.summary.failed} · {statusLabel(t, "inconclusive")} {run.summary.inconclusive}
             {run.summary.needsDecision > 0 && ` · ${statusLabel(t, "needs_decision")} ${run.summary.needsDecision}`}
           </span>
         )}
         <button
           onClick={onRerun}
-          className="ml-auto text-xs text-gray-400 hover:text-gray-600 underline"
+          className="ml-auto text-xs text-gray-500 hover:text-gray-600 underline"
         >
           {t.review.recheck}
         </button>
       </div>
 
       {/* Disclaimer */}
-      <p className="text-xs text-gray-400">{t.review.basisNote}</p>
-      <p className="text-xs text-gray-400">{t.review.verifyLiveNote}</p>
+      <p className="text-xs text-gray-500">{t.review.basisNote}</p>
+      <p className="text-xs text-gray-500">{t.review.verifyLiveNote}</p>
 
       {/* Error */}
       {run.status === "error" && run.errorMessage && (
@@ -1264,14 +1337,14 @@ function ReviewResultPanel({ run, onRerun }: { run: ReviewRun; onRerun: () => vo
                   <StatusText status={r.status} />
                 </span>
                 <span className="text-sm text-gray-800 flex-1 truncate">{r.title}</span>
-                <span className="text-gray-400 text-xs flex-shrink-0">{expanded === r.itemId ? "▲" : "▼"}</span>
+                <span className="text-gray-500 text-xs flex-shrink-0">{expanded === r.itemId ? "▲" : "▼"}</span>
               </button>
               {expanded === r.itemId && (
                 <div className="px-3 pb-3 space-y-2 border-t border-gray-100 pt-2">
                   <p className="text-xs text-gray-700">{r.reason}</p>
                   {r.evidence.length > 0 && (
                     <div>
-                      <p className="text-xs text-gray-400 mb-1">{t.review.evidenceLabel}</p>
+                      <p className="text-xs text-gray-500 mb-1">{t.review.evidenceLabel}</p>
                       <ul className="space-y-0.5">
                         {r.evidence.map((e, i) => (
                           <li key={i} className="text-xs text-gray-600 font-mono bg-gray-50 rounded px-2 py-0.5 truncate">

--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { getProject } from "@/lib/mock-data";
-import { getLocalProject, loadExtendedProjectData, getUserKey, saveProject, saveExtendedProjectData } from "@/lib/workflow-store";
+import { getLocalProject, loadExtendedProjectData, getUserKey, saveProject, saveExtendedProjectData, markProjectSyncFailed } from "@/lib/workflow-store";
 import { callWorkspaceApi } from "@/lib/workspace-api";
 import { saveProjectToDb } from "@/lib/workspace-check-api";
 import {
@@ -56,6 +56,7 @@ export default function GitHubPage() {
   const [pullsPhase, setPullsPhase] = useState<"idle" | "loading" | "done" | "error">("idle");
   const [pullsError, setPullsError] = useState("");
   const [linkedPulls, setLinkedPulls] = useState<LinkedPull[]>([]);
+  const [linkedLoadFailed, setLinkedLoadFailed] = useState(false);
   const [selectedPR, setSelectedPR] = useState<GitHubPull | null>(null);
   const [selectedItemIds, setSelectedItemIds] = useState<Set<string>>(new Set());
   const [linkPhase, setLinkPhase] = useState<"idle" | "saving" | "done" | "error">("idle");
@@ -128,7 +129,7 @@ export default function GitHubPage() {
       understood: generated.understood ?? {},
       productSpec: generated.productSpec,
       items: generated.items,
-    }).catch(() => undefined);
+    }).then((res) => { if (!res || res.ok !== true) markProjectSyncFailed(id); }).catch(() => markProjectSyncFailed(id));
     setGenPhase("idle");
     forceItemsRefresh((v) => v + 1); // re-read getLocalProject → picker appears
   }
@@ -150,6 +151,7 @@ export default function GitHubPage() {
       // must not be sent to settings to "connect" what is already connected.
       setLoadPhase("load_error");
     }
+    setLinkedLoadFailed(!linkedRes.ok);
     if (linkedRes.ok) {
       setLinkedPulls(linkedRes.pulls);
       // Load any existing review runs for linked PRs
@@ -450,6 +452,13 @@ export default function GitHubPage() {
                 {linkPhase === "done" && <span className="text-sm text-green-600">✓ {t.github.linked}</span>}
                 {linkPhase === "error" && <span className="text-sm text-red-500">{t.github.linkSaveError}</span>}
               </div>
+            </div>
+          )}
+
+          {linkedLoadFailed && (
+            <div className="callout callout-error flex items-center justify-between">
+              <span>{t.errors.loadFailed}</span>
+              <button onClick={() => void loadInitial()} className="btn btn-sm btn-secondary">{t.common.retry}</button>
             </div>
           )}
 

--- a/apps/dashboard/src/app/projects/[id]/idea/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/idea/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useParams } from "next/navigation";
 import { getProject } from "@/lib/mock-data";
 import { getLocalProject } from "@/lib/workflow-store";
@@ -12,22 +14,37 @@ export default function IdeaPage() {
   // Read on the client so locally-created (localStorage) projects resolve,
   // not just the bundled mock demos.
   const project = getLocalProject(id) ?? getProject(id);
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
+
+  // Code-branch projects legitimately start without a worked-up idea/spec —
+  // show a guiding empty state instead of blank cards.
+  const isEmpty = !project.spec.goal && project.spec.included.length === 0 && !project.description;
 
   return (
     <div className="max-w-2xl">
       <h1 className="page-title">{t.nav.idea}</h1>
       <p className="page-subtitle mb-8">{t.idea.subtitle}</p>
 
+      {isEmpty && (
+        <div className="empty-state mb-6">
+          <p className="text-sm text-gray-600">{t.idea.emptyBody}</p>
+          <a href={`/projects/${id}`} className="btn btn-md btn-primary mt-4">
+            {t.common.goOverview}
+          </a>
+        </div>
+      )}
+
+      {!isEmpty && (
+      <>
       <div className="card mb-6 p-6">
-        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-400">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
           {t.idea.yourInput}
         </h2>
         <p className="text-sm leading-relaxed text-gray-800">{project.description}</p>
       </div>
 
       <div className="card mb-6 p-6">
-        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-400">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
           {t.idea.understood}
         </h2>
         <p className="text-sm font-medium text-gray-800 mb-3">{project.spec.goal}</p>
@@ -54,6 +71,8 @@ export default function IdeaPage() {
           ))}
         </ul>
       </div>
+      </>
+      )}
       <StepNextButton />
     </div>
   );

--- a/apps/dashboard/src/app/projects/[id]/items/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/items/page.tsx
@@ -10,6 +10,7 @@ import {
   getUserKey,
   saveProject,
   saveExtendedProjectData,
+  markProjectSyncFailed,
 } from "@/lib/workflow-store";
 import { callWorkspaceApi } from "@/lib/workspace-api";
 import { saveProjectToDb } from "@/lib/workspace-check-api";
@@ -75,7 +76,7 @@ export default function ItemsPage() {
       understood: generated.understood ?? {},
       productSpec: generated.productSpec,
       items: generated.items,
-    }).catch(() => undefined);
+    }).then((res) => { if (!res || res.ok !== true) markProjectSyncFailed(id); }).catch(() => markProjectSyncFailed(id));
     setGenPhase("idle");
     forceRefresh((v) => v + 1);
   }

--- a/apps/dashboard/src/app/projects/[id]/items/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/items/page.tsx
@@ -1,8 +1,18 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
+import { useState } from "react";
 import { useParams } from "next/navigation";
 import { getProject } from "@/lib/mock-data";
-import { getLocalProject } from "@/lib/workflow-store";
+import {
+  getLocalProject,
+  getUserKey,
+  saveProject,
+  saveExtendedProjectData,
+} from "@/lib/workflow-store";
+import { callWorkspaceApi } from "@/lib/workspace-api";
+import { saveProjectToDb } from "@/lib/workspace-check-api";
 import { ACCEPTANCE_CRITERIA } from "@/lib/mock-generators";
 import { StatusBadge } from "@/components/StatusBadge";
 import { useI18n } from "@/i18n/I18nProvider";
@@ -11,13 +21,93 @@ import { StepNextButton } from "@/components/StepNextButton";
 export default function ItemsPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useI18n();
+  // Code-branch rescue (same pattern as the github-page PR panel): a project
+  // created without the optional one-liner has zero items, and this page used
+  // to be read-only — the overview's "확인 항목 만들기" CTA landed on a page
+  // that couldn't create items. The inline generator below closes that.
+  const [quickIdea, setQuickIdea] = useState("");
+  const [genPhase, setGenPhase] = useState<"idle" | "loading">("idle");
+  const [genError, setGenError] = useState<string | null>(null);
+  const [, forceRefresh] = useState(0);
+
   const project = getLocalProject(id) ?? getProject(id);
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
+
+  const hasItems = project.requirements.length > 0;
+
+  async function handleGenerateItems() {
+    if (!project || !quickIdea.trim() || genPhase === "loading") return;
+    setGenPhase("loading");
+    setGenError(null);
+    const res = await callWorkspaceApi({ idea: quickIdea.trim() });
+    if (!res.ok && res.error === "rate_limited") {
+      setGenError(t.common.rateLimited);
+      setGenPhase("idle");
+      return;
+    }
+    const generated = res.ok ? res.data : res.fallback;
+    if (!generated?.items?.length) {
+      setGenError(t.github.generateItemsError);
+      setGenPhase("idle");
+      return;
+    }
+    saveProject({
+      ...project,
+      requirements: generated.items.map((item) => ({
+        id: item.id,
+        title: item.title,
+        status: "not_started" as const,
+        category: "feature",
+        priority: "must" as const,
+      })),
+    });
+    saveExtendedProjectData(id, {
+      productSpec: generated.productSpec,
+      itemCriteria: Object.fromEntries(generated.items.map((i) => [i.id, i.criteria ?? []])),
+    });
+    // builtWith / entryPath omitted on purpose — the server upsert keeps the
+    // stored capture-once values (sticky).
+    saveProjectToDb({
+      id,
+      userKey: getUserKey(),
+      title: project.name,
+      idea: quickIdea.trim(),
+      understood: generated.understood ?? {},
+      productSpec: generated.productSpec,
+      items: generated.items,
+    }).catch(() => undefined);
+    setGenPhase("idle");
+    forceRefresh((v) => v + 1);
+  }
 
   return (
     <div className="max-w-3xl">
       <h1 className="page-title">{t.items.title}</h1>
       <p className="page-subtitle mb-8">{t.items.subtitle}</p>
+
+      {!hasItems && (
+        <div className="card p-6">
+          <p className="text-sm font-medium text-gray-700">{t.github.noItemsYet}</p>
+          <p className="mt-1 text-xs text-gray-500">{t.github.noItemsHint}</p>
+          <textarea
+            value={quickIdea}
+            onChange={(e) => setQuickIdea(e.target.value)}
+            rows={2}
+            placeholder={t.github.noItemsIdeaPlaceholder}
+            className="input mt-3"
+          />
+          <div className="mt-3 flex items-center gap-3">
+            <button
+              onClick={handleGenerateItems}
+              disabled={!quickIdea.trim() || genPhase === "loading"}
+              className="btn btn-md btn-primary"
+            >
+              {genPhase === "loading" ? t.github.generatingItems : t.github.generateItems}
+            </button>
+            {genError && <span className="text-sm text-red-500">{genError}</span>}
+          </div>
+        </div>
+      )}
 
       <div className="space-y-3">
         {project.requirements.map((req) => (
@@ -30,14 +120,14 @@ export default function ItemsPage() {
                 <p className="mb-2 text-sm font-medium text-gray-800">{req.title}</p>
                 <div className="flex flex-wrap items-center gap-2">
                   <StatusBadge status={req.status} />
-                  <span className="text-xs text-gray-400">{t.priority[req.priority]}</span>
+                  <span className="text-xs text-gray-500">{t.priority[req.priority]}</span>
                 </div>
               </div>
             </div>
 
             {ACCEPTANCE_CRITERIA[req.id] && (
               <div className="ml-17 pl-14">
-                <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-400">
+                <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
                   {t.items.criteria}
                 </p>
                 <ul className="space-y-1">
@@ -59,12 +149,14 @@ export default function ItemsPage() {
         ))}
       </div>
 
-      <div className="mt-6 flex items-center justify-between rounded-lg border border-brand-100 bg-brand-50 px-5 py-4">
-        <p className="text-sm text-brand-800">{t.items.ctaQuestion}</p>
-        <a href={`/projects/${id}/export`} className="text-sm font-medium text-brand-700 hover:text-brand-800">
-          {t.items.ctaButton} →
-        </a>
-      </div>
+      {hasItems && (
+        <div className="mt-6 flex items-center justify-between rounded-lg border border-brand-100 bg-brand-50 px-5 py-4">
+          <p className="text-sm text-brand-800">{t.items.ctaQuestion}</p>
+          <a href={`/projects/${id}/export`} className="text-sm font-medium text-brand-700 hover:text-brand-800">
+            {t.items.ctaButton} →
+          </a>
+        </div>
+      )}
       <StepNextButton />
     </div>
   );

--- a/apps/dashboard/src/app/projects/[id]/layout.tsx
+++ b/apps/dashboard/src/app/projects/[id]/layout.tsx
@@ -1,5 +1,5 @@
 export default function ProjectLayout({ children }: { children: React.ReactNode }) {
   // Navigation lives in the app-wide slim sidebar (AppSidebar). Here we just give the
   // page content generous, centered breathing room — AI-platform style.
-  return <div className="mx-auto max-w-3xl px-8 py-10">{children}</div>;
+  return <div className="mx-auto max-w-3xl px-4 py-6 md:px-8 md:py-10">{children}</div>;
 }

--- a/apps/dashboard/src/app/projects/[id]/map/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/map/page.tsx
@@ -101,7 +101,7 @@ export default function PlanMapPage() {
         </span>
       </div>
       <p className="mt-1 text-sm text-gray-500">{pm.subtitle}</p>
-      <p className="mt-2 text-xs text-gray-400">{pm.generatedNote}</p>
+      <p className="mt-2 text-xs text-gray-500">{pm.generatedNote}</p>
 
       {/* You are here */}
       <section className="card mt-5 p-5">
@@ -110,15 +110,15 @@ export default function PlanMapPage() {
         <p className="mt-0.5 text-sm text-gray-500">{goal}</p>
         <dl className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-3">
           <div className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
-            <dt className="text-[11px] text-gray-400">{pm.currentStage}</dt>
+            <dt className="text-[11px] text-gray-500">{pm.currentStage}</dt>
             <dd className="mt-0.5 font-medium text-gray-800">{currentStageLabel}</dd>
           </div>
           <div className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
-            <dt className="text-[11px] text-gray-400">{pm.currentTrain}</dt>
+            <dt className="text-[11px] text-gray-500">{pm.currentTrain}</dt>
             <dd className="mt-0.5 font-medium text-gray-800">{trainLabel}</dd>
           </div>
           <div className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
-            <dt className="text-[11px] text-gray-400">{pm.nextCheckpoint}</dt>
+            <dt className="text-[11px] text-gray-500">{pm.nextCheckpoint}</dt>
             <dd className="mt-0.5 font-medium text-gray-800">{checkpointLabel}</dd>
           </div>
         </dl>
@@ -135,7 +135,7 @@ export default function PlanMapPage() {
           <div key={key} className="card p-4">
             <p className="section-title mb-2">{pm.sections[key]}</p>
             {stages.length === 0 ? (
-              <p className="text-xs text-gray-400">—</p>
+              <p className="text-xs text-gray-500">—</p>
             ) : (
               <ul className="space-y-1.5">
                 {stages.map((s) => (
@@ -153,7 +153,7 @@ export default function PlanMapPage() {
         <div className="mt-3 grid grid-cols-3 gap-3 text-center">
           <div className="rounded-md border border-gray-100 bg-gray-50 px-2 py-3">
             <p className="text-xl font-semibold text-gray-800">{plan.evidence.completed}</p>
-            <p className="text-[11px] text-gray-400">{pm.status.completed}</p>
+            <p className="text-[11px] text-gray-500">{pm.status.completed}</p>
           </div>
           <div className="rounded-md border border-amber-100 bg-amber-50 px-2 py-3">
             <p className="text-xl font-semibold text-amber-700">{plan.evidence.notVerifiedCount}</p>
@@ -161,7 +161,7 @@ export default function PlanMapPage() {
           </div>
           <div className="rounded-md border border-gray-100 bg-gray-50 px-2 py-3">
             <p className="text-xl font-semibold text-gray-800">{plan.evidence.total}</p>
-            <p className="text-[11px] text-gray-400">{pm.evidenceLabel}</p>
+            <p className="text-[11px] text-gray-500">{pm.evidenceLabel}</p>
           </div>
         </div>
         {plan.evidence.notVerifiedCount > 0 && (
@@ -173,7 +173,7 @@ export default function PlanMapPage() {
       <section className="card mt-5 p-5">
         <p className="section-title">{pm.blockersLabel}</p>
         {plan.blockers.length === 0 ? (
-          <p className="mt-2 text-xs text-gray-400">{pm.noBlockers}</p>
+          <p className="mt-2 text-xs text-gray-500">{pm.noBlockers}</p>
         ) : (
           <ul className="mt-3 space-y-2">
             {plan.blockers.map((b) => (
@@ -181,7 +181,7 @@ export default function PlanMapPage() {
                 <span className="mt-0.5 text-gray-300">•</span>
                 <span className="flex-1 text-gray-700">
                   {pm.blockers[b.kind as keyof typeof pm.blockers] ?? b.kind}
-                  {b.count > 0 && <span className="ml-1 font-mono text-xs text-gray-400">({b.count})</span>}
+                  {b.count > 0 && <span className="ml-1 font-mono text-xs text-gray-500">({b.count})</span>}
                 </span>
                 {b.kind === "identity" && (
                   <span className="rounded-full border border-gray-200 bg-white px-2 py-0.5 text-[10px] text-gray-500">
@@ -217,11 +217,11 @@ export default function PlanMapPage() {
                 </div>
                 <dl className="mt-2 space-y-1 text-[11px]">
                   <div className="flex gap-1">
-                    <dt className="text-gray-400">{pm.changesLabel}:</dt>
+                    <dt className="text-gray-500">{pm.changesLabel}:</dt>
                     <dd className="text-gray-600">{gc.changes}</dd>
                   </div>
                   <div className="flex gap-1">
-                    <dt className="text-gray-400">{pm.unchangedLabel}:</dt>
+                    <dt className="text-gray-500">{pm.unchangedLabel}:</dt>
                     <dd className="text-gray-600">{gc.unchanged}</dd>
                   </div>
                 </dl>
@@ -241,7 +241,7 @@ export default function PlanMapPage() {
         </ul>
       </section>
 
-      <p className="mt-5 text-[11px] leading-relaxed text-gray-400">{pm.collabNote}</p>
+      <p className="mt-5 text-[11px] leading-relaxed text-gray-500">{pm.collabNote}</p>
 
       <div className="mt-4">
         <Link href={`/projects/${id}`} className="text-xs text-brand-700 hover:underline">

--- a/apps/dashboard/src/app/projects/[id]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { getProject, getProjectStats } from "@/lib/mock-data";
-import { getLocalProject, getUserKey } from "@/lib/workflow-store";
+import { getLocalProject, getUserKey , consumeProjectSyncFailed } from "@/lib/workflow-store";
 import { StatCard } from "@/components/StatCard";
 import { SpecCompleteness } from "@/components/SpecCompleteness";
 import { useI18n } from "@/i18n/I18nProvider";
@@ -52,7 +52,12 @@ const VC_TONE_CLASS: Record<VerdictTone, string> = {
 const VC_STATUS_SLATE_CLASS = "bg-slate-50 text-slate-600 border-slate-200";
 
 export default function ProjectOverviewPage() {
+  // One-time "server save failed" notice (marked by fire-and-forget saves).
+  const [syncFailed, setSyncFailed] = useState(false);
   const { id } = useParams<{ id: string }>();
+  useEffect(() => {
+    if (consumeProjectSyncFailed(id)) setSyncFailed(true);
+  }, [id]);
   const { t, locale } = useI18n();
   // Locally-created projects live in localStorage (client-only); mock demos are
   // bundled. Read on the client so real projects resolve.
@@ -64,6 +69,12 @@ export default function ProjectOverviewPage() {
 
   return (
     <div className="max-w-3xl">
+      {syncFailed && (
+        <div className="callout mb-4 flex items-start justify-between gap-3 border-amber-200 bg-amber-50 text-amber-800">
+          <span>{t.common.syncFailed}</span>
+          <button onClick={() => setSyncFailed(false)} aria-label={t.common.dismiss} className="text-amber-700 hover:text-amber-900">×</button>
+        </div>
+      )}
       <h1 className="text-2xl font-semibold tracking-tight text-gray-900">{project.name}</h1>
       <p className="mb-6 mt-1 text-sm text-gray-500">{project.description}</p>
 

--- a/apps/dashboard/src/app/projects/[id]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
@@ -55,7 +57,7 @@ export default function ProjectOverviewPage() {
   // Locally-created projects live in localStorage (client-only); mock demos are
   // bundled. Read on the client so real projects resolve.
   const project = getLocalProject(id) ?? getProject(id);
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
   const stats = getProjectStats(project);
   const hasReviewActivity =
     stats.passed + stats.failed + stats.inconclusive + stats.needsDecision > 0;
@@ -143,7 +145,7 @@ export default function ProjectOverviewPage() {
             </div>
           ))}
           {project.requirements.length > 4 && (
-            <div className="px-5 py-3 text-center font-mono text-xs text-gray-400">
+            <div className="px-5 py-3 text-center font-mono text-xs text-gray-500">
               + {project.requirements.length - 4} {t.common.more}
             </div>
           )}
@@ -158,7 +160,7 @@ export default function ProjectOverviewPage() {
         <details className="mb-8 rounded-lg border border-gray-100">
           <summary className="cursor-pointer list-none px-4 py-3 text-sm">
             <span className="font-medium text-gray-700">{t.evolution.advancedTitle}</span>
-            <span className="ml-2 text-xs text-gray-400">{t.evolution.advancedHint}</span>
+            <span className="ml-2 text-xs text-gray-500">{t.evolution.advancedHint}</span>
           </summary>
           <div className="border-t border-gray-100 px-4 pb-4 pt-4">
             <section className="mb-8">
@@ -232,7 +234,7 @@ function CommandCenterCard({
 
   return (
     <div className="card mb-8 p-5">
-      <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">{t.commandCenter.title}</p>
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">{t.commandCenter.title}</p>
       {c && next && (
         <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
           <p className="text-sm text-gray-700">{c.desc}</p>
@@ -312,28 +314,28 @@ function VisualChecksOverviewCard({
             </p>
             <Link
               href={`/projects/${projectId}/visual-checks`}
-              className="btn btn-primary btn-sm mt-3"
+              className="btn btn-secondary btn-sm mt-3"
             >
               {t.visualChecks.overview.runFirst}
             </Link>
           </>
         ) : (
           <>
-            <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">
               {t.visualChecks.overview.latestLabel}
             </p>
             <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
               <div className="flex min-w-0 flex-wrap items-center gap-2.5">
                 <OverviewRunChip run={run} t={t} />
                 <span className="truncate text-sm text-gray-700">{run.targetUrl}</span>
-                <span className="flex-shrink-0 text-xs text-gray-400">
+                <span className="flex-shrink-0 text-xs text-gray-500">
                   {relativeTimeLabel(run.createdAt, locale)}
                 </span>
               </div>
               <Link
                 href={`/projects/${projectId}/visual-checks/${run.id}`}
                 className={`flex-shrink-0 ${
-                  action.kind === "viewReport" ? "btn btn-primary btn-sm" : "btn btn-secondary btn-sm"
+                  action.kind === "viewReport" ? "btn btn-secondary btn-sm" : "btn btn-secondary btn-sm"
                 }`}
               >
                 {action.kind === "inProgress"
@@ -400,13 +402,13 @@ function EvolutionLearningCard({ projectId, t }: { projectId: string; t: Diction
   }, [projectId, userKey]);
 
   if (phase === "loading") {
-    return <p className="card p-5 text-xs text-gray-400">{t.outcome.loading}</p>;
+    return <p className="card p-5 text-xs text-gray-500">{t.outcome.loading}</p>;
   }
   if (phase === "error") {
     return <p className="card p-5 text-xs text-red-600">{t.errors.loadFailed}</p>;
   }
   if (!learning) {
-    return <p className="card p-5 text-xs text-gray-400">{t.evolution.learningEmpty}</p>;
+    return <p className="card p-5 text-xs text-gray-500">{t.evolution.learningEmpty}</p>;
   }
 
   return (
@@ -415,19 +417,19 @@ function EvolutionLearningCard({ projectId, t }: { projectId: string; t: Diction
 
       <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs sm:grid-cols-4">
         <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-          <dt className="text-gray-400">{t.evolution.learningExperiments}</dt>
+          <dt className="text-gray-500">{t.evolution.learningExperiments}</dt>
           <dd className="font-semibold text-gray-800">{learning.experimentCount}</dd>
         </div>
         <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-          <dt className="text-gray-400">{t.evolution.learningActionPacks}</dt>
+          <dt className="text-gray-500">{t.evolution.learningActionPacks}</dt>
           <dd className="font-semibold text-gray-800">{learning.actionPackCount}</dd>
         </div>
         <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-          <dt className="text-gray-400">{t.evolution.learningFollowedPacks}</dt>
+          <dt className="text-gray-500">{t.evolution.learningFollowedPacks}</dt>
           <dd className="font-semibold text-gray-800">{learning.followedPackCount}</dd>
         </div>
         <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-          <dt className="text-gray-400">{t.evolution.learningComparablePacks}</dt>
+          <dt className="text-gray-500">{t.evolution.learningComparablePacks}</dt>
           <dd className="font-semibold text-gray-800">{learning.comparablePackCount}</dd>
         </div>
       </dl>
@@ -439,38 +441,38 @@ function EvolutionLearningCard({ projectId, t }: { projectId: string; t: Diction
           {/* Verdict counts */}
           <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs sm:grid-cols-4">
             <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-              <dt className="text-gray-400">{t.evolution.summaryImprovedPacks}</dt>
+              <dt className="text-gray-500">{t.evolution.summaryImprovedPacks}</dt>
               <dd className="font-semibold text-emerald-700">{learning.verdictCounts.improved}</dd>
             </div>
             <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-              <dt className="text-gray-400">{t.evolution.summaryRegressedPacks}</dt>
+              <dt className="text-gray-500">{t.evolution.summaryRegressedPacks}</dt>
               <dd className="font-semibold text-red-700">{learning.verdictCounts.regressed}</dd>
             </div>
             <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-              <dt className="text-gray-400">{t.evolution.summaryUnchangedPacks}</dt>
+              <dt className="text-gray-500">{t.evolution.summaryUnchangedPacks}</dt>
               <dd className="font-semibold text-gray-700">{learning.verdictCounts.unchanged}</dd>
             </div>
             <div className="flex items-baseline justify-between gap-2 border-b border-gray-50 py-0.5">
-              <dt className="text-gray-400">{t.evolution.summaryInconclusivePacks}</dt>
+              <dt className="text-gray-500">{t.evolution.summaryInconclusivePacks}</dt>
               <dd className="font-semibold text-amber-700">{learning.verdictCounts.inconclusive}</dd>
             </div>
           </div>
 
           {/* Average change */}
           <div className="mt-3 rounded-md border border-gray-100 bg-gray-50 p-2">
-            <p className="text-[10px] uppercase tracking-wide text-gray-400">{t.evolution.learningAverageChange}</p>
+            <p className="text-[10px] uppercase tracking-wide text-gray-500">{t.evolution.learningAverageChange}</p>
             <dl className="mt-1 grid grid-cols-2 gap-x-4 gap-y-0.5 text-[11px] sm:grid-cols-4">
-              <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactPassRate}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaPercent(learning.averageDelta.passRateDelta)}</dd></div>
-              <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactCritical}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(learning.averageDelta.criticalIssueDelta)}</dd></div>
-              <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactNotVerified}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(learning.averageDelta.notVerifiedDelta)}</dd></div>
-              <div className="flex justify-between"><dt className="text-gray-400">{t.evolution.impactBlockers}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(learning.averageDelta.blockerDelta)}</dd></div>
+              <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactPassRate}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaPercent(learning.averageDelta.passRateDelta)}</dd></div>
+              <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactCritical}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(learning.averageDelta.criticalIssueDelta)}</dd></div>
+              <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactNotVerified}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(learning.averageDelta.notVerifiedDelta)}</dd></div>
+              <div className="flex justify-between"><dt className="text-gray-500">{t.evolution.impactBlockers}</dt><dd className="font-semibold text-gray-700">{formatAverageDeltaCount(learning.averageDelta.blockerDelta)}</dd></div>
             </dl>
           </div>
 
           {/* Recommended action effectiveness table */}
           {learning.recommendedActionEffectiveness.length > 0 && (
             <div className="mt-3">
-              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.evolution.learningEffectiveness}</p>
+              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.evolution.learningEffectiveness}</p>
               <ul className="mt-1 space-y-1 text-xs">
                 {learning.recommendedActionEffectiveness.map((r) => (
                   <li
@@ -496,7 +498,7 @@ function EvolutionLearningCard({ projectId, t }: { projectId: string; t: Diction
 
       {/* Top signals — always shown so the empty state has a place to live */}
       <div className="mt-3">
-        <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.evolution.learningTopSignals}</p>
+        <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.evolution.learningTopSignals}</p>
         <ul className="mt-1 space-y-1 text-xs text-gray-700">
           {learning.topSignals.map((sig, i) => (
             <li key={i} className="flex flex-wrap items-center gap-1.5 rounded-md border border-gray-100 bg-white px-2 py-1">
@@ -508,7 +510,7 @@ function EvolutionLearningCard({ projectId, t }: { projectId: string; t: Diction
 
       {learning.limitations.length > 0 && (
         <div className="mt-3">
-          <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{t.evolution.summaryLimitationsLabel}</p>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">{t.evolution.summaryLimitationsLabel}</p>
           <ul className="mt-1 flex flex-wrap gap-1.5">
             {learning.limitations.map((l) => (
               <li
@@ -522,7 +524,7 @@ function EvolutionLearningCard({ projectId, t }: { projectId: string; t: Diction
         </div>
       )}
 
-      <p className="mt-3 text-[11px] leading-relaxed text-gray-400">{t.evolution.learningDisclaimer}</p>
+      <p className="mt-3 text-[11px] leading-relaxed text-gray-500">{t.evolution.learningDisclaimer}</p>
     </div>
   );
 }
@@ -539,7 +541,7 @@ function TopSignalText({ signal, t }: { signal: ProjectLearningSignal; t: Dictio
         <span className="font-semibold text-gray-700">{t.evolution.learningEarlySignal}</span>
         <span className="text-[11px] font-medium text-gray-700">{enumActionLabel(t, signal.recommendedAction)}</span>
         <span className="text-emerald-700">{label}</span>
-        <span className="text-gray-400">
+        <span className="text-gray-500">
           ({signal.improved}/{signal.totalComparable})
         </span>
       </>
@@ -551,7 +553,7 @@ function TopSignalText({ signal, t }: { signal: ProjectLearningSignal; t: Dictio
       <span className="font-semibold text-gray-700">{t.evolution.learningEarlySignal}</span>
       <span className="text-[11px] font-medium text-gray-700">{enumActionLabel(t, signal.recommendedAction)}</span>
       <span className="text-red-700">{label}</span>
-      <span className="text-gray-400">
+      <span className="text-gray-500">
         ({signal.regressed}/{signal.totalComparable})
       </span>
     </>
@@ -559,6 +561,7 @@ function TopSignalText({ signal, t }: { signal: ProjectLearningSignal; t: Dictio
 }
 
 function EvolutionTimelineCard({ projectId, t }: { projectId: string; t: Dictionary }) {
+  const { locale } = useI18n();
   const [timeline, setTimeline] = useState<ProjectEvolutionTimeline | null>(null);
   const [phase, setPhase] = useState<"idle" | "loading" | "ready" | "error">("idle");
   const [userKey, setUserKey] = useState<string>("");
@@ -587,13 +590,13 @@ function EvolutionTimelineCard({ projectId, t }: { projectId: string; t: Diction
   }, [projectId, userKey]);
 
   if (phase === "loading") {
-    return <p className="card p-5 text-xs text-gray-400">{t.outcome.loading}</p>;
+    return <p className="card p-5 text-xs text-gray-500">{t.outcome.loading}</p>;
   }
   if (phase === "error") {
     return <p className="card p-5 text-xs text-red-600">{t.errors.loadFailed}</p>;
   }
   if (!timeline) {
-    return <p className="card p-5 text-xs text-gray-400">{t.evolution.timelineEmpty}</p>;
+    return <p className="card p-5 text-xs text-gray-500">{t.evolution.timelineEmpty}</p>;
   }
 
   return (
@@ -635,6 +638,7 @@ function TimelineEventRow({
   event: ProjectEvolutionTimelineEvent;
   t: Dictionary;
 }) {
+  const { locale } = useI18n();
   const labelKey = timelineEventLabelKey(event.type);
   const label = t.evolution[labelKey as keyof typeof t.evolution];
   const chipClass = badgeClassForEventType(event.type);
@@ -655,8 +659,8 @@ function TimelineEventRow({
         {event.summary && (
           <p className="mt-1 truncate text-xs text-gray-700">{event.summary}</p>
         )}
-        <p className="mt-0.5 text-[10px] text-gray-400">
-          {new Date(event.occurredAt).toLocaleString()}
+        <p className="mt-0.5 text-[10px] text-gray-500">
+          {new Date(event.occurredAt).toLocaleString(locale === "ko" ? "ko-KR" : "en-US")}
         </p>
       </div>
       {event.href && (

--- a/apps/dashboard/src/app/projects/[id]/settings/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/settings/page.tsx
@@ -347,7 +347,7 @@ export default function SettingsPage() {
       {phase === "loading" && (
         <div className="card p-8 text-center">
           <div className="mx-auto mb-3 h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
-          <p className="text-sm text-gray-400">{t.common.loading}</p>
+          <p className="text-sm text-gray-500">{t.common.loading}</p>
         </div>
       )}
 
@@ -363,7 +363,7 @@ export default function SettingsPage() {
             {t.github.connectGithub}
           </button>
           {/* Stage 273: GitHub binds the browser's current session instantly — say so upfront. */}
-          <p className="mx-auto mt-3 max-w-sm text-xs text-gray-400">
+          <p className="mx-auto mt-3 max-w-sm text-xs text-gray-500">
             {t.github.instantBindCaption}{" "}
             <a
               href="https://github.com/logout"
@@ -406,7 +406,7 @@ export default function SettingsPage() {
             )}
             <div>
               <p className="text-sm font-medium text-gray-800">{ghUser.name ?? ghUser.login}</p>
-              <p className="text-xs text-gray-400">@{ghUser.login} · {t.github.connectedAs}</p>
+              <p className="text-xs text-gray-500">@{ghUser.login} · {t.github.connectedAs}</p>
             </div>
             {/* Stage 273: disconnect (with confirm) replaces the old re-connect shortcut —
                 re-running OAuth silently re-binds the same account anyway. */}
@@ -452,10 +452,10 @@ export default function SettingsPage() {
                   {linkedRepo.fullName}
                 </a>
                 {linkedRepo.private && (
-                  <span className="rounded bg-gray-200 px-1.5 py-0.5 text-xs text-gray-400">{t.github.statePrivate}</span>
+                  <span className="rounded bg-gray-200 px-1.5 py-0.5 text-xs text-gray-500">{t.github.statePrivate}</span>
                 )}
                 {linkedRepo.defaultBranch && (
-                  <span className="text-xs text-gray-400">→ {linkedRepo.defaultBranch}</span>
+                  <span className="text-xs text-gray-500">→ {linkedRepo.defaultBranch}</span>
                 )}
               </div>
             </div>
@@ -472,7 +472,7 @@ export default function SettingsPage() {
             </button>
           )}
           {reposPhase === "loading" && (
-            <p className="mt-2 text-xs text-gray-400">{t.common.loading}</p>
+            <p className="mt-2 text-xs text-gray-500">{t.common.loading}</p>
           )}
           {reposPhase === "error" && (
             <p className="mt-2 text-xs text-red-500">{t.github.reposLoadError}</p>
@@ -505,7 +505,7 @@ export default function SettingsPage() {
                   >
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium text-gray-800 truncate">{repo.fullName}</p>
-                      <p className="text-xs text-gray-400">
+                      <p className="text-xs text-gray-500">
                         {repo.defaultBranch} · {repo.private ? t.github.statePrivate : t.github.statePublic}
                       </p>
                     </div>
@@ -515,7 +515,7 @@ export default function SettingsPage() {
                   </button>
                 ))}
                 {filteredRepos.length === 0 && (
-                  <p className="py-6 text-center text-xs text-gray-400">{t.github.noMatch}</p>
+                  <p className="py-6 text-center text-xs text-gray-500">{t.github.noMatch}</p>
                 )}
               </div>
             </>
@@ -524,7 +524,7 @@ export default function SettingsPage() {
           {/* Direct owner/repo entry — for org/collaborator repos GitHub's listing omits. */}
           <div className="border-t border-gray-100 bg-gray-50/60 p-4">
             <p className="mb-1 text-sm font-semibold text-gray-700">{t.github.manualTitle}</p>
-            <p className="mb-2 text-xs text-gray-400">{t.github.manualHint}</p>
+            <p className="mb-2 text-xs text-gray-500">{t.github.manualHint}</p>
             <div className="flex gap-2">
               <input
                 type="text"
@@ -537,7 +537,7 @@ export default function SettingsPage() {
               <button
                 onClick={() => void handleDirectLookup()}
                 disabled={lookupPhase === "loading" || linkPhase === "saving" || !directInput.trim()}
-                className="btn btn-md btn-primary flex-shrink-0"
+                className="btn btn-md btn-secondary flex-shrink-0"
               >
                 {lookupPhase === "loading" ? t.github.finding : t.github.connect}
               </button>
@@ -560,7 +560,7 @@ export default function SettingsPage() {
           </div>
 
           <div className="flex items-center justify-between border-t border-gray-100 p-4">
-            <p className="text-xs text-gray-400">
+            <p className="text-xs text-gray-500">
               {repos.length > 0 ? `${repos.length} ${t.github.publicReposCount}` : t.github.noReposListed}
             </p>
             <button onClick={() => setPhase("connected")} className="text-xs text-gray-500 hover:text-gray-700">
@@ -602,7 +602,7 @@ export default function SettingsPage() {
               disabled={!emConfigured}
               className="input disabled:opacity-50"
             />
-            <p className="mt-1 text-xs text-gray-400">{t.emailNotify.addressHint}</p>
+            <p className="mt-1 text-xs text-gray-500">{t.emailNotify.addressHint}</p>
           </div>
 
           <div className="flex items-center gap-2">
@@ -663,7 +663,7 @@ export default function SettingsPage() {
               disabled={!tgEnabled}
               className="input disabled:opacity-50"
             />
-            <p className="mt-1 text-xs text-gray-400">{t.telegram.chatIdHint}</p>
+            <p className="mt-1 text-xs text-gray-500">{t.telegram.chatIdHint}</p>
           </div>
 
           <div>
@@ -727,7 +727,7 @@ export default function SettingsPage() {
           </button>
         </div>
 
-        {notifPhase === "loading" && <p className="text-xs text-gray-400">{t.common.loading}</p>}
+        {notifPhase === "loading" && <p className="text-xs text-gray-500">{t.common.loading}</p>}
 
         {notifPhase === "error" && (
           <div className="flex items-center gap-3">
@@ -739,7 +739,7 @@ export default function SettingsPage() {
         )}
 
         {notifPhase === "done" && notifications.length === 0 && (
-          <p className="text-xs text-gray-400">{t.telegram.noHistory}</p>
+          <p className="text-xs text-gray-500">{t.telegram.noHistory}</p>
         )}
 
         {notifPhase === "done" && notifications.length > 0 && (
@@ -749,7 +749,7 @@ export default function SettingsPage() {
                 <div key={n.id} className="flex items-start gap-3 px-4 py-3">
                   <div className="mt-0.5 flex-shrink-0">
                     {n.status === "sent" && <span className="text-xs font-semibold text-green-500">{t.telegram.sent}</span>}
-                    {n.status === "skipped" && <span className="text-xs text-gray-400">{t.telegram.skipped}</span>}
+                    {n.status === "skipped" && <span className="text-xs text-gray-500">{t.telegram.skipped}</span>}
                     {n.status === "error" && <span className="text-xs font-semibold text-red-500">{t.telegram.failed}</span>}
                   </div>
                   <div className="min-w-0 flex-1">
@@ -757,10 +757,10 @@ export default function SettingsPage() {
                       {n.eventType === "pr_review_complete" ? t.telegram.prReviewComplete : n.eventType}
                       {n.destinationPreview ? ` · ${n.destinationPreview}` : ""}
                     </p>
-                    {n.messagePreview && <p className="mt-0.5 truncate text-xs text-gray-400">{n.messagePreview}</p>}
+                    {n.messagePreview && <p className="mt-0.5 truncate text-xs text-gray-500">{n.messagePreview}</p>}
                     {n.errorMessage && <p className="mt-0.5 truncate text-xs text-red-400">{n.errorMessage}</p>}
                   </div>
-                  <p className="flex-shrink-0 font-mono text-xs text-gray-400">
+                  <p className="flex-shrink-0 font-mono text-xs text-gray-500">
                     {new Date(n.createdAt).toLocaleString(locale === "ko" ? "ko-KR" : "en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
                   </p>
                 </div>
@@ -802,7 +802,7 @@ export default function SettingsPage() {
           </div>
 
           {!trainStorageConfigured && (
-            <p className="text-xs text-gray-400">{t.trainingConsent.storageNote}</p>
+            <p className="text-xs text-gray-500">{t.trainingConsent.storageNote}</p>
           )}
           {trainSavePhase === "done" && trainConsented && (
             <p className="text-xs text-green-600">✓ {t.trainingConsent.savedOn}</p>

--- a/apps/dashboard/src/app/projects/[id]/settings/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/settings/page.tsx
@@ -597,6 +597,7 @@ export default function SettingsPage() {
             <input
               type="email"
               value={emAddress}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleSaveEmSettings(); } }}
               onChange={(e) => setEmAddress(e.target.value)}
               placeholder={t.emailNotify.addressPlaceholder}
               disabled={!emConfigured}
@@ -658,6 +659,7 @@ export default function SettingsPage() {
             <input
               type="text"
               value={tgChatId}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleSaveTgSettings(); } }}
               onChange={(e) => setTgChatId(e.target.value)}
               placeholder={t.telegram.chatIdPlaceholder}
               disabled={!tgEnabled}

--- a/apps/dashboard/src/app/projects/[id]/sources/[sourceId]/draft/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/sources/[sourceId]/draft/page.tsx
@@ -149,7 +149,7 @@ export default function DocumentDraftPage() {
         <h2 className="page-title">{t.sources.draft.title}</h2>
         <p className="page-subtitle">{t.sources.draft.subtitle}</p>
         {sourceLabel && (
-          <p className="mt-2 text-xs text-gray-400">
+          <p className="mt-2 text-xs text-gray-500">
             {t.sources.draft.sourceLabel}: <span className="text-gray-600">{sourceLabel}</span>
           </p>
         )}
@@ -202,7 +202,7 @@ export default function DocumentDraftPage() {
           {draft.questions.length > 0 && (
             <div className="mb-6">
               <p className="mb-1 text-sm font-semibold text-gray-700">{t.sources.draft.questionsTitle}</p>
-              <p className="mb-3 text-xs text-gray-400">{t.sources.draft.questionsNote}</p>
+              <p className="mb-3 text-xs text-gray-500">{t.sources.draft.questionsNote}</p>
               <div className="space-y-2">
                 {draft.questions.map((q) => (
                   <div key={q.id} className="card p-4">
@@ -243,7 +243,7 @@ export default function DocumentDraftPage() {
             >
               {saving ? t.sources.draft.confirming : t.sources.draft.confirm}
             </button>
-            <p className="mt-2 text-center text-xs text-gray-400">{t.sources.draft.confirmHint}</p>
+            <p className="mt-2 text-center text-xs text-gray-500">{t.sources.draft.confirmHint}</p>
           </div>
         </div>
       )}

--- a/apps/dashboard/src/app/projects/[id]/sources/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/sources/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 // Stage 262 — Sources (연결). Connect a project's inputs: website URL,
 // GitHub repo (owner/repo) and PRD-style documents (md/txt/pdf, ≤10MB).
 // Client component (localStorage userKey); ownership enforced server-side.
@@ -87,7 +89,7 @@ export default function SourcesPage() {
     void load();
   }, [load]);
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   async function handleConnect(type: "website" | "github_repo") {
     const reference = (type === "website" ? websiteUrl : repoFullName).trim();
@@ -228,7 +230,7 @@ export default function SourcesPage() {
         <h3 className="section-title">{t.sources.connectedTitle}</h3>
 
         {phase === "loading" && (
-          <div className="flex items-center gap-2 text-sm text-gray-400">
+          <div className="flex items-center gap-2 text-sm text-gray-500">
             <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-gray-200 border-t-gray-500" />
             {t.sources.loading}
           </div>
@@ -256,7 +258,7 @@ export default function SourcesPage() {
                     <p className="truncate text-sm font-medium text-gray-800">
                       {source.type === "document" ? (source.label ?? source.reference) : source.reference}
                     </p>
-                    <p className="truncate text-[11px] text-gray-400">
+                    <p className="truncate text-[11px] text-gray-500">
                       {formatDate(source.createdAt, locale)}
                       {source.type === "document" && source.sizeBytes != null && ` · ${formatBytes(source.sizeBytes)}`}
                       {source.type !== "document" && source.label && ` · ${source.label}`}

--- a/apps/dashboard/src/app/projects/[id]/spec/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/spec/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 import { useParams } from "next/navigation";
 import { getProject } from "@/lib/mock-data";
 import { getLocalProject } from "@/lib/workflow-store";
@@ -11,7 +13,7 @@ export default function SpecPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useI18n();
   const project = getLocalProject(id) ?? getProject(id);
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   const { spec } = project;
 
@@ -26,6 +28,14 @@ export default function SpecPage() {
         <SpecCompleteness value={spec.completeness} />
       </div>
 
+      {!spec.goal && spec.included.length === 0 ? (
+        <div className="empty-state">
+          <p className="text-sm text-gray-600">{t.spec.emptyBody}</p>
+          <a href={`/projects/${id}`} className="btn btn-md btn-primary mt-4">
+            {t.common.goOverview}
+          </a>
+        </div>
+      ) : (
       <div className="space-y-5">
         <Section title={t.spec.goal}>
           <p className="text-sm leading-relaxed text-gray-700">{spec.goal}</p>
@@ -65,6 +75,7 @@ export default function SpecPage() {
           </Section>
         )}
       </div>
+      )}
       <StepNextButton />
     </div>
   );
@@ -73,7 +84,7 @@ export default function SpecPage() {
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="card p-5">
-      <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-400">{title}</h2>
+      <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">{title}</h2>
       {children}
     </div>
   );

--- a/apps/dashboard/src/app/projects/[id]/visual-checks/[runId]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/visual-checks/[runId]/page.tsx
@@ -94,15 +94,15 @@ function FindingCard({ finding, t }: { finding: NonDevFinding; t: Dictionary }) 
       </span>
       <dl className="mt-3 space-y-2.5">
         <div>
-          <dt className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">{t.visualChecks.findingWhat}</dt>
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">{t.visualChecks.findingWhat}</dt>
           <dd className="mt-0.5 text-sm font-medium text-gray-800">{finding.what}</dd>
         </div>
         <div>
-          <dt className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">{t.visualChecks.findingWhy}</dt>
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">{t.visualChecks.findingWhy}</dt>
           <dd className="mt-0.5 text-sm leading-relaxed text-gray-600">{finding.why}</dd>
         </div>
         <div>
-          <dt className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">{t.visualChecks.findingHow}</dt>
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">{t.visualChecks.findingHow}</dt>
           <dd className="mt-0.5 text-sm leading-relaxed text-gray-600">{finding.how}</dd>
         </div>
       </dl>
@@ -130,9 +130,9 @@ function ComparedFindingList({
 }) {
   return (
     <div>
-      <h4 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">{title}</h4>
+      <h4 className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">{title}</h4>
       {items.length === 0 ? (
-        <p className="mt-1.5 text-xs text-gray-400">{emptyText}</p>
+        <p className="mt-1.5 text-xs text-gray-500">{emptyText}</p>
       ) : (
         <ul className="mt-1.5 space-y-1.5">
           {items.map((f, i) => (
@@ -190,7 +190,7 @@ function ComparisonSection({
           <span className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${TONE_CLASS[fromVerdict.tone]}`}>
             {fromVerdict.label}
           </span>
-          <span aria-hidden className="text-xs text-gray-400">→</span>
+          <span aria-hidden className="text-xs text-gray-500">→</span>
           <span className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${TONE_CLASS[toVerdict.tone]}`}>
             {toVerdict.label}
           </span>
@@ -227,15 +227,15 @@ function ComparisonSection({
           </button>
           {showShots && (
             <div className="mt-3 space-y-4">
-              <h4 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+              <h4 className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
                 {t.visualChecks.compare.screenshotsTitle}
               </h4>
               {evidencePairs.pairs.length === 0 && (
-                <p className="text-xs text-gray-400">{t.visualChecks.compare.noPairs}</p>
+                <p className="text-xs text-gray-500">{t.visualChecks.compare.noPairs}</p>
               )}
               {evidencePairs.pairs.map((pair) => (
                 <div key={pair.name}>
-                  <p className="font-mono text-[10px] text-gray-400">{pair.name.replace(/^screenshots\//, "")}</p>
+                  <p className="font-mono text-[10px] text-gray-500">{pair.name.replace(/^screenshots\//, "")}</p>
                   <div className="mt-1.5 grid gap-3 sm:grid-cols-2">
                     {([
                       { label: t.visualChecks.compare.prevLabel, rid: prevRunId },
@@ -260,13 +260,13 @@ function ComparisonSection({
                 </div>
               ))}
               {evidencePairs.prevOnly.length > 0 && (
-                <p className="text-[11px] leading-relaxed text-gray-400">
+                <p className="text-[11px] leading-relaxed text-gray-500">
                   {t.visualChecks.compare.prevOnly}:{" "}
                   <span className="font-mono">{evidencePairs.prevOnly.map((n) => n.replace(/^screenshots\//, "")).join(", ")}</span>
                 </p>
               )}
               {evidencePairs.latestOnly.length > 0 && (
-                <p className="text-[11px] leading-relaxed text-gray-400">
+                <p className="text-[11px] leading-relaxed text-gray-500">
                   {t.visualChecks.compare.latestOnly}:{" "}
                   <span className="font-mono">{evidencePairs.latestOnly.map((n) => n.replace(/^screenshots\//, "")).join(", ")}</span>
                 </p>
@@ -395,7 +395,7 @@ function RepairSection({
       <p className="section-desc leading-relaxed">{s.desc}</p>
 
       {phase === "loading" && (
-        <div className="mt-3 flex items-center gap-2 text-sm text-gray-400">
+        <div className="mt-3 flex items-center gap-2 text-sm text-gray-500">
           <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-gray-200 border-t-gray-500" />
           {t.common.loading}
         </div>
@@ -593,7 +593,7 @@ export default function VisualCheckDetailPage() {
     return () => { cancelled = true; clearInterval(timer); };
   }, [isRunActive, id, runId, userKey]);
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <p className="text-sm text-gray-500">{t.common.notFound}</p>;
 
   async function handleCopyPrompt() {
     if (!check?.agentPrompt) return;
@@ -622,12 +622,12 @@ export default function VisualCheckDetailPage() {
 
   return (
     <div className="space-y-6">
-      <Link href={`/projects/${id}/visual-checks`} className="inline-flex items-center gap-1 text-xs text-gray-400 hover:text-gray-700">
+      <Link href={`/projects/${id}/visual-checks`} className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700">
         ← {t.visualChecks.backToList}
       </Link>
 
       {phase === "loading" && (
-        <div className="flex items-center gap-2 text-sm text-gray-400">
+        <div className="flex items-center gap-2 text-sm text-gray-500">
           <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-gray-200 border-t-gray-500" />
           {t.visualChecks.loading}
         </div>
@@ -654,7 +654,7 @@ export default function VisualCheckDetailPage() {
               {t.visualChecks.progressBody}
             </p>
           </div>
-          <p className="break-all font-mono text-[11px] text-gray-400">{check.targetUrl}</p>
+          <p className="break-all font-mono text-[11px] text-gray-500">{check.targetUrl}</p>
         </section>
       )}
 
@@ -683,7 +683,7 @@ export default function VisualCheckDetailPage() {
           <section className="card p-4">
             <dl className="space-y-2 text-sm">
               <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
-                <dt className="w-40 flex-shrink-0 text-xs font-medium text-gray-400">{t.visualChecks.metaTarget}</dt>
+                <dt className="w-40 flex-shrink-0 text-xs font-medium text-gray-500">{t.visualChecks.metaTarget}</dt>
                 <dd className="min-w-0 break-all text-gray-700">
                   <a href={check.targetUrl} target="_blank" rel="noreferrer" className="text-brand-600 hover:underline">
                     {check.targetUrl}
@@ -691,11 +691,11 @@ export default function VisualCheckDetailPage() {
                 </dd>
               </div>
               <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
-                <dt className="w-40 flex-shrink-0 text-xs font-medium text-gray-400">{t.visualChecks.metaIntent}</dt>
+                <dt className="w-40 flex-shrink-0 text-xs font-medium text-gray-500">{t.visualChecks.metaIntent}</dt>
                 <dd className="min-w-0 leading-relaxed text-gray-700">{report?.intent || check.intent}</dd>
               </div>
               <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
-                <dt className="w-40 flex-shrink-0 text-xs font-medium text-gray-400">
+                <dt className="w-40 flex-shrink-0 text-xs font-medium text-gray-500">
                   {check.executor === "container" ? t.visualChecks.executorContainer : t.visualChecks.executorLocal}
                 </dt>
                 <dd className="text-gray-500">{formatDateTime(check.createdAt, locale)}</dd>
@@ -719,7 +719,7 @@ export default function VisualCheckDetailPage() {
           <section className="space-y-3">
             <h3 className="section-title">{t.visualChecks.findingsTitle}</h3>
             {findings.length === 0 ? (
-              <p className="text-xs text-gray-400">{t.visualChecks.noFindings}</p>
+              <p className="text-xs text-gray-500">{t.visualChecks.noFindings}</p>
             ) : (
               findings.map((f, i) => <FindingCard key={i} finding={f} t={t} />)
             )}
@@ -741,7 +741,7 @@ export default function VisualCheckDetailPage() {
                       loading="lazy"
                       className="w-full bg-gray-50"
                     />
-                    <figcaption className="border-t border-gray-100 px-3 py-1.5 font-mono text-[10px] text-gray-400">
+                    <figcaption className="border-t border-gray-100 px-3 py-1.5 font-mono text-[10px] text-gray-500">
                       {name.replace(/^screenshots\//, "")}
                     </figcaption>
                   </figure>

--- a/apps/dashboard/src/app/projects/[id]/visual-checks/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/visual-checks/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ProjectNotFound } from "@/components/ProjectNotFound";
+
 // Stage 262 — Visual checks (시각 검수) list. Client component: reads the
 // project from localStorage (server components 404'd on local projects before)
 // and the runs from the central plane with the browser-persisted userKey.
@@ -134,7 +136,7 @@ export default function VisualChecksPage() {
     return () => { cancelled = true; clearInterval(timer); };
   }, [hasActiveRun, id, userKey]);
 
-  if (!project) return <p className="text-sm text-gray-400">{t.common.notFound}</p>;
+  if (!project) return <ProjectNotFound />;
 
   const buttonState = runButtonState({ hasWebsiteSource, hasActiveRun });
   // Stage 266 — verdict transition between the two most recent done runs
@@ -229,14 +231,17 @@ export default function VisualChecksPage() {
       </section>
 
       {phase === "loading" && (
-        <div className="flex items-center gap-2 text-sm text-gray-400">
+        <div className="flex items-center gap-2 text-sm text-gray-500">
           <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-gray-200 border-t-gray-500" />
           {t.visualChecks.loading}
         </div>
       )}
 
       {phase === "error" && (
-        <div className="callout callout-error">{t.visualChecks.loadError}</div>
+        <div className="callout callout-error flex items-center justify-between">
+          <span>{t.visualChecks.loadError}</span>
+          <button onClick={() => window.location.reload()} className="btn btn-sm btn-secondary">{t.common.retry}</button>
+        </div>
       )}
 
       {phase === "done" && checks.length === 0 && (
@@ -274,9 +279,9 @@ export default function VisualChecksPage() {
                       </span>
                       <span className="truncate text-sm font-medium text-gray-800">{check.targetUrl}</span>
                     </div>
-                    <span className="flex-shrink-0 text-xs text-gray-400">{formatDateTime(check.createdAt, locale)}</span>
+                    <span className="flex-shrink-0 text-xs text-gray-500">{formatDateTime(check.createdAt, locale)}</span>
                   </div>
-                  <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[11px] text-gray-400">
+                  <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[11px] text-gray-500">
                     <span className="inline-flex items-center rounded-full border border-gray-200 px-2 py-0.5">
                       {executorLabel(t, check.executor)}
                     </span>

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -398,7 +398,7 @@ export default function IntakePage() {
           {tr.intake.handoff.subtitle}
         </p>
         {/* Stage 119 — page-level beta feedback CTA */}
-        <p className="mt-2 text-xs text-gray-400">
+        <p className="mt-2 text-xs text-gray-500">
           <FeedbackLink label={tr.intake.handoff.feedbackLabel} context={{ section: "Intake workflow" }} />{" "}
           — {ob.safetyNotes.feedback}
         </p>
@@ -410,7 +410,7 @@ export default function IntakePage() {
           <ol className="mt-3 space-y-1">
             {ob.steps.map((step, i) => (
               <li key={step} className="flex gap-2 text-sm text-gray-700">
-                <span className="text-gray-400">{i + 1}.</span>
+                <span className="text-gray-500">{i + 1}.</span>
                 <span>{step}</span>
               </li>
             ))}
@@ -484,7 +484,7 @@ export default function IntakePage() {
             <label className="mb-2 block text-sm font-medium text-gray-900">
               {tr.intake.handoff.pasteLabel}
             </label>
-            <p className="text-xs text-gray-400">{meta.inputHint}</p>
+            <p className="text-xs text-gray-500">{meta.inputHint}</p>
             {/* Stage 120 — before-input beta safety note */}
             <p className="mb-2 mt-1 text-xs text-amber-600">
               {ob.safetyNotes.beforeInput}
@@ -563,7 +563,7 @@ export default function IntakePage() {
         {/* Step 3 — deterministic local preview */}
         {draft && (
           <div className="card mt-8 p-5">
-            <p className="text-xs uppercase tracking-wide text-gray-400">
+            <p className="text-xs uppercase tracking-wide text-gray-500">
               {ic.draftTitle}
             </p>
             <h2 className="mt-1 text-base font-semibold text-gray-900">
@@ -585,7 +585,7 @@ export default function IntakePage() {
               ))}
             </ul>
 
-            <p className="mt-4 text-xs text-gray-400">
+            <p className="mt-4 text-xs text-gray-500">
               {ic.draftPreviewNote}
             </p>
           </div>
@@ -594,7 +594,7 @@ export default function IntakePage() {
         {/* Stage 102 — deterministic PRD / spec preview (prd type only) */}
         {prdPreview && (
           <div className="card mt-6 p-5">
-            <p className="text-xs uppercase tracking-wide text-gray-400">
+            <p className="text-xs uppercase tracking-wide text-gray-500">
               {ic.prdTitle}
             </p>
             <TechDetails summary={ic.techDetails}>
@@ -629,7 +629,7 @@ export default function IntakePage() {
             />
             <PrdList title={ic.missingQuestions} items={prdPreview.missingQuestions} />
 
-            <p className="mt-4 text-xs text-gray-400">
+            <p className="mt-4 text-xs text-gray-500">
               {ic.prdPreviewNote}
             </p>
           </div>
@@ -638,7 +638,7 @@ export default function IntakePage() {
         {/* Stage 103 — deterministic Product URL preview (product_url type only) */}
         {urlPreview && (
           <div className="card mt-6 p-5">
-            <p className="text-xs uppercase tracking-wide text-gray-400">
+            <p className="text-xs uppercase tracking-wide text-gray-500">
               {ic.urlTitle}
             </p>
             <TechDetails summary={ic.techDetails}>
@@ -647,21 +647,21 @@ export default function IntakePage() {
 
             <dl className="mt-3 grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2">
               <div>
-                <dt className="text-xs text-gray-400">{ic.normalizedUrl}</dt>
+                <dt className="text-xs text-gray-500">{ic.normalizedUrl}</dt>
                 <dd className="break-all text-sm text-gray-700">
                   {urlPreview.normalizedUrl || "—"}
                 </dd>
               </div>
               <div>
-                <dt className="text-xs text-gray-400">{ic.domain}</dt>
+                <dt className="text-xs text-gray-500">{ic.domain}</dt>
                 <dd className="text-sm text-gray-700">{urlPreview.domain}</dd>
               </div>
               <div>
-                <dt className="text-xs text-gray-400">{ic.surfaceType}</dt>
+                <dt className="text-xs text-gray-500">{ic.surfaceType}</dt>
                 <dd className="text-sm text-gray-700">{urlPreview.pathType}</dd>
               </div>
               <div>
-                <dt className="text-xs text-gray-400">{ic.likelySurface}</dt>
+                <dt className="text-xs text-gray-500">{ic.likelySurface}</dt>
                 <dd className="text-sm text-gray-700">{urlPreview.likelySurface}</dd>
               </div>
             </dl>
@@ -673,7 +673,7 @@ export default function IntakePage() {
             />
             <PrdList title={ic.missingQuestions} items={urlPreview.missingQuestions} />
 
-            <p className="mt-4 text-xs text-gray-400">
+            <p className="mt-4 text-xs text-gray-500">
               {ic.urlPreviewNote}
             </p>
           </div>
@@ -682,7 +682,7 @@ export default function IntakePage() {
         {/* Stage 104 — deterministic GitHub repo preview (github_repo type only) */}
         {repoPreview && (
           <div className="card mt-6 p-5">
-            <p className="text-xs uppercase tracking-wide text-gray-400">
+            <p className="text-xs uppercase tracking-wide text-gray-500">
               {ic.repoTitle}
             </p>
             <TechDetails summary={ic.techDetails}>
@@ -691,23 +691,23 @@ export default function IntakePage() {
 
             <dl className="mt-3 grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2">
               <div>
-                <dt className="text-xs text-gray-400">{ic.normalizedRepo}</dt>
+                <dt className="text-xs text-gray-500">{ic.normalizedRepo}</dt>
                 <dd className="text-sm text-gray-700">{repoPreview.normalizedRepo}</dd>
               </div>
               <div>
-                <dt className="text-xs text-gray-400">{ic.owner}</dt>
+                <dt className="text-xs text-gray-500">{ic.owner}</dt>
                 <dd className="text-sm text-gray-700">{repoPreview.owner}</dd>
               </div>
               <div>
-                <dt className="text-xs text-gray-400">{ic.repository}</dt>
+                <dt className="text-xs text-gray-500">{ic.repository}</dt>
                 <dd className="text-sm text-gray-700">{repoPreview.repo}</dd>
               </div>
               <div>
-                <dt className="text-xs text-gray-400">{ic.likelyRepoType}</dt>
+                <dt className="text-xs text-gray-500">{ic.likelyRepoType}</dt>
                 <dd className="text-sm text-gray-700">{repoPreview.likelyRepoType}</dd>
               </div>
               <div className="sm:col-span-2">
-                <dt className="text-xs text-gray-400">{ic.repoUrl}</dt>
+                <dt className="text-xs text-gray-500">{ic.repoUrl}</dt>
                 <dd className="break-all text-sm text-gray-700">
                   {repoPreview.repoUrl || "—"}
                 </dd>
@@ -721,7 +721,7 @@ export default function IntakePage() {
             />
             <PrdList title={ic.missingQuestions} items={repoPreview.missingQuestions} />
 
-            <p className="mt-4 text-xs text-gray-400">
+            <p className="mt-4 text-xs text-gray-500">
               {ic.repoPreviewNote}
             </p>
           </div>
@@ -730,7 +730,7 @@ export default function IntakePage() {
         {/* Stage 105 — deterministic AI-built app recovery (ai_built_app only) */}
         {appPreview && (
           <div className="card mt-6 p-5">
-            <p className="text-xs uppercase tracking-wide text-gray-400">
+            <p className="text-xs uppercase tracking-wide text-gray-500">
               {ic.appTitle}
             </p>
             <TechDetails summary={ic.techDetails}>
@@ -780,7 +780,7 @@ export default function IntakePage() {
 
             <PrdList title={ic.missingQuestions} items={appPreview.missingQuestions} />
 
-            <p className="mt-4 text-xs text-gray-400">
+            <p className="mt-4 text-xs text-gray-500">
               {ic.appPreviewNote}
             </p>
           </div>
@@ -789,7 +789,7 @@ export default function IntakePage() {
         {/* Stage 106 — shared Acceptance Map (all intake types) */}
         {acceptanceMap && (
           <div className="card mt-6 p-5">
-            <p className="text-xs uppercase tracking-wide text-gray-400">
+            <p className="text-xs uppercase tracking-wide text-gray-500">
               {ic.acceptanceMapTitle}
             </p>
             <TechDetails summary={ic.techDetails}>
@@ -824,7 +824,7 @@ export default function IntakePage() {
                   className="rounded-md border border-gray-100 bg-gray-50 px-3 py-1.5 text-sm text-gray-700"
                 >
                   <span>{it.title}</span>
-                  <span className="ml-2 text-xs text-gray-400">
+                  <span className="ml-2 text-xs text-gray-500">
                     · {it.status.replace(/_/g, " ")}
                   </span>
                 </li>
@@ -840,7 +840,7 @@ export default function IntakePage() {
               {NEXT_STEP_LABELS[acceptanceMap.recommendedNextStep]}
             </p>
 
-            <p className="mt-4 text-xs text-gray-400">
+            <p className="mt-4 text-xs text-gray-500">
               {ic.acceptanceMapNote}
             </p>
           </div>
@@ -849,7 +849,7 @@ export default function IntakePage() {
         {/* Stage 107 — shared Stage Plan (all intake types) */}
         {stagePlan && (
           <div className="card mt-6 p-5">
-            <p className="text-xs uppercase tracking-wide text-gray-400">
+            <p className="text-xs uppercase tracking-wide text-gray-500">
               {ic.stagePlanTitle}
             </p>
             <TechDetails summary={ic.techDetails}>
@@ -902,7 +902,7 @@ export default function IntakePage() {
               </ul>
             </div>
 
-            <p className="mt-4 text-xs text-gray-400">
+            <p className="mt-4 text-xs text-gray-500">
               {ic.stagePlanNote}
             </p>
           </div>
@@ -911,7 +911,7 @@ export default function IntakePage() {
         {/* Stage 110 — Agent Run Plan (all intake types) */}
         {agentRunPlan && (
           <div className="card mt-6 p-5">
-            <p className="text-xs uppercase tracking-wide text-gray-400">
+            <p className="text-xs uppercase tracking-wide text-gray-500">
               {ic.agentRunPlanTitle}
             </p>
             <TechDetails summary={ic.techDetails}>
@@ -958,7 +958,7 @@ export default function IntakePage() {
               ))}
             </div>
 
-            <p className="mt-4 text-xs text-gray-400">
+            <p className="mt-4 text-xs text-gray-500">
               {ic.agentRunPlanNote}
             </p>
           </div>
@@ -967,7 +967,7 @@ export default function IntakePage() {
         {/* Stage 111 — Evidence Plan (all intake types) */}
         {evidencePlan && (
           <div className="card mt-6 p-5">
-            <p className="text-xs uppercase tracking-wide text-gray-400">
+            <p className="text-xs uppercase tracking-wide text-gray-500">
               {ic.evidencePlanTitle} · {ic.overallLabel}{" "}
               {EVIDENCE_STATUS_LABELS[evidencePlan.overallEvidenceStatus]}
             </p>
@@ -1016,7 +1016,7 @@ export default function IntakePage() {
               items={evidencePlan.missingEvidenceQuestions}
             />
 
-            <p className="mt-4 text-xs text-gray-400">
+            <p className="mt-4 text-xs text-gray-500">
               {ic.evidencePlanNote}
             </p>
             {/* Stage 119 — preview-section feedback CTA */}
@@ -1032,7 +1032,7 @@ export default function IntakePage() {
         {/* Stage 112 — save the generated workflow snapshot (optional) */}
         {evidencePlan && (
           <div className="card mt-6 p-5">
-            <p className="text-xs uppercase tracking-wide text-gray-400">
+            <p className="text-xs uppercase tracking-wide text-gray-500">
               {ic.saveTitle}
             </p>
             <p className="mt-2 text-sm text-gray-500">
@@ -1080,7 +1080,7 @@ export default function IntakePage() {
               </div>
             )}
 
-            <p className="mt-4 text-xs text-gray-400">
+            <p className="mt-4 text-xs text-gray-500">
               {ic.saveOptionalNote}
             </p>
           </div>
@@ -1089,7 +1089,7 @@ export default function IntakePage() {
         {/* Stage 112 — saved workflow plans (list + reopen) */}
         <div className="card mt-6 p-5">
           <div className="flex items-center justify-between">
-            <p className="text-xs uppercase tracking-wide text-gray-400">
+            <p className="text-xs uppercase tracking-wide text-gray-500">
               {ic.savedListTitle}
             </p>
             <div className="flex items-center gap-2">
@@ -1120,9 +1120,9 @@ export default function IntakePage() {
           </div>
 
           {/* Stage 120/122 — beta tenant-scope + retention + usage-boundary notes */}
-          <p className="mt-2 text-xs text-gray-400">{ub.savedWorkflowNote}</p>
-          <p className="mt-1 text-xs text-gray-400">{ob.safetyNotes.savedScope}</p>
-          <p className="mt-1 text-xs text-gray-400">{ob.safetyNotes.savedRetention}</p>
+          <p className="mt-2 text-xs text-gray-500">{ub.savedWorkflowNote}</p>
+          <p className="mt-1 text-xs text-gray-500">{ob.safetyNotes.savedScope}</p>
+          <p className="mt-1 text-xs text-gray-500">{ob.safetyNotes.savedRetention}</p>
 
           {manageMsg && (
             <p className="mt-2 text-xs text-gray-500">{manageMsg}</p>
@@ -1137,7 +1137,7 @@ export default function IntakePage() {
             <p className="mt-3 text-sm text-gray-500">{ob.emptyStates.noSavedRecords}</p>
           )}
           {savedList !== null && savedList.length > 0 && !openRecord && !detailLoading && (
-            <p className="mt-3 text-xs text-gray-400">{ob.emptyStates.noOpenedRecord}</p>
+            <p className="mt-3 text-xs text-gray-500">{ob.emptyStates.noOpenedRecord}</p>
           )}
           {savedList !== null && savedList.length > 0 && (
             <ul className="mt-3 space-y-2">
@@ -1158,7 +1158,7 @@ export default function IntakePage() {
                     </span>
                   </div>
                   <p className="mt-1 text-xs text-gray-500">{r.sourceSummary}</p>
-                  <p className="mt-1 text-xs text-gray-400">
+                  <p className="mt-1 text-xs text-gray-500">
                     {r.id} · {ic.listCreated} {r.createdAt} · {ic.listUpdated} {r.updatedAt}
                   </p>
                   <div className="mt-2 flex flex-wrap gap-2">
@@ -1253,7 +1253,7 @@ export default function IntakePage() {
                   )}
                 </pre>
               </details>
-              <p className="mt-2 text-xs text-gray-400">
+              <p className="mt-2 text-xs text-gray-500">
                 {ic.savedSnapshotNote}
               </p>
               {/* Stage 119 — saved-workflow feedback CTA */}
@@ -1271,7 +1271,7 @@ export default function IntakePage() {
               {/* Stage 113 — benchmark handoff preview from the saved record */}
               {handoff && (
                 <div className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
-                  <p className="text-xs uppercase tracking-wide text-gray-400">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">
                     {ic.handoffTitle}
                   </p>
                   <TechDetails summary={ic.techDetails}>
@@ -1359,7 +1359,7 @@ export default function IntakePage() {
                   />
                   <StageDetail label={ic.notIncludedYet} items={handoff.notIncludedYet} />
 
-                  <p className="mt-4 text-xs text-gray-400">
+                  <p className="mt-4 text-xs text-gray-500">
                     {ic.handoffNote}
                   </p>
                 </div>
@@ -1368,7 +1368,7 @@ export default function IntakePage() {
               {/* Stage 114 — decision / outcome link preview from the saved record */}
               {outcomeLink && (
                 <div className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
-                  <p className="text-xs uppercase tracking-wide text-gray-400">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">
                     {ic.outcomeTitle}
                   </p>
                   <TechDetails summary={ic.techDetails}>
@@ -1444,7 +1444,7 @@ export default function IntakePage() {
                       ] as const
                     ).map(([key, label]) => (
                       <div key={key}>
-                        <dt className="text-xs text-gray-400">{label}</dt>
+                        <dt className="text-xs text-gray-500">{label}</dt>
                         <dd className="text-sm text-gray-700">
                           {outcomeLink.outcomeScorecardSignals[key]}
                         </dd>
@@ -1458,7 +1458,7 @@ export default function IntakePage() {
                   />
                   <StageDetail label={ic.notIncludedYet} items={outcomeLink.notIncludedYet} />
 
-                  <p className="mt-4 text-xs text-gray-400">
+                  <p className="mt-4 text-xs text-gray-500">
                     {ic.outcomeNote}
                   </p>
                 </div>
@@ -1467,7 +1467,7 @@ export default function IntakePage() {
               {/* Stage 115 — evolution action pack preview from the saved record */}
               {actionPack && (
                 <div className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
-                  <p className="text-xs uppercase tracking-wide text-gray-400">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">
                     {ic.actionPackTitle}
                   </p>
                   <TechDetails summary={ic.techDetails}>
@@ -1505,7 +1505,7 @@ export default function IntakePage() {
                           <span className="rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-500">
                             {a.priority}
                           </span>
-                          <span className="text-xs text-gray-400">{a.id}</span>
+                          <span className="text-xs text-gray-500">{a.id}</span>
                         </div>
                         <p className="mt-1 text-sm text-gray-600">{a.rationale}</p>
                         <p className="mt-1 text-xs text-gray-500">
@@ -1541,7 +1541,7 @@ export default function IntakePage() {
                   />
                   <StageDetail label={ic.notIncludedYet} items={actionPack.notIncludedYet} />
 
-                  <p className="mt-4 text-xs text-gray-400">
+                  <p className="mt-4 text-xs text-gray-500">
                     {ic.actionPackNote}
                   </p>
                 </div>
@@ -1550,7 +1550,7 @@ export default function IntakePage() {
               {/* Stage 126 — derived Acceptance Graph view from the saved record */}
               {graphView && (
                 <div className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
-                  <p className="text-xs uppercase tracking-wide text-gray-400">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">
                     {ic.graphTitle}
                   </p>
                   <TechDetails summary={ic.techDetails}>
@@ -1572,7 +1572,7 @@ export default function IntakePage() {
                       ] as const
                     ).map(([key, label]) => (
                       <div key={key}>
-                        <dt className="text-xs text-gray-400">{label}</dt>
+                        <dt className="text-xs text-gray-500">{label}</dt>
                         <dd className="text-sm text-gray-700">
                           {graphView.signalSummary[key]}
                         </dd>
@@ -1623,7 +1623,7 @@ export default function IntakePage() {
                   <ul className="mt-1 space-y-0.5 text-xs text-gray-600">
                     {graphView.nodes.slice(0, 6).map((n) => (
                       <li key={n.id}>
-                        <span className="text-gray-400">{n.type.replace(/_/g, " ")}:</span>{" "}
+                        <span className="text-gray-500">{n.type.replace(/_/g, " ")}:</span>{" "}
                         {n.label}
                       </li>
                     ))}
@@ -1631,14 +1631,14 @@ export default function IntakePage() {
                   <ul className="mt-1 space-y-0.5 text-xs text-gray-500">
                     {graphView.edges.slice(0, 6).map((e) => (
                       <li key={e.id}>
-                        {e.from} <span className="text-gray-400">{e.label} →</span> {e.to}
+                        {e.from} <span className="text-gray-500">{e.label} →</span> {e.to}
                       </li>
                     ))}
                   </ul>
 
                   <StageDetail label={ic.notIncludedYet} items={graphView.notIncludedYet} />
 
-                  <p className="mt-4 text-xs text-gray-400">
+                  <p className="mt-4 text-xs text-gray-500">
                     {ic.graphNote}
                   </p>
                 </div>
@@ -1647,7 +1647,7 @@ export default function IntakePage() {
               {/* Stage 127 — recurring blocker signals from the saved record */}
               {blockerView && (
                 <div className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
-                  <p className="text-xs uppercase tracking-wide text-gray-400">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">
                     {ic.blockersTitle}
                   </p>
                   <TechDetails summary={ic.techDetails}>
@@ -1708,7 +1708,7 @@ export default function IntakePage() {
 
                   <StageDetail label={ic.notIncludedYet} items={blockerView.notIncludedYet} />
 
-                  <p className="mt-4 text-xs text-gray-400">
+                  <p className="mt-4 text-xs text-gray-500">
                     {ic.blockersNote}
                   </p>
                 </div>
@@ -1717,7 +1717,7 @@ export default function IntakePage() {
               {/* Stage 128 — agent/tool recommendation memory from the saved record */}
               {toolMemory && (
                 <div className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
-                  <p className="text-xs uppercase tracking-wide text-gray-400">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">
                     {ic.toolMemoryTitle}
                   </p>
                   <TechDetails summary={ic.techDetails}>
@@ -1786,7 +1786,7 @@ export default function IntakePage() {
 
                   <StageDetail label={ic.notIncludedYet} items={toolMemory.notIncludedYet} />
 
-                  <p className="mt-4 text-xs text-gray-400">
+                  <p className="mt-4 text-xs text-gray-500">
                     {ic.toolMemoryNote}
                   </p>
                 </div>
@@ -1795,7 +1795,7 @@ export default function IntakePage() {
               {/* Stage 129 — template effectiveness signals from the saved record */}
               {templateSignals && (
                 <div className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
-                  <p className="text-xs uppercase tracking-wide text-gray-400">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">
                     {ic.templateSignalsTitle}
                   </p>
                   <TechDetails summary={ic.techDetails}>
@@ -1869,7 +1869,7 @@ export default function IntakePage() {
 
                   <StageDetail label={ic.notIncludedYet} items={templateSignals.notIncludedYet} />
 
-                  <p className="mt-4 text-xs text-gray-400">
+                  <p className="mt-4 text-xs text-gray-500">
                     {ic.templateSignalsNote}
                   </p>
                 </div>
@@ -1913,8 +1913,8 @@ function FeedbackLink({
 function TechDetails({ summary, children }: { summary: string; children: ReactNode }) {
   return (
     <details className="mt-1">
-      <summary className="cursor-pointer text-xs text-gray-400">{summary}</summary>
-      <p className="mt-1 text-xs text-gray-400">{children}</p>
+      <summary className="cursor-pointer text-xs text-gray-500">{summary}</summary>
+      <p className="mt-1 text-xs text-gray-500">{children}</p>
     </details>
   );
 }

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 // Stage 101 — unified intake foundation UI.
 // One front door with multiple starting points. Deterministic local preview
 // only — no backend, no model call, no external fetch. Future stages wire real
@@ -391,6 +393,12 @@ export default function IntakePage() {
   return (
     <div className="flex flex-1 justify-center px-4 py-12">
       <div className="w-full max-w-2xl">
+        <Link
+          href="/projects/new"
+          className="mb-6 inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:border-gray-300 hover:text-gray-900"
+        >
+          <span aria-hidden>←</span> {tr.branch.backToChooser}
+        </Link>
         <h1 className="text-2xl font-semibold tracking-tight text-gray-900">
           {tr.intake.handoff.title}
         </h1>

--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { callWorkspaceApi } from "@/lib/workspace-api";
 import {
   saveProject,
@@ -36,7 +36,17 @@ const BUILT_WITH_OPTIONS: ReadonlyArray<{ id: string; labelKey: keyof Dictionary
 ];
 
 export default function NewProjectPage() {
+  // useSearchParams needs a Suspense boundary when the route is prerendered.
+  return (
+    <Suspense fallback={null}>
+      <NewProjectInner />
+    </Suspense>
+  );
+}
+
+function NewProjectInner() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { t } = useI18n();
   const [step, setStep] = useState<Step>(1);
   const [ideaText, setIdeaText] = useState("");
@@ -52,6 +62,11 @@ export default function NewProjectPage() {
   const [builtWithOther, setBuiltWithOther] = useState("");
   // Single entry → adaptive branch. The chosen branch fills the P1 entry_path.
   // Until a branch is picked the chooser shows; then the step flow proceeds.
+  //
+  // The chosen branch is mirrored in the URL (?path=idea|code|spec) so every
+  // way "back" works: the browser back button, the sidebar "새 프로젝트" link
+  // (plain /projects/new → chooser), and the visible back button below. Typed
+  // input is intentionally kept when returning — only the screen changes.
   const [entryPath, setEntryPath] = useState<"idea" | "code" | "spec" | null>(null);
   // Code branch: skip the idea step entirely (that's the branch's normal path).
   const [appName, setAppName] = useState("");
@@ -64,6 +79,39 @@ export default function NewProjectPage() {
 
   const answeredCount = Object.keys(answers).length;
   const questions = result?.questions ?? [];
+
+  // URL is the source of truth for the chosen branch: /projects/new shows the
+  // chooser; ?path=idea|code|spec shows that branch. This makes browser-back
+  // and a re-click on the sidebar "new project" link both land on the chooser.
+  useEffect(() => {
+    const raw = searchParams.get("path");
+    const fromUrl = raw === "idea" || raw === "code" || raw === "spec" ? raw : null;
+    setEntryPath(fromUrl);
+    if (fromUrl === null) setStep(1);
+  }, [searchParams]);
+
+  function chooseBranch(id: "idea" | "code" | "spec") {
+    setEntryPath(id); // immediate — the effect above re-confirms from the URL
+    setStep(1);
+    router.push(`/projects/new?path=${id}`);
+  }
+
+  function backToChooser() {
+    router.push("/projects/new");
+  }
+
+  /** Prominent "back to the three choices" button, shown on every branch screen. */
+  function BackToChooserButton() {
+    return (
+      <button
+        type="button"
+        onClick={backToChooser}
+        className="mb-6 inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:border-gray-300 hover:text-gray-900"
+      >
+        <span aria-hidden="true">←</span> {t.branch.backToChooser}
+      </button>
+    );
+  }
 
   async function handleGenerateUnderstanding() {
     if (!ideaText.trim()) return;
@@ -270,7 +318,7 @@ export default function NewProjectPage() {
                   <button
                     key={id}
                     type="button"
-                    onClick={() => { setEntryPath(id); setStep(1); }}
+                    onClick={() => chooseBranch(id)}
                     className="card w-full p-5 text-left transition-colors hover:border-brand-300"
                   >
                     <span className="block text-sm font-semibold text-gray-900">{title}</span>
@@ -287,6 +335,7 @@ export default function NewProjectPage() {
               normal path, not a deficit. */}
           {entryPath === "code" && step === 1 && (
             <div>
+              <BackToChooserButton />
               <h1 className="text-2xl font-semibold tracking-tight text-gray-900">{t.branch.codeStepTitle}</h1>
               <p className="mb-8 mt-2 text-sm text-gray-500">{t.branch.codeStepSub}</p>
 
@@ -348,6 +397,7 @@ export default function NewProjectPage() {
           {/* SPEC branch step 1 — paste the plan → one-shot conversion → preview. */}
           {entryPath === "spec" && step === 1 && (
             <div>
+              <BackToChooserButton />
               <h1 className="text-2xl font-semibold tracking-tight text-gray-900">{t.branch.specStepTitle}</h1>
               <p className="mb-8 mt-2 text-sm text-gray-500">{t.branch.specStepSub}</p>
               <textarea
@@ -371,6 +421,7 @@ export default function NewProjectPage() {
 
           {entryPath === "idea" && step === 1 && (
             <div>
+              <BackToChooserButton />
               <h1 className="text-2xl font-semibold tracking-tight text-gray-900">{t.np.step1Title}</h1>
               <p className="mb-8 mt-2 text-sm text-gray-500">{t.np.step1Sub}</p>
               <textarea

--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { callWorkspaceApi } from "@/lib/workspace-api";
@@ -8,6 +10,7 @@ import {
   generateProjectId,
   saveExtendedProjectData,
   getUserKey,
+  markProjectSyncFailed,
 } from "@/lib/workflow-store";
 import { saveProjectToDb } from "@/lib/workspace-check-api";
 import type {
@@ -88,6 +91,19 @@ function NewProjectInner() {
     const fromUrl = raw === "idea" || raw === "code" || raw === "spec" ? raw : null;
     setEntryPath(fromUrl);
     if (fromUrl === null) setStep(1);
+    // ?fresh=<nonce> (sidebar "new project" while already here) = full reset:
+    // the user asked for a NEW project, so typed state is cleared too.
+    if (searchParams.get("fresh")) {
+      setIdeaText("");
+      setResult(null);
+      setSpecResult(null);
+      setAnswers({});
+      setAppName("");
+      setCodeDesc("");
+      setBuiltWithTools([]);
+      setBuiltWithOther("");
+      setRateLimitMsg(null);
+    }
   }, [searchParams]);
 
   function chooseBranch(id: "idea" | "code" | "spec") {
@@ -240,7 +256,7 @@ function NewProjectInner() {
           ? { tools: builtWithTools, other: builtWithOther.trim() || undefined }
           : undefined,
       entryPath: "code",
-    }).catch(() => undefined);
+    }).then((res) => { if (!res || res.ok !== true) markProjectSyncFailed(id); }).catch(() => markProjectSyncFailed(id));
     // Straight to code connect — that IS this branch's step 1.
     router.push(`/projects/${id}/settings`);
   }
@@ -288,7 +304,7 @@ function NewProjectInner() {
           : undefined,
       // The branch the user chose at the single entry (idea/code/spec).
       entryPath: entryPath ?? "idea",
-    }).catch(() => undefined);
+    }).then((res) => { if (!res || res.ok !== true) markProjectSyncFailed(id); }).catch(() => markProjectSyncFailed(id));
     router.push(`/projects/${id}`);
   }
 
@@ -307,6 +323,9 @@ function NewProjectInner() {
               sets entry_path (idea/code/spec) which persists to the P1 envelope. */}
           {entryPath === null && (
             <div>
+              <Link href="/projects" className="mb-4 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800">
+                <span aria-hidden>←</span> {t.nav.allProjects}
+              </Link>
               <h1 className="text-2xl font-semibold tracking-tight text-gray-900">{t.branch.title}</h1>
               <p className="mb-8 mt-2 text-sm text-gray-500">{t.branch.subtitle}</p>
               <div className="space-y-3">
@@ -635,6 +654,12 @@ function ApiQuestionCard({
           placeholder={t.np.typeYourOwn}
           className="input mt-3"
           onBlur={(e) => e.target.value && onAnswer(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              const v = (e.target as HTMLInputElement).value;
+              if (v) onAnswer(v);
+            }
+          }}
         />
       )}
     </div>

--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -349,7 +349,7 @@ function NewProjectInner() {
               />
 
               <p className="mb-1 text-xs font-semibold text-gray-600">{t.builtWith.question}</p>
-              <p className="mb-3 text-xs text-gray-400">{t.builtWith.hint}</p>
+              <p className="mb-3 text-xs text-gray-500">{t.builtWith.hint}</p>
               <div className="mb-6 flex flex-wrap gap-2">
                 {BUILT_WITH_OPTIONS.map((opt) => (
                   <button
@@ -415,7 +415,7 @@ function NewProjectInner() {
                 {isLoading ? t.np.reading : `${t.branch.specGenerate} →`}
               </button>
               {rateLimitMsg && <div className="callout mt-4 border-amber-200 bg-amber-50 text-amber-800">{rateLimitMsg}</div>}
-              <p className="mt-3 text-center text-xs text-gray-400">{t.np.freeBeta}</p>
+              <p className="mt-3 text-center text-xs text-gray-500">{t.np.freeBeta}</p>
             </div>
           )}
 
@@ -432,7 +432,7 @@ function NewProjectInner() {
                 className="input resize-none rounded-lg"
               />
               <div className="mb-8 mt-4">
-                <p className="mb-2 text-xs text-gray-400">{t.np.examplesLabel}</p>
+                <p className="mb-2 text-xs text-gray-500">{t.np.examplesLabel}</p>
                 <div className="flex flex-col gap-2">
                   {t.np.examples.map((ex, i) => (
                     <button
@@ -453,7 +453,7 @@ function NewProjectInner() {
                 {isLoading ? t.np.reading : `${t.np.generateSpec} →`}
               </button>
               {rateLimitMsg && <div className="callout mt-4 border-amber-200 bg-amber-50 text-amber-800">{rateLimitMsg}</div>}
-              <p className="mt-3 text-center text-xs text-gray-400">{t.np.freeBeta}</p>
+              <p className="mt-3 text-center text-xs text-gray-500">{t.np.freeBeta}</p>
             </div>
           )}
 
@@ -477,7 +477,7 @@ function NewProjectInner() {
               <button onClick={() => setStep(3)} className="btn btn-primary w-full py-3">
                 {t.np.confirmAnswer} →
               </button>
-              <button onClick={() => setStep(1)} className="mt-3 w-full text-center text-xs text-gray-400 underline hover:text-gray-600">
+              <button onClick={() => setStep(1)} className="mt-3 w-full text-center text-xs text-gray-500 underline hover:text-gray-600">
                 {t.np.editIdea}
               </button>
             </div>
@@ -545,7 +545,17 @@ function NewProjectInner() {
                   className="input mt-3 text-sm"
                 />
               </div>
-              <SpecPreview t={t} data={(specResult ?? result)!} isFallback={isFallback} onBack={() => setStep(3)} onSave={handleSave} />
+              {/* Spec branch never visited the question steps — its back goes to
+                  the paste screen (step 1). Sending it to step 3 stranded the
+                  user on an empty-questions screen with a blank step 2 behind it. */}
+              <SpecPreview
+                t={t}
+                data={(specResult ?? result)!}
+                isFallback={isFallback}
+                backLabel={entryPath === "spec" ? t.branch.backToPaste : t.np.editQuestions}
+                onBack={() => setStep(entryPath === "spec" ? 1 : 3)}
+                onSave={handleSave}
+              />
             </>
           )}
         </div>
@@ -574,9 +584,9 @@ function ApiQuestionCard({
   return (
     <div className="card p-6">
       <div className="mb-4 flex items-center gap-2">
-        <span className="font-mono text-xs text-gray-400">{index + 1} / {total}</span>
+        <span className="font-mono text-xs text-gray-500">{index + 1} / {total}</span>
         {answer && answer !== "defer" && <span className="text-xs font-medium text-green-600">✓ {t.np.answered}</span>}
-        {answer === "defer" && <span className="text-xs text-gray-400">{t.np.decideLater}</span>}
+        {answer === "defer" && <span className="text-xs text-gray-500">{t.np.decideLater}</span>}
       </div>
       <p className="mb-4 text-base font-medium leading-snug text-gray-900">{question.question}</p>
       <div className="mb-5 rounded-lg bg-brand-50 px-4 py-3">
@@ -601,7 +611,7 @@ function ApiQuestionCard({
           <button
             onClick={() => onAnswer("defer")}
             className={`rounded-lg border px-4 py-2 text-sm transition-all ${
-              answer === "defer" ? "border-gray-300 bg-gray-200 text-gray-700" : "border-gray-200 bg-white text-gray-400 hover:bg-gray-50"
+              answer === "defer" ? "border-gray-300 bg-gray-200 text-gray-700" : "border-gray-200 bg-white text-gray-500 hover:bg-gray-50"
             }`}
           >
             {t.np.decideLater}
@@ -635,12 +645,14 @@ function SpecPreview({
   t,
   data,
   isFallback,
+  backLabel,
   onBack,
   onSave,
 }: {
   t: Dictionary;
   data: IdeaToSpecDraftResponse;
   isFallback: boolean;
+  backLabel: string;
   onBack: () => void;
   onSave: () => void;
 }) {
@@ -655,7 +667,7 @@ function SpecPreview({
 
       <div className="flex gap-3">
         <button onClick={onBack} className="btn btn-secondary flex-1 py-3">
-          ← {t.np.editQuestions}
+          ← {backLabel}
         </button>
         <button onClick={onSave} className="btn btn-primary flex-[2] py-3">
           {t.np.saveAndStart} →

--- a/apps/dashboard/src/app/projects/page.tsx
+++ b/apps/dashboard/src/app/projects/page.tsx
@@ -57,7 +57,7 @@ export default function ProjectsPage() {
       {MOCK_PROJECTS.length > 0 && (
         <div className="mt-10">
           <h2 className="text-sm font-semibold text-gray-700">{t.projects.examplesTitle}</h2>
-          <p className="mt-0.5 text-xs text-gray-400">{t.projects.examplesNote}</p>
+          <p className="mt-0.5 text-xs text-gray-500">{t.projects.examplesNote}</p>
           <div className="mt-3 grid gap-4">
             {MOCK_PROJECTS.map((project) => (
               <ProjectCard key={project.id} project={project} t={t} exampleBadge={t.projects.exampleBadge} />
@@ -96,7 +96,7 @@ function ProjectCard({
           </h2>
           <p className="mt-0.5 text-sm text-gray-500">{project.description}</p>
         </div>
-        <span className="whitespace-nowrap text-xs text-gray-400">{project.createdAt}</span>
+        <span className="whitespace-nowrap text-xs text-gray-500">{project.createdAt}</span>
       </div>
 
       <div className="mb-3">
@@ -111,7 +111,7 @@ function ProjectCard({
         <span className="font-medium text-red-600">{statusLabel(t, "failed")} {stats.failed}</span>
         <span className="font-medium text-amber-600">{statusLabel(t, "inconclusive")} {stats.inconclusive}</span>
         <span className="font-medium text-slate-600">{statusLabel(t, "needs_decision")} {stats.needsDecision}</span>
-        <span className="text-gray-400">{statusLabel(t, "not_started")} {stats.notStarted}</span>
+        <span className="text-gray-500">{statusLabel(t, "not_started")} {stats.notStarted}</span>
       </div>
     </Link>
   );

--- a/apps/dashboard/src/components/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar.tsx
@@ -26,6 +26,10 @@ export function AppSidebar() {
   const projectId = useProjectId(pathname);
 
   const [collapsed, setCollapsed] = useState(false);
+  // Mobile (<md): the sidebar is hidden and replaced by a fixed top bar with a
+  // menu button that opens the SAME expanded body as an overlay drawer. Without
+  // this the fixed w-60 rail left ~120px of content on a 360px phone.
+  const [mobileOpen, setMobileOpen] = useState(false);
   const [projects, setProjects] = useState<Project[]>([]);
   const [query, setQuery] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -57,6 +61,11 @@ export function AppSidebar() {
       .catch(() => {});
     return () => { cancelled = true; };
   }, [projectId, pathname]);
+
+  // Navigating closes the mobile drawer (links inside it change the pathname).
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
 
   function toggleCollapse() {
     setCollapsed((c) => {
@@ -111,35 +120,21 @@ export function AppSidebar() {
     status === "done" ? "✓" : status === "current" ? "●" : "○";
   const advancedItems = [["experiment", t.nav.experiment], ["benchmark", t.nav.benchmark]] as const;
 
-  // ── Collapsed rail ──────────────────────────────────────────────────────────
-  if (collapsed) {
-    return (
-      <aside className="sticky top-0 flex h-screen w-14 flex-shrink-0 flex-col items-center border-r border-gray-200 bg-white py-4">
-        <button onClick={toggleCollapse} aria-label="Expand sidebar" className="mb-4 grid h-8 w-8 place-items-center rounded-md hover:bg-gray-100">
-          <span aria-hidden className="h-3 w-3 rounded-full border-[1.5px] border-gold-500" />
-        </button>
-        <Link href="/projects/new" aria-label={t.nav.newProject} className="mb-2 grid h-8 w-8 place-items-center rounded-md border border-gray-200 text-gray-500 hover:bg-gray-50">＋</Link>
-        <Link href="/projects" aria-label={t.nav.allProjects} className="grid h-8 w-8 place-items-center rounded-md text-gray-500 hover:bg-gray-50">▦</Link>
-        <Link href="/account" aria-label={t.account.openLabel} className="mt-auto grid h-8 w-8 place-items-center rounded-full bg-brand-600 text-xs font-semibold text-white hover:bg-brand-700">{initial}</Link>
-      </aside>
-    );
-  }
-
-  // ── Expanded sidebar ────────────────────────────────────────────────────────
-  return (
-    <aside className="sticky top-0 flex h-screen w-60 flex-shrink-0 flex-col border-r border-gray-200 bg-white">
+  // ── Expanded body (shared by the desktop aside and the mobile drawer) ──────
+  const expandedBody = (
+    <>
       {/* Brand + collapse */}
       <div className="flex items-center justify-between px-3 pb-2 pt-4">
         <Link href="/projects" className="group flex items-center gap-2.5 px-1.5">
           <span aria-hidden className="h-3 w-3 rounded-full border-[1.5px] border-gold-500 transition-colors group-hover:bg-gold-500" />
           <span className="text-[15px] font-semibold tracking-[-0.02em] text-gray-900">{t.brand.wordmark}</span>
         </Link>
-        <button onClick={toggleCollapse} aria-label="Collapse sidebar" className="grid h-7 w-7 place-items-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-700">«</button>
+        <button onClick={toggleCollapse} aria-label="Collapse sidebar" className="grid h-7 w-7 place-items-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700">«</button>
       </div>
 
       <div className="px-3 py-1.5">
         <Link href="/projects/new" className="flex items-center gap-2 rounded-md border border-gray-200 px-2.5 py-1.5 text-[13px] font-medium text-gray-700 transition-colors hover:bg-gray-50">
-          <span className="text-gray-400">＋</span>
+          <span className="text-gray-500">＋</span>
           {t.nav.newProject}
         </Link>
       </div>
@@ -148,7 +143,7 @@ export function AppSidebar() {
       <nav className="min-h-0 flex-1 overflow-y-auto px-3 py-2">
         {project ? (
           <>
-            <Link href="/projects" className="mb-2 flex items-center gap-1 px-1.5 text-xs text-gray-400 hover:text-gray-700">
+            <Link href="/projects" className="mb-2 flex items-center gap-1 px-1.5 text-xs text-gray-500 hover:text-gray-700">
               ← {t.nav.allProjects}
             </Link>
             <p className="truncate px-1.5 pb-2 text-xs font-medium text-gray-700">{project.name}</p>
@@ -168,7 +163,7 @@ export function AppSidebar() {
                 <div key={step.key} className="mb-3">
                   <p
                     className={`flex items-center gap-2 px-2.5 pb-1 text-[11px] font-semibold tracking-wide ${
-                      locked ? "text-gray-300" : step.status === "current" ? "text-gray-900" : "text-gray-500"
+                      locked ? "text-gray-400" : step.status === "current" ? "text-gray-900" : "text-gray-500"
                     }`}
                   >
                     <span
@@ -178,20 +173,20 @@ export function AppSidebar() {
                           ? "text-green-600"
                           : step.status === "current"
                             ? "text-brand-600"
-                            : "text-gray-300"
+                            : "text-gray-400"
                       }`}
                     >
                       {statusGlyph(step.status)}
                     </span>
                     {i + 1} · {meta.label}
                     {step.optional && (
-                      <span className="rounded-full border border-gray-200 px-1.5 py-px text-[9px] font-medium text-gray-400">
+                      <span className="rounded-full border border-gray-200 px-1.5 py-px text-[9px] font-medium text-gray-500">
                         {t.stepsNav.optionalTag}
                       </span>
                     )}
                   </p>
                   {locked ? (
-                    <p className="px-2.5 pb-1 pl-[30px] text-[11px] text-gray-300">{lockHint(step.lockReason)}</p>
+                    <p className="px-2.5 pb-1 pl-[30px] text-[11px] text-gray-500">{lockHint(step.lockReason)}</p>
                   ) : (
                     <ul className="space-y-0.5 pl-[18px]">
                       {meta.items.map(([slug, label]) => {
@@ -211,7 +206,7 @@ export function AppSidebar() {
               <button
                 type="button"
                 onClick={() => setShowAdvanced((v) => !v)}
-                className="flex w-full items-center justify-between px-2.5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-300 hover:text-gray-500"
+                className="flex w-full items-center justify-between px-2.5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-500 hover:text-gray-700"
               >
                 {t.nav.groupAdvanced}
                 <span aria-hidden>{showAdvanced ? "−" : "+"}</span>
@@ -236,26 +231,27 @@ export function AppSidebar() {
         ) : (
           <>
             <input
+              aria-label={t.nav.searchProjects}
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder={t.nav.searchProjects}
-              className="mb-2 w-full rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-[13px] placeholder:text-gray-400 focus:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-100"
+              className="mb-2 w-full rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-[13px] placeholder:text-gray-500 focus:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-100"
             />
-            <p className="px-2.5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-300">{t.nav.allProjects}</p>
+            <p className="px-2.5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-500">{t.nav.allProjects}</p>
             <ul className="space-y-0.5">
               {filtered.map((p) => (
                 <li key={p.id}>
                   <Link href={`/projects/${p.id}`} className={itemClass(pathname.startsWith(`/projects/${p.id}`))}>
                     {p.name}
                     {MOCK_IDS.has(p.id) && (
-                      <span className="ml-1.5 rounded-full border border-gray-200 bg-gray-50 px-1.5 py-px text-[9px] font-medium text-gray-400">
+                      <span className="ml-1.5 rounded-full border border-gray-200 bg-gray-50 px-1.5 py-px text-[9px] font-medium text-gray-500">
                         {t.projects.exampleBadge}
                       </span>
                     )}
                   </Link>
                 </li>
               ))}
-              {filtered.length === 0 && <li className="px-2.5 py-2 text-xs text-gray-400">{t.nav.noProjects}</li>}
+              {filtered.length === 0 && <li className="px-2.5 py-2 text-xs text-gray-500">{t.nav.noProjects}</li>}
             </ul>
           </>
         )}
@@ -265,7 +261,7 @@ export function AppSidebar() {
       <div className="border-t border-gray-100 p-2">
         <a
           href={buildBetaFeedbackMailto({ route: pathname, section: "Dashboard" })}
-          className="mb-1 block rounded-md px-2.5 py-1.5 text-[12px] text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-700"
+          className="mb-1 block rounded-md px-2.5 py-1.5 text-[12px] text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700"
         >
           {t.nav.feedback}
         </a>
@@ -273,10 +269,70 @@ export function AppSidebar() {
           <span className="grid h-7 w-7 flex-shrink-0 place-items-center rounded-full bg-brand-600 text-xs font-semibold text-white">{initial}</span>
           <span className="min-w-0 flex-1">
             <span className="block truncate text-[13px] font-medium text-gray-900">{t.account.workspace}</span>
-            <span className="block truncate text-[11px] text-gray-400">{t.account.plan}</span>
+            <span className="block truncate text-[11px] text-gray-500">{t.account.plan}</span>
           </span>
         </Link>
       </div>
-    </aside>
+    </>
+  );
+
+  // ── Mobile chrome: fixed top bar + overlay drawer (always <md only) ────────
+  const mobileChrome = (
+    <>
+      <div className="fixed inset-x-0 top-0 z-40 flex h-12 items-center gap-2 border-b border-gray-200 bg-white px-3 md:hidden">
+        <button
+          type="button"
+          onClick={() => setMobileOpen(true)}
+          aria-label={t.nav.openMenu}
+          className="grid h-9 w-9 place-items-center rounded-md text-lg text-gray-700 hover:bg-gray-100"
+        >
+          <span aria-hidden>☰</span>
+        </button>
+        <Link href="/projects" className="flex items-center gap-2">
+          <span aria-hidden className="h-3 w-3 rounded-full border-[1.5px] border-gold-500" />
+          <span className="text-[15px] font-semibold tracking-[-0.02em] text-gray-900">{t.brand.wordmark}</span>
+        </Link>
+      </div>
+      {mobileOpen && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <button
+            type="button"
+            aria-label={t.nav.closeMenu}
+            onClick={() => setMobileOpen(false)}
+            className="absolute inset-0 bg-black/30"
+          />
+          <div className="absolute inset-y-0 left-0 flex w-72 max-w-[85vw] flex-col overflow-y-auto bg-white shadow-xl">
+            {expandedBody}
+          </div>
+        </div>
+      )}
+    </>
+  );
+
+  // ── Collapsed rail (desktop only) ───────────────────────────────────────────
+  if (collapsed) {
+    return (
+      <>
+        {mobileChrome}
+        <aside className="sticky top-0 hidden h-screen w-14 flex-shrink-0 flex-col items-center border-r border-gray-200 bg-white py-4 md:flex">
+          <button onClick={toggleCollapse} aria-label="Expand sidebar" className="mb-4 grid h-8 w-8 place-items-center rounded-md hover:bg-gray-100">
+            <span aria-hidden className="h-3 w-3 rounded-full border-[1.5px] border-gold-500" />
+          </button>
+          <Link href="/projects/new" aria-label={t.nav.newProject} className="mb-2 grid h-8 w-8 place-items-center rounded-md border border-gray-200 text-gray-500 hover:bg-gray-50">＋</Link>
+          <Link href="/projects" aria-label={t.nav.allProjects} className="grid h-8 w-8 place-items-center rounded-md text-gray-500 hover:bg-gray-50">▦</Link>
+          <Link href="/account" aria-label={t.account.openLabel} className="mt-auto grid h-8 w-8 place-items-center rounded-full bg-brand-600 text-xs font-semibold text-white hover:bg-brand-700">{initial}</Link>
+        </aside>
+      </>
+    );
+  }
+
+  // ── Expanded sidebar (desktop) ──────────────────────────────────────────────
+  return (
+    <>
+      {mobileChrome}
+      <aside className="sticky top-0 hidden h-screen w-60 flex-shrink-0 flex-col border-r border-gray-200 bg-white md:flex">
+        {expandedBody}
+      </aside>
+    </>
   );
 }

--- a/apps/dashboard/src/components/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useI18n } from "@/i18n/I18nProvider";
 import { loadLocalProjects, loadExtendedProjectData, getUserKey } from "@/lib/workflow-store";
@@ -23,6 +23,7 @@ function useProjectId(pathname: string): string | null {
 export function AppSidebar() {
   const { t } = useI18n();
   const pathname = usePathname() ?? "";
+  const router = useRouter();
   const projectId = useProjectId(pathname);
 
   const [collapsed, setCollapsed] = useState(false);
@@ -133,7 +134,18 @@ export function AppSidebar() {
       </div>
 
       <div className="px-3 py-1.5">
-        <Link href="/projects/new" className="flex items-center gap-2 rounded-md border border-gray-200 px-2.5 py-1.5 text-[13px] font-medium text-gray-700 transition-colors hover:bg-gray-50">
+        <Link
+          href="/projects/new"
+          onClick={(e) => {
+            // Already on the new-project flow: same-href Link is a no-op, so
+            // force a full reset instead (?fresh nonce → the flow clears state).
+            if (pathname.startsWith("/projects/new")) {
+              e.preventDefault();
+              router.push(`/projects/new?fresh=${Date.now()}`);
+            }
+          }}
+          className="flex items-center gap-2 rounded-md border border-gray-200 px-2.5 py-1.5 text-[13px] font-medium text-gray-700 transition-colors hover:bg-gray-50"
+        >
           <span className="text-gray-500">＋</span>
           {t.nav.newProject}
         </Link>

--- a/apps/dashboard/src/components/LanguageToggle.tsx
+++ b/apps/dashboard/src/components/LanguageToggle.tsx
@@ -21,7 +21,7 @@ export function LanguageToggle() {
             onClick={() => setLocale(o.value)}
             aria-pressed={active}
             className={`rounded-[5px] px-2 py-0.5 text-[11px] font-medium tracking-wide transition-colors ${
-              active ? "bg-white text-gray-900 shadow-sm" : "text-gray-400 hover:text-gray-700"
+              active ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-700"
             }`}
           >
             {o.label}

--- a/apps/dashboard/src/components/MockUserBadge.tsx
+++ b/apps/dashboard/src/components/MockUserBadge.tsx
@@ -9,7 +9,7 @@ export function MockUserBadge() {
   return (
     <div className="px-3 py-3 border-t border-gray-100 mt-auto">
       <p className="text-xs font-medium text-gray-700 truncate">{MOCK_USER.workspace}</p>
-      <p className="text-xs text-gray-400 mt-0.5">
+      <p className="text-xs text-gray-500 mt-0.5">
         {MOCK_USER.githubConnected ? "GitHub 연결됨" : "GitHub 연결 예정"}
       </p>
     </div>

--- a/apps/dashboard/src/components/ProjectNotFound.tsx
+++ b/apps/dashboard/src/components/ProjectNotFound.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+/**
+ * Shared "project not in this browser" state.
+ *
+ * Projects live in localStorage, so a shared URL / fresh browser / cleared
+ * storage resolves to null on every /projects/[id]/* route. The old guard
+ * rendered a bare three-word "찾을 수 없습니다." with no why and no next
+ * action (UX audit P1, systemic across 11 routes). This card explains the
+ * why in user language and always offers a way forward.
+ */
+import Link from "next/link";
+import { useI18n } from "@/i18n/I18nProvider";
+
+export function ProjectNotFound() {
+  const { t } = useI18n();
+  return (
+    <div className="empty-state max-w-xl">
+      <p className="text-base font-semibold text-gray-800">{t.nf.title}</p>
+      <p className="mx-auto mt-2 max-w-sm text-sm text-gray-500">{t.nf.body}</p>
+      <div className="mt-6 flex items-center justify-center gap-3">
+        <Link href="/projects" className="btn btn-md btn-primary">
+          {t.nf.allProjects}
+        </Link>
+        <Link href="/projects/new" className="btn btn-md btn-secondary">
+          {t.nf.newProject}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/QuestionCard.tsx
+++ b/apps/dashboard/src/components/QuestionCard.tsx
@@ -73,6 +73,12 @@ export function QuestionCard({ question, index, total, answer, onAnswer }: Props
           placeholder={t.np.typeYourOwn}
           className="mt-3 w-full text-sm border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-300"
           onBlur={(e) => e.target.value && onAnswer(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              const v = (e.target as HTMLInputElement).value;
+              if (v) onAnswer(v);
+            }
+          }}
         />
       )}
     </div>

--- a/apps/dashboard/src/components/QuestionCard.tsx
+++ b/apps/dashboard/src/components/QuestionCard.tsx
@@ -16,14 +16,14 @@ export function QuestionCard({ question, index, total, answer, onAnswer }: Props
   return (
     <div className="bg-white rounded-xl border border-gray-200 p-6">
       <div className="flex items-center gap-2 mb-4">
-        <span className="text-xs font-mono text-gray-400">
+        <span className="text-xs font-mono text-gray-500">
           {index + 1} / {total}
         </span>
         {answer && answer !== "defer" && (
           <span className="text-xs text-green-600 font-medium">{t.np.answered}</span>
         )}
         {answer === "defer" && (
-          <span className="text-xs text-gray-400">{t.np.decideLater}</span>
+          <span className="text-xs text-gray-500">{t.np.decideLater}</span>
         )}
       </div>
 

--- a/apps/dashboard/src/components/SpecDraftView.tsx
+++ b/apps/dashboard/src/components/SpecDraftView.tsx
@@ -26,7 +26,7 @@ export function UnderstoodCard({
     <div className="card mb-6 p-6">
       <p className="mb-5 text-sm leading-relaxed text-gray-800">{understood.summary}</p>
       <div className="mb-4">
-        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">{t.np.mainUsers}</p>
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">{t.np.mainUsers}</p>
         <ul className="space-y-1">
           {understood.targetUsers.map((u, i) => (
             <li key={i} className="flex gap-2 text-sm text-gray-700">
@@ -36,7 +36,7 @@ export function UnderstoodCard({
         </ul>
       </div>
       <div>
-        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">{t.np.mainFlow}</p>
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">{t.np.mainFlow}</p>
         <ol className="space-y-1">
           {understood.mainFlow.map((f, i) => (
             <li key={i} className="flex gap-2 text-sm text-gray-700">
@@ -68,7 +68,7 @@ export function SpecDraftBody({
         <SpecRow label={t.np.problem} value={productSpec.problem} />
 
         <div className="mt-4">
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">{t.np.included}</p>
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">{t.np.included}</p>
           <ul className="space-y-1">
             {productSpec.included.map((item, i) => (
               <li key={i} className="flex gap-2 text-sm text-gray-700">
@@ -80,7 +80,7 @@ export function SpecDraftBody({
 
         {productSpec.excluded.length > 0 && (
           <div className="mt-4">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">{t.np.excluded}</p>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">{t.np.excluded}</p>
             <ul className="space-y-1">
               {productSpec.excluded.map((item, i) => (
                 <li key={i} className="flex gap-2 text-sm text-gray-500">
@@ -141,7 +141,7 @@ export function RequirementRow({ item }: { item: WorkspaceRequirementItem }) {
 export function SpecRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="mb-3">
-      <p className="mb-0.5 text-xs font-semibold uppercase tracking-wide text-gray-400">{label}</p>
+      <p className="mb-0.5 text-xs font-semibold uppercase tracking-wide text-gray-500">{label}</p>
       <p className="text-sm text-gray-700">{value}</p>
     </div>
   );

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -148,6 +148,8 @@ export type Dictionary = {
   };
   fix: { title: string; subtitle: string };
   common: {
+    syncFailed: string;
+    dismiss: string;
     goOverview: string;
     loading: string;
     save: string;

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -237,6 +237,7 @@ export type Dictionary = {
   branch: {
     title: string;
     subtitle: string;
+    backToChooser: string;
     ideaTitle: string;
     ideaDesc: string;
     codeTitle: string;

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -22,6 +22,8 @@ export type Dictionary = {
   brand: { wordmark: string; tagline: string };
   lang: { label: string; english: string; korean: string };
   nav: {
+    openMenu: string;
+    closeMenu: string;
     overview: string;
     idea: string;
     spec: string;
@@ -146,6 +148,7 @@ export type Dictionary = {
   };
   fix: { title: string; subtitle: string };
   common: {
+    goOverview: string;
     loading: string;
     save: string;
     cancel: string;
@@ -238,6 +241,7 @@ export type Dictionary = {
     title: string;
     subtitle: string;
     backToChooser: string;
+    backToPaste: string;
     ideaTitle: string;
     ideaDesc: string;
     codeTitle: string;
@@ -267,7 +271,7 @@ export type Dictionary = {
     gsStep2: string;
     gsStep3: string;
   };
-  idea: { subtitle: string; yourInput: string; understood: string; excluded: string };
+  idea: { emptyBody: string; subtitle: string; yourInput: string; understood: string; excluded: string };
   np: {
     title: string;
     ideaPlaceholder: string;
@@ -306,6 +310,7 @@ export type Dictionary = {
     customInput: string;
   };
   spec: {
+    emptyBody: string;
     title: string;
     reviewNote: string;
     completeness: string;
@@ -324,6 +329,7 @@ export type Dictionary = {
   };
   priority: { must: string; should: string; could: string };
   fixesScreen: {
+    generateError: string;
     title: string;
     reviewFirst: string;
     allPassed: string;
@@ -343,6 +349,7 @@ export type Dictionary = {
     doNotDo: string;
   };
   checks: {
+    pageSubtitle: string;
     draftTitle: string;
     draftDesc: string;
     prTitle: string;
@@ -745,6 +752,12 @@ export type Dictionary = {
     testSent: string;
     testError: string;
   };
+  nf: {
+    title: string;
+    body: string;
+    allProjects: string;
+    newProject: string;
+  };
   trainingConsent: {
     title: string;
     desc: string;
@@ -813,6 +826,9 @@ export type Dictionary = {
     generateItems: string;
     generatingItems: string;
     generateItemsError: string;
+    reviewingHint: string;
+    connectionLoadError: string;
+    copyManually: string;
     selected: string;
     saveLink: string;
     linked: string;
@@ -843,6 +859,7 @@ export type Dictionary = {
     nextLabel: string;
   };
   comment: {
+    postConfirm: string;
     title: string;
     desc: string;
     publicOnly: string;
@@ -1135,6 +1152,7 @@ export type Dictionary = {
     recordDecision: string;
   };
   experiment: {
+    titleRequired: string;
     title: string;
     subtitle: string;
     chooseTemplate: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -20,6 +20,8 @@ const EN = {
   brand: { wordmark: "Simsa", tagline: "The acceptance layer for AI-built software." },
   lang: { label: "Language", english: "English", korean: "한국어" },
   nav: {
+    openMenu: "Open menu",
+    closeMenu: "Close menu",
     overview: "Overview",
     idea: "Idea",
     spec: "Product brief",
@@ -197,6 +199,7 @@ const EN = {
     subtitle: "Clear instructions you can hand to Claude Code, Codex, or a teammate.",
   },
   common: {
+    goOverview: "Go to project overview",
     loading: "Loading…",
     save: "Save",
     cancel: "Cancel",
@@ -292,6 +295,7 @@ const EN = {
     title: "What do you have to start with?",
     subtitle: "Pick whatever fits — you'll end up in the same place: your app, reviewed.",
     backToChooser: "Back to the three choices",
+    backToPaste: "Back to your document",
     ideaTitle: "💡 I just have an idea",
     ideaDesc: "Describe what you want to build. We'll turn it into things to check.",
     codeTitle: "🔗 I already built an app",
@@ -322,6 +326,7 @@ const EN = {
     gsStep3: "Run a review — pick the code changes and check them against your acceptance items.",
   },
   idea: {
+    emptyBody: "Nothing here yet — this project started from code, so there's no written idea. You can keep going from the overview.",
     subtitle: "What Simsa understood from your input.",
     yourInput: "Your idea",
     understood: "What Simsa understood",
@@ -369,6 +374,7 @@ const EN = {
     customInput: "Custom",
   },
   spec: {
+    emptyBody: "No plan yet — this project started from code. Reviews use your checking items, so you can keep going from the overview.",
     title: "Product brief",
     reviewNote: "Review the product intent before using it for acceptance checks.",
     completeness: "Completeness",
@@ -387,6 +393,7 @@ const EN = {
   },
   priority: { must: "Must", should: "Should", could: "Could" },
   fixesScreen: {
+    generateError: "Could not create the fix note.",
     title: "Fix instructions",
     reviewFirst: "Review your items in the Review results tab first.",
     allPassed: "All items passed.",
@@ -406,6 +413,7 @@ const EN = {
     doNotDo: "Do not",
   },
   checks: {
+    pageSubtitle: "The results of checking your product against its checking items.",
     draftTitle: "Draft review",
     draftDesc: "Checks your product brief and acceptance items before connecting code.",
     prTitle: "Code review (GitHub)",
@@ -833,6 +841,12 @@ const EN = {
     testSent: "Test email sent. Check your inbox.",
     testError: "Could not send. Check the address and try again.",
   },
+  nf: {
+    title: "We can't find this project in this browser",
+    body: "Projects are stored in the browser where they were created. If you made it in another browser or an incognito window, open it there.",
+    allProjects: "All projects",
+    newProject: "New project",
+  },
   trainingConsent: {
     title: "Help improve Simsa",
     desc: "Optional. Let Simsa keep the code changes it reviewed and the review results, to improve future review quality — including a future model trained on this data.",
@@ -901,6 +915,9 @@ const EN = {
     generateItems: "Create checking items",
     generatingItems: "Creating…",
     generateItemsError: "Could not create the items. Please try again.",
+    reviewingHint: "This usually takes 1–2 minutes. The result is saved even if you leave this screen.",
+    connectionLoadError: "Couldn't check the repository connection just now. This is usually temporary.",
+    copyManually: "Automatic copy was blocked — copy the text below manually.",
     selected: "selected",
     saveLink: "Save link",
     linked: "Linked.",
@@ -931,6 +948,7 @@ const EN = {
     nextLabel: "Next",
   },
   comment: {
+    postConfirm: "This will post a PUBLIC comment on your PR on GitHub, under your account. You can update it later, but you can't delete it from here. Post it?",
     title: "Share results on GitHub",
     desc: "Post the review results as a comment on the GitHub page for these code changes. This step does not change any code.",
     publicOnly: "Results can only be posted for public repositories.",
@@ -1223,6 +1241,7 @@ const EN = {
     recordDecision: "Record decision",
   },
   experiment: {
+    titleRequired: "Enter a title to enable saving.",
     title: "Manual multi-agent experiment",
     subtitle: "Plan a single-agent vs multi-agent build experiment using the same product brief and acceptance items.",
     chooseTemplate: "Choose a template",
@@ -2106,6 +2125,8 @@ const KO = {
   brand: { wordmark: "Simsa", tagline: "AI가 만든 소프트웨어를 검수하는 작업공간" },
   lang: { label: "언어", english: "English", korean: "한국어" },
   nav: {
+    openMenu: "메뉴 열기",
+    closeMenu: "메뉴 닫기",
     overview: "개요",
     idea: "아이디어",
     spec: "제품 설명서",
@@ -2282,6 +2303,7 @@ const KO = {
     subtitle: "Claude Code, Codex, 또는 동료에게 그대로 넘길 수 있는 수정 안내입니다.",
   },
   common: {
+    goOverview: "프로젝트 개요로 가기",
     loading: "불러오는 중…",
     save: "저장",
     cancel: "취소",
@@ -2374,6 +2396,7 @@ const KO = {
     title: "무엇부터 시작할까요?",
     subtitle: "지금 갖고 계신 걸 고르세요 — 어느 쪽이든 결국 '내 앱 검수'로 이어져요.",
     backToChooser: "처음 선택으로 돌아가기",
+    backToPaste: "붙여넣기로 돌아가기",
     ideaTitle: "💡 아이디어만 있어요",
     ideaDesc: "만들고 싶은 걸 말하면 확인할 항목으로 정리해드려요.",
     codeTitle: "🔗 이미 만든 앱이 있어요",
@@ -2404,6 +2427,7 @@ const KO = {
     gsStep3: "확인 실행 — 코드 변경을 골라 검수 항목 기준으로 확인하세요.",
   },
   idea: {
+    emptyBody: "아직 정리된 내용이 없어요 — 이 프로젝트는 코드에서 시작해서 적어둔 아이디어가 없어요. 개요에서 계속 진행하시면 돼요.",
     subtitle: "입력한 내용을 Simsa가 어떻게 이해했는지 보여줘요.",
     yourInput: "입력한 아이디어",
     understood: "Simsa가 이해한 내용",
@@ -2451,6 +2475,7 @@ const KO = {
     customInput: "직접 입력",
   },
   spec: {
+    emptyBody: "아직 기획 내용이 없어요 — 이 프로젝트는 코드에서 시작했어요. 검수는 확인 항목 기준으로 진행되니, 개요에서 계속 진행하시면 돼요.",
     title: "제품 설명서",
     reviewNote: "검수에 사용하기 전에 제품 의도를 확인하세요.",
     completeness: "완성도",
@@ -2469,6 +2494,7 @@ const KO = {
   },
   priority: { must: "필수", should: "권장", could: "선택" },
   fixesScreen: {
+    generateError: "수정 안내를 만들지 못했어요.",
     title: "수정 지시서",
     reviewFirst: "먼저 확인 결과 탭에서 항목을 검토해주세요.",
     allPassed: "모든 항목이 통과됐습니다.",
@@ -2488,6 +2514,7 @@ const KO = {
     doNotDo: "하지 말아야 할 것",
   },
   checks: {
+    pageSubtitle: "확인 항목을 기준으로 제품을 확인한 결과예요.",
     draftTitle: "제품 설명서 기준 사전 확인",
     draftDesc: "코드를 연결하기 전에 제품 설명서와 검수 항목을 확인합니다.",
     prTitle: "코드 확인 (GitHub)",
@@ -2915,6 +2942,12 @@ const KO = {
     testSent: "테스트 메일을 보냈어요. 받은편지함을 확인해주세요.",
     testError: "전송에 실패했어요. 주소가 맞는지 확인해주세요.",
   },
+  nf: {
+    title: "이 브라우저에서 프로젝트를 찾을 수 없어요",
+    body: "프로젝트는 만든 브라우저에 저장돼요. 다른 브라우저나 시크릿 창에서 만들었다면 그곳에서 열어주세요.",
+    allProjects: "모든 프로젝트",
+    newProject: "새 프로젝트",
+  },
   trainingConsent: {
     title: "Simsa 개선에 참여하기",
     desc: "선택 사항이에요. Simsa가 확인한 코드 변경과 확인 결과를 보관해서 앞으로의 확인 품질을 높이는 데 쓰도록 허용합니다 — 이 데이터로 학습한 자체 모델을 만드는 것까지 포함해요.",
@@ -2983,6 +3016,9 @@ const KO = {
     generateItems: "확인 항목 만들기",
     generatingItems: "만드는 중…",
     generateItemsError: "항목을 만들지 못했어요. 다시 시도해주세요.",
+    reviewingHint: "보통 1~2분 정도 걸려요. 이 화면을 떠나도 결과는 저장돼요.",
+    connectionLoadError: "저장소 연결 상태를 지금 확인하지 못했어요. 대부분 일시적인 문제예요.",
+    copyManually: "자동 복사가 막혔어요 — 아래 내용을 직접 복사해주세요.",
     selected: "개 선택됨",
     saveLink: "연결 저장",
     linked: "연결됐어요.",
@@ -3013,6 +3049,7 @@ const KO = {
     nextLabel: "다음",
   },
   comment: {
+    postConfirm: "GitHub의 코드 변경(PR)에 내 계정으로 공개 코멘트가 남아요. 나중에 수정은 되지만 여기서 삭제는 안 돼요. 남길까요?",
     title: "GitHub에 결과 남기기",
     desc: "확인 결과를 GitHub의 해당 코드 변경(PR) 페이지에 코멘트로 남길 수 있어요. 이 단계에서는 코드를 자동으로 고치지 않습니다.",
     publicOnly: "현재는 공개 저장소에만 결과를 남길 수 있어요.",
@@ -3305,6 +3342,7 @@ const KO = {
     recordDecision: "결정 기록",
   },
   experiment: {
+    titleRequired: "저장하려면 제목을 입력해주세요.",
     title: "수동 다중 에이전트 실험",
     subtitle: "같은 제품 설명서와 검수 항목을 기준으로 단일 에이전트와 다중 에이전트 개발 실험을 계획합니다.",
     chooseTemplate: "템플릿 선택",

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -199,6 +199,8 @@ const EN = {
     subtitle: "Clear instructions you can hand to Claude Code, Codex, or a teammate.",
   },
   common: {
+    syncFailed: "Saving to the server failed — your work is safe on this device. Check your connection; the next save will sync it.",
+    dismiss: "Dismiss",
     goOverview: "Go to project overview",
     loading: "Loading…",
     save: "Save",
@@ -2303,6 +2305,8 @@ const KO = {
     subtitle: "Claude Code, Codex, 또는 동료에게 그대로 넘길 수 있는 수정 안내입니다.",
   },
   common: {
+    syncFailed: "서버 저장에 실패했어요 — 이 기기에는 저장돼 있어요. 인터넷 연결을 확인하고 다음 저장 때 다시 동기화돼요.",
+    dismiss: "닫기",
     goOverview: "프로젝트 개요로 가기",
     loading: "불러오는 중…",
     save: "저장",

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -291,6 +291,7 @@ const EN = {
   branch: {
     title: "What do you have to start with?",
     subtitle: "Pick whatever fits — you'll end up in the same place: your app, reviewed.",
+    backToChooser: "Back to the three choices",
     ideaTitle: "💡 I just have an idea",
     ideaDesc: "Describe what you want to build. We'll turn it into things to check.",
     codeTitle: "🔗 I already built an app",
@@ -2372,6 +2373,7 @@ const KO = {
   branch: {
     title: "무엇부터 시작할까요?",
     subtitle: "지금 갖고 계신 걸 고르세요 — 어느 쪽이든 결국 '내 앱 검수'로 이어져요.",
+    backToChooser: "처음 선택으로 돌아가기",
     ideaTitle: "💡 아이디어만 있어요",
     ideaDesc: "만들고 싶은 걸 말하면 확인할 항목으로 정리해드려요.",
     codeTitle: "🔗 이미 만든 앱이 있어요",

--- a/apps/dashboard/src/lib/workflow-store.ts
+++ b/apps/dashboard/src/lib/workflow-store.ts
@@ -170,3 +170,33 @@ export function generateOutcomeId(): string {
   const rand = Math.random().toString(36).slice(2, 5);
   return `oc_${ts}${rand}`;
 }
+
+// ── Server-sync failure flag (UX P1: silent .catch(() => undefined) saves) ──
+// Local-first saves fire-and-forget to the server; when that write fails the
+// user must still learn about it. Callers mark the project here and the
+// project overview shows a one-time dismissible banner.
+const SYNC_FAILED_KEY = "simsa:sync-failed";
+
+export function markProjectSyncFailed(projectId: string): void {
+  try {
+    const raw = window.localStorage.getItem(SYNC_FAILED_KEY);
+    const list: string[] = raw ? (JSON.parse(raw) as string[]) : [];
+    if (!list.includes(projectId)) list.push(projectId);
+    window.localStorage.setItem(SYNC_FAILED_KEY, JSON.stringify(list));
+  } catch {
+    /* storage unavailable — nothing else we can do */
+  }
+}
+
+export function consumeProjectSyncFailed(projectId: string): boolean {
+  try {
+    const raw = window.localStorage.getItem(SYNC_FAILED_KEY);
+    if (!raw) return false;
+    const list = JSON.parse(raw) as string[];
+    if (!list.includes(projectId)) return false;
+    window.localStorage.setItem(SYNC_FAILED_KEY, JSON.stringify(list.filter((x) => x !== projectId)));
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
라이브 스모크 피드백: "아이디어만 있어요" 진입 후 갈래 선택으로 돌아갈 수 없고, 이미 /projects/new에 있으면 사이드바 "새 프로젝트" 버튼이 무반응(같은 주소 링크 + 클라이언트 state 유지).

수정 — 갈래 선택을 URL로 미러링 (`/projects/new` = 선택 화면, `?path=idea|code|spec` = 해당 갈래):
- **브라우저 뒤로가기** 작동 (URL이 바뀌므로)
- **"새 프로젝트" 재클릭** → plain /projects/new 이동 → 선택 화면 복귀
- 각 갈래 스텝1 상단에 **테두리 있는 "← 처음 선택으로 돌아가기" 버튼** (티나게)
- 돌아가도 입력하던 텍스트는 유지 (화면만 전환)
- useSearchParams Suspense 래핑, branch.backToChooser EN/KO

dashboard 406 pass · typecheck/build green. 머지 후 dashboard만 재배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)