### PR TITLE
Baseline UX QA PR1: rubric data + Zod contracts (@simsa/core/ux-rubric)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,10 @@
     "./plain-summary": {
       "types": "./dist/plain-summary.d.ts",
       "import": "./dist/plain-summary.js"
+    },
+    "./ux-rubric": {
+      "types": "./dist/ux-rubric/index.d.ts",
+      "import": "./dist/ux-rubric/index.js"
     }
   },
   "files": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -206,6 +206,40 @@ export type {
   FileSystemBaselineStoreOptions,
 } from "./federated/index.js";
 
+// Baseline UX QA rubric (§2/§4/§8) — versioned, git-tracked rule data + Zod
+// contracts that a machine UX pass grades a live surface against. Pure data:
+// detectors that emit the graded signals ship in a later PR. Re-exported here
+// for convenience; dedicated subpath at @simsa/core/ux-rubric.
+export {
+  RUBRIC_VERSION,
+  BASELINE_UX_RUBRIC,
+  RubricItemSchema,
+  RubricSchema,
+  RawSignalSchema,
+  RubricFindingSchema,
+  requiresInteraction,
+  isStaticDetector,
+  getRunnableRules,
+  getGatingRules,
+  getRuleById,
+  classifySignals,
+  assertRubricInvariants,
+  DOGFOOD_SIGNALS,
+  CLEAN_SIGNALS,
+} from "./ux-rubric/index.js";
+export type {
+  RubricLayer,
+  RubricDetector,
+  RubricSeverity,
+  RubricStatus,
+  RubricItem,
+  Rubric,
+  RawSignal,
+  RubricFinding,
+  RunnableCapabilities,
+  ClassifyResult,
+} from "./ux-rubric/index.js";
+
 // Efficiency Gate (decision #22: first-class from day 1) — every LLM call
 // routes through `EfficiencyGate.run(...)`. Re-exported here for convenience;
 // the dedicated subpath export lives at @simsa/core/efficiency.

--- a/packages/core/src/ux-rubric/fixture.ts
+++ b/packages/core/src/ux-rubric/fixture.ts
@@ -1,0 +1,39 @@
+/**
+ * Baseline UX QA — dogfood fixture for the §8 acceptance scaffold.
+ *
+ * Four synthetic detector signals, one per statically-runnable rule, that a
+ * clean classification must map 4/4. Paired with an empty CLEAN_SIGNALS set that
+ * must yield zero findings — the false-positive floor. Real browser detection
+ * lands in a later PR; this fixture is what PR2's detectors must reproduce.
+ */
+import type { RawSignal } from "./schema.js";
+
+/** One violation per static (gating) rule — the "known-bad" surface. */
+export const DOGFOOD_SIGNALS: RawSignal[] = [
+  {
+    ruleId: "L1-a11y-button-name",
+    evidence: "<button> with no text, aria-label, or aria-labelledby",
+    url: "https://example.test/",
+    selector: "header > button:nth-child(2)",
+  },
+  {
+    ruleId: "L1-link-broken",
+    evidence: 'Footer link "Docs" resolves to HTTP 404',
+    url: "https://example.test/",
+    selector: "footer a[href='/docs']",
+  },
+  {
+    ruleId: "L2-escape-hatch",
+    evidence: "Project detail view renders no back, close, or home control",
+    url: "https://example.test/projects/1",
+  },
+  {
+    ruleId: "L2-silent-failure",
+    evidence: 'Result panel shows "예시 초안입니다" placeholder while data-degraded="true" is set',
+    url: "https://example.test/projects/1/spec",
+    selector: "[data-degraded='true']",
+  },
+];
+
+/** A clean surface emits nothing — classification must return zero findings. */
+export const CLEAN_SIGNALS: RawSignal[] = [];

