### PR TITLE
simsa-dev: reskin placeholder to the new seal/oxblood design system

### DIFF
--- a/apps/simsa-dev/src/app/globals.css
+++ b/apps/simsa-dev/src/app/globals.css
@@ -1,11 +1,18 @@
 :root {
-  --bg: #faf8f3;
-  --fg: #18181b;        /* zinc-900 */
-  --muted: #52525b;     /* zinc-600 */
-  --faint: #a1a1aa;     /* zinc-400 (disabled/coming-soon) */
-  --accent: #15803d;    /* deep green (dashboard brand-600) */
-  --accent-hover: #166534;
-  --border: #e7e5e4;
+  --bg: #faf8f3;          /* parchment (landing-aligned) */
+  --fg: #1f1a17;          /* warm ink black (stone-900) */
+  --muted: #57534e;
+  --faint: #8b857d;
+  --brand: #8e2c39;       /* review-stamp ink (oxblood 500) */
+  --brand-deep: #4b0e17;  /* imprint (oxblood 700) */
+  --brand-cta: #5c111c;   /* oxblood 600 */
+  --border: #eae6df;
+  --pill: #f1eee8;
+  --pill-hover: #e9e5dd;
+  --panel: #ffffff;
+  --radius-lg: 18px;
+  --shadow-card: 0 0 0 1px rgba(31, 26, 23, 0.03), 0 1px 2px rgba(31, 26, 23, 0.04),
+    0 10px 30px -14px rgba(31, 26, 23, 0.1);
 }
 
 * {
@@ -19,11 +26,25 @@ body {
 }
 
 body {
-  background: var(--bg);
+  background:
+    linear-gradient(to bottom, rgba(142, 44, 57, 0.04), rgba(250, 248, 243, 0) 24rem),
+    var(--bg);
   color: var(--fg);
-  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+  font-family: "Pretendard Variable", Pretendard, ui-sans-serif, system-ui,
+    -apple-system, "Segoe UI", Roboto, "Apple SD Gothic Neo", "Noto Sans KR",
     Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
+  line-height: 1.55;
+}
+
+a {
+  color: inherit;
+}
+
+:focus-visible {
+  outline: 2px solid rgba(142, 44, 57, 0.45);
+  outline-offset: 2px;
+  border-radius: 6px;
 }
 
 .wrap {
@@ -39,30 +60,47 @@ body {
 
 .card {
   max-width: 36rem;
+  background: var(--panel);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: 2.75rem 2.4rem;
+}
+
+.seal {
+  display: flex;
+  justify-content: center;
+  margin: 0 0 1.25rem;
+  filter: drop-shadow(0 6px 14px rgba(75, 14, 23, 0.18));
+}
+
+.seal svg {
+  display: block;
 }
 
 .wordmark {
-  font-size: 0.9rem;
-  letter-spacing: 0.2em;
+  font-size: 0.82rem;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--accent);
+  color: var(--brand);
   font-weight: 600;
-  margin: 0 0 1.25rem;
+  margin: 0 0 1rem;
 }
 
 .tagline {
-  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  font-size: clamp(1.5rem, 4vw, 2.1rem);
   line-height: 1.15;
-  font-weight: 600;
-  letter-spacing: -0.02em;
+  font-weight: 700;
+  letter-spacing: -0.025em;
   margin: 0 0 1rem;
+  word-break: keep-all;
 }
 
 .lede {
   font-size: 1.05rem;
-  line-height: 1.5;
+  line-height: 1.55;
   color: var(--muted);
   margin: 0 0 2rem;
+  word-break: keep-all;
 }
 
 .actions {
@@ -73,41 +111,54 @@ body {
   justify-content: center;
 }
 
+/* ── Primary CTA — oxblood pill ─────────────────────────────────────────── */
 .cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.7rem 1.4rem;
-  border-radius: 0.5rem;
-  background: var(--accent);
+  padding: 0.7rem 1.5rem;
+  border-radius: 999px;
+  background: var(--brand-cta);
   color: #ffffff;
   font-weight: 600;
   font-size: 0.95rem;
   text-decoration: none;
-  transition: background-color 0.15s ease;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 2px 6px rgba(75, 14, 23, 0.25), 0 10px 24px -10px rgba(92, 17, 28, 0.5);
+  transition: background-color 120ms ease, transform 100ms ease;
 }
 
 .cta:hover {
-  background: var(--accent-hover);
+  background: var(--brand-deep);
+  transform: translateY(-1px);
 }
 
+.cta:active {
+  transform: scale(0.97);
+}
+
+/* ── Secondary CTA — quiet pill ─────────────────────────────────────────── */
 .cta-secondary {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.7rem 1.4rem;
-  border-radius: 0.5rem;
-  border: 1px solid var(--border);
-  background: #ffffff;
+  padding: 0.7rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--pill);
   color: var(--fg);
   font-weight: 600;
   font-size: 0.95rem;
   text-decoration: none;
-  transition: background-color 0.15s ease;
+  transition: background-color 120ms ease, transform 100ms ease;
 }
 
 .cta-secondary:hover {
-  background: #f4f4f5;
+  background: var(--pill-hover);
+}
+
+.cta-secondary:active {
+  transform: scale(0.97);
 }
 
 .soon {
@@ -122,15 +173,23 @@ body {
 
 .foot {
   font-size: 0.8rem;
-  color: var(--muted);
+  color: var(--faint);
   line-height: 1.6;
 }
 
 .foot a {
-  color: var(--accent);
+  color: var(--brand);
   text-decoration: none;
+  font-weight: 500;
 }
 
 .foot a:hover {
   text-decoration: underline;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cta,
+  .cta-secondary {
+    transition: none;
+  }
 }

--- a/apps/simsa-dev/src/app/layout.tsx
+++ b/apps/simsa-dev/src/app/layout.tsx
@@ -14,6 +14,13 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        {/* Pretendard variable — Korean-first typography (dynamic subset, cached CDN). */}
+        <link
+          rel="stylesheet"
+          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
+        />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/apps/simsa-dev/src/app/page.tsx
+++ b/apps/simsa-dev/src/app/page.tsx
@@ -11,10 +11,55 @@ const EARLY_ACCESS_MAILTO = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponen
   "Simsa early access request",
 )}`;
 
+// Simsa seal mark (전각 인장) — solid oxblood square with "심사" carved in
+// right-angle seal-script strokes (절곡 인장체: vertical/horizontal only,
+// square caps). 심 left / 사 right so it reads 심사 left-to-right. Clean
+// (non-textured) copy of the landing brand mark — simsa-dev is a separate app.
+const SEAL_STROKES = [
+  // 심: ㅅ (squared Y)
+  "M17 8 V16 M12 16 H22 M12 16 V27 M22 16 V27",
+  // 심: ㅣ
+  "M28 8 V27",
+  // 심: ㅁ
+  "M12 35 H28 V55 M12 35 V55 M12 55 H28",
+  // 사: ㅅ (tall squared Y)
+  "M41 8 V21 M36 21 H46 M36 21 V41 M46 21 V41 M36 41 V55 M46 41 V55",
+  // 사: ㅏ
+  "M53 8 V55 M53 29 H57",
+];
+
+function StampMark({ size = 48 }: { size?: number }) {
+  const strokeW = size <= 28 ? 5 : 4;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      aria-hidden
+      focusable="false"
+    >
+      <rect x="2" y="2" width="60" height="60" rx="7" fill="#8e2c39" />
+      <g
+        stroke="#faf6ee"
+        fill="none"
+        strokeWidth={strokeW}
+        strokeLinecap="square"
+      >
+        {SEAL_STROKES.map((d) => (
+          <path key={d} d={d} />
+        ))}
+      </g>
+    </svg>
+  );
+}
+
 export default function Home() {
   return (
     <main className="wrap">
       <section className="card">
+        <div className="seal">
+          <StampMark size={48} />
+        </div>
         <p className="wordmark">Simsa for Developers</p>
         <h1 className="tagline">Developer docs are coming soon.</h1>
         <p className="lede">


### PR DESCRIPTION
## What

Restyles `apps/simsa-dev` (the developer-docs placeholder) to a **mini version** of the redesigned Simsa landing design system. Skin only — routes, IA, and the page's copy/wording are unchanged. It stays a single-card placeholder.

## Changes

- **Seal StampMark** — clean, non-textured copy of the landing brand mark, added inline (simsa-dev is a separate app, so it gets its own copy — no cross-app import). Replaces the old green wordmark-only mark. ~48px above the wordmark.
- **Oxblood pill CTA** — primary action is a 999px-radius pill with `--brand-cta` fill and the landing's CTA shadow; secondary is a quiet pill.
- **Parchment background** — `#faf8f3` warm white with faint ink drift, matching the landing.
- **Pretendard Variable** — same jsDelivr CDN `<link>` in `<head>`; Pretendard-first font stack (no Geist in this app), KO fallbacks included.
- **Card** — white panel with the landing's `--shadow-card` + `--radius-lg`.

## Constraints honored (§6)

No dark mode, no emoji icons, no gradient-text, no new colors (only landing brand/parchment tokens). No marketing-scale hero typography. No new sections or routes. Copy unchanged.

## Gate

`pnpm turbo run typecheck lint build --filter @simsa/simsa-dev` — all 3 green (ESLint clean, build compiled, no `<img>`/no-img-element issues). Pre-push `pnpm verify` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)