### PR TITLE
Landing fixes: clickable feature cards + footer partnership + Codex in FAQ

### DIFF
--- a/apps/simsa-landing/src/app/globals.css
+++ b/apps/simsa-landing/src/app/globals.css
@@ -617,6 +617,10 @@ body::after {
   box-shadow: var(--shadow-card);
   overflow: hidden;
   transition: transform 150ms ease, box-shadow 150ms ease;
+  /* the whole card is a link (→ /demo); keep it visually a card, not a text link */
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
 }
 
 .feat:hover {
@@ -970,6 +974,23 @@ body::after {
 
 .foot-links a:hover {
   color: var(--fg);
+}
+
+.foot-contact {
+  margin: 0 0 0.4rem;
+  font-size: 0.82rem;
+  color: var(--faint);
+  text-align: center;
+}
+
+.foot-contact a {
+  color: var(--brand);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.foot-contact a:hover {
+  text-decoration: underline;
 }
 
 .foot-tag {

--- a/apps/simsa-landing/src/app/page.tsx
+++ b/apps/simsa-landing/src/app/page.tsx
@@ -9,9 +9,9 @@ import { useEffect, useState } from "react";
 import { LANDING_DICT, LANG_STORAGE_KEY, resolveInitialLang } from "../lib/dictionary.mjs";
 
 const APP_URL = "https://app.trysimsa.com";
-// Real contact mailbox (operator-provided). No trysimsa.com mailbox is wired
-// yet — do not invent hi@trysimsa.com until it exists.
-const CONTACT_EMAIL = "seunghunbae@b2w.kr";
+// Partnership / contact mailbox — 3SVS (operator's company). No trysimsa.com
+// mailbox is wired yet — do not invent hi@trysimsa.com until it exists.
+const CONTACT_EMAIL = "seunghunbae@3svs.com";
 
 // Feedback channel for beta members — mailto only, no backend / DB / provider.
 const FEEDBACK_SUBJECT = "Simsa beta feedback";
@@ -269,7 +269,7 @@ export default function Home() {
           <p>{t.creates.body}</p>
           <div className="bento">
             {t.creates.outputs.map((output, i) => (
-              <div className="feat" key={output}>
+              <Link className="feat" href="/demo" key={output}>
                 <div className="feat-head">
                   <h3>{output}</h3>
                   <span className="feat-arrow" aria-hidden>→</span>
@@ -290,7 +290,7 @@ export default function Home() {
                     <Image className="feat-shot fs-pack" src="/shots/shot-export.webp" alt="" width={1800} height={1200} />
                   )}
                 </div>
-              </div>
+              </Link>
             ))}
           </div>
         </div>
@@ -315,10 +315,6 @@ export default function Home() {
         <div className="container reveal">
           <h2>{t.forWhom.title}</h2>
           <p className="note">{t.forWhom.body}</p>
-          <p>{t.forWhom.contactLead}</p>
-          <a className="contact-link" href={`mailto:${CONTACT_EMAIL}`}>
-            {CONTACT_EMAIL}
-          </a>
         </div>
       </section>
 
@@ -365,8 +361,11 @@ export default function Home() {
             <Link href="/demo">{t.footer.demo}</Link>
             <Link href="/privacy">{t.footer.privacy}</Link>
             <Link href="/terms">{t.footer.terms}</Link>
-            <a href={`mailto:${CONTACT_EMAIL}`}>{t.footer.contact}</a>
           </nav>
+          <p className="foot-contact">
+            {t.footer.partnership} · 3SVS ·{" "}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+          </p>
           <p className="foot-tag">{t.footer.tag}</p>
         </div>
       </footer>

--- a/apps/simsa-landing/src/lib/dictionary.d.mts
+++ b/apps/simsa-landing/src/lib/dictionary.d.mts
@@ -22,7 +22,7 @@ export interface LandingDict {
   forWhom: { title: string; body: string; contactLead: string };
   joinBeta: { title: string; p1: string; p2: string; ctaStart: string; ctaFeedback: string };
   faq: { title: string; items: { q: string; a: string }[] };
-  footer: { demo: string; privacy: string; terms: string; contact: string; tag: string };
+  footer: { demo: string; privacy: string; terms: string; contact: string; partnership: string; tag: string };
 }
 
 export declare const LANDING_DICT: { en: LandingDict; ko: LandingDict };

--- a/apps/simsa-landing/src/lib/dictionary.mjs
+++ b/apps/simsa-landing/src/lib/dictionary.mjs
@@ -88,7 +88,7 @@ export const LANDING_DICT = {
       items: [
         { q: "Is it free?", a: "Yes — Simsa is free during the open beta. No card, no limits beyond a light daily cap." },
         { q: "How is my data handled?", a: "Your work stays in your browser and your account. Reviews are only kept if you opt in, under an anonymized ID — we share patterns, never people." },
-        { q: "Which AI tools does it support?", a: "Anything you built with — Lovable, v0, Bolt, Cursor, Claude Code, Replit, Windsurf, and more. You can also just paste a plan or connect a GitHub repo." },
+        { q: "Which AI tools does it support?", a: "Anything you built with — Claude Code, Codex, Lovable, v0, Bolt, Cursor, Replit, Windsurf, and more. You can also just paste a plan or connect a GitHub repo." },
         { q: "Do I need to know how to code?", a: "No. Simsa is built for non-developers — describe what your app should do in plain language and it checks the result for you." },
         { q: "How do I get in touch?", a: "Use the in-app feedback button (bug, question, or idea) — we read every note." },
       ],
@@ -98,6 +98,7 @@ export const LANDING_DICT = {
       privacy: "Privacy",
       terms: "Terms",
       contact: "Contact",
+      partnership: "Partnerships",
       tag: "The checking layer for AI-built apps.",
     },
   },
@@ -163,7 +164,7 @@ export const LANDING_DICT = {
       items: [
         { q: "무료인가요?", a: "네 — 오픈 베타 기간에는 무료예요. 카드도 필요 없고, 가벼운 하루 사용량 제한 외에는 한도도 없어요." },
         { q: "제 데이터는 어떻게 처리되나요?", a: "작업물은 브라우저와 계정 안에 있어요. 확인 결과는 동의하실 때만 익명 ID로 보관돼요 — 패턴은 공유해도 개인은 절대 아니에요." },
-        { q: "어떤 AI 도구를 지원하나요?", a: "Lovable, v0, Bolt, Cursor, Claude Code, Replit, Windsurf 등 무엇으로 만드셨든 괜찮아요. 기획서를 붙여넣거나 GitHub 저장소를 연결해도 돼요." },
+        { q: "어떤 AI 도구를 지원하나요?", a: "Claude Code, Codex, Lovable, v0, Bolt, Cursor, Replit, Windsurf 등 무엇으로 만드셨든 괜찮아요. 기획서를 붙여넣거나 GitHub 저장소를 연결해도 돼요." },
         { q: "코드를 몰라도 되나요?", a: "네. Simsa는 비개발자를 위해 만들었어요 — 앱이 무엇을 해야 하는지 말로 알려주시면 결과를 대신 확인해드려요." },
         { q: "문의는 어떻게 하나요?", a: "앱 안의 피드백 버튼(버그·질문·제안)을 눌러주세요 — 모든 메모를 읽어요." },
       ],
@@ -173,6 +174,7 @@ export const LANDING_DICT = {
       privacy: "개인정보 처리방침",
       terms: "이용약관",
       contact: "문의",
+      partnership: "제휴문의",
       tag: "AI로 만든 앱을 위한 확인 레이어.",
     },
   },


### PR DESCRIPTION
Live-QA fixes on simsa.dev.

- **Dead arrow buttons** → the "what Simsa creates" feature cards had a `→` affordance (and a hover lift + arrow-slide) but were plain `<div>`s — clicking did nothing. Each card is now a `<Link>` to `/demo` (see a real example), so the arrow means what it looks like. `.feat` gets `text-decoration:none / color:inherit / cursor:pointer` so it still reads as a card, not a text link.
- **Partnership contact** → moved out of the "who it's for" section into the **footer**, labeled **제휴문의 · 3SVS · seunghunbae@3svs.com** (was `seunghunbae@b2w.kr` in the body). Removed the now-redundant generic footer "contact" link.
- **FAQ tool list** → added **Codex** (was missing) and led with **Claude Code, Codex**.

EN + KO both. typecheck + lint (no warnings) + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)