### PR TITLE
Idea flow: freeform + skip on every product-spec question

### DIFF
--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -822,26 +822,28 @@ function ApiQuestionCard({
             {opt}
           </button>
         ))}
-        {question.allowLater && (
-          <button
-            onClick={() => onAnswer("defer")}
-            className={`rounded-lg border px-4 py-2 text-sm transition-all ${
-              answer === "defer" ? "border-gray-300 bg-gray-200 text-gray-700" : "border-gray-200 bg-white text-gray-500 hover:bg-gray-50"
-            }`}
-          >
-            {t.np.decideLater}
-          </button>
-        )}
-        {question.allowCustom && (
-          <button
-            onClick={() => onAnswer("custom")}
-            className={`rounded-lg border px-4 py-2 text-sm transition-all ${
-              answer === "custom" ? "border-gray-800 bg-gray-800 text-white" : "border-gray-200 bg-white text-gray-500 hover:bg-gray-50"
-            }`}
-          >
-            {t.np.customInput}
-          </button>
-        )}
+        {/* Freeform + skip are offered on every question — a chip set never
+            covers every real answer, and users were getting stranded when none
+            fit. The server flags (allowCustom / allowLater) only ever widened
+            the choices, so always showing both is a superset that never
+            regresses the flagged case. The answer representation ("custom" →
+            freeform input, "defer" → skip) is unchanged. */}
+        <button
+          onClick={() => onAnswer("defer")}
+          className={`rounded-lg border px-4 py-2 text-sm transition-all ${
+            answer === "defer" ? "border-gray-300 bg-gray-200 text-gray-700" : "border-gray-200 bg-white text-gray-500 hover:bg-gray-50"
+          }`}
+        >
+          {t.np.decideLater}
+        </button>
+        <button
+          onClick={() => onAnswer("custom")}
+          className={`rounded-lg border px-4 py-2 text-sm transition-all ${
+            answer === "custom" ? "border-gray-800 bg-gray-800 text-white" : "border-gray-200 bg-white text-gray-500 hover:bg-gray-50"
+          }`}
+        >
+          {t.np.customInput}
+        </button>
       </div>
       {answer === "custom" && (
         <input


### PR DESCRIPTION
## Problem (live QA #5)
During the idea→spec flow, clarifying "product spec" questions only exposed a freeform **"custom" (직접 입력)** input and a **"skip / 나중에 정하기"** option when the server flagged the question with `allowCustom` / `allowLater`. When none of the option chips fit, users had no way to answer and got stuck.

## Change
In `ApiQuestionCard` (`apps/dashboard/src/app/projects/new/page.tsx`):
- Always render the **freeform "custom"** button (not only when `allowCustom` is set).
- Always render the **"skip / decide later" ("defer")** button (not only when `allowLater` is set).

This mirrors the standalone `components/QuestionCard.tsx`, which already always offers a custom option. It is a **superset** of the previous behavior, so the flagged case does not regress.

## Contract & counter
No server contract or request-shape change. The answer representation already existed and is reused: `"custom"` → freeform input, `"defer"` → skip. The "answered N/total" counter is untouched. Answering remains optional and the generate button stays enabled.

## i18n / tests
Reuses existing `np.customInput` / `np.decideLater` / `np.typeYourOwn` keys — no new labels. The change is purely presentational (removing two flag guards), so no new tests were added.

## Gates (local, all green)
- `typecheck --filter @simsa/dashboard` ✔
- dashboard `node --test test/*.test.mjs` → 448 pass ✔
- `lint --filter @simsa/dashboard` ✔ (only pre-existing warnings)
- `build --filter @simsa/dashboard` ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)