### PR TITLE
AI Gateway 활성화 — Anthropic을 게이트웨이 simsa로 라우팅

### DIFF
--- a/apps/central-plane/wrangler.toml
+++ b/apps/central-plane/wrangler.toml
@@ -17,6 +17,11 @@ ENVIRONMENT = "production"
 # Was fail-closed (unset → disabled) since Stage 241. Sign-in/session were never gated
 # by this policy; only POST /api/auth/sign-up/* is affected.
 AUTH_SIGNUP_MODE = "open"
+# Cloudflare AI Gateway (gateway "simsa") — routes Anthropic calls through the
+# gateway instead of api.anthropic.com directly, eliminating the ~60% 403
+# "Request not allowed" on direct Worker egress (2026-07-05). Base only; the
+# code appends /v1/messages. Gateway is unauthenticated (no token header).
+CF_AI_GATEWAY_ANTHROPIC_URL = "https://gateway.ai.cloudflare.com/v1/8735d5a7b0af1d7f97dd46f705ace797/simsa/anthropic"
 # Open-deploy batch (2026-07-05) — Better Auth canonical origin. Required for the
 # GitHub LOGIN OAuth app (#213): without it Better Auth derives the base URL from
 # the proxied request (workers.dev) and the GitHub callback becomes


### PR DESCRIPTION
게이트웨이 라이브 검증 완료: `/anthropic` 경로로 요청이 Anthropic까지 도달(dummy 키 → 정상 401, direct-egress 403 아님). 게이트웨이 unauthenticated → URL만으로 활성화(토큰 헤더 불필요).

#228(CF_AI_GATEWAY_ANTHROPIC_URL 읽는 코드)와 짝. 배포 후 ~60% 403이 사라질 것으로 기대 — 배포 직후 제가 8회 재측정.

config-only(wrangler.toml [vars] 1줄). ★Bae: 채팅 노출된 cfut_ 토큰은 안 쓰지만 CF 대시보드에서 로테이트 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)