### PR TITLE
정직한 실패 — 조용한 강등 전면 제거 + KO 생성 prefill 수정

### DIFF
--- a/apps/central-plane/src/routes/workspace-document-intake.ts
+++ b/apps/central-plane/src/routes/workspace-document-intake.ts
@@ -168,8 +168,8 @@ export function createWorkspaceDocumentIntakeRoutes(): Hono<{ Bindings: Env }> {
     }
 
     // ── Generate via the SAME path as idea-to-spec-draft ────────────────────
-    // generateIdeaToSpecDraft degrades to a deterministic mock-fallback when
-    // ANTHROPIC_API_KEY is absent or the LLM call fails — preserved here.
+    // generateIdeaToSpecDraft keeps the keyless dev mock, but an LLM FAILURE
+    // now surfaces as 503 llm_unavailable (honest-failures policy).
     const input = buildDocumentDraftPrompt(extracted.text, {
       title: project.title,
       idea: typeof project.idea === "string" ? project.idea : "",
@@ -184,6 +184,11 @@ export function createWorkspaceDocumentIntakeRoutes(): Hono<{ Bindings: Env }> {
     }
 
     await incrementRateLimitCount(c.env.DB, ipHash, hourUtc);
+
+    // Honest failure: never hand a fabricated draft for a real document.
+    if (result.ok === false) {
+      return c.json({ ok: false, error: "llm_unavailable" }, 503);
+    }
 
     // Record usage event (non-fatal)
     await insertUsageEvent(c.env, {

--- a/apps/central-plane/src/routes/workspace-membership.ts
+++ b/apps/central-plane/src/routes/workspace-membership.ts
@@ -70,7 +70,8 @@ export function createWorkspaceMembershipRoutes(): Hono<{ Bindings: Env }> {
           name: String(r.name),
           role: String(r.role),
         }));
-      } catch {
+      } catch (err) {
+        console.error("[workspace-membership] workspaces query failed (shown as none):", err);
         workspaces = [];
       }
     }
@@ -83,7 +84,8 @@ export function createWorkspaceMembershipRoutes(): Hono<{ Bindings: Env }> {
           .first<{ n?: number }>();
         const n = Number(row?.n ?? 0);
         legacyProjectCount = Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
-      } catch {
+      } catch (err) {
+        console.error("[workspace-membership] project-count query failed (shown as 0):", err);
         legacyProjectCount = 0;
       }
     }

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -238,6 +238,15 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
     // Increment rate-limit counter after successful generation (non-fatal)
     await incrementRateLimitCount(c.env.DB, ipHash, hourUtc);
 
+    // Honest failure (2026-07-05): the LLM being down must LOOK down — a 503
+    // the client renders as "다시 시도해주세요", never a fabricated draft.
+    if (result.ok === false) {
+      return new Response(JSON.stringify({ ok: false, error: "llm_unavailable" }), {
+        status: 503,
+        headers: { "content-type": "application/json", ...headers },
+      });
+    }
+
     // Record usage event (non-fatal)
     await insertUsageEvent(c.env, {
       userKey: typeof (body as Record<string, unknown>)["userKey"] === "string"
@@ -423,6 +432,10 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
 
     await incrementRateLimitCount(c.env.DB, ipHash, hourUtc);
 
+    if (result.ok === false) {
+      return new Response(JSON.stringify({ ok: false, error: "llm_unavailable" }), { status: 503, headers: { "content-type": "application/json", ...headers } });
+    }
+
     // Best-effort persist check run to D1 — only into projects the caller owns.
     if (req.projectId && checkProjectOwned) {
       saveCheckRun(c.env, req.projectId, result.source, result).catch(() => undefined);
@@ -488,6 +501,10 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
 
     await incrementRateLimitCount(c.env.DB, ipHash, hourUtc);
 
+    if (result.ok === false) {
+      return new Response(JSON.stringify({ ok: false, error: "llm_unavailable" }), { status: 503, headers: { "content-type": "application/json", ...headers } });
+    }
+
     if (req.projectId && fixProjectOwned) {
       saveFixSuggestionToDb(c.env, req.projectId, req.item.id, result.suggestion).catch(() => undefined);
     }
@@ -547,7 +564,10 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
           items: Array.isArray(dbProj.items) ? dbProj.items : [],
         };
       } catch (err) {
-        console.warn("[workspace/export] D1 load failed:", err);
+        // Honest failure: a DB error must not become an empty "successful"
+        // export (ok:true, fileCount:0) — say it failed so the user retries.
+        console.error("[workspace/export] D1 load failed:", err);
+        return new Response(JSON.stringify({ ok: false, error: "project_load_failed" }), { status: 500, headers: { "content-type": "application/json", ...headers } });
       }
     }
 