--- a/packages/core/src/ux-rubric/index.ts
+++ b/packages/core/src/ux-rubric/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Baseline UX QA rubric — public surface (@simsa/core/ux-rubric).
+ *
+ * Pure data + Zod contracts for the machine UX QA pass. Detectors that produce
+ * the RawSignals graded here ship in a later PR; this module has no browser, LLM,
+ * or network dependency.
+ */
+export {
+  RubricLayerSchema,
+  RubricDetectorSchema,
+  RubricSeveritySchema,
+  RubricStatusSchema,
+  RubricItemSchema,
+  RubricSchema,
+  RawSignalSchema,
+  RubricFindingSchema,
+} from "./schema.js";
+export type {
+  RubricLayer,
+  RubricDetector,
+  RubricSeverity,
+  RubricStatus,
+  RubricItem,
+  Rubric,
+  RawSignal,
+  RubricFinding,
+} from "./schema.js";
+
+export {
+  RUBRIC_VERSION,
+  BASELINE_UX_RUBRIC,
+  requiresInteraction,
+  isStaticDetector,
+  getRunnableRules,
+  getGatingRules,
+  getRuleById,
+  classifySignals,
+  assertRubricInvariants,
+} from "./rubric.js";
+export type { RunnableCapabilities, ClassifyResult } from "./rubric.js";
+
+export { DOGFOOD_SIGNALS, CLEAN_SIGNALS } from "./fixture.js";

