### PR TITLE
Fix cross-account project leak + reactive sign-in/out (QA #1/#2/#3)

### DIFF
--- a/apps/dashboard/src/app/account/page.tsx
+++ b/apps/dashboard/src/app/account/page.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/lib/account-preferences.mjs";
 import { getAuthSession, signOutAuth, resolveAuthStatus, getMembership, claimWorkspace } from "@/lib/auth-client.mjs";
 import type { MembershipBridge, ClaimResult } from "@/lib/auth-client.mjs";
-import { getUserKey } from "@/lib/workflow-store";
+import { getUserKey, setActiveAccountNamespace, clearActiveAccount } from "@/lib/workflow-store";
 
 export default function AccountPage() {
   return (
@@ -50,7 +50,12 @@ function AccountInner() {
     let active = true;
     getAuthSession()
       .then((s) => {
-        if (active) setAuthSession(s);
+        if (!active) return;
+        setAuthSession(s);
+        // Reconcile local storage to the signed-in identity so this browser's
+        // project list is this account's — not whoever was here before.
+        const email = (s as { user?: { email?: string } } | null)?.user?.email;
+        setActiveAccountNamespace(typeof email === "string" ? email : null);
       })
       .finally(() => {
         if (active) setAuthLoading(false);
@@ -82,6 +87,10 @@ function AccountInner() {
       setMembership(null);
       setClaimPhase("idle");
       setClaimResult(null);
+      // Return local storage to the (empty) anonymous bucket and tell the
+      // sidebar to drop its stale signed-in identity immediately.
+      clearActiveAccount();
+      if (typeof window !== "undefined") window.dispatchEvent(new Event("simsa:auth-changed"));
     } else {
       setAuthError(true);
     }
@@ -111,10 +120,22 @@ function AccountInner() {
       <section className="card mt-6 p-5">
         <p className="section-title">{a.auth.heading}</p>
 
-        {claimFailedRedirect && claimPhase === "idle" && (
-          <p className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
-            {a.auth.claimError}
-          </p>
+        {claimFailedRedirect && claimPhase !== "done" && (
+          <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-800">
+            <p className="font-semibold">{a.auth.claimFailedTitle}</p>
+            <p className="mt-1">{a.auth.claimError}</p>
+            <button
+              type="button"
+              onClick={onClaim}
+              disabled={claimPhase === "working"}
+              className="btn btn-secondary btn-sm mt-2"
+            >
+              {claimPhase === "working" ? a.auth.claimWorking : a.auth.claimRetry}
+            </button>
+            {claimPhase === "error" && (
+              <p className="mt-2 text-red-600">{a.auth.claimRetryFailed}</p>
+            )}
+          </div>
         )}
 
         {authStatus.status === "loading" && (

--- a/apps/dashboard/src/app/login/page.tsx
+++ b/apps/dashboard/src/app/login/page.tsx
@@ -15,7 +15,8 @@ import { Suspense, useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useI18n } from "@/i18n/I18nProvider";
-import { getUserKey } from "@/lib/workflow-store";
+import { getUserKey, setActiveAccountNamespace } from "@/lib/workflow-store";
+import { isPlausibleEmail } from "@/lib/email-validate.mjs";
 import {
   getAuthSession,
   signInEmail,
@@ -45,6 +46,13 @@ function LoginInner() {
   // 로그인됨 ≠ 데이터연결됨 — the single post-login path: claim FIRST, then go.
   const claimAndGo = useCallback(async () => {
     setPhase("claiming");
+    // Bind local storage to this identity so the next/previous account never
+    // sees these projects (moving anon→account claims pre-sign-in work). Then
+    // tell the sidebar its session changed so it refreshes reactively.
+    const session = await getAuthSession().catch(() => null);
+    const email = (session as { user?: { email?: string } } | null)?.user?.email ?? null;
+    setActiveAccountNamespace(typeof email === "string" ? email : null);
+    if (typeof window !== "undefined") window.dispatchEvent(new Event("simsa:auth-changed"));
     const claim = await claimWorkspace(getUserKey()).catch(() => null);
     if (!claim || claim.ok !== true) {
       // Honest failure: the whole point of logging in was linking this
@@ -84,6 +92,13 @@ function LoginInner() {
     e.preventDefault();
     if (phase !== "idle") return;
     setErrorMsg("");
+    // Soft email check on sign-up (beta: verification is off, so at least reject
+    // obviously fake addresses like a@a.com). Sign-in doesn't re-validate — the
+    // account already exists.
+    if (mode === "signup" && !isPlausibleEmail(email)) {
+      setErrorMsg(t.login.invalidEmail);
+      return;
+    }
     setPhase("working");
     const res =
       mode === "signup"

--- a/apps/dashboard/src/components/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar.tsx
@@ -2,12 +2,12 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useI18n } from "@/i18n/I18nProvider";
-import { loadLocalProjects, loadExtendedProjectData, getUserKey } from "@/lib/workflow-store";
+import { loadLocalProjects, loadExtendedProjectData, getUserKey, setActiveAccountNamespace, clearActiveAccount } from "@/lib/workflow-store";
 import { MOCK_PROJECTS, type Project } from "@/lib/mock-data";
 import { FeedbackModal } from "@/components/FeedbackModal";
-import { getAuthSession } from "@/lib/auth-client.mjs";
+import { getAuthSession, signOutAuth } from "@/lib/auth-client.mjs";
 import { computeProjectSteps } from "@/lib/project-steps.mjs";
 import { fetchProjectRepo, listProjectReviewHistory } from "@/lib/workspace-github-api";
 
@@ -35,6 +35,9 @@ export function AppSidebar() {
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   // Signed-in identity for the bottom profile block (null = signed out/unknown).
   const [authEmail, setAuthEmail] = useState<string | null>(null);
+  const [accountMenuOpen, setAccountMenuOpen] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
+  const accountMenuRef = useRef<HTMLDivElement | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
   const [query, setQuery] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -43,18 +46,58 @@ export function AppSidebar() {
   const [hasRepo, setHasRepo] = useState<boolean | null>(null);
   const [hasReviewRun, setHasReviewRun] = useState<boolean | null>(null);
 
+  // Fetch the session, reconcile local storage to that identity, then (re)load
+  // the project list from the now-correct account bucket. Called on mount and
+  // whenever a "simsa:auth-changed" event fires (sign-in/out elsewhere), so the
+  // sidebar never shows a stale signed-in identity or another account's projects.
+  const syncSession = useCallback(async () => {
+    const sess = await getAuthSession().catch(() => null);
+    const email = (sess as { user?: { email?: string } } | null)?.user?.email;
+    const resolved = typeof email === "string" ? email : null;
+    setActiveAccountNamespace(resolved);
+    setAuthEmail(resolved);
+    setProjects([...loadLocalProjects(), ...MOCK_PROJECTS]);
+  }, []);
+
   useEffect(() => {
     try {
       setCollapsed(window.localStorage.getItem(COLLAPSE_KEY) === "1");
     } catch {}
+    // Optimistic first paint from whatever bucket is active; syncSession then
+    // reconciles to the confirmed identity and reloads.
     setProjects([...loadLocalProjects(), ...MOCK_PROJECTS]);
-    getAuthSession()
-      .then((sess) => {
-        const email = (sess as { user?: { email?: string } } | null)?.user?.email;
-        setAuthEmail(typeof email === "string" ? email : null);
-      })
-      .catch(() => {});
-  }, []);
+    void syncSession();
+    const onAuthChanged = () => void syncSession();
+    window.addEventListener("simsa:auth-changed", onAuthChanged);
+    return () => window.removeEventListener("simsa:auth-changed", onAuthChanged);
+  }, [syncSession]);
+
+  // Close the account menu on outside click / Escape.
+  useEffect(() => {
+    if (!accountMenuOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (accountMenuRef.current && !accountMenuRef.current.contains(e.target as Node)) {
+        setAccountMenuOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setAccountMenuOpen(false); };
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [accountMenuOpen]);
+
+  const handleSignOut = useCallback(async () => {
+    setSigningOut(true);
+    await signOutAuth().catch(() => false);
+    clearActiveAccount();
+    setAccountMenuOpen(false);
+    setSigningOut(false);
+    if (typeof window !== "undefined") window.dispatchEvent(new Event("simsa:auth-changed"));
+    router.push("/projects");
+  }, [router]);
 
   // Observe repo-link + review-run facts for the progress map (best-effort;
   // errors leave the fact unknown → fail-open, no false locks).
@@ -319,24 +362,70 @@ export function AppSidebar() {
         >
           {t.nav.feedback}
         </button>
-        <Link href="/account" aria-label={t.account.openLabel} className="flex w-full items-center gap-2.5 rounded-md px-1.5 py-1.5 hover:bg-gray-50">
-          <span className="grid h-7 w-7 flex-shrink-0 place-items-center rounded-full bg-brand-600 text-xs font-semibold text-white">
-            {(authEmail?.[0] ?? initial).toUpperCase()}
-          </span>
-          <span className="min-w-0 flex-1">
-            {authEmail ? (
-              <>
-                <span className="block truncate text-[13px] font-medium text-gray-900">{authEmail}</span>
-                <span className="block truncate text-[11px] text-gray-500">{t.account.plan}</span>
-              </>
-            ) : (
-              <>
-                <span className="block truncate text-[13px] font-medium text-gray-900">{t.account.workspace}</span>
-                <span className="block truncate text-[11px] text-brand-700">{t.account.auth.signIn} →</span>
-              </>
-            )}
-          </span>
-        </Link>
+        <div ref={accountMenuRef} className="relative">
+          <button
+            type="button"
+            onClick={() => setAccountMenuOpen((v) => !v)}
+            aria-haspopup="menu"
+            aria-expanded={accountMenuOpen}
+            aria-label={t.account.openLabel}
+            className="flex w-full items-center gap-2.5 rounded-md px-1.5 py-1.5 text-left hover:bg-gray-50"
+          >
+            <span className="grid h-7 w-7 flex-shrink-0 place-items-center rounded-full bg-brand-600 text-xs font-semibold text-white">
+              {(authEmail?.[0] ?? initial).toUpperCase()}
+            </span>
+            <span className="min-w-0 flex-1">
+              {authEmail ? (
+                <>
+                  <span className="block truncate text-[13px] font-medium text-gray-900">{authEmail}</span>
+                  <span className="block truncate text-[11px] text-gray-500">{t.account.plan}</span>
+                </>
+              ) : (
+                <>
+                  <span className="block truncate text-[13px] font-medium text-gray-900">{t.account.workspace}</span>
+                  <span className="block truncate text-[11px] text-brand-700">{t.account.auth.signIn} →</span>
+                </>
+              )}
+            </span>
+            <span aria-hidden className="text-gray-400">{accountMenuOpen ? "⌄" : "⌃"}</span>
+          </button>
+
+          {accountMenuOpen && (
+            <div
+              role="menu"
+              className="absolute bottom-full left-0 z-20 mb-1 w-full overflow-hidden rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+            >
+              <Link
+                href="/account"
+                role="menuitem"
+                onClick={() => setAccountMenuOpen(false)}
+                className="block px-3 py-1.5 text-[13px] text-gray-700 hover:bg-gray-50"
+              >
+                {t.account.menu.settings}
+              </Link>
+              {authEmail ? (
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={handleSignOut}
+                  disabled={signingOut}
+                  className="block w-full px-3 py-1.5 text-left text-[13px] text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                >
+                  {signingOut ? t.account.menu.signingOut : t.account.menu.signOut}
+                </button>
+              ) : (
+                <Link
+                  href="/login?next=/projects"
+                  role="menuitem"
+                  onClick={() => setAccountMenuOpen(false)}
+                  className="block px-3 py-1.5 text-[13px] text-brand-700 hover:bg-gray-50"
+                >
+                  {t.account.menu.signIn}
+                </Link>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </>
   );

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -56,6 +56,12 @@ export type Dictionary = {
     title: string;
     subtitle: string;
     openLabel: string;
+    menu: {
+      settings: string;
+      signOut: string;
+      signingOut: string;
+      signIn: string;
+    };
     sections: {
       profile: string;
       preferences: string;
@@ -110,7 +116,10 @@ export type Dictionary = {
       claimDone: string;
       claimAlreadyDone: string;
       claimTakenError: string;
+      claimFailedTitle: string;
       claimError: string;
+      claimRetry: string;
+      claimRetryFailed: string;
     };
     badges: { local: string; planned: string; requiresSignIn: string; readOnly: string };
   };
@@ -220,6 +229,7 @@ export type Dictionary = {
     linking: string;
     signInFailed: string;
     signUpFailed: string;
+    invalidEmail: string;
     keepsLocal: string;
     skip: string;
   };

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -55,7 +55,13 @@ const EN = {
     title: "Account",
     subtitle:
       "Local preferences for this browser. Sign-in, teams, and connected-account management are planned.",
-    openLabel: "Open account settings",
+    openLabel: "Open account menu",
+    menu: {
+      settings: "Account settings",
+      signOut: "Sign out",
+      signingOut: "Signing out…",
+      signIn: "Sign in",
+    },
     sections: {
       profile: "Profile",
       preferences: "Preferences",
@@ -114,7 +120,11 @@ const EN = {
       claimDone: "Linked {n} project(s) to your account.",
       claimAlreadyDone: "Already linked to your account — any new projects were included.",
       claimTakenError: "This browser's data is already linked to a different account.",
-      claimError: "Could not link. Please try again.",
+      claimFailedTitle: "You're signed in — but your projects aren't linked yet",
+      claimError:
+        "Sign-in worked. We just couldn't link this browser's projects to your account. Your projects are safe on this device; try linking again.",
+      claimRetry: "Link my projects",
+      claimRetryFailed: "Still couldn't link. Check your connection and try once more.",
     },
     badges: {
       local: "Local",
@@ -283,6 +293,7 @@ const EN = {
     linking: "Linking your projects to your account…",
     signInFailed: "Email or password doesn't match.",
     signUpFailed: "Couldn't create the account. Try a different email or a longer password.",
+    invalidEmail: "Please enter a real email address.",
     keepsLocal: "No account? You can keep using Simsa in this browser.",
     skip: "Maybe later",
   },
@@ -2218,7 +2229,13 @@ const KO = {
     // Stage 170 — 로컬 계정 설정 스텁(인증 없음).
     title: "계정",
     subtitle: "이 브라우저의 로컬 환경설정입니다. 로그인·팀·연결 계정 관리는 예정되어 있습니다.",
-    openLabel: "계정 설정 열기",
+    openLabel: "계정 메뉴 열기",
+    menu: {
+      settings: "계정 설정",
+      signOut: "로그아웃",
+      signingOut: "로그아웃 중…",
+      signIn: "로그인",
+    },
     sections: {
       profile: "프로필",
       preferences: "환경설정",
@@ -2277,7 +2294,11 @@ const KO = {
       claimDone: "프로젝트 {n}개를 계정에 연결했어요.",
       claimAlreadyDone: "이미 계정에 연결되어 있어요 — 새 프로젝트가 있으면 함께 연결했습니다.",
       claimTakenError: "이 브라우저의 데이터는 이미 다른 계정에 연결되어 있어요.",
-      claimError: "연결하지 못했어요. 다시 시도해주세요.",
+      claimFailedTitle: "로그인은 됐어요 — 다만 프로젝트가 아직 계정에 연결되지 않았어요",
+      claimError:
+        "로그인은 정상적으로 됐어요. 이 브라우저의 프로젝트를 계정에 연결하는 것만 실패했습니다. 프로젝트는 이 기기에 그대로 있으니, 아래에서 다시 연결해 주세요.",
+      claimRetry: "프로젝트 연결하기",
+      claimRetryFailed: "여전히 연결하지 못했어요. 연결 상태를 확인하고 한 번 더 시도해 주세요.",
     },
     badges: {
       local: "로컬",
@@ -2443,6 +2464,7 @@ const KO = {
     linking: "프로젝트를 계정에 연결하는 중…",
     signInFailed: "이메일 또는 비밀번호가 맞지 않아요.",
     signUpFailed: "계정을 만들지 못했어요. 다른 이메일이나 더 긴 비밀번호로 시도해주세요.",
+    invalidEmail: "실제 사용하는 이메일 주소를 입력해주세요.",
     keepsLocal: "계정 없이도 이 브라우저에서는 계속 쓸 수 있어요.",
     skip: "나중에 하기",
   },

--- a/apps/dashboard/src/lib/email-validate.d.mts
+++ b/apps/dashboard/src/lib/email-validate.d.mts
@@ -1,0 +1,1 @@
+export function isPlausibleEmail(email: string): boolean;

--- a/apps/dashboard/src/lib/email-validate.mjs
+++ b/apps/dashboard/src/lib/email-validate.mjs
@@ -1,0 +1,45 @@
+/**
+ * email-validate.mjs — soft signup email validation (pure).
+ *
+ * Beta policy (2026-07-05): email verification stays OFF (no friction for
+ * invited testers), but we soft-reject obviously fake addresses like "a@a.com"
+ * so the account list isn't polluted. This is heuristic, not authoritative — it
+ * only catches format errors and toy placeholder domains. Testable under Node 20.
+ */
+
+// Second-level labels / domains that are unmistakably placeholders.
+const PLACEHOLDER_DOMAINS = new Set([
+  "test.com",
+  "test.org",
+  "example.com",
+  "example.org",
+  "example.net",
+  "domain.com",
+  "email.com",
+  "mail.mail",
+  "a.com",
+  "b.com",
+  "abc.com",
+  "asdf.com",
+]);
+
+/**
+ * True when the address is a plausible real email: correct shape, a domain
+ * whose second-level label is ≥ 2 chars, a TLD ≥ 2 chars, and not a known
+ * placeholder domain. Soft heuristic — never blocks a legitimately-shaped
+ * address at a real-looking domain.
+ * @param {string} email
+ * @returns {boolean}
+ */
+export function isPlausibleEmail(email) {
+  const value = String(email ?? "").trim().toLowerCase();
+  // one @, non-empty local, dotted domain, TLD of 2+ letters
+  if (!/^[^\s@]+@[^\s@]+\.[a-z]{2,}$/.test(value)) return false;
+  const domain = value.slice(value.indexOf("@") + 1);
+  if (PLACEHOLDER_DOMAINS.has(domain)) return false;
+  const labels = domain.split(".");
+  const sld = labels[labels.length - 2] ?? "";
+  // "a@a.com" → second-level label "a" (length 1) → reject
+  if (sld.length < 2) return false;
+  return true;
+}

--- a/apps/dashboard/src/lib/project-namespace.d.mts
+++ b/apps/dashboard/src/lib/project-namespace.d.mts
@@ -1,0 +1,17 @@
+export const PROJECTS_BASE: string;
+export const DRAFT_BASE: string;
+export const ACTIVE_NS_KEY: string;
+export const ANON_NS: string;
+
+export function hashAccount(accountId: string): string;
+export function namespaceFor(accountId: string | null | undefined): string;
+export function projectsKeyFor(ns: string): string;
+export function draftKeyFor(ns: string): string;
+export function mergeProjectsById<T extends { id: string }>(
+  existing: readonly T[],
+  incoming: readonly T[],
+): T[];
+export function planNamespaceTransition(
+  prevNs: string,
+  accountId: string | null | undefined,
+): { nextNs: string; claimAnon: boolean };

--- a/apps/dashboard/src/lib/project-namespace.mjs
+++ b/apps/dashboard/src/lib/project-namespace.mjs
@@ -1,0 +1,104 @@
+/**
+ * project-namespace.mjs — account-scoped local storage keys (pure logic).
+ *
+ * The bug this closes: local projects lived under ONE global localStorage key,
+ * so signing out and signing up as a new account (or a second person on a shared
+ * browser) still showed the previous account's projects. Here we compute a
+ * per-account namespace so each identity reads/writes its own bucket, plus the
+ * one-time migrations (legacy global blob → current bucket; anonymous bucket →
+ * account bucket on sign-in "claim").
+ *
+ * Pure and deterministic — no localStorage, no window — so it is unit-testable
+ * under the Node 20 CI (which cannot type-strip .ts). workflow-store.ts wires
+ * these into the real storage. Types live in project-namespace.d.mts.
+ */
+
+export const PROJECTS_BASE = "conclave_wf_projects";
+export const DRAFT_BASE = "conclave_wf_draft";
+export const ACTIVE_NS_KEY = "conclave_active_ns";
+export const ANON_NS = "anon";
+
+/**
+ * Stable, non-cryptographic hash of an account identifier → namespace token.
+ * This only partitions localStorage buckets; it is not a security boundary.
+ * @param {string} accountId
+ * @returns {string}
+ */
+export function hashAccount(accountId) {
+  const s = String(accountId ?? "").trim().toLowerCase();
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (Math.imul(h, 31) + s.charCodeAt(i)) | 0;
+  }
+  return `a_${(h >>> 0).toString(36)}`;
+}
+
+/**
+ * The namespace token for a given identity. Signed out / empty → the anonymous
+ * bucket; signed in → a per-account bucket.
+ * @param {string | null | undefined} accountId
+ * @returns {string}
+ */
+export function namespaceFor(accountId) {
+  const id = typeof accountId === "string" ? accountId.trim() : "";
+  return id ? hashAccount(id) : ANON_NS;
+}
+
+/**
+ * localStorage key for the project list in a namespace.
+ * @param {string} ns
+ * @returns {string}
+ */
+export function projectsKeyFor(ns) {
+  return `${PROJECTS_BASE}:${ns || ANON_NS}`;
+}
+
+/**
+ * localStorage key for the in-progress draft in a namespace.
+ * @param {string} ns
+ * @returns {string}
+ */
+export function draftKeyFor(ns) {
+  return `${DRAFT_BASE}:${ns || ANON_NS}`;
+}
+
+/**
+ * Merge two project lists by id, preferring `incoming` and keeping it first.
+ * Used to fold the anonymous bucket into an account bucket on claim without
+ * losing either side or duplicating a shared id.
+ * @template {{ id: string }} T
+ * @param {readonly T[]} existing
+ * @param {readonly T[]} incoming
+ * @returns {T[]}
+ */
+export function mergeProjectsById(existing, incoming) {
+  const out = [];
+  const seen = new Set();
+  for (const p of incoming ?? []) {
+    if (!p || typeof p.id !== "string" || seen.has(p.id)) continue;
+    seen.add(p.id);
+    out.push(p);
+  }
+  for (const p of existing ?? []) {
+    if (!p || typeof p.id !== "string" || seen.has(p.id)) continue;
+    seen.add(p.id);
+    out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Decide the namespace transition when the resolved identity changes. Returns
+ * the next namespace and whether the anonymous bucket should be claimed
+ * (migrated) into it. Claim happens only when moving FROM anonymous TO an
+ * account — so projects built before signing in are not stranded, while a
+ * second account on the same browser never inherits them.
+ * @param {string} prevNs   the currently-stored active namespace
+ * @param {string | null | undefined} accountId  the resolved signed-in identity (null = signed out)
+ * @returns {{ nextNs: string, claimAnon: boolean }}
+ */
+export function planNamespaceTransition(prevNs, accountId) {
+  const nextNs = namespaceFor(accountId);
+  const claimAnon = Boolean(accountId) && (prevNs || ANON_NS) === ANON_NS && nextNs !== ANON_NS;
+  return { nextNs, claimAnon };
+}

--- a/apps/dashboard/src/lib/workflow-store.ts
+++ b/apps/dashboard/src/lib/workflow-store.ts
@@ -1,6 +1,17 @@
 "use client";
 
 import type { Project, RequirementItem } from "./mock-data";
+import {
+  PROJECTS_BASE,
+  DRAFT_BASE,
+  ACTIVE_NS_KEY,
+  ANON_NS,
+  namespaceFor,
+  projectsKeyFor,
+  draftKeyFor,
+  mergeProjectsById,
+  planNamespaceTransition,
+} from "./project-namespace.mjs";
 
 export type WorkflowDraft = {
   ideaText: string;
@@ -28,18 +39,68 @@ export type GeneratedSpec = {
   openDecisions: string[];
 };
 
-const DRAFT_KEY = "conclave_wf_draft";
-const PROJECTS_KEY = "conclave_wf_projects";
+// ─── Account-scoped storage keys ─────────────────────────────────────────────
+// Projects/drafts live under a per-account namespace (see project-namespace.mjs)
+// so a second account on the same browser never inherits the first account's
+// projects. `conclave_active_ns` records the current identity's namespace;
+// `setActiveAccountNamespace` / `clearActiveAccount` reconcile it on sign-in and
+// sign-out. Old un-namespaced blobs are migrated into the current namespace once.
+
+function activeNamespace(): string {
+  if (typeof window === "undefined") return ANON_NS;
+  try {
+    return localStorage.getItem(ACTIVE_NS_KEY) || ANON_NS;
+  } catch {
+    return ANON_NS;
+  }
+}
+
+function readProjectsAt(key: string): Project[] {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as Project[]) : [];
+  } catch (err) {
+    console.error("[workflow-store] corrupt localStorage entry — data hidden from UI:", err);
+    return [];
+  }
+}
+
+// One-time move of the pre-namespace global blobs into the current namespace, so
+// existing users don't see their local projects vanish when this ships. The
+// legacy keys are the bare bases (no ":ns" suffix); after the move they're
+// removed, making this idempotent.
+function migrateLegacyBlobs(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const ns = activeNamespace();
+    const legacyProjects = localStorage.getItem(PROJECTS_BASE);
+    if (legacyProjects !== null) {
+      const dest = projectsKeyFor(ns);
+      const merged = mergeProjectsById(readProjectsAt(dest), readProjectsAt(PROJECTS_BASE));
+      localStorage.setItem(dest, JSON.stringify(merged));
+      localStorage.removeItem(PROJECTS_BASE);
+    }
+    const legacyDraft = localStorage.getItem(DRAFT_BASE);
+    if (legacyDraft !== null) {
+      const dest = draftKeyFor(ns);
+      if (localStorage.getItem(dest) === null) localStorage.setItem(dest, legacyDraft);
+      localStorage.removeItem(DRAFT_BASE);
+    }
+  } catch (err) {
+    console.error("[workflow-store] legacy migration failed:", err);
+  }
+}
 
 export function saveDraft(draft: WorkflowDraft): void {
   if (typeof window === "undefined") return;
-  localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+  localStorage.setItem(draftKeyFor(activeNamespace()), JSON.stringify(draft));
 }
 
 export function loadDraft(): WorkflowDraft | null {
   if (typeof window === "undefined") return null;
+  migrateLegacyBlobs();
   try {
-    const raw = localStorage.getItem(DRAFT_KEY);
+    const raw = localStorage.getItem(draftKeyFor(activeNamespace()));
     return raw ? (JSON.parse(raw) as WorkflowDraft) : null;
   } catch (err) {
     console.error("[workflow-store] corrupt localStorage entry — data hidden from UI:", err);
@@ -49,7 +110,7 @@ export function loadDraft(): WorkflowDraft | null {
 
 export function clearDraft(): void {
   if (typeof window === "undefined") return;
-  localStorage.removeItem(DRAFT_KEY);
+  localStorage.removeItem(draftKeyFor(activeNamespace()));
 }
 
 export function saveProject(project: Project): void {
@@ -61,18 +122,47 @@ export function saveProject(project: Project): void {
   } else {
     projects.unshift(project);
   }
-  localStorage.setItem(PROJECTS_KEY, JSON.stringify(projects));
+  localStorage.setItem(projectsKeyFor(activeNamespace()), JSON.stringify(projects));
 }
 
 export function loadLocalProjects(): Project[] {
   if (typeof window === "undefined") return [];
+  migrateLegacyBlobs();
+  return readProjectsAt(projectsKeyFor(activeNamespace()));
+}
+
+/**
+ * Reconcile the active namespace to a signed-in identity. Call on every
+ * confirmed sign-in (with the account email/id) and on sign-out (with null).
+ * Moving FROM anonymous TO an account "claims" the anonymous projects into the
+ * account bucket so pre-sign-in work isn't stranded; a different account never
+ * inherits them.
+ */
+export function setActiveAccountNamespace(accountId: string | null): void {
+  if (typeof window === "undefined") return;
   try {
-    const raw = localStorage.getItem(PROJECTS_KEY);
-    return raw ? (JSON.parse(raw) as Project[]) : [];
+    migrateLegacyBlobs();
+    const prevNs = activeNamespace();
+    const { nextNs, claimAnon } = planNamespaceTransition(prevNs, accountId);
+    if (claimAnon) {
+      const anonKey = projectsKeyFor(ANON_NS);
+      const anonProjects = readProjectsAt(anonKey);
+      if (anonProjects.length) {
+        const destKey = projectsKeyFor(nextNs);
+        const merged = mergeProjectsById(readProjectsAt(destKey), anonProjects);
+        localStorage.setItem(destKey, JSON.stringify(merged));
+        localStorage.removeItem(anonKey);
+      }
+    }
+    localStorage.setItem(ACTIVE_NS_KEY, nextNs);
   } catch (err) {
-    console.error("[workflow-store] corrupt localStorage entry — data hidden from UI:", err);
-    return [];
+    console.error("[workflow-store] namespace reconcile failed:", err);
   }
+}
+
+/** Sign-out: return to the (empty) anonymous bucket; account data is preserved. */
+export function clearActiveAccount(): void {
+  setActiveAccountNamespace(null);
 }
 
 export function getLocalProject(id: string): Project | undefined {

--- a/apps/dashboard/test/email-validate.test.mjs
+++ b/apps/dashboard/test/email-validate.test.mjs
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isPlausibleEmail } from "../src/lib/email-validate.mjs";
+
+test("accepts real-looking addresses", () => {
+  for (const e of [
+    "seunghunbae@gmail.com",
+    "jane.doe@company.co.kr",
+    "user+tag@sub.domain.io",
+    "j@gmail.com", // 1-char local at a real domain is allowed
+  ]) {
+    assert.equal(isPlausibleEmail(e), true, e);
+  }
+});
+
+test("rejects the reported fake and other toy/malformed addresses", () => {
+  for (const e of [
+    "a@a.com", // second-level label "a" — the reported case
+    "x@x.x",
+    "test@test.com",
+    "foo@example.com",
+    "notanemail",
+    "no@tld",
+    "a@b", // no dot
+    "@nodomain.com",
+    "spaces in@email.com",
+    "",
+    "   ",
+  ]) {
+    assert.equal(isPlausibleEmail(e), false, e);
+  }
+});
+
+test("is trim/case-insensitive", () => {
+  assert.equal(isPlausibleEmail("  Alice@Gmail.COM  "), true);
+});

--- a/apps/dashboard/test/project-namespace.test.mjs
+++ b/apps/dashboard/test/project-namespace.test.mjs
@@ -1,0 +1,83 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ANON_NS,
+  hashAccount,
+  namespaceFor,
+  projectsKeyFor,
+  draftKeyFor,
+  mergeProjectsById,
+  planNamespaceTransition,
+} from "../src/lib/project-namespace.mjs";
+
+test("namespaceFor: signed out / empty → anon, signed in → stable per-account", () => {
+  assert.equal(namespaceFor(null), ANON_NS);
+  assert.equal(namespaceFor(undefined), ANON_NS);
+  assert.equal(namespaceFor(""), ANON_NS);
+  assert.equal(namespaceFor("   "), ANON_NS);
+  const a = namespaceFor("alice@example.com");
+  assert.equal(a, namespaceFor("alice@example.com")); // deterministic
+  assert.notEqual(a, ANON_NS);
+});
+
+test("hashAccount is case/whitespace-insensitive and distinct per identity", () => {
+  assert.equal(hashAccount("Alice@Example.com"), hashAccount("  alice@example.com "));
+  assert.notEqual(hashAccount("alice@example.com"), hashAccount("bob@example.com"));
+});
+
+test("two different accounts get different project buckets (the leak fix)", () => {
+  const aliceKey = projectsKeyFor(namespaceFor("alice@example.com"));
+  const bobKey = projectsKeyFor(namespaceFor("bob@example.com"));
+  const anonKey = projectsKeyFor(ANON_NS);
+  assert.notEqual(aliceKey, bobKey);
+  assert.notEqual(aliceKey, anonKey);
+  assert.notEqual(bobKey, anonKey);
+});
+
+test("key builders are namespaced and never collide with the legacy base key", () => {
+  assert.equal(projectsKeyFor(ANON_NS), "conclave_wf_projects:anon");
+  assert.equal(draftKeyFor(ANON_NS), "conclave_wf_draft:anon");
+  // legacy bare keys ("conclave_wf_projects") have no ":ns" suffix, so
+  // getItem on the base never returns a namespaced bucket
+  assert.notEqual(projectsKeyFor(ANON_NS), "conclave_wf_projects");
+});
+
+test("mergeProjectsById: incoming wins and stays first, dedup by id, existing appended", () => {
+  const existing = [{ id: "a", n: 1 }, { id: "b", n: 1 }];
+  const incoming = [{ id: "b", n: 2 }, { id: "c", n: 2 }];
+  const merged = mergeProjectsById(existing, incoming);
+  assert.deepEqual(merged.map((p) => p.id), ["b", "c", "a"]);
+  assert.equal(merged.find((p) => p.id === "b").n, 2); // incoming won
+});
+
+test("mergeProjectsById ignores malformed entries", () => {
+  const merged = mergeProjectsById([{ id: "a" }, null, { nope: 1 }], [undefined, { id: "b" }]);
+  assert.deepEqual(merged.map((p) => p.id), ["b", "a"]);
+});
+
+test("planNamespaceTransition: anon → account claims the anon bucket", () => {
+  const { nextNs, claimAnon } = planNamespaceTransition(ANON_NS, "alice@example.com");
+  assert.equal(nextNs, namespaceFor("alice@example.com"));
+  assert.equal(claimAnon, true);
+});
+
+test("planNamespaceTransition: account → different account switches, no claim", () => {
+  const aliceNs = namespaceFor("alice@example.com");
+  const { nextNs, claimAnon } = planNamespaceTransition(aliceNs, "bob@example.com");
+  assert.equal(nextNs, namespaceFor("bob@example.com"));
+  assert.equal(claimAnon, false); // Bob must NOT inherit anon/Alice projects
+});
+
+test("planNamespaceTransition: sign-out → anon, no claim", () => {
+  const aliceNs = namespaceFor("alice@example.com");
+  const { nextNs, claimAnon } = planNamespaceTransition(aliceNs, null);
+  assert.equal(nextNs, ANON_NS);
+  assert.equal(claimAnon, false);
+});
+
+test("planNamespaceTransition: same account re-reconcile is a no-op (no re-claim)", () => {
+  const aliceNs = namespaceFor("alice@example.com");
+  const { nextNs, claimAnon } = planNamespaceTransition(aliceNs, "alice@example.com");
+  assert.equal(nextNs, aliceNs);
+  assert.equal(claimAnon, false);
+});


### PR DESCRIPTION
Fixes the auth/session cluster from live QA. **Root cause: sign-in was never bound to the local project store.**

## The live bug (P0, privacy)
Local projects lived under one global `localStorage` key. Logging out and signing up as a **new account** — or a second person on a shared browser — still showed the **previous account's projects** (the reported "새 계정인데 1인 부동산 프로젝트가 그대로").

## Fixes
- **#3 Isolation** — projects/drafts now live under a **per-account namespace** (`project-namespace.mjs`, pure + unit-tested). Sign-in reconciles to the identity and *claims* the anonymous bucket (pre-sign-in work isn't stranded); a different account gets its own empty bucket; sign-out returns to the anonymous bucket (account data preserved for next sign-in). A one-time migration folds the old global blob into the current bucket so existing users lose nothing.
- **#2 Session reactivity** — the sidebar identity was a one-shot mount fetch with no logout hook (stale "logged-in" look). It now reconciles + reloads on a `simsa:auth-changed` event that sign-in/out dispatch. The bottom-left account block is now a **menu** (account settings / sign in / **sign out**, Claude-style) with a real sign-out.
- **#2 Claim-error honesty** — "연결하지 못했어요. 다시 시도해주세요." was actually a **failed post-login workspace-claim** (login had succeeded). It now says so plainly and offers a real **retry** that re-runs the claim, not a re-login.
- **#2 Fake email** — beta keeps verification **off** (no friction for testers) but sign-up **soft-rejects** obviously fake addresses like `a@a.com` (`email-validate.mjs`, pure + unit-tested).

## Tests
23 new tests (namespace transitions + email heuristic). Dashboard **442/442**, typecheck + build + lint green.

## Deferred to follow-ups (tracked)
- Google OAuth (decided: add now) — separate PR
- Server-side profile-name save
- Idea-path builder-pack redesign + progress storytelling + freeform question answers (#4/#5/#6)

Note: per-project ext/outcome localStorage keys are only reachable via the now-namespaced project list, so namespacing the list is the effective isolation gate; hardening those per-key is a low-risk follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)