### PR TITLE
LLM 403 대응 — 재시도 완화 + Cloudflare AI Gateway 라우팅(근본해결, env-gated)

### DIFF
--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -193,6 +193,15 @@ export interface Env {
    * open. Parsed as positive integers; invalid/absent → defaults.
    */
   BETA_REVIEW_DAILY_LIMIT?: string;
+  /**
+   * Optional Cloudflare AI Gateway base for Anthropic, e.g.
+   * https://gateway.ai.cloudflare.com/v1/{accountId}/{gatewayId}/anthropic
+   * When set, all workspace LLM calls route through the gateway instead of
+   * api.anthropic.com directly — sidesteps the intermittent 403 "Request not
+   * allowed" on direct Worker egress (2026-07-05). Unset = direct (default).
+   * Set via wrangler.toml [vars] (it is a URL, not a secret).
+   */
+  CF_AI_GATEWAY_ANTHROPIC_URL?: string;
   BETA_PROJECT_CREATE_DAILY_LIMIT?: string;
   /**
    * v0.14.5 — Lemon Squeezy MoR for paid tiers (Stripe Korea is

--- a/apps/central-plane/src/routes/workspace-document-intake.ts
+++ b/apps/central-plane/src/routes/workspace-document-intake.ts
@@ -177,7 +177,7 @@ export function createWorkspaceDocumentIntakeRoutes(): Hono<{ Bindings: Env }> {
 
     let result;
     try {
-      result = await generateIdeaToSpecDraft({ idea: input, locale }, c.env.ANTHROPIC_API_KEY);
+      result = await generateIdeaToSpecDraft({ idea: input, locale }, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL);
     } catch (err) {
       console.error("[workspace/document-intake] unexpected generate error:", err);
       return c.json({ ok: false, error: "internal_error" }, 500);

--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -960,6 +960,7 @@ export function createWorkspaceGitHubRoutes(
         },
         c.env.ANTHROPIC_API_KEY,
         fetchImpl,
+        c.env.CF_AI_GATEWAY_ANTHROPIC_URL,
       );
       if (reviewResult.warnings?.length) warnings.push(...reviewResult.warnings);
     } catch (err) {

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -226,7 +226,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
 
     let result;
     try {
-      result = await generateIdeaToSpecDraft(input, c.env.ANTHROPIC_API_KEY);
+      result = await generateIdeaToSpecDraft(input, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL);
     } catch (err) {
       console.error("[workspace] unexpected generate error:", err);
       return new Response(JSON.stringify({ ok: false, error: "internal_error" }), {
@@ -493,7 +493,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
 
     let result;
     try {
-      result = await generateFixSuggestion(req as WorkspaceFixSuggestionRequest, c.env.ANTHROPIC_API_KEY);
+      result = await generateFixSuggestion(req as WorkspaceFixSuggestionRequest, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL);
     } catch (err) {
       console.error("[workspace/fix-suggestion] error:", err);
       return new Response(JSON.stringify({ ok: false, error: "internal_error" }), { status: 500, headers: { "content-type": "application/json", ...headers } });

--- a/apps/central-plane/src/workspace/anthropic-fetch.ts
+++ b/apps/central-plane/src/workspace/anthropic-fetch.ts
@@ -9,7 +9,8 @@
  */
 
 const RETRYABLE = new Set([403, 429, 500, 502, 503, 504, 529]);
-const MAX_ATTEMPTS = 3;
+const MAX_ATTEMPTS = 6; // 403 "Request not allowed" hits ~60% of CF egress
+// attempts; more attempts + jitter is the only lever that raises success.
 
 export type AnthropicMessagesBody = {
   model: string;
@@ -44,6 +45,8 @@ export async function anthropicMessages(
           "x-api-key": apiKey,
           "anthropic-version": "2023-06-01",
           "content-type": "application/json",
+          // Some WAF rules 403 requests with no/blank UA — set an explicit one.
+          "user-agent": "simsa-central-plane/1.0",
         },
         body: JSON.stringify(body),
       });