--- a/packages/core/src/ux-rubric/rubric.ts
+++ b/packages/core/src/ux-rubric/rubric.ts
@@ -1,0 +1,289 @@
+/**
+ * Baseline UX QA — the rubric itself plus pure grading helpers (PR1, §2/§4/§8).
+ *
+ * The rubric is versioned data, parsed and invariant-checked at module load so a
+ * malformed edit fails the build/test rather than shipping. Detectors live in a
+ * later PR; everything here is deterministic and browser-free.
+ */
+import {
+  RubricSchema,
+  RawSignalSchema,
+  type Rubric,
+  type RubricItem,
+  type RubricDetector,
+  type RawSignal,
+  type RubricFinding,
+} from "./schema.js";
+
+/** Bumped whenever the set of rules changes. Consumers can pin/compare on this. */
+export const RUBRIC_VERSION = 1;
+
+/**
+ * Layer 1 — mechanical. Automated tools on a statically loaded page. These run
+ * today (no interaction) and gate.
+ */
+const LAYER_1: RubricItem[] = [
+  {
+    id: "L1-a11y-button-name",
+    layer: 1,
+    rule: "Every interactive control exposes an accessible name.",
+    severity: "blocker",
+    detector: "axe",
+    status: "active",
+    version: 1,
+    reference: "WCAG 4.1.2 Name, Role, Value",
+    remediation: "Give the control visible text, aria-label, or aria-labelledby.",
+  },
+  {
+    id: "L1-a11y-color-contrast",
+    layer: 1,
+    rule: "Text and interactive elements meet a 4.5:1 (3:1 for large text) contrast ratio.",
+    severity: "major",
+    detector: "axe",
+    status: "active",
+    version: 1,
+    reference: "WCAG 1.4.3 Contrast (Minimum)",
+    remediation: "Adjust foreground/background colors to meet the ratio.",
+  },
+  {
+    id: "L1-a11y-image-alt",
+    layer: 1,
+    rule: "Every meaningful image has a text alternative.",
+    severity: "major",
+    detector: "axe",
+    status: "active",
+    version: 1,
+    reference: "WCAG 1.1.1 Non-text Content",
+    remediation: 'Add alt text; mark decorative images with alt="".',
+  },
+  {
+    id: "L1-a11y-form-label",
+    layer: 1,
+    rule: "Every form input has a programmatically associated label.",
+    severity: "major",
+    detector: "axe",
+    status: "active",
+    version: 1,
+    reference: "WCAG 3.3.2 Labels or Instructions",
+    remediation: "Associate a <label for> or aria-label with the input.",
+  },
+  {
+    id: "L1-a11y-lang",
+    layer: 1,
+    rule: "The document declares its language.",
+    severity: "minor",
+    detector: "axe",
+    status: "active",
+    version: 1,
+    reference: "WCAG 3.1.1 Language of Page",
+    remediation: "Set the <html lang> attribute.",
+  },
+  {
+    id: "L1-link-broken",
+    layer: 1,
+    rule: "No navigation link or CTA resolves to a 4xx/5xx or empty target.",
+    severity: "major",
+    detector: "link-crawl",
+    status: "active",
+    version: 1,
+    reference: "Internal policy: no dead ends",
+    remediation: "Fix or remove the broken destination.",
+  },
+  {
+    id: "L1-cwv-lcp",
+    layer: 1,
+    rule: "Largest Contentful Paint is under 2.5s on a mid-tier connection.",
+    severity: "minor",
+    detector: "cwv",
+    status: "active",
+    version: 1,
+    reference: "Core Web Vitals: LCP",
+    remediation: "Optimize the largest above-the-fold asset.",
+  },
+  {
+    id: "L1-cwv-cls",
+    layer: 1,
+    rule: "Cumulative Layout Shift stays under 0.1.",
+    severity: "minor",
+    detector: "cwv",
+    status: "active",
+    version: 1,
+    reference: "Core Web Vitals: CLS",
+    remediation: "Reserve space for async and media content.",
+  },
+];
+
+/**
+ * Layer 2 — heuristic. Four high-signal usability rules, split by detector per
+ * the accepted assessment: two are statically DOM-inspectable and gate today;
+ * two need the INSPECTOR to click/type and ship in shadow (calibrate the
+ * false-positive rate before promoting them to gating — §8).
+ */
+const LAYER_2: RubricItem[] = [
+  {
+    id: "L2-escape-hatch",
+    layer: 2,
+    rule: "Every non-entry view exposes a visible way back, close, or home.",
+    severity: "major",
+    detector: "dom-inspect",
+    status: "active",
+    version: 1,
+    reference: "Nielsen #3 User control and freedom",
+    remediation: "Add a persistent back / close / home affordance.",
+  },
+  {
+    id: "L2-silent-failure",
+    layer: 2,
+    rule: "A result surface never presents placeholder, mock, or example content as a real result while a degraded or error flag is set.",
+    severity: "blocker",
+    detector: "dom-inspect",
+    status: "active",
+    version: 1,
+    reference: "Internal policy: honest failures (2026-07-05 mock-draft incident)",
+    remediation: "Render an explicit error with a retry path instead of a success-shaped placeholder.",
+  },
+  {
+    id: "L2-dead-button",
+    layer: 2,
+    rule: "Activating a primary action produces an observable state change or explicit feedback.",
+    severity: "blocker",
+    detector: "interaction",
+    status: "shadow",
+    version: 1,
+    reference: "Nielsen #1 Visibility of system status",
+    remediation: "Wire the handler, or disable / relabel the control until it is functional.",
+  },
+  {
+    id: "L2-enter-noop",
+    layer: 2,
+    rule: "A primary text input submits on Enter or clearly shows how to submit.",
+    severity: "major",
+    detector: "interaction",
+    status: "shadow",
+    version: 1,
+    reference: "Nielsen #7 Flexibility and efficiency of use",
+    remediation: "Handle the Enter key, or surface the submit control next to the field.",
+  },
+];
+
+/**
+ * Layer 3 — domain overlay. Intentionally empty for now; the schema accepts
+ * layer-3 items so a later PR can add product-specific rules without a shape
+ * change.
+ */
+const LAYER_3: RubricItem[] = [];
+
+/**
+ * The baseline rubric. Parsed at load so a malformed edit fails immediately, and
+ * invariant-checked (layer↔detector consistency, unique ids) beyond what Zod can
+ * express on its own.
+ */
+export const BASELINE_UX_RUBRIC: Rubric = assertRubricInvariants(
+  RubricSchema.parse({
+    version: RUBRIC_VERSION,
+    items: [...LAYER_1, ...LAYER_2, ...LAYER_3],
+  }),
+);
+
+/** Detectors that run on a static page load — no INSPECTOR interaction needed. */
+const STATIC_DETECTORS: readonly RubricDetector[] = ["axe", "link-crawl", "cwv", "dom-inspect"];
+
+/** True when a rule can only be evaluated by clicking/typing (not yet shippable). */
+export function requiresInteraction(detector: RubricDetector): boolean {
+  return detector === "interaction";
+}
+
+/** True when a rule runs on a static page load. */
+export function isStaticDetector(detector: RubricDetector): boolean {
+  return STATIC_DETECTORS.includes(detector);
+}
+
+export interface RunnableCapabilities {
+  /** Whether the runner can click and type (INSPECTOR interaction). */
+  canInteract: boolean;
+}
+
+/**
+ * The subset of rules a runner with the given capabilities can actually evaluate.
+ * Static rules always qualify; interaction rules only when `canInteract`; manual
+ * (layer-3) rules never run automatically.
+ */
+export function getRunnableRules(rubric: Rubric, caps: RunnableCapabilities): RubricItem[] {
+  return rubric.items.filter((item) => {
+    if (item.detector === "manual") return false;
+    if (requiresInteraction(item.detector)) return caps.canInteract;
+    return true;
+  });
+}
+
+/** Rules that gate (status "active"). Shadow rules are reported but never block. */
+export function getGatingRules(rubric: Rubric): RubricItem[] {
+  return rubric.items.filter((item) => item.status === "active");
+}
+
+export function getRuleById(rubric: Rubric, id: string): RubricItem | undefined {
+  return rubric.items.find((item) => item.id === id);
+}
+
+export interface ClassifyResult {
+  /** Signals whose ruleId matched a known rule, enriched with grading metadata. */
+  findings: RubricFinding[];
+  /** Signals whose ruleId is not in the rubric — never invented into a finding. */
+  unknown: RawSignal[];
+}
+
+/**
+ * Classify detector signals against the rubric. Pure and total:
+ *   - a known ruleId becomes an enriched finding,
+ *   - an unknown ruleId is collected separately (never dropped, never invented),
+ *   - empty input yields empty output (the false-positive floor — §8).
+ * Each signal is Zod-validated at the boundary before use.
+ */
+export function classifySignals(signals: readonly RawSignal[], rubric: Rubric): ClassifyResult {
+  const findings: RubricFinding[] = [];
+  const unknown: RawSignal[] = [];
+  for (const raw of signals) {
+    const signal = RawSignalSchema.parse(raw);
+    const rule = getRuleById(rubric, signal.ruleId);
+    if (!rule) {
+      unknown.push(signal);
+      continue;
+    }
+    findings.push({
+      ruleId: rule.id,
+      layer: rule.layer,
+      severity: rule.severity,
+      status: rule.status,
+      rule: rule.rule,
+      evidence: signal.evidence,
+      ...(signal.url === undefined ? {} : { url: signal.url }),
+      ...(signal.selector === undefined ? {} : { selector: signal.selector }),
+    });
+  }
+  return { findings, unknown };
+}
+
+/**
+ * Enforce invariants Zod can't express on its own, then return the rubric so this
+ * can wrap the parse expression. Throws on any violation.
+ */
+export function assertRubricInvariants(rubric: Rubric): Rubric {
+  const seen = new Set<string>();
+  for (const item of rubric.items) {
+    if (seen.has(item.id)) {
+      throw new Error(`ux-rubric: duplicate rule id "${item.id}"`);
+    }
+    seen.add(item.id);
+
+    const detectorOk =
+      (item.layer === 1 && (item.detector === "axe" || item.detector === "link-crawl" || item.detector === "cwv")) ||
+      (item.layer === 2 && (item.detector === "dom-inspect" || item.detector === "interaction")) ||
+      (item.layer === 3 && item.detector === "manual");
+    if (!detectorOk) {
+      throw new Error(
+        `ux-rubric: rule "${item.id}" has detector "${item.detector}" that is invalid for layer ${item.layer}`,
+      );
+    }
+  }
+  return rubric;
+}

