### PR TITLE
UIUX #5 — 화면별 primary CTA 위계 (주인공 버튼 1개)

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -356,7 +356,7 @@ export default function ExportPage() {
               {TARGET_VALUES.map((value) => (
                 <button key={value} onClick={() => handleTargetChange(value)}
                   disabled={phase === "loading"}
-                  className={`flex-1 text-sm px-3 py-2 rounded-lg border font-medium transition-all disabled:opacity-50 ${target === value ? "bg-indigo-600 text-white border-indigo-600" : "bg-white text-gray-700 border-gray-200 hover:border-indigo-300"}`}>
+                  className={`flex-1 text-sm px-3 py-2 rounded-lg border font-medium transition-all disabled:opacity-50 ${target === value ? "bg-brand-600 text-white border-brand-600" : "bg-white text-gray-700 border-gray-200 hover:border-brand-300"}`}>
                   {targetOptionLabel(t, value)}
                 </button>
               ))}
@@ -367,7 +367,7 @@ export default function ExportPage() {
             <div className="flex gap-2">
               {(["all", "selected"] as const).map((mode) => (
                 <button key={mode} onClick={() => setSelectionMode(mode)}
-                  className={`flex-1 text-sm px-3 py-2 rounded-lg border font-medium transition-all ${selectionMode === mode ? "bg-indigo-600 text-white border-indigo-600" : "bg-white text-gray-700 border-gray-200 hover:border-indigo-300"}`}>
+                  className={`flex-1 text-sm px-3 py-2 rounded-lg border font-medium transition-all ${selectionMode === mode ? "bg-brand-600 text-white border-brand-600" : "bg-white text-gray-700 border-gray-200 hover:border-brand-300"}`}>
                   {mode === "all" ? t.exportPage.scopeAll : t.exportPage.scopeSelected}
                 </button>
               ))}
@@ -425,7 +425,7 @@ export default function ExportPage() {
           </div>
           <div className="mt-4 flex items-center justify-end">
             <button onClick={handleGenerate} disabled={phase === "loading"}
-              className="text-sm px-4 py-2 rounded-xl font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors">
+              className="btn btn-md btn-primary">
               {phase === "loading" ? t.exportPage.generating : t.exportPage.generate}
             </button>
           </div>
@@ -468,7 +468,7 @@ export default function ExportPage() {
             </div>
             <div className="flex gap-2 flex-wrap">
               <button onClick={handleZipDownload} disabled={isZipping}
-                className="text-xs px-3 py-1.5 rounded-lg font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-60 transition-colors">
+                className="btn btn-sm btn-primary">
                 {isZipping ? t.exportPage.zipping : t.exportPage.downloadZip}
               </button>
               <button onClick={handleCopyAll}
@@ -616,7 +616,7 @@ function OutcomeRecorder({
             className="w-full text-sm border border-gray-200 rounded-xl px-4 py-3 mb-3 focus:outline-none focus:ring-2 focus:ring-indigo-300 resize-none"
           />
           <button onClick={onSave} disabled={!outcomeStatus || savePhase === "saving"}
-            className="text-sm px-4 py-2 rounded-xl font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+            className="btn btn-md btn-secondary">
             {savePhase === "saving" ? t.exportPage.saving : t.exportPage.save}
           </button>
         </>

--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -371,7 +371,7 @@ export default function GitHubPage() {
               </a>
               {repo.defaultBranch && <span className="ml-2 text-xs text-gray-500">→ {repo.defaultBranch}</span>}
             </div>
-            <button onClick={handleLoadPulls} disabled={pullsPhase === "loading"} className="btn btn-md btn-primary">
+            <button onClick={handleLoadPulls} disabled={pullsPhase === "loading"} className="btn btn-md btn-secondary">
               {pullsPhase === "loading" ? t.common.loading : t.github.loadPulls}
             </button>
           </div>

--- a/apps/dashboard/src/app/projects/[id]/idea/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/idea/page.tsx
@@ -28,7 +28,7 @@ export default function IdeaPage() {
       {isEmpty && (
         <div className="empty-state mb-6">
           <p className="text-sm text-gray-600">{t.idea.emptyBody}</p>
-          <a href={`/projects/${id}`} className="btn btn-md btn-primary mt-4">
+          <a href={`/projects/${id}`} className="btn btn-md btn-secondary mt-4">
             {t.common.goOverview}
           </a>
         </div>

--- a/apps/dashboard/src/app/projects/[id]/settings/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/settings/page.tsx
@@ -635,7 +635,7 @@ export default function SettingsPage() {
             <button
               onClick={handleSaveEmSettings}
               disabled={!emConfigured || !emAddress.trim() || emSavePhase === "saving"}
-              className="btn btn-md btn-primary"
+              className="btn btn-md btn-secondary"
             >
               {emSavePhase === "saving" ? t.emailNotify.saving : t.common.save}
             </button>
@@ -711,7 +711,7 @@ export default function SettingsPage() {
             <button
               onClick={handleSaveTgSettings}
               disabled={!tgEnabled || !tgChatId.trim() || tgSavePhase === "saving"}
-              className="btn btn-md btn-primary"
+              className="btn btn-md btn-secondary"
             >
               {tgSavePhase === "saving" ? t.telegram.saving : t.common.save}
             </button>

--- a/apps/dashboard/src/app/projects/[id]/spec/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/spec/page.tsx
@@ -31,7 +31,7 @@ export default function SpecPage() {
       {!spec.goal && spec.included.length === 0 ? (
         <div className="empty-state">
           <p className="text-sm text-gray-600">{t.spec.emptyBody}</p>
-          <a href={`/projects/${id}`} className="btn btn-md btn-primary mt-4">
+          <a href={`/projects/${id}`} className="btn btn-md btn-secondary mt-4">
             {t.common.goOverview}
           </a>
         </div>

--- a/apps/dashboard/src/app/projects/[id]/visual-checks/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/visual-checks/page.tsx
@@ -194,7 +194,7 @@ export default function VisualChecksPage() {
         <button
           onClick={handleRun}
           disabled={submitting || buttonState.disabled}
-          className="btn btn-primary btn-sm mt-3 disabled:cursor-not-allowed disabled:opacity-50"
+          className="btn btn-primary btn-md mt-3 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {submitting ? t.visualChecks.runSubmitting : t.visualChecks.runButton}
         </button>


### PR DESCRIPTION
지시서 5번(최상위): 화면마다 채운 brand-primary 주인공 버튼 하나만, 나머지는 물러남.

- **settings**: 이메일·Telegram Save 2개가 primary라 첫 방문 주인공 "GitHub 연결"을 묻음 → 둘 다 secondary
- **export**: off-system indigo 채움 3개(생성/ZIP 다운로드/결과 저장) — indigo는 브랜드 팔레트도 아님. 생성+다운로드는 primary(다른 단계/영역), 결과 저장 secondary, 세그먼트 토글 indigo→brand
- **github**: "PR 불러오기"가 진짜 주인공 "검수 실행" 위에서 primary였음 → secondary. ★개요 nextProjectAction("검수 실행")↔github 화면 불일치도 해소
- **idea/spec 빈상태**: goOverview가 forward StepNext와 경쟁 → secondary
- **visual-checks**: 실행 버튼 btn-sm→btn-md (화면 간 주인공 크기 통일)

export에 off-system indigo 버튼 0개. dashboard 406 pass · typecheck/build green.
개요·new·visual-checks 등은 이미 1-primary라 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)