### PR TITLE
feat(reentry): D1-b regression loop — pack-embedded hook + /p/[id]/connect deep link

### DIFF
--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -36,6 +36,7 @@ import {
   generateBuilderPack,
   type WorkspaceExportBuilderPackRequest,
 } from "../workspace/export.js";
+import { BRAND } from "../workspace/brand.js";
 import {
   saveOutcome,
   listOutcomes,
@@ -571,8 +572,14 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
       }
     }
 
+    // D1-b: thread projectId + resolved app base URL so the pack can embed the
+    // `/p/{projectId}/connect` re-entry link. Env is resolved here (route) to
+    // keep generateBuilderPack pure. Omitted cleanly when projectId is absent.
+    const appBaseUrl = c.env.DASHBOARD_BASE_URL ?? BRAND.appUrl;
     const result = generateBuilderPack({
       project,
+      projectId: req.projectId,
+      appBaseUrl,
       target: req.target,
       format: req.format ?? "json",
       locale: req.locale ?? "ko",

--- a/apps/central-plane/src/workspace/export.ts
+++ b/apps/central-plane/src/workspace/export.ts
@@ -68,6 +68,11 @@ export type ExportFixSuggestion = {
 
 export type WorkspaceExportBuilderPackRequest = {
   projectId?: string;
+  /** D1-b regression loop: resolved app base URL (e.g. https://app.trysimsa.com).
+   *  Passed in by the route so the pure generator stays env-free. When present
+   *  together with projectId, the pack embeds a `/p/{projectId}/connect`
+   *  re-entry instruction; when either is absent, the block is omitted cleanly. */
+  appBaseUrl?: string;
   project?: {
     title: string;
     idea?: string;
@@ -516,6 +521,31 @@ function genCodexPrompt(
   ].join("\n");
 }
 
+// ─── D1-b regression hook ─────────────────────────────────────────────────────
+
+/**
+ * Fixed closing instruction that closes the idea-only loop: it tells the
+ * building agent to self-check against the acceptance criteria and then send
+ * the user back to Simsa with their deployed URL, via a project-scoped deep
+ * link. Deterministic and English (it is an instruction to a coding agent).
+ *
+ * Returns null when projectId or baseUrl is missing so the pack never emits a
+ * broken `/p//connect` link. The base URL is normalised (trailing slashes
+ * stripped) to avoid `//p/...`.
+ */
+export function regressionHookBlock(projectId?: string, appBaseUrl?: string): string | null {
+  const pid = (projectId ?? "").trim();
+  const base = (appBaseUrl ?? "").trim().replace(/\/+$/, "");
+  if (!pid || !base) return null;
+  const connectUrl = `${base}/p/${encodeURIComponent(pid)}/connect`;
+  return [
+    "## After building",
+    "",
+    "After you finish building, self-check the result against the acceptance criteria above.",
+    `Then tell the user to paste their deployed app URL at \`${connectUrl}\` so Simsa can review the live app.`,
+  ].join("\n");
+}
+
 // ─── Main export function ─────────────────────────────────────────────────────
 
 export function generateBuilderPack(
@@ -570,11 +600,15 @@ export function generateBuilderPack(
         )
       : fixSuggestions;
 
+  // ── D1-b regression hook (omitted cleanly when projectId/baseUrl absent) ───
+  const hook = regressionHookBlock(req.projectId, req.appBaseUrl);
+  const hookSuffix = hook ? `\n\n${hook}` : "";
+
   // ── Generate files ────────────────────────────────────────────────────────
   const baseFiles: ExportFile[] = [
     {
       path: "conclave-build-pack/README.md",
-      content: genReadme(title, target, allItems.length, effectiveItems.length),
+      content: genReadme(title, target, allItems.length, effectiveItems.length) + hookSuffix,
     },
     {
       path: "conclave-build-pack/product.md",
@@ -597,13 +631,15 @@ export function generateBuilderPack(
   if (target !== "codex") {
     baseFiles.push({
       path: "conclave-build-pack/CLAUDE_CODE_PROMPT.md",
-      content: genClaudeCodePrompt(title, effectiveItems, allItems.length),
+      content: genClaudeCodePrompt(title, effectiveItems, allItems.length) + hookSuffix,
     });
   }
   if (target !== "claude_code") {
     baseFiles.push({
       path: "conclave-build-pack/CODEX_PROMPT.md",
-      content: genCodexPrompt(title, productSpec, effectiveItems, allItems.length, effectiveFixSuggestions),
+      content:
+        genCodexPrompt(title, productSpec, effectiveItems, allItems.length, effectiveFixSuggestions) +
+        hookSuffix,
     });
   }
 

--- a/apps/central-plane/test/workspace-export.test.mjs
+++ b/apps/central-plane/test/workspace-export.test.mjs
@@ -280,3 +280,88 @@ describe("workspace export-builder-pack (Stage 7: selectedItemIds)", () => {
     assert.ok(readme.content.includes(`${MOCK_ITEMS.length}개 중`), "total item count missing from README");
   });
 });
+
+// ─── D1-b: regression re-entry hook ──────────────────────────────────────────
+
+describe("workspace export-builder-pack (D1-b: regression hook)", () => {
+  const HOOK_FILES = ["README.md", "CLAUDE_CODE_PROMPT.md", "CODEX_PROMPT.md"];
+
+  function filesEndingWith(res, suffixes) {
+    return res.bundle.files.filter((f) => suffixes.some((s) => f.path.endsWith(s)));
+  }
+
+  it("embeds the /p/{projectId}/connect link when projectId + appBaseUrl are given", () => {
+    const res = generateBuilderPack({
+      ...makeReq("both"),
+      projectId: "proj_abc123",
+      appBaseUrl: "https://app.trysimsa.com",
+    });
+    const expected = "https://app.trysimsa.com/p/proj_abc123/connect";
+    for (const file of filesEndingWith(res, HOOK_FILES)) {
+      assert.ok(file.content.includes(expected), `connect link missing from ${file.path}`);
+      assert.ok(file.content.includes("## After building"), `hook heading missing from ${file.path}`);
+    }
+  });
+
+  it("omits the hook cleanly when projectId is absent (no broken /p//connect)", () => {
+    const res = generateBuilderPack({
+      ...makeReq("both"),
+      appBaseUrl: "https://app.trysimsa.com",
+    });
+    for (const file of res.bundle.files) {
+      assert.ok(!file.content.includes("/p//connect"), `broken link in ${file.path}`);
+      assert.ok(!file.content.includes("/connect"), `hook should be absent in ${file.path}`);
+      assert.ok(!file.content.includes("## After building"), `hook heading leaked in ${file.path}`);
+    }
+  });
+
+  it("omits the hook cleanly when appBaseUrl is absent", () => {
+    const res = generateBuilderPack({
+      ...makeReq("both"),
+      projectId: "proj_abc123",
+    });
+    for (const file of res.bundle.files) {
+      assert.ok(!file.content.includes("/connect"), `hook should be absent in ${file.path}`);
+    }
+  });
+
+  it("never emits /p//connect even if projectId is blank", () => {
+    const res = generateBuilderPack({
+      ...makeReq("both"),
+      projectId: "   ",
+      appBaseUrl: "https://app.trysimsa.com",
+    });
+    for (const file of res.bundle.files) {
+      assert.ok(!file.content.includes("/p//connect"), `broken link in ${file.path}`);
+      assert.ok(!file.content.includes("/connect"), `hook should be absent in ${file.path}`);
+    }
+  });
+
+  it("strips a trailing slash from appBaseUrl (no double slash)", () => {
+    const res = generateBuilderPack({
+      ...makeReq("both"),
+      projectId: "proj_abc123",
+      appBaseUrl: "https://app.trysimsa.com/",
+    });
+    const readme = res.bundle.files.find((f) => f.path.endsWith("README.md"));
+    assert.ok(readme, "README.md missing");
+    assert.ok(
+      readme.content.includes("https://app.trysimsa.com/p/proj_abc123/connect"),
+      "trailing slash not normalised",
+    );
+    assert.ok(!readme.content.includes(".com//p/"), "double slash present");
+  });
+
+  it("hook introduces no banned developer terms", () => {
+    const res = generateBuilderPack({
+      ...makeReq("both", { checkResults: MOCK_CHECK_RESULTS, fixSuggestions: MOCK_FIX }),
+      projectId: "proj_abc123",
+      appBaseUrl: "https://app.trysimsa.com",
+    });
+    for (const file of res.bundle.files) {
+      for (const term of BANNED_USER_FACING_TERMS) {
+        assert.ok(!file.content.includes(term), `Banned term "${term}" found in ${file.path}`);
+      }
+    }
+  });
+});

--- a/apps/dashboard/src/app/p/[id]/connect/page.tsx
+++ b/apps/dashboard/src/app/p/[id]/connect/page.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+/**
+ * D1-b — project-scoped re-entry deep link: /p/{id}/connect
+ *
+ * The builder pack (central-plane) instructs the user's building agent to send
+ * the user here with their deployed app URL, so the idea-only loop closes
+ * without waiting for the user to drift back. This page:
+ *   - restores project context from the route id (the source of truth), showing
+ *     the project name when it is resolvable in this browser;
+ *   - auto-focuses a deploy-URL input, soft-validates http(s);
+ *   - connects the URL as a website source via the existing sources API, then
+ *     routes to the project's visual checks so a live review can run;
+ *   - degrades gracefully for the not-signed-in / cross-device case (the page
+ *     still works with the anonymous userKey; a device-scoped note is shown when
+ *     the project is not stored in this browser).
+ *
+ * Reuses existing endpoints only — no new backend surface.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { getLocalProject, getUserKey } from "@/lib/workflow-store";
+import { getProject } from "@/lib/mock-data";
+import { connectProjectSource } from "@/lib/workspace-sources-api";
+import { normalizeDeployUrl } from "@/lib/connect-url.mjs";
+import { Spinner } from "@/components/Spinner";
+import { useToast } from "@/components/Toast";
+import { useI18n } from "@/i18n/I18nProvider";
+
+export default function ConnectReentryPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const { t } = useI18n();
+  const toast = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // localStorage / userKey are client-only; resolve after mount so the first
+  // paint is deterministic (no hydration mismatch) and the device-note is honest.
+  const [mounted, setMounted] = useState(false);
+  const [projectName, setProjectName] = useState<string | null>(null);
+  const [knownHere, setKnownHere] = useState(false);
+
+  const [url, setUrl] = useState("");
+  const [error, setError] = useState<"invalid" | "connect" | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const project = getLocalProject(id) ?? getProject(id);
+    setKnownHere(Boolean(project));
+    setProjectName(project?.name ?? null);
+  }, [id]);
+
+  useEffect(() => {
+    if (mounted) inputRef.current?.focus();
+  }, [mounted]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+
+    const normalized = normalizeDeployUrl(url);
+    if (!normalized.ok) {
+      setError("invalid");
+      inputRef.current?.focus();
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+    const res = await connectProjectSource(id, {
+      userKey: getUserKey(),
+      type: "website",
+      reference: normalized.url,
+    });
+
+    if (res.ok) {
+      toast.success(t.connectReentry.success);
+      // Route to the live visual check; the user runs the inspection there.
+      router.push(`/projects/${id}/visual-checks`);
+      return;
+    }
+
+    setSubmitting(false);
+    setError("connect");
+    toast.error(t.connectReentry.errConnectFailed);
+  }
+
+  const c = t.connectReentry;
+
+  return (
+    <div className="mx-auto max-w-xl px-4 py-10 md:py-16">
+      <div className="mb-6">
+        <h1 className="page-title">{c.title}</h1>
+        <p className="page-subtitle">{c.subtitle}</p>
+      </div>
+
+      <section className="card p-5 md:p-6">
+        <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+          {c.projectLabel}
+        </p>
+        <p className="mt-1 text-sm font-medium text-gray-800">
+          {mounted && projectName ? projectName : id}
+        </p>
+
+        {mounted && !knownHere && (
+          <div className="callout callout-info mt-4">
+            <p className="font-medium">{c.deviceNoteTitle}</p>
+            <p className="mt-1 leading-relaxed">{c.deviceNoteBody}</p>
+            <Link href="/login" className="btn btn-secondary btn-sm mt-3">
+              {t.nav.backToProjects}
+            </Link>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="mt-5">
+          <label htmlFor="deploy-url" className="text-xs font-medium text-gray-500">
+            {c.urlLabel}
+          </label>
+          <input
+            id="deploy-url"
+            ref={inputRef}
+            type="url"
+            inputMode="url"
+            value={url}
+            onChange={(e) => {
+              setUrl(e.target.value);
+              if (error) setError(null);
+            }}
+            placeholder={c.urlPlaceholder}
+            autoComplete="url"
+            className="input mt-1"
+          />
+          <p className="mt-1.5 text-xs text-gray-400">{c.urlHint}</p>
+
+          {error === "invalid" && (
+            <div className="callout callout-error mt-3">{c.errInvalidUrl}</div>
+          )}
+          {error === "connect" && (
+            <div className="callout callout-error mt-3">{c.errConnectFailed}</div>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            data-loading={submitting ? "true" : undefined}
+            className="btn btn-primary btn-md mt-4 w-full"
+          >
+            {submitting ? (
+              <>
+                <Spinner />
+                {c.submitting}
+              </>
+            ) : error === "connect" ? (
+              c.retry
+            ) : (
+              c.submit
+            )}
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -1972,6 +1972,22 @@ export type Dictionary = {
       latestLabel: string;
     };
   };
+  connectReentry: {
+    title: string;
+    subtitle: string;
+    projectLabel: string;
+    urlLabel: string;
+    urlPlaceholder: string;
+    urlHint: string;
+    submit: string;
+    submitting: string;
+    errInvalidUrl: string;
+    errConnectFailed: string;
+    retry: string;
+    success: string;
+    deviceNoteTitle: string;
+    deviceNoteBody: string;
+  };
   sources: {
     title: string;
     subtitle: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -2116,6 +2116,26 @@ const EN = {
       latestLabel: "Latest inspection",
     },
   },
+  // D1-b — project-scoped re-entry deep link (/p/{id}/connect). The builder pack
+  // sends the user here with their deployed URL so Simsa can review the live app.
+  connectReentry: {
+    title: "Connect your live app",
+    subtitle:
+      "Paste the address where your app is deployed. Simsa connects it and opens a visual check of the live app.",
+    projectLabel: "Project",
+    urlLabel: "Deployed app URL",
+    urlPlaceholder: "https://your-app.vercel.app",
+    urlHint: "The public web address where your finished app is running.",
+    submit: "Connect and review",
+    submitting: "Connecting…",
+    errInvalidUrl: "Enter a valid web address starting with http:// or https://.",
+    errConnectFailed: "We couldn't connect that address. Please try again.",
+    retry: "Try again",
+    success: "Connected. Opening the visual check…",
+    deviceNoteTitle: "This link is device-scoped",
+    deviceNoteBody:
+      "This project was created in another browser or device, so its details aren't stored here. You can still connect your deployed URL below. Sign in to sync your projects across devices.",
+  },
   // Stage 262 — project sources (연결): website, GitHub repo, uploaded documents.
   sources: {
     title: "Sources",
@@ -4304,6 +4324,26 @@ const KO = {
       viewReport: "리포트 보기",
       latestLabel: "최근 검수",
     },
+  },
+  // D1-b — 프로젝트별 재진입 딥링크 (/p/{id}/connect). 만들기 패키지가 배포된
+  // URL과 함께 사용자를 여기로 보내면 Simsa가 라이브 앱을 검수해요.
+  connectReentry: {
+    title: "라이브 앱 연결하기",
+    subtitle:
+      "앱이 배포된 주소를 붙여넣으세요. Simsa가 연결한 뒤 라이브 앱의 시각 검수를 바로 열어드려요.",
+    projectLabel: "프로젝트",
+    urlLabel: "배포된 앱 주소",
+    urlPlaceholder: "https://your-app.vercel.app",
+    urlHint: "완성된 앱이 돌아가고 있는 공개 웹 주소예요.",
+    submit: "연결하고 검수하기",
+    submitting: "연결 중…",
+    errInvalidUrl: "http:// 또는 https:// 로 시작하는 올바른 주소를 입력해주세요.",
+    errConnectFailed: "주소를 연결하지 못했어요. 다시 시도해주세요.",
+    retry: "다시 시도",
+    success: "연결됐어요. 시각 검수를 여는 중…",
+    deviceNoteTitle: "이 링크는 기기 전용이에요",
+    deviceNoteBody:
+      "이 프로젝트는 다른 브라우저나 기기에서 만들어져 여기에는 세부 정보가 저장돼 있지 않아요. 그래도 아래에서 배포된 주소를 연결할 수 있어요. 로그인하면 기기 간에 프로젝트가 동기화돼요.",
   },
   // Stage 262 — 연결(프로젝트 소스): 웹사이트 · GitHub 저장소 · 문서 업로드.
   sources: {

--- a/apps/dashboard/src/lib/connect-url.d.mts
+++ b/apps/dashboard/src/lib/connect-url.d.mts
@@ -1,0 +1,7 @@
+/** Type declarations for connect-url.mjs (D1-b re-entry deploy-URL normaliser). */
+
+export type NormalizeDeployUrlResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: "empty" | "invalid" | "scheme" | "host" };
+
+export function normalizeDeployUrl(input: unknown): NormalizeDeployUrlResult;

--- a/apps/dashboard/src/lib/connect-url.mjs
+++ b/apps/dashboard/src/lib/connect-url.mjs
@@ -1,0 +1,39 @@
+/**
+ * connect-url.mjs — pure deploy-URL normaliser for the D1-b re-entry page.
+ *
+ * Soft validation: accepts a bare host ("myapp.vercel.app") by defaulting to
+ * https://, rejects empty / scheme-less-non-http / host-less input. Kept as a
+ * pure .mjs (+ .d.mts types) so Node 20 `node --test` can exercise it without
+ * type-stripping. No network, no side effects.
+ */
+
+/**
+ * @param {unknown} input
+ * @returns {{ ok: true, url: string } | { ok: false, reason: "empty" | "invalid" | "scheme" | "host" }}
+ */
+export function normalizeDeployUrl(input) {
+  const raw = typeof input === "string" ? input.trim() : "";
+  if (!raw) return { ok: false, reason: "empty" };
+
+  // A scheme other than http(s) (e.g. ftp:, javascript:) is rejected outright.
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) && !/^https?:\/\//i.test(raw)) {
+    return { ok: false, reason: "scheme" };
+  }
+  const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+
+  let parsed;
+  try {
+    parsed = new URL(withScheme);
+  } catch {
+    return { ok: false, reason: "invalid" };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, reason: "scheme" };
+  }
+  // A deployed app needs a real host (a dotted domain). Bare "localhost" or a
+  // single token has no dot — treat as not-yet-a-URL so the user fixes it.
+  if (!parsed.hostname || !parsed.hostname.includes(".")) {
+    return { ok: false, reason: "host" };
+  }
+  return { ok: true, url: parsed.href };
+}

--- a/apps/dashboard/test/connect-url.test.mjs
+++ b/apps/dashboard/test/connect-url.test.mjs
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeDeployUrl } from "../src/lib/connect-url.mjs";
+
+describe("normalizeDeployUrl", () => {
+  it("accepts a full https URL and returns a normalised href", () => {
+    const res = normalizeDeployUrl("https://my-app.vercel.app");
+    assert.equal(res.ok, true);
+    assert.equal(res.url, "https://my-app.vercel.app/");
+  });
+
+  it("accepts a full http URL", () => {
+    const res = normalizeDeployUrl("http://example.com/path");
+    assert.equal(res.ok, true);
+    assert.equal(res.url, "http://example.com/path");
+  });
+
+  it("defaults a scheme-less host to https", () => {
+    const res = normalizeDeployUrl("my-app.vercel.app");
+    assert.equal(res.ok, true);
+    assert.equal(res.url, "https://my-app.vercel.app/");
+  });
+
+  it("trims surrounding whitespace", () => {
+    const res = normalizeDeployUrl("  https://example.com  ");
+    assert.equal(res.ok, true);
+    assert.equal(res.url, "https://example.com/");
+  });
+
+  it("rejects empty / whitespace input", () => {
+    assert.deepEqual(normalizeDeployUrl(""), { ok: false, reason: "empty" });
+    assert.deepEqual(normalizeDeployUrl("   "), { ok: false, reason: "empty" });
+    assert.deepEqual(normalizeDeployUrl(null), { ok: false, reason: "empty" });
+    assert.deepEqual(normalizeDeployUrl(undefined), { ok: false, reason: "empty" });
+  });
+
+  it("rejects a non-http(s) scheme", () => {
+    assert.equal(normalizeDeployUrl("ftp://example.com").ok, false);
+    assert.equal(normalizeDeployUrl("ftp://example.com").reason, "scheme");
+    assert.equal(normalizeDeployUrl("javascript://alert(1)").reason, "scheme");
+  });
+
+  it("rejects a host with no dot (bare word / localhost)", () => {
+    assert.equal(normalizeDeployUrl("myapp").reason, "host");
+    assert.equal(normalizeDeployUrl("http://localhost:3000").reason, "host");
+  });
+
+  it("preserves the path and query of a valid URL", () => {
+    const res = normalizeDeployUrl("https://app.example.com/dashboard?tab=live");
+    assert.equal(res.ok, true);
+    assert.equal(res.url, "https://app.example.com/dashboard?tab=live");
+  });
+});


### PR DESCRIPTION
## What & why (D1-b, 2026-07-05)

Idea-only Simsa projects finish at a builder handoff pack + a deploy-URL visual check (PR #239). This closes the loop so users actually come back: the pack itself instructs the user's building agent to send them back, via a project-scoped deep link — instead of waiting for the user to drift back.

Ships the **two high-value core pieces**. The email-reminder layer is deferred to a separate follow-up.

## Piece 1 — pack-embedded regression hook (central-plane)
- `generateBuilderPack` appends a fixed English closing instruction to the **README + CLAUDE_CODE_PROMPT.md + CODEX_PROMPT.md**: after building, self-check against the acceptance criteria, then tell the user to paste their deployed URL at `` `{appBaseUrl}/p/{projectId}/connect` `` so Simsa can review the live app.
- New pure helper `regressionHookBlock(projectId, appBaseUrl)` — deterministic, no LLM/token. Returns `null` (block omitted) when either input is absent or blank; normalises trailing slashes so a broken `/p//connect` link is **never** emitted.
- Threaded `projectId` + resolved app base URL through `POST /workspace/export-builder-pack`. Base URL = `env.DASHBOARD_BASE_URL`, default `BRAND.appUrl` (`https://app.trysimsa.com`) — resolved in the **route** so the pure generator stays env-free. Backward compatible: no projectId ⇒ no block.

## Piece 2 — `/p/[id]/connect` re-entry page (dashboard)
- New client route: restores project context from the route id (source of truth), shows the project name when resolvable, **auto-focuses** a deploy-URL input.
- Soft-validates http(s) via a pure `normalizeDeployUrl` helper (`.mjs` + `.d.mts`), connects the URL as a website source via the **existing** `connectProjectSource` API, then routes to `/projects/{id}/visual-checks`.
- Honest handling of: invalid URL, connect failure (retry + toast), and the cross-device / not-signed-in case (works with the anonymous `userKey`; shows a device-scoped note when the project isn't in this browser). Reuses `Spinner`/`Toast`, `.btn`/`.input`/`.card`, Linear/neutral/deep-green, no emoji. **No new endpoints.**
- New `connectReentry` i18n namespace in `en` + `ko` (+ types).

## Tests / gates (all green locally)
- central-plane: **+6** hook tests (link present / omitted when projectId absent / omitted when baseUrl absent / never `/p//connect` on blank / trailing-slash normalised / no banned dev terms). 28/28 export tests.
- dashboard: **+8** `normalizeDeployUrl` tests. 456/456 dashboard tests; i18n parity holds.
- `typecheck` + `build` green for `@simsa/central-plane` + `@simsa/dashboard`; route `/p/[id]/connect` compiles; lint clean for new files.

## Deferred
- Email-reminder layer (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)