--- a/packages/core/src/ux-rubric/schema.ts
+++ b/packages/core/src/ux-rubric/schema.ts
@@ -1,0 +1,106 @@
+/**
+ * Baseline UX QA — rubric data contracts (PR1, §2/§4/§8).
+ *
+ * This is the pure data + Zod layer of the Baseline UX QA system: the versioned,
+ * git-tracked rubric a machine QA pass grades a live surface against, plus the
+ * signal/finding contracts the detectors (PR2+) emit and are classified into.
+ * No browser, no LLM, no network here — only shapes and their validators.
+ *
+ * Three layers (§2):
+ *   1. mechanical — automated tools on a statically loaded page (axe / link-crawl / CWV)
+ *   2. heuristic  — a small set of high-signal usability rules. Per the accepted
+ *      assessment these split by DETECTOR into statically DOM-inspectable rules
+ *      (no interaction) and rules that need the INSPECTOR to click/type.
+ *   3. domain     — product-specific overlay. Schema-ready but intentionally empty
+ *      for now (filled in a later PR).
+ */
+import { z } from "zod";
+
+/** 1 = mechanical, 2 = heuristic, 3 = domain overlay. */
+export const RubricLayerSchema = z.union([z.literal(1), z.literal(2), z.literal(3)]);
+export type RubricLayer = z.infer<typeof RubricLayerSchema>;
+
+/**
+ * How a rule is detected. This field is what encodes the §4 capability mapping
+ * and the accepted L2 split: `dom-inspect` runs on a static load, `interaction`
+ * needs the INSPECTOR's click/type (not yet shipped), `manual` is human-only.
+ */
+export const RubricDetectorSchema = z.enum([
+  "axe", //          automated a11y (axe-core)        — L1, static
+  "link-crawl", //   dead-link / dead-end crawler     — L1, static
+  "cwv", //          Core Web Vitals / Lighthouse     — L1, static
+  "dom-inspect", //  static DOM signature, no clicking — L2, static
+  "interaction", //  requires click / type            — L2, needs INSPECTOR
+  "manual", //       human judgement only             — L3
+]);
+export type RubricDetector = z.infer<typeof RubricDetectorSchema>;
+
+/** Reuses the council severity vocabulary so a UX finding sorts alongside code blockers. */
+export const RubricSeveritySchema = z.enum(["blocker", "major", "minor", "nit"]);
+export type RubricSeverity = z.infer<typeof RubricSeveritySchema>;
+
+/**
+ * active = counts toward the gate. shadow = detected and reported but never gates
+ * — used to calibrate the false-positive rate before a rule is promoted (§8).
+ */
+export const RubricStatusSchema = z.enum(["active", "shadow"]);
+export type RubricStatus = z.infer<typeof RubricStatusSchema>;
+
+export const RubricItemSchema = z
+  .object({
+    /** Stable slug, e.g. "L2-dead-button". Never reused for a different rule. */
+    id: z.string().min(1),
+    layer: RubricLayerSchema,
+    /** Canonical English statement of the rule. Localization happens downstream. */
+    rule: z.string().min(1),
+    severity: RubricSeveritySchema,
+    detector: RubricDetectorSchema,
+    status: RubricStatusSchema,
+    /** Bumped when the rule's meaning changes; enables per-rule migration. */
+    version: z.number().int().positive(),
+    /** Provenance for auditability — a WCAG SC, a Nielsen heuristic, or an internal policy. */
+    reference: z.string().min(1),
+    /** What a builder does to fix a violation. */
+    remediation: z.string().min(1),
+  })
+  .strict();
+export type RubricItem = z.infer<typeof RubricItemSchema>;
+
+export const RubricSchema = z
+  .object({
+    version: z.number().int().positive(),
+    items: z.array(RubricItemSchema),
+  })
+  .strict();
+export type Rubric = z.infer<typeof RubricSchema>;
+
+/**
+ * A raw signal is what a detector emits BEFORE it is classified against the
+ * rubric. PR1 owns this contract; real detectors (PR2+) produce these and hand
+ * them to `classifySignals`. Keeping detection and classification separate is
+ * what lets the classifier be pure and unit-testable without a browser.
+ */
+export const RawSignalSchema = z
+  .object({
+    ruleId: z.string().min(1),
+    evidence: z.string().min(1),
+    url: z.string().optional(),
+    selector: z.string().optional(),
+  })
+  .strict();
+export type RawSignal = z.infer<typeof RawSignalSchema>;
+
+/** A signal that matched a known rule, enriched with that rule's grading metadata. */
+export const RubricFindingSchema = z
+  .object({
+    ruleId: z.string().min(1),
+    layer: RubricLayerSchema,
+    severity: RubricSeveritySchema,
+    status: RubricStatusSchema,
+    rule: z.string().min(1),
+    evidence: z.string().min(1),
+    url: z.string().optional(),
+    selector: z.string().optional(),
+  })
+  .strict();
+export type RubricFinding = z.infer<typeof RubricFindingSchema>;

