### PR TITLE
베타 무료 정직 표기 + 결과→목록 반영 + 전역 드래그앤드롭

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { I18nProvider } from "@/i18n/I18nProvider";
 import { AppSidebar } from "@/components/AppSidebar";
+import { GlobalDropZone } from "@/components/GlobalDropZone";
 import { LanguageToggle } from "@/components/LanguageToggle";
 import { BRAND } from "@/lib/brand.mjs";
 
@@ -21,6 +22,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
       <body className="bg-[#faf8f3] text-gray-900 antialiased">
         <I18nProvider>
+          <GlobalDropZone />
           {/* App shell: slim left sidebar (like an AI-platform workspace) + spacious main */}
           <div className="flex min-h-screen">
             <AppSidebar />

--- a/apps/dashboard/src/app/projects/[id]/github/history/[runId]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/history/[runId]/page.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { getProject } from "@/lib/mock-data";
-import { getLocalProject, loadExtendedProjectData, getUserKey } from "@/lib/workflow-store";
+import { getLocalProject, loadExtendedProjectData, getUserKey, applyReviewResultsToLocalProject } from "@/lib/workflow-store";
 import {
   getReviewRunDetail,
   generatePRFixBrief,
@@ -817,6 +817,11 @@ function ReviewItemSelectionPanel({
         <p className="text-xs text-gray-500 mt-0.5">
           {t.runDetail.selDesc}
         </p>
+        {items.length > 0 && items.every((i) => i.status === "passed") && (
+          <p className="mt-1.5 rounded-md bg-green-50 px-2.5 py-1.5 text-xs text-green-700">
+            {t.runDetail.allPassedNote}
+          </p>
+        )}
         <div className="flex flex-wrap gap-1.5 mt-2.5">
           <button
             onClick={() => onChange(recommendedRerunItemIds(items))}
@@ -1012,6 +1017,10 @@ export default function RunDetailPage() {
         return;
       }
       setDetail({ repoFullName: res.repoFullName, prNumber: res.prNumber, run: res.run });
+      // Keep list/overview progress in sync with what this run concluded.
+      if (res.run.status !== "running" && res.run.results) {
+        applyReviewResultsToLocalProject(id, res.run.results);
+      }
 
       // Stage 44: restore stored selection, else recommended fallback.
       const validItemIds = res.run.results.map((r) => r.itemId);

--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { getProject } from "@/lib/mock-data";
-import { getLocalProject, loadExtendedProjectData, getUserKey, saveProject, saveExtendedProjectData, markProjectSyncFailed } from "@/lib/workflow-store";
+import { getLocalProject, loadExtendedProjectData, getUserKey, saveProject, saveExtendedProjectData, markProjectSyncFailed, applyReviewResultsToLocalProject } from "@/lib/workflow-store";
 import { callWorkspaceApi } from "@/lib/workspace-api";
 import { saveProjectToDb } from "@/lib/workspace-check-api";
 import {
@@ -132,6 +132,7 @@ export default function GitHubPage() {
         setReviewRuns((prev) => ({ ...prev, [prNumber]: latest.run! }));
         setReviewPhase((prev) => ({ ...prev, [prNumber]: "done" }));
         setJustCompletedByPr((prev) => ({ ...prev, [prNumber]: true }));
+        if (latest.run.results) applyReviewResultsToLocalProject(id, latest.run.results);
         return true;
       }
     }
@@ -163,6 +164,9 @@ export default function GitHubPage() {
         const reviewRes = await getLatestPRReview(id, lp.number, getUserKey());
         if (reviewRes.ok && reviewRes.run) {
           setReviewRuns((prev) => ({ ...prev, [lp.number]: reviewRes.run! }));
+          if (reviewRes.run.status !== "running" && reviewRes.run.results) {
+            applyReviewResultsToLocalProject(id, reviewRes.run.results);
+          }
           if (reviewRes.run.status === "running") {
             // A review is still executing server-side (user navigated away and
             // came back) — resume the running view and keep polling instead of
@@ -268,6 +272,7 @@ export default function GitHubPage() {
       setReviewRuns((prev) => ({ ...prev, [lp.number]: res.run }));
       setReviewPhase((prev) => ({ ...prev, [lp.number]: "done" }));
       setJustCompletedByPr((prev) => ({ ...prev, [lp.number]: true }));
+      if (res.run.results) applyReviewResultsToLocalProject(id, res.run.results);
       if (res.creditEnforcement) {
         setCreditDryRunByPr((prev) => ({ ...prev, [lp.number]: res.creditEnforcement! }));
       } else if (res.creditDryRun) {
@@ -695,6 +700,17 @@ function CreditDryRunBanner({ t, dryRun, projectId }: { t: Dictionary; dryRun: C
   const covered = dryRun.allowance?.coveredByAllowance === true;
   const enforcement = dryRun as CreditEnforcementResult;
   const blocked = enforcement.actualDebitsEnabled === true && enforcement.blocked === true;
+
+  // Beta: actual debits are OFF. The "이번 달 0/5 · 5회 무료 남음" counter is a
+  // post-beta pricing SIMULATION and read like a real limit ("5번 무료?" — Bae).
+  // While debits are off, say the one true thing and nothing else.
+  if (enforcement.actualDebitsEnabled !== true) {
+    return (
+      <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+        <p className="text-xs text-slate-600">{t.credit.disabledBeta}</p>
+      </div>
+    );
+  }
 
   // Product-friendly: hide internal billing flags (dry-run, rollout, debit ledger).
   // During beta actual debits are off, so the common case is "charging disabled".

--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -19,6 +19,7 @@ import type {
 } from "@/lib/workspace-types";
 // Stage 267 — draft rendering shared with the document-intake draft page.
 import { UnderstoodCard, SpecDraftBody } from "@/components/SpecDraftView";
+import { DROPPED_DOC_KEY, DROPPED_DOC_NAME_KEY } from "@/components/GlobalDropZone";
 import { useI18n } from "@/i18n/I18nProvider";
 import type { Dictionary } from "@/i18n/dictionary.mjs";
 
@@ -105,6 +106,38 @@ function NewProjectInner() {
       setRateLimitMsg(null);
     }
   }, [searchParams]);
+
+  // A document dropped anywhere on the site (GlobalDropZone) lands here:
+  // prefill the paste box from the sessionStorage hand-off, once.
+  const [loadedFileName, setLoadedFileName] = useState<string | null>(null);
+  useEffect(() => {
+    if (searchParams.get("path") !== "spec") return;
+    try {
+      const text = window.sessionStorage.getItem(DROPPED_DOC_KEY);
+      if (text) {
+        setIdeaText(text);
+        setLoadedFileName(window.sessionStorage.getItem(DROPPED_DOC_NAME_KEY));
+        window.sessionStorage.removeItem(DROPPED_DOC_KEY);
+        window.sessionStorage.removeItem(DROPPED_DOC_NAME_KEY);
+      }
+    } catch {
+      /* storage unavailable */
+    }
+  }, [searchParams]);
+
+  async function handleSpecFile(file: File | undefined) {
+    if (!file) return;
+    if (!(file.type.startsWith("text/") || /\.(txt|md|markdown)$/i.test(file.name))) {
+      setRateLimitMsg(t.dropzone.unsupported);
+      return;
+    }
+    const text = await file.slice(0, 300_000).text().catch(() => "");
+    if (text.trim()) {
+      setIdeaText(text);
+      setLoadedFileName(file.name);
+      setRateLimitMsg(null);
+    }
+  }
 
   function chooseBranch(id: "idea" | "code" | "spec") {
     setEntryPath(id); // immediate — the effect above re-confirms from the URL
@@ -418,7 +451,24 @@ function NewProjectInner() {
             <div>
               <BackToChooserButton />
               <h1 className="text-2xl font-semibold tracking-tight text-gray-900">{t.branch.specStepTitle}</h1>
-              <p className="mb-8 mt-2 text-sm text-gray-500">{t.branch.specStepSub}</p>
+              <p className="mb-4 mt-2 text-sm text-gray-500">{t.branch.specStepSub}</p>
+              <div className="mb-3 flex flex-wrap items-center gap-3">
+                <label className="btn btn-md btn-secondary cursor-pointer">
+                  {t.branch.uploadFile}
+                  <input
+                    type="file"
+                    accept=".txt,.md,.markdown,text/plain,text/markdown"
+                    className="hidden"
+                    onChange={(e) => void handleSpecFile(e.target.files?.[0])}
+                  />
+                </label>
+                <span className="text-xs text-gray-500">{t.branch.uploadHint}</span>
+                {loadedFileName && (
+                  <span className="rounded-full border border-green-200 bg-green-50 px-2.5 py-1 text-xs text-green-700">
+                    ✓ {loadedFileName}
+                  </span>
+                )}
+              </div>
               <textarea
                 value={ideaText}
                 onChange={(e) => setIdeaText(e.target.value)}

--- a/apps/dashboard/src/components/GlobalDropZone.tsx
+++ b/apps/dashboard/src/components/GlobalDropZone.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+/**
+ * Site-wide drag-and-drop target (Bae: "드래그앤드롭은 전체 사이트 어디에 놔도
+ * 들어가게"). Dropping a text document anywhere starts the spec branch with
+ * the file's content prefilled.
+ *
+ * Scope (honest): reads .txt / .md / text/* client-side. PDF/Word need a
+ * parsing pipeline — until then the overlay says so instead of failing
+ * silently. Content is handed off via sessionStorage (never uploaded here).
+ */
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useI18n } from "@/i18n/I18nProvider";
+
+export const DROPPED_DOC_KEY = "simsa:dropped-doc";
+export const DROPPED_DOC_NAME_KEY = "simsa:dropped-doc-name";
+const MAX_TEXT_BYTES = 300_000;
+
+function isTextLike(file: File): boolean {
+  if (file.type.startsWith("text/")) return true;
+  return /\.(txt|md|markdown)$/i.test(file.name);
+}
+
+export function GlobalDropZone() {
+  const { t } = useI18n();
+  const router = useRouter();
+  const [dragging, setDragging] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  // dragenter/leave fire for every child element — depth counter avoids flicker.
+  const depthRef = useRef(0);
+
+  useEffect(() => {
+    function hasFiles(e: DragEvent): boolean {
+      return Array.from(e.dataTransfer?.types ?? []).includes("Files");
+    }
+    function onDragEnter(e: DragEvent) {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      depthRef.current += 1;
+      setDragging(true);
+    }
+    function onDragOver(e: DragEvent) {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+    }
+    function onDragLeave(e: DragEvent) {
+      if (!hasFiles(e)) return;
+      depthRef.current = Math.max(0, depthRef.current - 1);
+      if (depthRef.current === 0) setDragging(false);
+    }
+    function onDrop(e: DragEvent) {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      depthRef.current = 0;
+      setDragging(false);
+      const file = e.dataTransfer?.files?.[0];
+      if (!file) return;
+      if (!isTextLike(file)) {
+        setNotice(t.dropzone.unsupported);
+        window.setTimeout(() => setNotice(null), 6000);
+        return;
+      }
+      file
+        .slice(0, MAX_TEXT_BYTES)
+        .text()
+        .then((text) => {
+          if (!text.trim()) return;
+          try {
+            window.sessionStorage.setItem(DROPPED_DOC_KEY, text);
+            window.sessionStorage.setItem(DROPPED_DOC_NAME_KEY, file.name);
+          } catch {
+            /* storage unavailable — nothing to hand off */
+            return;
+          }
+          router.push("/projects/new?path=spec&dropped=1");
+        })
+        .catch(() => {
+          setNotice(t.dropzone.readError);
+          window.setTimeout(() => setNotice(null), 6000);
+        });
+    }
+    window.addEventListener("dragenter", onDragEnter);
+    window.addEventListener("dragover", onDragOver);
+    window.addEventListener("dragleave", onDragLeave);
+    window.addEventListener("drop", onDrop);
+    return () => {
+      window.removeEventListener("dragenter", onDragEnter);
+      window.removeEventListener("dragover", onDragOver);
+      window.removeEventListener("dragleave", onDragLeave);
+      window.removeEventListener("drop", onDrop);
+    };
+  }, [router, t]);
+
+  return (
+    <>
+      {dragging && (
+        <div className="pointer-events-none fixed inset-0 z-[100] flex items-center justify-center bg-brand-600/10 backdrop-blur-[1px]">
+          <div className="rounded-xl border-2 border-dashed border-brand-400 bg-white px-8 py-6 text-center shadow-lg">
+            <p className="text-base font-semibold text-gray-900">{t.dropzone.title}</p>
+            <p className="mt-1 text-sm text-gray-500">{t.dropzone.hint}</p>
+          </div>
+        </div>
+      )}
+      {notice && (
+        <div className="fixed bottom-4 left-1/2 z-[100] -translate-x-1/2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-800 shadow-md">
+          {notice}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -247,6 +247,8 @@ export type Dictionary = {
     subtitle: string;
     backToChooser: string;
     backToPaste: string;
+    uploadFile: string;
+    uploadHint: string;
     ideaTitle: string;
     ideaDesc: string;
     codeTitle: string;
@@ -768,6 +770,12 @@ export type Dictionary = {
     testSent: string;
     testError: string;
   };
+  dropzone: {
+    title: string;
+    hint: string;
+    unsupported: string;
+    readError: string;
+  };
   nf: {
     title: string;
     body: string;
@@ -926,6 +934,7 @@ export type Dictionary = {
     usageNote: string;
   };
   runDetail: {
+    allPassedNote: string;
     backToHistory: string;
     loading: string;
     notFoundTitle: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -301,6 +301,8 @@ const EN = {
     subtitle: "Pick whatever fits — you'll end up in the same place: your app, reviewed.",
     backToChooser: "Back to the three choices",
     backToPaste: "Back to your document",
+    uploadFile: "Load from file",
+    uploadHint: "Text files (.txt / .md) — or drop a file anywhere on the screen.",
     ideaTitle: "💡 I just have an idea",
     ideaDesc: "Describe what you want to build. We'll turn it into things to check.",
     codeTitle: "🔗 I already built an app",
@@ -857,6 +859,12 @@ const EN = {
     testSent: "Test email sent. Check your inbox.",
     testError: "Could not send. Check the address and try again.",
   },
+  dropzone: {
+    title: "Drop it here to start from your document",
+    hint: "Text files (.txt / .md) are read right away.",
+    unsupported: "Only text files (.txt / .md) can be read for now — PDF/Word is coming. Please copy and paste the content instead.",
+    readError: "Couldn't read that file. Please copy and paste the content instead.",
+  },
   nf: {
     title: "We can't find this project in this browser",
     body: "Projects are stored in the browser where they were created. If you made it in another browser or an incognito window, open it there.",
@@ -1015,6 +1023,7 @@ const EN = {
     usageNote: "Download the ZIP, unzip it into your project's code folder (the top of the repository), and use it directly in Claude Code or Codex. When the AI has updated the code changes (PR), come back and press Check again.",
   },
   runDetail: {
+    allPassedNote: "Everything passed — re-checking is optional. As a final step, open your live app and try it yourself.",
     backToHistory: "← Back to review history",
     loading: "Loading the review…",
     notFoundTitle: "We couldn't find this review.",
@@ -2423,6 +2432,8 @@ const KO = {
     subtitle: "지금 갖고 계신 걸 고르세요 — 어느 쪽이든 결국 '내 앱 검수'로 이어져요.",
     backToChooser: "처음 선택으로 돌아가기",
     backToPaste: "붙여넣기로 돌아가기",
+    uploadFile: "파일에서 불러오기",
+    uploadHint: "텍스트 파일(.txt/.md) — 화면 아무 데나 끌어다 놓아도 돼요.",
     ideaTitle: "💡 아이디어만 있어요",
     ideaDesc: "만들고 싶은 걸 말하면 확인할 항목으로 정리해드려요.",
     codeTitle: "🔗 이미 만든 앱이 있어요",
@@ -2979,6 +2990,12 @@ const KO = {
     testSent: "테스트 메일을 보냈어요. 받은편지함을 확인해주세요.",
     testError: "전송에 실패했어요. 주소가 맞는지 확인해주세요.",
   },
+  dropzone: {
+    title: "여기에 놓으면 이 문서로 시작해요",
+    hint: "텍스트 파일(.txt/.md)은 바로 읽어 드려요.",
+    unsupported: "지금은 텍스트 파일(.txt/.md)만 읽을 수 있어요 — PDF/Word는 준비 중이에요. 내용을 복사해 붙여넣어 주세요.",
+    readError: "파일을 읽지 못했어요. 내용을 복사해 붙여넣어 주세요.",
+  },
   nf: {
     title: "이 브라우저에서 프로젝트를 찾을 수 없어요",
     body: "프로젝트는 만든 브라우저에 저장돼요. 다른 브라우저나 시크릿 창에서 만들었다면 그곳에서 열어주세요.",
@@ -3137,6 +3154,7 @@ const KO = {
     usageNote: "ZIP을 다운받아 프로젝트 코드 폴더(저장소 최상위)에 압축 해제하면 Claude Code나 Codex에서 바로 사용할 수 있어요. AI가 코드 변경(PR)을 갱신하면 돌아와서 다시 확인을 눌러주세요.",
   },
   runDetail: {
+    allPassedNote: "모든 항목이 통과했어요 — 다시 확인은 선택이에요. 마지막으로 라이브 앱을 직접 열어 확인해보는 걸 추천해요.",
     backToHistory: "← 확인 기록으로 돌아가기",
     loading: "확인 결과를 불러오는 중…",
     notFoundTitle: "확인 결과를 찾을 수 없어요.",

--- a/apps/dashboard/src/lib/workflow-store.ts
+++ b/apps/dashboard/src/lib/workflow-store.ts
@@ -202,3 +202,32 @@ export function consumeProjectSyncFailed(projectId: string): boolean {
     return false;
   }
 }
+
+/**
+ * Apply PR-review run results to the local project's requirement statuses.
+ *
+ * Review results lived only in the run — the project list kept showing
+ * "0% · 시작 전 N" even after items passed (2026-07-05 live finding). Any
+ * surface that lands a finished run calls this so 목록/개요 진행률이 실제
+ * 검수 결과를 반영한다. Unknown itemIds are ignored (deleted items).
+ */
+export function applyReviewResultsToLocalProject(
+  projectId: string,
+  results: ReadonlyArray<{ itemId: string; status: string }>,
+): void {
+  if (typeof window === "undefined" || results.length === 0) return;
+  const project = getLocalProject(projectId);
+  if (!project) return; // mock/demo projects are read-only
+  const byId = new Map(results.map((r) => [r.itemId, r.status]));
+  const allowed = new Set(["passed", "failed", "inconclusive", "needs_decision"]);
+  let changed = false;
+  const requirements = project.requirements.map((req) => {
+    const next = byId.get(req.id);
+    if (next && allowed.has(next) && next !== req.status) {
+      changed = true;
+      return { ...req, status: next as typeof req.status };
+    }
+    return req;
+  });
+  if (changed) saveProject({ ...project, requirements });
+}


### PR DESCRIPTION
라이브 테스트 추가 지적 4건:

1. **"5번 무료?" 혼란 제거** — 크레딧 배너의 "이번 달 0/5 · 5회 무료 남음"은 베타 후 요금 모델의 시뮬레이션인데 실제 제한처럼 읽혔음. 실차감 OFF(베타) 동안은 **"베타 기간이라 이 확인은 무료예요" 한 줄만** 표시 (카운터·잔액 링크 숨김). 차감이 실제로 켜지면 기존 표시로 복귀.
2. **전부 통과 시** — 선택 패널에 초록 안내: "모든 항목이 통과했어요 — 다시 확인은 선택이에요. 마지막으로 라이브 앱을 직접 열어 확인해보는 걸 추천해요." (1개 선택돼 있던 건 이전 실행 때 저장한 선택이 유지된 것)
3. **검수 결과 → 프로젝트 목록 반영** — 결과가 run에만 있어 목록이 "0% · 시작 전 8"이던 문제. `applyReviewResultsToLocalProject`가 결과를 항목 상태로 되써서 목록/개요 진행률이 실제를 반영 (실행 성공·폴링 복귀·탭 재방문·run 상세 로드 전부에서).
4. **전역 드래그앤드롭 + 파일 업로드** — 사이트 아무 데나 문서를 놓으면 기획서 갈래가 내용 채워진 채 열림(GlobalDropZone), 기획서 화면에 "파일에서 불러오기" 버튼. 정직한 범위: 지금은 .txt/.md, PDF/Word는 "준비 중" 안내(무음 실패 금지).

dashboard 406 pass · typecheck/build green. 머지 후 dashboard만 재배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)