### PR TITLE
D3 Google login + D2 verify-to-sync banner

### DIFF
--- a/apps/central-plane/src/better-auth-spike.ts
+++ b/apps/central-plane/src/better-auth-spike.ts
@@ -79,6 +79,24 @@ export function resolveGithubLoginProvider(
   return { clientId, clientSecret };
 }
 
+/**
+ * Google social-login provider config (D3). Many non-developers have a Google
+ * account, so this is the first-class social option for the open beta (Kakao is
+ * deferred until post-open — its email scope requires a Kakao Biz app / identity
+ * verification). DORMANT until BOTH AUTH_GOOGLE_CLIENT_ID and
+ * AUTH_GOOGLE_CLIENT_SECRET are set (fail-safe: partial config yields no
+ * provider). Pure + exported so the gating is unit-testable.
+ */
+export function resolveGoogleLoginProvider(
+  env: Partial<Env> | undefined,
+): { clientId: string; clientSecret: string } | null {
+  const e = env ?? {};
+  const clientId = typeof e.AUTH_GOOGLE_CLIENT_ID === "string" ? e.AUTH_GOOGLE_CLIENT_ID.trim() : "";
+  const clientSecret = typeof e.AUTH_GOOGLE_CLIENT_SECRET === "string" ? e.AUTH_GOOGLE_CLIENT_SECRET.trim() : "";
+  if (!clientId || !clientSecret) return null;
+  return { clientId, clientSecret };
+}
+
 export function createBetterAuthRuntime(env: Partial<Env> | undefined) {
   if (resolveAuthRuntimeGate(env) !== "ready") return null;
   const e = env ?? {};
@@ -90,6 +108,11 @@ export function createBetterAuthRuntime(env: Partial<Env> | undefined) {
   // options identical to before (origin derived from the request). Never activates auth.
   const topology = resolveAuthTopologyConfig(e);
   const github = resolveGithubLoginProvider(e);
+  const google = resolveGoogleLoginProvider(e);
+  const socialProviders = {
+    ...(github ? { github } : {}),
+    ...(google ? { google } : {}),
+  };
   // D2 soft-auth: send a verification email on sign-up ONLY when Resend is
   // configured (else we couldn't deliver it). `emailAndPassword` deliberately
   // does NOT set requireEmailVerification — sign-in is never blocked; the
@@ -113,7 +136,7 @@ export function createBetterAuthRuntime(env: Partial<Env> | undefined) {
           },
         }
       : {}),
-    ...(github ? { socialProviders: { github } } : {}),
+    ...(Object.keys(socialProviders).length > 0 ? { socialProviders } : {}),
     ...(topology.baseURL ? { baseURL: topology.baseURL } : {}),
     ...(topology.trustedOrigins ? { trustedOrigins: topology.trustedOrigins } : {}),
   });