--- a/packages/core/test/ux-rubric.test.mjs
+++ b/packages/core/test/ux-rubric.test.mjs
@@ -1,0 +1,194 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  RUBRIC_VERSION,
+  BASELINE_UX_RUBRIC,
+  RubricItemSchema,
+  RawSignalSchema,
+  RubricFindingSchema,
+  requiresInteraction,
+  isStaticDetector,
+  getRunnableRules,
+  getGatingRules,
+  getRuleById,
+  classifySignals,
+  assertRubricInvariants,
+  DOGFOOD_SIGNALS,
+  CLEAN_SIGNALS,
+} from "../dist/index.js";
+// Also exercise the dedicated subpath so the exports map stays wired.
+import { BASELINE_UX_RUBRIC as VIA_SUBPATH } from "../dist/ux-rubric/index.js";
+
+test("rubric parses at load and pins the version", () => {
+  assert.equal(BASELINE_UX_RUBRIC.version, RUBRIC_VERSION);
+  assert.ok(Array.isArray(BASELINE_UX_RUBRIC.items));
+  assert.ok(BASELINE_UX_RUBRIC.items.length > 0);
+});
+
+test("subpath export resolves to the same rubric", () => {
+  assert.equal(VIA_SUBPATH.version, BASELINE_UX_RUBRIC.version);
+  assert.equal(VIA_SUBPATH.items.length, BASELINE_UX_RUBRIC.items.length);
+});
+
+test("every rule id is unique", () => {
+  const ids = BASELINE_UX_RUBRIC.items.map((i) => i.id);
+  assert.equal(new Set(ids).size, ids.length);
+});
+
+test("layer↔detector invariants hold for every item", () => {
+  // assertRubricInvariants runs at load; re-running must not throw.
+  assert.doesNotThrow(() => assertRubricInvariants(BASELINE_UX_RUBRIC));
+  for (const item of BASELINE_UX_RUBRIC.items) {
+    if (item.layer === 1) assert.ok(["axe", "link-crawl", "cwv"].includes(item.detector));
+    if (item.layer === 2) assert.ok(["dom-inspect", "interaction"].includes(item.detector));
+    if (item.layer === 3) assert.equal(item.detector, "manual");
+  }
+});
+
+test("assertRubricInvariants rejects a bad layer/detector pairing", () => {
+  const bad = {
+    version: 1,
+    items: [
+      {
+        id: "X-bad",
+        layer: 1,
+        rule: "r",
+        severity: "minor",
+        detector: "interaction", // interaction is not valid for layer 1
+        status: "active",
+        version: 1,
+        reference: "test",
+        remediation: "test",
+      },
+    ],
+  };
+  assert.throws(() => assertRubricInvariants(bad), /invalid for layer 1/);
+});
+
+test("assertRubricInvariants rejects duplicate ids", () => {
+  const one = BASELINE_UX_RUBRIC.items[0];
+  assert.throws(
+    () => assertRubricInvariants({ version: 1, items: [one, one] }),
+    /duplicate rule id/,
+  );
+});
+
+test("three layers: L1 and L2 populated, L3 empty but schema-ready", () => {
+  const byLayer = (n) => BASELINE_UX_RUBRIC.items.filter((i) => i.layer === n);
+  assert.ok(byLayer(1).length >= 1);
+  assert.ok(byLayer(2).length >= 1);
+  assert.equal(byLayer(3).length, 0);
+  // schema still accepts a layer-3 item (proves L3 is ready, not blocked)
+  assert.doesNotThrow(() =>
+    RubricItemSchema.parse({
+      id: "L3-example",
+      layer: 3,
+      rule: "domain rule",
+      severity: "minor",
+      detector: "manual",
+      status: "shadow",
+      version: 1,
+      reference: "internal",
+      remediation: "review manually",
+    }),
+  );
+});
+
+test("L2 has exactly 4 rules split 2 dom-inspect + 2 interaction (accepted assessment)", () => {
+  const l2 = BASELINE_UX_RUBRIC.items.filter((i) => i.layer === 2);
+  assert.equal(l2.length, 4);
+  assert.equal(l2.filter((i) => i.detector === "dom-inspect").length, 2);
+  assert.equal(l2.filter((i) => i.detector === "interaction").length, 2);
+  // interaction rules ship in shadow (calibrate FP before gating — §8)
+  for (const i of l2.filter((x) => x.detector === "interaction")) {
+    assert.equal(i.status, "shadow");
+  }
+});
+
+test("requiresInteraction / isStaticDetector classify detectors correctly", () => {
+  assert.equal(requiresInteraction("interaction"), true);
+  assert.equal(requiresInteraction("dom-inspect"), false);
+  assert.equal(isStaticDetector("axe"), true);
+  assert.equal(isStaticDetector("dom-inspect"), true);
+  assert.equal(isStaticDetector("interaction"), false);
+  assert.equal(isStaticDetector("manual"), false);
+});
+
+test("getRunnableRules gates interaction rules on capability, never runs manual", () => {
+  const staticOnly = getRunnableRules(BASELINE_UX_RUBRIC, { canInteract: false });
+  assert.ok(staticOnly.every((i) => i.detector !== "interaction" && i.detector !== "manual"));
+
+  const withInteraction = getRunnableRules(BASELINE_UX_RUBRIC, { canInteract: true });
+  assert.ok(withInteraction.some((i) => i.detector === "interaction"));
+  assert.ok(withInteraction.every((i) => i.detector !== "manual"));
+  assert.ok(withInteraction.length > staticOnly.length);
+});
+
+test("getGatingRules excludes shadow rules", () => {
+  const gating = getGatingRules(BASELINE_UX_RUBRIC);
+  assert.ok(gating.every((i) => i.status === "active"));
+  assert.ok(gating.length < BASELINE_UX_RUBRIC.items.length); // some are shadow
+});
+
+test("getRuleById finds and misses", () => {
+  assert.ok(getRuleById(BASELINE_UX_RUBRIC, "L2-silent-failure"));
+  assert.equal(getRuleById(BASELINE_UX_RUBRIC, "nope"), undefined);
+});
+
+// ── §8 dogfood acceptance scaffold ────────────────────────────────────────────
+
+test("§8 dogfood: 4 known-bad signals classify 4/4", () => {
+  const { findings, unknown } = classifySignals(DOGFOOD_SIGNALS, BASELINE_UX_RUBRIC);
+  assert.equal(findings.length, 4);
+  assert.equal(unknown.length, 0);
+  // every fixture ruleId is a real, static (runnable-now) rule
+  for (const f of findings) {
+    const rule = getRuleById(BASELINE_UX_RUBRIC, f.ruleId);
+    assert.ok(rule);
+    assert.ok(isStaticDetector(rule.detector));
+    assert.equal(f.severity, rule.severity);
+    assert.equal(f.layer, rule.layer);
+  }
+  const parsed = RubricFindingSchema.array().parse(findings);
+  assert.equal(parsed.length, 4);
+});
+
+test("§8 false-positive floor: a clean surface yields zero findings", () => {
+  const { findings, unknown } = classifySignals(CLEAN_SIGNALS, BASELINE_UX_RUBRIC);
+  assert.equal(findings.length, 0);
+  assert.equal(unknown.length, 0);
+});
+
+test("classifySignals never invents: unknown ruleId goes to unknown[], not findings", () => {
+  const { findings, unknown } = classifySignals(
+    [{ ruleId: "L1-a11y-lang", evidence: "no lang attr" }, { ruleId: "made-up", evidence: "x" }],
+    BASELINE_UX_RUBRIC,
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].ruleId, "L1-a11y-lang");
+  assert.equal(unknown.length, 1);
+  assert.equal(unknown[0].ruleId, "made-up");
+});
+
+test("RawSignal schema is strict (rejects extra keys)", () => {
+  assert.throws(() =>
+    RawSignalSchema.parse({ ruleId: "x", evidence: "y", bogus: true }),
+  );
+});
+
+test("RubricItemSchema rejects invalid detector/severity", () => {
+  const base = {
+    id: "x",
+    layer: 1,
+    rule: "r",
+    severity: "major",
+    detector: "axe",
+    status: "active",
+    version: 1,
+    reference: "ref",
+    remediation: "fix",
+  };
+  assert.doesNotThrow(() => RubricItemSchema.parse(base));
+  assert.throws(() => RubricItemSchema.parse({ ...base, detector: "nope" }));
+  assert.throws(() => RubricItemSchema.parse({ ...base, severity: "critical" }));
+});


