### PR TITLE
Add branded 404 / not-found pages (landing + dashboard)

### DIFF
--- a/apps/dashboard/src/app/not-found.tsx
+++ b/apps/dashboard/src/app/not-found.tsx
@@ -1,0 +1,45 @@
+// Branded 404 — app-router not-found. Static bilingual copy (no useI18n: keeps
+// the page safe if it renders outside providers) + one primary action back to
+// the projects workspace (Nielsen H3). Matches the dashboard .btn primitives.
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "찾을 수 없는 페이지예요 · Page not found — Simsa",
+  description: "요청한 페이지를 찾을 수 없습니다. Page not found.",
+};
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-[100dvh] flex-col items-center justify-center gap-5 px-6 py-12 text-center">
+      {/* Simsa seal mark */}
+      <svg
+        width="52"
+        height="52"
+        viewBox="0 0 64 64"
+        aria-hidden="true"
+        className="drop-shadow-[0_8px_18px_rgba(75,14,23,0.24)]"
+      >
+        <rect x="2" y="2" width="60" height="60" rx="9" fill="#8e2c39" />
+        <g stroke="#faf6ee" fill="none" strokeWidth="5" strokeLinecap="square">
+          <path d="M17 8 V16 M12 16 H22 M12 16 V27 M22 16 V27" />
+          <path d="M28 8 V27" />
+          <path d="M12 35 H28 V55 M12 35 V55 M12 55 H28" />
+          <path d="M41 8 V21 M36 21 H46 M36 21 V41 M46 21 V41 M36 41 V55 M46 41 V55" />
+          <path d="M53 8 V55 M53 29 H57" />
+        </g>
+      </svg>
+
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight text-gray-900">
+          찾을 수 없는 페이지예요
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">Page not found</p>
+      </div>
+
+      <Link href="/projects" className="btn btn-primary btn-md">
+        돌아가기 · Go home
+      </Link>
+    </main>
+  );
+}

--- a/apps/simsa-landing/src/app/not-found.tsx
+++ b/apps/simsa-landing/src/app/not-found.tsx
@@ -1,0 +1,66 @@
+// Branded 404 — app-router not-found. Static, bilingual (KO leads), one primary
+// action back home (Nielsen H3). Reuses the landing's parchment + .cta pill.
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "페이지를 찾을 수 없어요 · Page not found — Simsa",
+  description: "요청한 페이지를 찾을 수 없습니다. Page not found.",
+};
+
+export default function NotFound() {
+  return (
+    <main
+      style={{
+        minHeight: "100dvh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        textAlign: "center",
+        padding: "3rem 1.5rem",
+        gap: "1.25rem",
+      }}
+    >
+      {/* Simsa seal mark */}
+      <svg
+        width="52"
+        height="52"
+        viewBox="0 0 64 64"
+        aria-hidden="true"
+        style={{ filter: "drop-shadow(0 8px 18px rgba(75, 14, 23, 0.24))" }}
+      >
+        <rect x="2" y="2" width="60" height="60" rx="9" fill="#8e2c39" />
+        <g stroke="#faf6ee" fill="none" strokeWidth="5" strokeLinecap="square">
+          <path d="M17 8 V16 M12 16 H22 M12 16 V27 M22 16 V27" />
+          <path d="M28 8 V27" />
+          <path d="M12 35 H28 V55 M12 35 V55 M12 55 H28" />
+          <path d="M41 8 V21 M36 21 H46 M36 21 V41 M46 21 V41 M36 41 V55 M46 41 V55" />
+          <path d="M53 8 V55 M53 29 H57" />
+        </g>
+      </svg>
+
+      <div>
+        <h1
+          style={{
+            margin: "0 0 0.4rem",
+            fontSize: "1.5rem",
+            fontWeight: 700,
+            letterSpacing: "-0.02em",
+            color: "var(--fg)",
+            wordBreak: "keep-all",
+          }}
+        >
+          이 페이지를 찾을 수 없어요
+        </h1>
+        <p style={{ margin: 0, fontSize: "1rem", color: "var(--muted)" }}>
+          Page not found
+        </p>
+      </div>
+
+      <Link className="cta" href="/">
+        돌아가기 · Go home
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## What

Adds an app-router `not-found.tsx` to both Next 15 apps so a bad URL lands on a branded, on-message page instead of Next's default 404.

Each page shows:
- the **Simsa seal mark** (inline self-contained SVG, `aria-hidden`)
- a short bilingual line — "이 페이지를 찾을 수 없어요 · Page not found"
- **exactly one primary action** back home (Nielsen H3): landing → `/`, dashboard → `/projects`

## Per app

- **`apps/simsa-landing`** — reuses the landing's parchment surface + `.cta` pill. Static bilingual copy, matching the existing static legal pages (`/privacy`, `/terms`); no over-engineered i18n for a 404. No page existed before.
- **`apps/dashboard`** — matches the `.btn` / `.btn-primary` / `.btn-md` Tailwind primitives. Static bilingual copy (does **not** call `useI18n`) so it stays safe even if rendered outside providers. No page existed before.

## Constraints honored

No dark mode, no emoji, no gradient text; brand oxblood `#8e2c39` / parchment / existing tokens only. One primary button per page, modest (not hero-scale) density.

## Gate

`pnpm turbo run typecheck lint build --filter @simsa/simsa-landing --filter @simsa/dashboard` → **6/6 green** (lint clean, dashboard `/_not-found` prerendered static).

🤖 Generated with [Claude Code](https://claude.com/claude-code)