--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -311,6 +311,17 @@ export interface Env {
   AUTH_GH_CLIENT_ID?: string;
   AUTH_GH_CLIENT_SECRET?: string;
   /**
+   * D3 — Google SOCIAL LOGIN (Better Auth socialProviders.google). Many
+   * non-developers have a Google account, so this is the first-class social
+   * option for the open beta. Callback lives on the DASHBOARD origin
+   * (https://app.trysimsa.com/api/auth/callback/google via the /api/auth proxy).
+   * Dormant until BOTH are set. Secret via the set-worker-secrets workflow —
+   * never local wrangler. (Kakao is deferred post-open: its email scope needs a
+   * Kakao Biz app / identity verification.)
+   */
+  AUTH_GOOGLE_CLIENT_ID?: string;
+  AUTH_GOOGLE_CLIENT_SECRET?: string;
+  /**
    * Stage 241 — auth sign-up exposure guard. Controls whether the public
    * `POST /api/auth/sign-up/*` endpoint is allowed, INDEPENDENTLY of AUTH_ENABLED.
    * Fail-closed: default (unset / unknown) = "disabled" → sign-up is blocked (403

--- a/apps/central-plane/test/better-auth-spike.test.mjs
+++ b/apps/central-plane/test/better-auth-spike.test.mjs
@@ -123,3 +123,16 @@ test("resolveGithubLoginProvider: dormant unless BOTH id+secret are set", async 
     { clientId: "cid", clientSecret: "csec" },
   );
 });
+
+test("resolveGoogleLoginProvider: dormant unless BOTH id+secret are set (D3)", async () => {
+  const { resolveGoogleLoginProvider } = await import("../dist/better-auth-spike.js");
+  assert.equal(resolveGoogleLoginProvider({}), null);
+  assert.equal(resolveGoogleLoginProvider(undefined), null);
+  assert.equal(resolveGoogleLoginProvider({ AUTH_GOOGLE_CLIENT_ID: "id_only" }), null);
+  assert.equal(resolveGoogleLoginProvider({ AUTH_GOOGLE_CLIENT_SECRET: "secret_only" }), null);
+  assert.equal(resolveGoogleLoginProvider({ AUTH_GOOGLE_CLIENT_ID: "  ", AUTH_GOOGLE_CLIENT_SECRET: "s" }), null);
+  assert.deepEqual(
+    resolveGoogleLoginProvider({ AUTH_GOOGLE_CLIENT_ID: "cid", AUTH_GOOGLE_CLIENT_SECRET: "csec" }),
+    { clientId: "cid", clientSecret: "csec" },
+  );
+});

--- a/apps/dashboard/src/app/account/page.tsx
+++ b/apps/dashboard/src/app/account/page.tsx
@@ -18,7 +18,7 @@ import {
   displayInitial,
   DISPLAY_NAME_MAX,
 } from "@/lib/account-preferences.mjs";
-import { getAuthSession, signOutAuth, resolveAuthStatus, getMembership, claimWorkspace } from "@/lib/auth-client.mjs";
+import { getAuthSession, signOutAuth, resolveAuthStatus, getMembership, claimWorkspace, sendVerificationEmail } from "@/lib/auth-client.mjs";
 import type { MembershipBridge, ClaimResult } from "@/lib/auth-client.mjs";
 import { getUserKey, setActiveAccountNamespace, clearActiveAccount } from "@/lib/workflow-store";
 
@@ -41,8 +41,24 @@ function AccountInner() {
   const [membership, setMembership] = useState<MembershipBridge | null>(null);
   const [claimPhase, setClaimPhase] = useState<"idle" | "working" | "done" | "error">("idle");
   const [claimResult, setClaimResult] = useState<ClaimResult | null>(null);
+  const [resendPhase, setResendPhase] = useState<"idle" | "working" | "done" | "error">("idle");
   const searchParams = useSearchParams();
   const claimFailedRedirect = searchParams?.get("claim") === "failed";
+  const verifyRequested = searchParams?.get("verify") === "1";
+
+  // D2 soft-auth: the session carries emailVerified. Show the "verify to sync
+  // across devices" banner when signed in but not yet verified (or when the
+  // login claim bounced here with ?verify=1). Verifying never blocks usage.
+  const sessionUser = (authSession as { user?: { email?: string; emailVerified?: boolean } } | null)?.user;
+  const sessionEmail = typeof sessionUser?.email === "string" ? sessionUser.email : "";
+  const emailUnverified = sessionUser?.emailVerified === false;
+
+  async function onResendVerification() {
+    if (!sessionEmail) return;
+    setResendPhase("working");
+    const res = await sendVerificationEmail(sessionEmail, "/account");
+    setResendPhase(res.ok ? "done" : "error");
+  }
 
   useEffect(() => {
     setDisplayName(readDisplayName(typeof window !== "undefined" ? window.localStorage : null, ""));
@@ -164,6 +180,30 @@ function AccountInner() {
               </button>
               {authError && <p className="mt-1 text-xs text-red-500">{a.auth.signOutError}</p>}
             </div>
+
+            {/* D2 soft-auth: guidance (not a block) to verify for cross-device sync. */}
+            {(emailUnverified || verifyRequested) && (
+              <div className="mt-4 rounded-md border border-blue-200 bg-blue-50 px-4 py-3">
+                <p className="text-xs font-semibold text-blue-900">{a.auth.verifyTitle}</p>
+                <p className="mt-1 text-xs text-blue-800">{a.auth.verifyDesc}</p>
+                <div className="mt-2">
+                  <button
+                    type="button"
+                    onClick={onResendVerification}
+                    disabled={resendPhase === "working" || !sessionEmail}
+                    className="btn btn-secondary btn-sm"
+                  >
+                    {resendPhase === "working" ? a.auth.verifySending : a.auth.verifyResend}
+                  </button>
+                </div>
+                {resendPhase === "done" && (
+                  <p className="mt-2 text-xs text-green-700">{a.auth.verifySent}</p>
+                )}
+                {resendPhase === "error" && (
+                  <p className="mt-2 text-xs text-red-600">{a.auth.verifyError}</p>
+                )}
+              </div>
+            )}
 
             {/* Claim: attach this browser's userKey-scoped data to the account. */}
             {membership?.canClaimProjects && (

--- a/apps/dashboard/src/app/login/page.tsx
+++ b/apps/dashboard/src/app/login/page.tsx
@@ -22,6 +22,7 @@ import {
   signInEmail,
   signUpEmail,
   startGithubLogin,
+  startGoogleLogin,
   claimWorkspace,
 } from "@/lib/auth-client.mjs";
 
@@ -42,6 +43,7 @@ function LoginInner() {
   const [phase, setPhase] = useState<"idle" | "working" | "claiming">("idle");
   const [errorMsg, setErrorMsg] = useState("");
   const [ghUnavailable, setGhUnavailable] = useState(false);
+  const [googleUnavailable, setGoogleUnavailable] = useState(false);
 
   // 로그인됨 ≠ 데이터연결됨 — the single post-login path: claim FIRST, then go.
   const claimAndGo = useCallback(async () => {
@@ -55,6 +57,13 @@ function LoginInner() {
     if (typeof window !== "undefined") window.dispatchEvent(new Event("simsa:auth-changed"));
     const claim = await claimWorkspace(getUserKey()).catch(() => null);
     if (!claim || claim.ok !== true) {
+      // D2 soft-auth: an unverified email doesn't block using Simsa — only the
+      // cross-device claim. Route to the "verify to sync" guidance, not the
+      // generic claim-failed banner.
+      if (claim && claim.ok === false && claim.error === "email_unverified") {
+        router.replace(`/account?verify=1`);
+        return;
+      }
       // Honest failure: the whole point of logging in was linking this
       // browser's projects — a silent claim failure defeats it. The account
       // page can retry; navigation continues so the user isn't stranded.
@@ -88,6 +97,19 @@ function LoginInner() {
     setPhase("idle");
   }
 
+  async function handleGoogle() {
+    setErrorMsg("");
+    setPhase("working");
+    const res = await startGoogleLogin(`/login?next=${encodeURIComponent(nextPath)}`);
+    if (res.ok) {
+      window.location.href = res.url;
+      return;
+    }
+    // Provider not configured yet (dormant) or transient failure — degrade to email.
+    setGoogleUnavailable(true);
+    setPhase("idle");
+  }
+
   async function handleEmailSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (phase !== "idle") return;
@@ -118,12 +140,25 @@ function LoginInner() {
         <h1 className="text-2xl font-semibold tracking-tight text-gray-900">{t.login.title}</h1>
         <p className="mb-8 mt-2 text-sm text-gray-500">{t.login.subtitle}</p>
 
+        {/* Google is the first-class social option for the non-developer beta
+            audience; GitHub is secondary (for the developer path). */}
         <button
-          onClick={handleGithub}
+          onClick={handleGoogle}
           disabled={phase !== "idle"}
           className="btn btn-primary w-full py-3"
         >
-          {phase === "claiming" ? t.login.linking : t.login.github}
+          {phase === "claiming" ? t.login.linking : t.login.google}
+        </button>
+        {googleUnavailable && (
+          <p className="mt-2 text-xs text-amber-600">{t.login.googleUnavailable}</p>
+        )}
+
+        <button
+          onClick={handleGithub}
+          disabled={phase !== "idle"}
+          className="btn btn-secondary mt-2 w-full py-3"
+        >
+          {t.login.github}
         </button>
         {ghUnavailable && (
           <p className="mt-2 text-xs text-amber-600">{t.login.githubUnavailable}</p>

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -120,6 +120,12 @@ export type Dictionary = {
       claimError: string;
       claimRetry: string;
       claimRetryFailed: string;
+      verifyTitle: string;
+      verifyDesc: string;
+      verifyResend: string;
+      verifySending: string;
+      verifySent: string;
+      verifyError: string;
     };
     badges: { local: string; planned: string; requiresSignIn: string; readOnly: string };
   };
@@ -215,6 +221,8 @@ export type Dictionary = {
   login: {
     title: string;
     subtitle: string;
+    google: string;
+    googleUnavailable: string;
     github: string;
     githubUnavailable: string;
     or: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -125,6 +125,13 @@ const EN = {
         "Sign-in worked. We just couldn't link this browser's projects to your account. Your projects are safe on this device; try linking again.",
       claimRetry: "Link my projects",
       claimRetryFailed: "Still couldn't link. Check your connection and try once more.",
+      verifyTitle: "Verify your email to sync across devices",
+      verifyDesc:
+        "You can keep using Simsa in this browser. Verify your email to link your projects to your account and see them on other devices.",
+      verifyResend: "Resend verification email",
+      verifySending: "Sending…",
+      verifySent: "Sent — check your inbox for the verification link.",
+      verifyError: "Couldn't send the email. Try again in a moment.",
     },
     badges: {
       local: "Local",
@@ -279,6 +286,8 @@ const EN = {
   login: {
     title: "Sign in to Simsa",
     subtitle: "Keep your projects and review results — on any device, in any browser.",
+    google: "Continue with Google",
+    googleUnavailable: "Google sign-in isn't available right now — use email below.",
     github: "Continue with GitHub",
     githubUnavailable: "GitHub sign-in isn't available right now — use email below.",
     or: "or",
@@ -2330,6 +2339,13 @@ const KO = {
         "로그인은 정상적으로 됐어요. 이 브라우저의 프로젝트를 계정에 연결하는 것만 실패했습니다. 프로젝트는 이 기기에 그대로 있으니, 아래에서 다시 연결해 주세요.",
       claimRetry: "프로젝트 연결하기",
       claimRetryFailed: "여전히 연결하지 못했어요. 연결 상태를 확인하고 한 번 더 시도해 주세요.",
+      verifyTitle: "다른 기기에서도 보려면 이메일을 인증하세요",
+      verifyDesc:
+        "인증 전에도 이 브라우저에서는 그대로 사용하실 수 있어요. 이메일을 인증하면 프로젝트가 계정에 연결되어 다른 기기에서도 볼 수 있습니다.",
+      verifyResend: "인증 메일 다시 보내기",
+      verifySending: "보내는 중…",
+      verifySent: "보냈어요 — 받은 편지함에서 인증 링크를 확인해주세요.",
+      verifyError: "메일을 보내지 못했어요. 잠시 후 다시 시도해주세요.",
     },
     badges: {
       local: "로컬",
@@ -2481,6 +2497,8 @@ const KO = {
   login: {
     title: "Simsa 로그인",
     subtitle: "프로젝트와 확인 결과를 계정에 보관하세요 — 어떤 기기, 어떤 브라우저에서도 유지돼요.",
+    google: "Google로 계속하기",
+    googleUnavailable: "지금은 Google 로그인을 쓸 수 없어요 — 아래 이메일로 로그인해주세요.",
     github: "GitHub으로 계속하기",
     githubUnavailable: "지금은 GitHub 로그인을 쓸 수 없어요 — 아래 이메일로 로그인해주세요.",
     or: "또는",

--- a/apps/dashboard/src/lib/auth-client.d.mts
+++ b/apps/dashboard/src/lib/auth-client.d.mts
@@ -36,3 +36,12 @@ export function startGithubLogin(
   callbackURL: string,
   fetchImpl?: typeof fetch,
 ): Promise<{ ok: true; url: string } | { ok: false; error: string }>;
+export function startGoogleLogin(
+  callbackURL: string,
+  fetchImpl?: typeof fetch,
+): Promise<{ ok: true; url: string } | { ok: false; error: string }>;
+export function sendVerificationEmail(
+  email: string,
+  callbackURL?: string,
+  fetchImpl?: typeof fetch,
+): Promise<AuthActionResult>;

--- a/apps/dashboard/src/lib/auth-client.mjs
+++ b/apps/dashboard/src/lib/auth-client.mjs
@@ -201,6 +201,62 @@ export async function startGithubLogin(callbackURL, fetchImpl) {
 }
 
 /**
+ * Start Google social login (D3). Many non-developers have a Google account, so
+ * this is the first-class social option. Returns the provider redirect URL — the
+ * caller navigates to it. Dormant server-side until AUTH_GOOGLE_* is configured
+ * (then this returns an error the UI degrades on). Never throws.
+ * @param {string} callbackURL where Better Auth lands the browser after OAuth
+ * @param {typeof fetch} [fetchImpl]
+ * @returns {Promise<{ ok: true, url: string } | { ok: false, error: string }>}
+ */
+export async function startGoogleLogin(callbackURL, fetchImpl) {
+  const f = fetchImpl || (typeof fetch !== "undefined" ? fetch : null);
+  if (!f) return { ok: false, error: "no_fetch" };
+  try {
+    const res = await f(SIGN_IN_SOCIAL_PATH, {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ provider: "google", callbackURL }),
+    });
+    const data = res ? await res.json().catch(() => null) : null;
+    if (res && res.ok && data && typeof data.url === "string" && data.url) {
+      return { ok: true, url: data.url };
+    }
+    return { ok: false, error: data && typeof data.message === "string" ? data.message : `http_${res ? res.status : 0}` };
+  } catch {
+    return { ok: false, error: "network" };
+  }
+}
+
+/**
+ * Re-send the email-verification link (D2 soft-auth). Uses Better Auth's built-in
+ * endpoint. Verifying is what unlocks the workspace claim (cross-device sync);
+ * it never blocks sign-in. Never throws.
+ * @param {string} email
+ * @param {string} [callbackURL] where to land after the user clicks the link
+ * @param {typeof fetch} [fetchImpl]
+ * @returns {Promise<{ ok: true } | { ok: false, error: string }>}
+ */
+export async function sendVerificationEmail(email, callbackURL, fetchImpl) {
+  const f = fetchImpl || (typeof fetch !== "undefined" ? fetch : null);
+  if (!f) return { ok: false, error: "no_fetch" };
+  try {
+    const res = await f("/api/auth/send-verification-email", {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, ...(callbackURL ? { callbackURL } : {}) }),
+    });
+    if (res && res.ok) return { ok: true };
+    const data = res ? await res.json().catch(() => null) : null;
+    return { ok: false, error: data && typeof data.message === "string" ? data.message : `http_${res ? res.status : 0}` };
+  } catch {
+    return { ok: false, error: "network" };
+  }
+}
+
+/**
  * Resolve a UI auth status from a session fetch result. Pure + deterministic.
  * @param {{ loading?: boolean, error?: boolean, session?: any }} input
  * @returns {{ status: "loading" | "error" | "signed_in" | "signed_out", email: string | null }}


### PR DESCRIPTION
Two related auth-surface items (they share `login/page`, `account/page`, `auth-client`), so one PR.

## D3 — Google login
Many non-developers have a Google account, so it's now the **first-class social option** on `/login` (GitHub demoted to secondary, for the developer path; email+password unchanged).
- `resolveGoogleLoginProvider(env)` — pure, **dormant until BOTH `AUTH_GOOGLE_CLIENT_ID` + `AUTH_GOOGLE_CLIENT_SECRET`** are set — wired into better-auth `socialProviders` alongside GitHub.
- `auth-client` gains `startGoogleLogin`; login page gains a Google button + `googleUnavailable` degrade.
- Kakao stays deferred post-open (its email scope requires a Kakao Biz app / identity verification — confirmed earlier).

## D2 — dashboard follow-up (verify-to-sync)
Surfaces the soft-auth claim gate from #240. **Verifying never blocks usage — only cross-device sync.**
- When a signed-in user's email is unverified (`session.emailVerified === false`) or the post-login claim bounced with `email_unverified`, the account page shows a **non-blocking banner** + a **"resend verification email"** button (better-auth's built-in `/api/auth/send-verification-email` via the new `sendVerificationEmail` client).
- The login claim now routes `email_unverified` → `/account?verify=1` instead of the generic claim-failed banner.

## Tests
`resolveGoogleLoginProvider` dormancy/config (mirrors the GitHub test). **central-plane 1602/1602, dashboard 448/448**, typecheck + build + lint green.

## To activate Google in prod
Set `AUTH_GOOGLE_CLIENT_ID` / `AUTH_GOOGLE_CLIENT_SECRET` (Google Cloud OAuth client; callback `https://app.trysimsa.com/api/auth/callback/google`) via the set-worker-secrets workflow. Inert until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)