### PR DESCRIPTION
PR1 of the Baseline UX QA system — **pure data + Zod schema only**. No browser, LLM, or network. Lands parallel to the open with zero product risk; the open gate stays human QA and this rubric does **not** gate the open.

## What
New `@simsa/core/ux-rubric` subpath: the versioned, git-tracked rubric a machine UX pass grades a live surface against, plus the signal→finding contracts detectors (PR2+) emit.

### §2 — three-layer rubric, parsed + invariant-checked at load
- **L1 mechanical** (8 rules) — axe / link-crawl / CWV, static load, gating
- **L2 heuristic** (4 rules) — split by detector per the accepted assessment:
  - 2 `dom-inspect` (escape-hatch, silent-failure) — gate today
  - 2 `interaction` (dead-button, enter-noop) — ship in **shadow** until the INSPECTOR gains click/type and their false-positive rate is calibrated
- **L3 domain overlay** — empty but schema-ready

Invariants beyond Zod (layer↔detector consistency, unique ids) are enforced at module load, so a malformed edit fails the build/test.

### §4 — detector → capability mapping
`requiresInteraction` / `isStaticDetector` / `getRunnableRules(caps)`: static rules always run, interaction rules gate on INSPECTOR capability, manual (L3) never runs automatically. `getGatingRules` excludes shadow.

### §8 — classification + dogfood acceptance scaffold
`classifySignals` is pure and total: known ruleId → enriched finding, unknown → collected (never invented), empty in → empty out (the false-positive floor). Dogfood fixture proves **4 known-bad signals classify 4/4** and a clean surface yields **0**. This is the scaffold PR2's real detectors must reproduce.

## Tests
17 new tests, **430/430 core green**, typecheck clean (strict + noUncheckedIndexedAccess).

## Not in this PR
Real detectors (axe/link-crawl/CWV runners, DOM inspection, INSPECTOR click/type interaction) — that's PR2, which reproduces the dogfood fixture against a live surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)