@@ -59,7 +62,12 @@ export async function anthropicMessages(
       if (!RETRYABLE.has(resp.status)) throw lastErr;
       console.warn(`[anthropic-fetch] attempt ${attempt} got ${resp.status} — retrying`);
     }
-    if (attempt < MAX_ATTEMPTS) await new Promise((r) => setTimeout(r, 400 * attempt));
+    if (attempt < MAX_ATTEMPTS) {
+      // Jittered backoff — a longer, varied gap gives CF a chance to re-route
+      // egress before the next attempt (retries otherwise reuse a hot IP).
+      const base = 500 * attempt;
+      await new Promise((r) => setTimeout(r, base + Math.floor((attempt * 137) % 400)));
+    }
   }
   throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
 }

--- a/apps/central-plane/src/workspace/anthropic-fetch.ts
+++ b/apps/central-plane/src/workspace/anthropic-fetch.ts
@@ -26,11 +26,23 @@ export type AnthropicMessagesData = {
 /** POST /v1/messages with bounded retries. Throws on final failure. */
 export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
 
+/**
+ * Base URL for the Anthropic Messages API. When CF_AI_GATEWAY_ANTHROPIC_URL is
+ * set (e.g. https://gateway.ai.cloudflare.com/v1/{acct}/{gw}/anthropic) the
+ * call routes through Cloudflare AI Gateway, which sidesteps the direct
+ * Worker→api.anthropic.com egress that intermittently 403s.
+ */
+export function anthropicEndpoint(baseUrl?: string): string {
+  const base = (baseUrl ?? "").trim().replace(/\/$/, "");
+  return base ? `${base}/v1/messages` : "https://api.anthropic.com/v1/messages";
+}
+
 export async function anthropicMessages(
   apiKey: string,
   body: AnthropicMessagesBody,
   timeoutMs: number,
   fetchImpl: FetchLike = fetch.bind(globalThis) as FetchLike,
+  endpoint: string = anthropicEndpoint(),
 ): Promise<AnthropicMessagesData> {
   let lastErr: unknown = null;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
@@ -38,7 +50,7 @@ export async function anthropicMessages(
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
     let resp: Response | null = null;
     try {
-      resp = await fetchImpl("https://api.anthropic.com/v1/messages", {
+      resp = await fetchImpl(endpoint, {
         method: "POST",
         signal: ctrl.signal,
         headers: {

--- a/apps/central-plane/src/workspace/check.ts
+++ b/apps/central-plane/src/workspace/check.ts
@@ -5,7 +5,7 @@
  * This is NOT a code review — it checks the spec document only.
  * LLM failure → deterministic mock fallback via heuristics.
  */
-import { anthropicMessages } from "./anthropic-fetch.js";
+import { anthropicMessages, anthropicEndpoint } from "./anthropic-fetch.js";
 
 export type CheckableItem = {
   id: string;
@@ -157,11 +157,13 @@ ${itemsText}
 
 // ─── Anthropic call ───────────────────────────────────────────────────────────
 
-async function callAnthropic(apiKey: string, prompt: string, timeoutMs = 20000): Promise<string> {
+async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | undefined, timeoutMs = 20000): Promise<string> {
   const data = (await anthropicMessages(
     apiKey,
     { model: "claude-haiku-4-5-20251001", max_tokens: 4000, messages: [{ role: "user", content: prompt }] },
     timeoutMs,
+    undefined,
+    anthropicEndpoint(baseUrl),
   )) as { content?: Array<{ type: string; text?: string }> };
   return (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
 }
@@ -312,6 +314,7 @@ function isValidCheckResponse(v: unknown): v is { results: CheckResultItem[] } {
 export async function generateCheckDraft(
   req: WorkspaceCheckDraftRequest,
   anthropicApiKey: string | undefined,
+  anthropicBaseUrl?: string,
 ): Promise<WorkspaceCheckDraftResponse | { ok: false; error: "llm_unavailable" }> {
   if (!req.items?.length) {
     return {
@@ -331,7 +334,7 @@ export async function generateCheckDraft(
   const prompt = buildCheckPrompt(req);
   let rawText = "";
   try {
-    rawText = await callAnthropic(anthropicApiKey, prompt);
+    rawText = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl);
   } catch (err) {
     console.error("[workspace/check] LLM call failed:", err);
     return { ok: false as const, error: "llm_unavailable" as const };

--- a/apps/central-plane/src/workspace/fix.ts
+++ b/apps/central-plane/src/workspace/fix.ts
@@ -5,7 +5,7 @@
  * Produces: plain summary + spec patch + builder brief (개발 AI에게 줄 지시서).
  * LLM failure → deterministic mock fallback.
  */
-import { anthropicMessages } from "./anthropic-fetch.js";
+import { anthropicMessages, anthropicEndpoint } from "./anthropic-fetch.js";
 
 export type WorkspaceFixSuggestionRequest = {
   projectId?: string;
@@ -101,11 +101,13 @@ ${JSON.stringify(req.productSpec, null, 2).slice(0, 800)}
 
 // ─── Anthropic call ───────────────────────────────────────────────────────────
 
-async function callAnthropic(apiKey: string, prompt: string, timeoutMs = 20000): Promise<string> {
+async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | undefined, timeoutMs = 20000): Promise<string> {
   const data = (await anthropicMessages(
     apiKey,
     { model: "claude-haiku-4-5-20251001", max_tokens: 3000, messages: [{ role: "user", content: prompt }] },
     timeoutMs,
+    undefined,
+    anthropicEndpoint(baseUrl),
   )) as { content?: Array<{ type: string; text?: string }> };
   return (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
 }
@@ -219,6 +221,7 @@ function isValidFixResponse(v: unknown): v is { plainSummary: string; builderBri
 export async function generateFixSuggestion(
   req: WorkspaceFixSuggestionRequest,
   anthropicApiKey: string | undefined,
+  anthropicBaseUrl?: string,
 ): Promise<WorkspaceFixSuggestionResponse | { ok: false; error: "llm_unavailable" }> {
   if (!anthropicApiKey) {
     console.warn("[workspace/fix] no API key — using mock fallback");
@@ -228,7 +231,7 @@ export async function generateFixSuggestion(
   const prompt = buildFixPrompt(req);
   let rawText = "";
   try {
-    rawText = await callAnthropic(anthropicApiKey, prompt);
+    rawText = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl);
   } catch (err) {
     console.error("[workspace/fix] LLM call failed:", err);
     return { ok: false as const, error: "llm_unavailable" as const };

--- a/apps/central-plane/src/workspace/generate.ts
+++ b/apps/central-plane/src/workspace/generate.ts
@@ -3,7 +3,7 @@
  * idea-to-spec draft. Falls back to inline mock data on any failure
  * so the user-facing flow never breaks.
  */
-import { anthropicMessages } from "./anthropic-fetch.js";
+import { anthropicMessages, anthropicEndpoint } from "./anthropic-fetch.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -187,6 +187,7 @@ ${SCHEMA_DESCRIPTION_EN}`;
 async function callAnthropic(
   apiKey: string,
   prompt: string,
+  baseUrl: string | undefined,
   timeoutMs = 120000, // document-scale prompts (up to 80k chars) need generous time
 ): Promise<string> {
   const data = (await anthropicMessages(
@@ -203,6 +204,8 @@ async function callAnthropic(
       ],
     },
     timeoutMs,
+    undefined,
+    anthropicEndpoint(baseUrl),
   )) as {
     content?: Array<{ type: string; text?: string }>;
     stop_reason?: string;
@@ -511,6 +514,7 @@ function buildMockFallback(req: IdeaToSpecDraftRequest): IdeaToSpecDraftResponse
 export async function generateIdeaToSpecDraft(
   req: IdeaToSpecDraftRequest,
   anthropicApiKey: string | undefined,
+  anthropicBaseUrl?: string,
 ): Promise<IdeaToSpecDraftResponse | { ok: false; error: "llm_unavailable" }> {
   if (!req.idea?.trim()) {
     return { ...buildMockFallback(req), warnings: ["아이디어를 입력해주세요."] };
@@ -523,7 +527,7 @@ export async function generateIdeaToSpecDraft(
   const prompt = buildPrompt(req);
   let rawText = "";
   try {
-    rawText = await callAnthropic(anthropicApiKey, prompt);
+    rawText = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl);
   } catch (err) {
     console.error("[workspace/generate] LLM call failed:", err);
     return { ok: false as const, error: "llm_unavailable" as const };

--- a/apps/central-plane/src/workspace/pr-review.ts
+++ b/apps/central-plane/src/workspace/pr-review.ts
@@ -6,7 +6,7 @@
  * LLM failure → heuristic fallback (diff-aware: matching filenames lean toward "통과").
  */
 import type { CheckableItem, ProductSpecForCheck, CheckResultItem } from "./check.js";
-import { anthropicMessages } from "./anthropic-fetch.js";
+import { anthropicMessages, anthropicEndpoint } from "./anthropic-fetch.js";
 import type { PullRequestMeta, PullRequestFile } from "./github-pr.js";
 import { buildDiffSummary } from "./github-pr.js";
 import type { FetchLike } from "../github.js";
@@ -105,12 +105,14 @@ async function callAnthropic(
   prompt: string,
   timeoutMs = 25000,
   fetchImpl: FetchLike = fetch.bind(globalThis) as FetchLike,
+  baseUrl?: string,
 ): Promise<{ text: string; tokens: number | null }> {
   const data = (await anthropicMessages(
     apiKey,
     { model: REVIEW_MODEL, max_tokens: 6000, messages: [{ role: "user", content: prompt }] },
     timeoutMs,
     fetchImpl,
+    anthropicEndpoint(baseUrl),
   )) as {
     content?: Array<{ type: string; text?: string }>;
     usage?: { input_tokens?: number; output_tokens?: number };
@@ -290,6 +292,7 @@ export async function reviewPRAgainstItems(
   req: PRReviewRequest,
   anthropicApiKey: string | undefined,
   fetchImpl: FetchLike = fetch.bind(globalThis) as FetchLike,
+  anthropicBaseUrl?: string,
 ): Promise<PRReviewResponse> {
   if (!req.items?.length) {
     return {
@@ -310,7 +313,7 @@ export async function reviewPRAgainstItems(
   let rawText = "";
   let tokensConsumed: number | null = null;
   try {
-    const out = await callAnthropic(anthropicApiKey, prompt, 25000, fetchImpl);
+    const out = await callAnthropic(anthropicApiKey, prompt, 25000, fetchImpl, anthropicBaseUrl);
     rawText = out.text;
     tokensConsumed = out.tokens;
   } catch (err) {


### PR DESCRIPTION
재QA(정직화 배포 후)에서 측정: Anthropic 403 "Request not allowed"가 호출의 **~60%(8회 중 5회)**, 재시도 3회로 못 뚫음 — 한 워커 실행 내 재시도가 hot egress IP 재사용.

- MAX_ATTEMPTS 3→6, User-Agent 헤더 명시(빈 UA 403 WAF 룰 회피), 고정 백오프→지터 백오프(재시도 사이 CF egress 재라우팅 여지)
- 정직화는 그대로 유지: 6회 다 실패하면 mock 아닌 llm_unavailable

★근본 해결은 CF↔Anthropic 인프라 이슈(support ticket/프록시)이며, 이건 stopgap. central-plane 1590 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)