--- a/apps/central-plane/src/workspace/check.ts
+++ b/apps/central-plane/src/workspace/check.ts
@@ -312,7 +312,7 @@ function isValidCheckResponse(v: unknown): v is { results: CheckResultItem[] } {
 export async function generateCheckDraft(
   req: WorkspaceCheckDraftRequest,
   anthropicApiKey: string | undefined,
-): Promise<WorkspaceCheckDraftResponse> {
+): Promise<WorkspaceCheckDraftResponse | { ok: false; error: "llm_unavailable" }> {
   if (!req.items?.length) {
     return {
       ok: true,
@@ -334,20 +334,26 @@ export async function generateCheckDraft(
     rawText = await callAnthropic(anthropicApiKey, prompt);
   } catch (err) {
     console.error("[workspace/check] LLM call failed:", err);
-    return buildMockCheckFallback(req);
+    return { ok: false as const, error: "llm_unavailable" as const };
   }
 
   const jsonMatch = rawText.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) return buildMockCheckFallback(req);
+  if (!jsonMatch) {
+    console.warn("[workspace/check] LLM returned non-JSON. head:", rawText.slice(0, 200));
+    return { ok: false as const, error: "llm_unavailable" as const };
+  }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonMatch[0]);
   } catch {
-    return buildMockCheckFallback(req);
+    return { ok: false as const, error: "llm_unavailable" as const };
   }
 
-  if (!isValidCheckResponse(parsed)) return buildMockCheckFallback(req);
+  if (!isValidCheckResponse(parsed)) {
+    console.warn("[workspace/check] response failed shape validation");
+    return { ok: false as const, error: "llm_unavailable" as const };
+  }
 
   const resultMap = new Map(req.items.map((i) => [i.id, i.title]));
   const results: CheckResultItem[] = (parsed.results as CheckResultItem[]).map((r) => ({

--- a/apps/central-plane/src/workspace/fix.ts
+++ b/apps/central-plane/src/workspace/fix.ts
@@ -219,7 +219,7 @@ function isValidFixResponse(v: unknown): v is { plainSummary: string; builderBri
 export async function generateFixSuggestion(
   req: WorkspaceFixSuggestionRequest,
   anthropicApiKey: string | undefined,
-): Promise<WorkspaceFixSuggestionResponse> {
+): Promise<WorkspaceFixSuggestionResponse | { ok: false; error: "llm_unavailable" }> {
   if (!anthropicApiKey) {
     console.warn("[workspace/fix] no API key — using mock fallback");
     return buildMockFixFallback(req);
@@ -231,20 +231,27 @@ export async function generateFixSuggestion(
     rawText = await callAnthropic(anthropicApiKey, prompt);
   } catch (err) {
     console.error("[workspace/fix] LLM call failed:", err);
-    return buildMockFixFallback(req);
+    return { ok: false as const, error: "llm_unavailable" as const };
   }
 
   const jsonMatch = rawText.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) return buildMockFixFallback(req);
+  if (!jsonMatch) {
+    console.warn("[workspace/fix] LLM returned non-JSON. head:", rawText.slice(0, 200));
+    return { ok: false as const, error: "llm_unavailable" as const };
+  }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonMatch[0]);
   } catch {
-    return buildMockFixFallback(req);
+    console.warn("[workspace/fix] JSON parse failed");
+    return { ok: false as const, error: "llm_unavailable" as const };
   }
 
-  if (!isValidFixResponse(parsed)) return buildMockFixFallback(req);
+  if (!isValidFixResponse(parsed)) {
+    console.warn("[workspace/fix] response failed shape validation");
+    return { ok: false as const, error: "llm_unavailable" as const };
+  }
 
   const p = parsed as FixSuggestion;
   return {

--- a/apps/central-plane/src/workspace/generate.ts
+++ b/apps/central-plane/src/workspace/generate.ts
@@ -191,7 +191,17 @@ async function callAnthropic(
 ): Promise<string> {
   const data = (await anthropicMessages(
     apiKey,
-    { model: "claude-haiku-4-5-20251001", max_tokens: 8000, messages: [{ role: "user", content: prompt }] },
+    {
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 8000,
+      // Assistant prefill: the reply MUST continue from "{" — a refusal or a
+      // prose preamble becomes impossible. (Live 2026-07-05: the KO prompt
+      // consistently got a 222-char text answer instead of JSON.)
+      messages: [
+        { role: "user", content: prompt },
+        { role: "assistant", content: "{" },
+      ],
+    },
     timeoutMs,
   )) as {
     content?: Array<{ type: string; text?: string }>;
@@ -204,7 +214,7 @@ async function callAnthropic(
     `[workspace/generate] blocks=${(data.content ?? []).map((b) => b.type).join(",") || "none"}` +
       ` textLen=${text.length} stop=${data.stop_reason ?? "?"}`,
   );
-  return text;
+  return "{" + text;
 }
 
 // ─── Validation ───────────────────────────────────────────────────────────────
@@ -501,7 +511,7 @@ function buildMockFallback(req: IdeaToSpecDraftRequest): IdeaToSpecDraftResponse
 export async function generateIdeaToSpecDraft(
   req: IdeaToSpecDraftRequest,
   anthropicApiKey: string | undefined,
-): Promise<IdeaToSpecDraftResponse> {
+): Promise<IdeaToSpecDraftResponse | { ok: false; error: "llm_unavailable" }> {
   if (!req.idea?.trim()) {
     return { ...buildMockFallback(req), warnings: ["아이디어를 입력해주세요."] };
   }
@@ -516,28 +526,29 @@ export async function generateIdeaToSpecDraft(
     rawText = await callAnthropic(anthropicApiKey, prompt);
   } catch (err) {
     console.error("[workspace/generate] LLM call failed:", err);
-    return buildMockFallback(req);
+    return { ok: false as const, error: "llm_unavailable" as const };
   }
 
   // Extract JSON — LLM sometimes wraps in code fences despite instructions
   const cleaned = rawText.replace(/```(?:json)?/g, "").trim();
   const jsonMatch = cleaned.match(/\{[\s\S]*\}/);
   if (!jsonMatch) {
-    console.warn("[workspace/generate] LLM returned non-JSON, falling back");
-    return buildMockFallback(req);
+    // Head of the model text (ops diagnostic — this only fires on failure).
+    console.warn("[workspace/generate] LLM returned non-JSON. head:", cleaned.slice(0, 200));
+    return { ok: false as const, error: "llm_unavailable" as const };
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonMatch[0]);
   } catch {
-    console.warn("[workspace/generate] JSON parse failed, falling back");
-    return buildMockFallback(req);
+    console.warn("[workspace/generate] JSON parse failed. head:", cleaned.slice(0, 200));
+    return { ok: false as const, error: "llm_unavailable" as const };
   }
 
   if (!isValidResponse(parsed)) {
-    console.warn("[workspace/generate] Response failed shape validation, falling back");
-    return buildMockFallback(req);
+    console.warn("[workspace/generate] Response failed shape validation");
+    return { ok: false as const, error: "llm_unavailable" as const };
   }
 
   // Ensure all items have status: "not_started"

--- a/apps/central-plane/src/workspace/pr-review.ts
+++ b/apps/central-plane/src/workspace/pr-review.ts
@@ -314,21 +314,31 @@ export async function reviewPRAgainstItems(
     rawText = out.text;
     tokensConsumed = out.tokens;
   } catch (err) {
+    // Honest failure (2026-07-05 census #1): heuristic verdicts could emit
+    // "passed" for code no model ever reviewed — and even reach a GitHub
+    // comment. An LLM failure now fails the run visibly (error + retry).
     console.error("[workspace/pr-review] LLM call failed:", err);
-    return buildMockFallback(req);
+    throw new Error("llm_unavailable");
   }
 
   const jsonMatch = rawText.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) return buildMockFallback(req);
+  if (!jsonMatch) {
+    console.warn("[workspace/pr-review] LLM returned non-JSON. head:", rawText.slice(0, 200));
+    throw new Error("llm_unavailable");
+  }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonMatch[0]);
   } catch {
-    return buildMockFallback(req);
+    console.warn("[workspace/pr-review] JSON parse failed");
+    throw new Error("llm_unavailable");
   }
 
-  if (!isValidResponse(parsed)) return buildMockFallback(req);
+  if (!isValidResponse(parsed)) {
+    console.warn("[workspace/pr-review] response failed shape validation");
+    throw new Error("llm_unavailable");
+  }
 
   const resultMap = new Map(req.items.map((i) => [i.id, i.title]));
   const results: CheckResultItem[] = (parsed.results as CheckResultItem[]).map((r) => ({

--- a/apps/central-plane/test/workspace-generate.test.mjs
+++ b/apps/central-plane/test/workspace-generate.test.mjs
@@ -82,16 +82,15 @@ describe("generateIdeaToSpecDraft", () => {
     assert.ok(Array.isArray(result.warnings));
   });
 
-  it("returns mock-fallback when Anthropic returns non-JSON", async () => {
-    // Simulate malformed LLM response via a fake API key that hits a mock
-    // We test the fallback path by passing a key that will get a network error
+  it("returns an EXPLICIT llm_unavailable error when the LLM call fails (honest-failures policy)", async () => {
+    // 2026-07-05: a failing LLM must never fabricate a draft that looks real.
+    // A bad key exhausts the retry helper and surfaces as an explicit error.
     const result = await generateIdeaToSpecDraft(
       { idea: "테스트 아이디어" },
       "fake-key-will-fail",
     );
-    // Should still return valid shape (fallback)
-    assert.equal(result.ok, true);
-    assertValidResponse(result);
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "llm_unavailable");
   });
 
   it("items all have status not_started", async () => {

--- a/apps/dashboard/src/app/account/page.tsx
+++ b/apps/dashboard/src/app/account/page.tsx
@@ -7,7 +7,8 @@
 // scaffold): the requiresSignIn/planned badge farm and the "공개 가입이
 // 아닙니다" copy are gone — sign-up IS open, login is a first-class flow, and
 // this page is where "who am I / how do I sign out" must be obvious.
-import { useEffect, useState } from "react";
+import { useEffect, useState, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useI18n } from "@/i18n/I18nProvider";
 import { LanguageToggle } from "@/components/LanguageToggle";
@@ -22,6 +23,14 @@ import type { MembershipBridge, ClaimResult } from "@/lib/auth-client.mjs";
 import { getUserKey } from "@/lib/workflow-store";
 
 export default function AccountPage() {
+  return (
+    <Suspense fallback={null}>
+      <AccountInner />
+    </Suspense>
+  );
+}
+
+function AccountInner() {
   const { t } = useI18n();
   const a = t.account;
   const [displayName, setDisplayName] = useState("");
@@ -32,6 +41,8 @@ export default function AccountPage() {
   const [membership, setMembership] = useState<MembershipBridge | null>(null);
   const [claimPhase, setClaimPhase] = useState<"idle" | "working" | "done" | "error">("idle");
   const [claimResult, setClaimResult] = useState<ClaimResult | null>(null);
+  const searchParams = useSearchParams();
+  const claimFailedRedirect = searchParams?.get("claim") === "failed";
 
   useEffect(() => {
     setDisplayName(readDisplayName(typeof window !== "undefined" ? window.localStorage : null, ""));
@@ -99,6 +110,12 @@ export default function AccountPage() {
       {/* Sign-in state — the first thing this page must answer. */}
       <section className="card mt-6 p-5">
         <p className="section-title">{a.auth.heading}</p>
+
+        {claimFailedRedirect && claimPhase === "idle" && (
+          <p className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+            {a.auth.claimError}
+          </p>
+        )}
 
         {authStatus.status === "loading" && (
           <p className="mt-3 text-sm text-gray-500">{a.auth.loading}</p>

--- a/apps/dashboard/src/app/login/page.tsx
+++ b/apps/dashboard/src/app/login/page.tsx
@@ -45,7 +45,15 @@ function LoginInner() {
   // 로그인됨 ≠ 데이터연결됨 — the single post-login path: claim FIRST, then go.
   const claimAndGo = useCallback(async () => {
     setPhase("claiming");
-    await claimWorkspace(getUserKey()).catch(() => undefined);
+    const claim = await claimWorkspace(getUserKey()).catch(() => null);
+    if (!claim || claim.ok !== true) {
+      // Honest failure: the whole point of logging in was linking this
+      // browser's projects — a silent claim failure defeats it. The account
+      // page can retry; navigation continues so the user isn't stranded.
+      console.error("[login] claim failed after sign-in", claim);
+      router.replace(`/account?claim=failed`);
+      return;
+    }
     router.replace(nextPath);
   }, [router, nextPath]);
 

--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -88,7 +88,12 @@ export default function GitHubPage() {
       setGenPhase("idle");
       return;
     }
-    const generated = res.ok ? res.data : res.fallback;
+    if (!res.ok) {
+      setGenError(t.errors.llmUnavailable);
+      setGenPhase("idle");
+      return;
+    }
+    const generated = res.data;
     if (!generated?.items?.length) {
       setGenError(t.github.generateItemsError);
       setGenPhase("idle");

--- a/apps/dashboard/src/app/projects/[id]/items/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/items/page.tsx
@@ -140,7 +140,12 @@ export default function ItemsPage() {
       setGenPhase("idle");
       return;
     }
-    const generated = res.ok ? res.data : res.fallback;
+    if (!res.ok) {
+      setGenError(t.errors.llmUnavailable);
+      setGenPhase("idle");
+      return;
+    }
+    const generated = res.data;
     if (!generated?.items?.length) {
       setGenError(t.github.generateItemsError);
       setGenPhase("idle");

--- a/apps/dashboard/src/app/projects/[id]/settings/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/settings/page.tsx
@@ -38,7 +38,7 @@ export default function SettingsPage() {
   const justConnected = searchParams?.get("github") === "connected";
   const { t, locale } = useI18n();
 
-  const [phase, setPhase] = useState<"loading" | "disconnected" | "connected" | "selecting">("loading");
+  const [phase, setPhase] = useState<"loading" | "disconnected" | "status_error" | "connected" | "selecting">("loading");
   const [ghUser, setGhUser] = useState<GitHubUser | null>(null);
   const [repos, setRepos] = useState<GitHubRepo[]>([]);
   const [reposPhase, setReposPhase] = useState<"idle" | "loading" | "done" | "error">("idle");
@@ -223,7 +223,11 @@ export default function SettingsPage() {
       fetchProjectRepo(id, getUserKey()),
     ]);
 
-    if (statusRes.connected) {
+    if (statusRes.ok === false) {
+      // A transient status failure must not read as "not connected" — the user
+      // would re-run OAuth for nothing. Distinct error state + retry.
+      setPhase("status_error");
+    } else if (statusRes.connected) {
       setGhUser(statusRes.user);
       setPhase("connected");
     } else {
@@ -352,6 +356,15 @@ export default function SettingsPage() {
       )}
 
       {/* Not connected */}
+      {phase === "status_error" && (
+        <div className="card p-8 text-center">
+          <p className="mb-4 text-sm text-gray-600">{t.github.connectionLoadError}</p>
+          <button onClick={() => void loadStatus()} className="btn btn-md btn-primary">
+            {t.common.retry}
+          </button>
+        </div>
+      )}
+
       {phase === "disconnected" && (
         <div className="card p-8 text-center">
           {disconnectPhase === "done" && (

--- a/apps/dashboard/src/app/projects/[id]/sources/[sourceId]/draft/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/sources/[sourceId]/draft/page.tsx
@@ -35,6 +35,7 @@ import {
   loadExtendedProjectData,
   saveProject,
   saveExtendedProjectData,
+  markProjectSyncFailed,
 } from "@/lib/workflow-store";
 import { saveProjectToDb } from "@/lib/workspace-check-api";
 
@@ -131,7 +132,8 @@ export default function DocumentDraftPage() {
       understood: draft.understood,
       productSpec: draft.productSpec,
       items: draft.items,
-    }).catch(() => undefined);
+    }).then((res) => { if (!res || res.ok !== true) markProjectSyncFailed(id); })
+      .catch(() => markProjectSyncFailed(id));
     router.push(`/projects/${id}/spec`);
   }
 

--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -193,9 +193,8 @@ function NewProjectInner() {
     } else if (res.error === "rate_limited") {
       setRateLimitMsg(t.common.rateLimited);
     } else {
-      setResult(res.fallback);
-      setIsFallback(true);
-      setStep(2);
+      // Honest failure: no fabricated draft — say it failed, let them retry.
+      setRateLimitMsg(t.errors.llmUnavailable);
     }
     setIsLoading(false);
   }
@@ -216,9 +215,7 @@ function NewProjectInner() {
     } else if (res.error === "rate_limited") {
       setRateLimitMsg(t.common.rateLimited);
     } else {
-      setSpecResult(res.fallback);
-      setIsFallback(true);
-      setStep(4);
+      setRateLimitMsg(t.errors.llmUnavailable);
     }
     setIsGeneratingSpec(false);
   }
@@ -239,9 +236,7 @@ function NewProjectInner() {
     } else if (res.error === "rate_limited") {
       setRateLimitMsg(t.common.rateLimited);
     } else {
-      setSpecResult(res.fallback);
-      setIsFallback(true);
-      setStep(4);
+      setRateLimitMsg(t.errors.llmUnavailable);
     }
     setIsLoading(false);
   }
@@ -260,8 +255,10 @@ function NewProjectInner() {
     let generated: IdeaToSpecDraftResponse | null = null;
     if (codeDesc.trim()) {
       const res = await callWorkspaceApi({ idea: codeDesc.trim() });
+      // Honest failure: if generation fails the project is simply created
+      // without draft items (normal for this branch) — never with mock items
+      // silently saved as if they were real.
       if (res.ok) generated = res.data;
-      else if (res.error !== "rate_limited") generated = res.fallback;
     }
 
     const id = generateProjectId();

--- a/apps/dashboard/src/components/GlobalDropZone.tsx
+++ b/apps/dashboard/src/components/GlobalDropZone.tsx
@@ -83,6 +83,8 @@ export function GlobalDropZone() {
             );
           }
         } catch {
+          setNotice(t.dropzone.readError);
+          window.setTimeout(() => setNotice(null), 6000);
           return;
         }
         router.push("/projects/new?path=spec&dropped=1");

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -166,6 +166,7 @@ export type Dictionary = {
     rateLimited: string;
   };
   errors: {
+    llmUnavailable: string;
     generic: string;
     network: string;
     timeout: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -220,6 +220,7 @@ const EN = {
   // never see a raw code like "db_error" or "HTTP 500". Map at the render site
   // via errorText(t, code); unknown codes fall back to `generic`.
   errors: {
+    llmUnavailable: "The AI connection is having trouble right now. Please try again in a moment — your input is still here.",
     generic: "Something went wrong. Please try again.",
     network: "Couldn't reach the server. Check your connection and try again.",
     timeout: "This is taking longer than expected. Please try again.",
@@ -2358,6 +2359,7 @@ const KO = {
     rateLimited: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
   },
   errors: {
+    llmUnavailable: "지금 AI 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요 — 입력하신 내용은 그대로 남아 있어요.",
     generic: "문제가 발생했어요. 잠시 후 다시 시도해주세요.",
     network: "서버에 연결하지 못했어요. 인터넷 연결을 확인하고 다시 시도해주세요.",
     timeout: "시간이 조금 오래 걸리고 있어요. 다시 시도해주세요.",

--- a/apps/dashboard/src/i18n/error-text.mjs
+++ b/apps/dashboard/src/i18n/error-text.mjs
@@ -46,6 +46,7 @@ export function errorText(t, codeOrMessage, fallbackKey = "generic") {
   const fallback = errors[fallbackKey] ?? errors.generic ?? "Something went wrong.";
   if (!codeOrMessage || typeof codeOrMessage !== "string") return fallback;
 
+  if (codeOrMessage === "llm_unavailable") return errors.llmUnavailable ?? fallback;
   const raw = codeOrMessage.trim();
   const lower = raw.toLowerCase();
 

--- a/apps/dashboard/src/lib/workflow-store.ts
+++ b/apps/dashboard/src/lib/workflow-store.ts
@@ -41,7 +41,8 @@ export function loadDraft(): WorkflowDraft | null {
   try {
     const raw = localStorage.getItem(DRAFT_KEY);
     return raw ? (JSON.parse(raw) as WorkflowDraft) : null;
-  } catch {
+  } catch (err) {
+    console.error("[workflow-store] corrupt localStorage entry — data hidden from UI:", err);
     return null;
   }
 }
@@ -68,7 +69,8 @@ export function loadLocalProjects(): Project[] {
   try {
     const raw = localStorage.getItem(PROJECTS_KEY);
     return raw ? (JSON.parse(raw) as Project[]) : [];
-  } catch {
+  } catch (err) {
+    console.error("[workflow-store] corrupt localStorage entry — data hidden from UI:", err);
     return [];
   }
 }
@@ -127,7 +129,8 @@ export function loadExtendedProjectData(projectId: string): ExtendedProjectData 
   try {
     const raw = localStorage.getItem(EXT_KEY(projectId));
     return raw ? (JSON.parse(raw) as ExtendedProjectData) : null;
-  } catch {
+  } catch (err) {
+    console.error("[workflow-store] corrupt localStorage entry — data hidden from UI:", err);
     return null;
   }
 }
@@ -162,7 +165,8 @@ export function loadOutcomes(projectId: string): BuilderPackOutcome[] {
   try {
     const raw = localStorage.getItem(OUTCOMES_KEY(projectId));
     return raw ? (JSON.parse(raw) as BuilderPackOutcome[]) : [];
-  } catch {
+  } catch (err) {
+    console.error("[workflow-store] corrupt localStorage entry — data hidden from UI:", err);
     return [];
   }
 }

--- a/apps/dashboard/src/lib/workspace-github-api.ts
+++ b/apps/dashboard/src/lib/workspace-github-api.ts
@@ -20,7 +20,8 @@ export type GitHubUser = { login: string; name?: string; avatarUrl?: string };
 
 export type GitHubStatusResponse =
   | { ok: true; connected: false }
-  | { ok: true; connected: true; user: GitHubUser };
+  | { ok: true; connected: true; user: GitHubUser }
+  | { ok: false; error: string };
 
 export type GitHubRepo = {
   id: string;
@@ -84,10 +85,11 @@ export async function fetchGitHubStatus(userKey: string): Promise<GitHubStatusRe
       `${CENTRAL_PLANE_URL}/workspace/github/status?userKey=${encodeURIComponent(userKey)}`,
       { signal: AbortSignal.timeout(8000) },
     );
-    if (!resp.ok) return { ok: true, connected: false };
+    if (!resp.ok) return { ok: false, error: `HTTP ${resp.status}` };
     return (await resp.json()) as GitHubStatusResponse;
   } catch {
-    return { ok: true, connected: false };
+    // Honest failure: an error is not "disconnected" — callers show a retry.
+    return { ok: false, error: "network" };
   }
 }
 


### PR DESCRIPTION
전수 조사(서버 24 + 클라 18 HIDDEN-BAD) 기반 정책 반영: **실패를 숨기는 경로 전부 → 명시적 에러 + 재시도 안내.**

### 서버
- **generate/check/fix**: LLM 실패 4경로 전부 `503 llm_unavailable` — mock 초안/판정 조작 종료 (keyless는 로컬 개발·테스트 전용 유지)
- **pr-review**: LLM 실패 시 run이 **가시적으로 실패** — 파일명 휴리스틱이 "통과"를 내고 GitHub 코멘트까지 무표기 게시되던 census #1 제거
- **★KO 생성 수정 후보**: assistant prefill(`{`) — 모델이 JSON으로 시작할 수밖에 없음 (라이브 진단: KO 프롬프트만 222자 텍스트 정상종료 응답). non-JSON 시 200자 head 로그
- export D1 실패 → 500 (빈 "성공" 팩 제거) / membership DB 오류 로깅

### 클라이언트
- fallback 렌더·**저장** 전면 제거 (new 3경로+코드갈래+github/items 생성기) → llmUnavailable 안내+입력 보존+재시도
- login claim 실패 → `/account?claim=failed` 가시화 / sources-draft 저장 실패 → syncFailed 배너 / GitHub status 오류 ≠ "미연결"(재시도 상태) / 드롭존 저장 실패 안내 / 손상 localStorage 로드 console.error

### 검증
- 구계약 테스트 1건을 신계약으로 갱신. central-plane **1590** · dashboard **406** pass · 빌드 green
- **머지 후**: worker+dashboard 재배포 → KO 생성 마커 QA(source=llm + ZQX 반영) + 전수 QA 재실행으로 판정 기준 ①② 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)