### PR TITLE
OG images for all 3 apps (seal + wordmark + tagline) via next/og (§4-b)

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -14,6 +14,7 @@ const geistSans = Geist({ subsets: ["latin"], variable: "--font-geist-sans" });
 const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono" });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://app.trysimsa.com"),
   title: BRAND.metadataTitle,
   description: BRAND.metadataDescription,
 };

--- a/apps/dashboard/src/app/opengraph-image.tsx
+++ b/apps/dashboard/src/app/opengraph-image.tsx
@@ -1,0 +1,61 @@
+import { ImageResponse } from "next/og";
+
+// Shared Simsa OG card (seal + wordmark + tagline), rendered by next/og. Used for
+// KakaoTalk/Threads link previews (KO-first channels). The KO tagline renders only
+// when the Pretendard font loads — otherwise we fall back to the English line so a
+// missing font can never ship tofu (□) or break the build.
+
+export const runtime = "edge";
+export const alt = "Simsa — the checking layer for AI-built apps";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const SEAL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect x="2" y="2" width="60" height="60" rx="9" fill="#8e2c39"/><g stroke="#faf6ee" fill="none" stroke-width="5" stroke-linecap="square"><path d="M17 8 V16 M12 16 H22 M12 16 V27 M22 16 V27"/><path d="M28 8 V27"/><path d="M12 35 H28 V55 M12 35 V55 M12 55 H28"/><path d="M41 8 V21 M36 21 H46 M36 21 V41 M46 21 V41 M36 41 V55 M46 41 V55"/><path d="M53 8 V55 M53 29 H57"/></g></svg>`;
+const SEAL_DATA_URI = `data:image/svg+xml;utf8,${encodeURIComponent(SEAL_SVG)}`;
+
+export default async function OpengraphImage() {
+  let koFont: ArrayBuffer | null = null;
+  try {
+    const res = await fetch(
+      "https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/public/static/Pretendard-SemiBold.otf",
+    );
+    if (res.ok) koFont = await res.arrayBuffer();
+  } catch {
+    koFont = null;
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          background: "#faf8f3",
+          padding: "0 96px",
+          fontFamily: "sans-serif",
+        }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img width="128" height="128" src={SEAL_DATA_URI} alt="" />
+        <div style={{ marginTop: 40, fontSize: 96, fontWeight: 700, color: "#18181b", letterSpacing: "-0.02em" }}>
+          Simsa
+        </div>
+        {koFont ? (
+          <div style={{ marginTop: 10, fontSize: 42, color: "#52525b", fontFamily: "Pretendard" }}>
+            AI로 만든 앱을 위한 확인 레이어
+          </div>
+        ) : null}
+        <div style={{ marginTop: koFont ? 4 : 14, fontSize: 30, fontWeight: 600, color: "#8e2c39" }}>
+          The checking layer for AI-built apps
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      ...(koFont ? { fonts: [{ name: "Pretendard", data: koFont, weight: 600, style: "normal" }] } : {}),
+    },
+  );
+}

--- a/apps/simsa-dev/src/app/layout.tsx
+++ b/apps/simsa-dev/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://simsa.dev"),
   title: "Simsa for Developers",
   description:
     "Developer docs for Simsa — review, compare, and accept AI-built software with evidence.",

--- a/apps/simsa-dev/src/app/opengraph-image.tsx
+++ b/apps/simsa-dev/src/app/opengraph-image.tsx
@@ -1,0 +1,61 @@
+import { ImageResponse } from "next/og";
+
+// Shared Simsa OG card (seal + wordmark + tagline), rendered by next/og. Used for
+// KakaoTalk/Threads link previews (KO-first channels). The KO tagline renders only
+// when the Pretendard font loads — otherwise we fall back to the English line so a
+// missing font can never ship tofu (□) or break the build.
+
+export const runtime = "edge";
+export const alt = "Simsa — the checking layer for AI-built apps";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const SEAL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect x="2" y="2" width="60" height="60" rx="9" fill="#8e2c39"/><g stroke="#faf6ee" fill="none" stroke-width="5" stroke-linecap="square"><path d="M17 8 V16 M12 16 H22 M12 16 V27 M22 16 V27"/><path d="M28 8 V27"/><path d="M12 35 H28 V55 M12 35 V55 M12 55 H28"/><path d="M41 8 V21 M36 21 H46 M36 21 V41 M46 21 V41 M36 41 V55 M46 41 V55"/><path d="M53 8 V55 M53 29 H57"/></g></svg>`;
+const SEAL_DATA_URI = `data:image/svg+xml;utf8,${encodeURIComponent(SEAL_SVG)}`;
+
+export default async function OpengraphImage() {
+  let koFont: ArrayBuffer | null = null;
+  try {
+    const res = await fetch(
+      "https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/public/static/Pretendard-SemiBold.otf",
+    );
+    if (res.ok) koFont = await res.arrayBuffer();
+  } catch {
+    koFont = null;
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          background: "#faf8f3",
+          padding: "0 96px",
+          fontFamily: "sans-serif",
+        }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img width="128" height="128" src={SEAL_DATA_URI} alt="" />
+        <div style={{ marginTop: 40, fontSize: 96, fontWeight: 700, color: "#18181b", letterSpacing: "-0.02em" }}>
+          Simsa
+        </div>
+        {koFont ? (
+          <div style={{ marginTop: 10, fontSize: 42, color: "#52525b", fontFamily: "Pretendard" }}>
+            AI로 만든 앱을 위한 확인 레이어
+          </div>
+        ) : null}
+        <div style={{ marginTop: koFont ? 4 : 14, fontSize: 30, fontWeight: 600, color: "#8e2c39" }}>
+          The checking layer for AI-built apps
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      ...(koFont ? { fonts: [{ name: "Pretendard", data: koFont, weight: 600, style: "normal" }] } : {}),
+    },
+  );
+}

--- a/apps/simsa-landing/src/app/layout.tsx
+++ b/apps/simsa-landing/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 // distribution is Korean-first (link previews on Threads/KakaoTalk). The page
 // itself detects browser language and offers a manual EN/KO toggle.
 export const metadata: Metadata = {
+  metadataBase: new URL("https://simsa.dev"),
   title: "Simsa — AI로 만든 앱, 제대로 작동하는지 확인하세요",
   description:
     "AI로 만든 결과물이 요청한 대로 됐는지 근거와 함께 확인하세요. 오픈 베타 — 베타 기간 무료. Built an app with AI? Make sure it actually works.",

--- a/apps/simsa-landing/src/app/opengraph-image.tsx
+++ b/apps/simsa-landing/src/app/opengraph-image.tsx
@@ -1,0 +1,61 @@
+import { ImageResponse } from "next/og";
+
+// Shared Simsa OG card (seal + wordmark + tagline), rendered by next/og. Used for
+// KakaoTalk/Threads link previews (KO-first channels). The KO tagline renders only
+// when the Pretendard font loads — otherwise we fall back to the English line so a
+// missing font can never ship tofu (□) or break the build.
+
+export const runtime = "edge";
+export const alt = "Simsa — the checking layer for AI-built apps";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const SEAL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect x="2" y="2" width="60" height="60" rx="9" fill="#8e2c39"/><g stroke="#faf6ee" fill="none" stroke-width="5" stroke-linecap="square"><path d="M17 8 V16 M12 16 H22 M12 16 V27 M22 16 V27"/><path d="M28 8 V27"/><path d="M12 35 H28 V55 M12 35 V55 M12 55 H28"/><path d="M41 8 V21 M36 21 H46 M36 21 V41 M46 21 V41 M36 41 V55 M46 41 V55"/><path d="M53 8 V55 M53 29 H57"/></g></svg>`;
+const SEAL_DATA_URI = `data:image/svg+xml;utf8,${encodeURIComponent(SEAL_SVG)}`;
+
+export default async function OpengraphImage() {
+  let koFont: ArrayBuffer | null = null;
+  try {
+    const res = await fetch(
+      "https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/public/static/Pretendard-SemiBold.otf",
+    );
+    if (res.ok) koFont = await res.arrayBuffer();
+  } catch {
+    koFont = null;
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          background: "#faf8f3",
+          padding: "0 96px",
+          fontFamily: "sans-serif",
+        }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img width="128" height="128" src={SEAL_DATA_URI} alt="" />
+        <div style={{ marginTop: 40, fontSize: 96, fontWeight: 700, color: "#18181b", letterSpacing: "-0.02em" }}>
+          Simsa
+        </div>
+        {koFont ? (
+          <div style={{ marginTop: 10, fontSize: 42, color: "#52525b", fontFamily: "Pretendard" }}>
+            AI로 만든 앱을 위한 확인 레이어
+          </div>
+        ) : null}
+        <div style={{ marginTop: koFont ? 4 : 14, fontSize: 30, fontWeight: 600, color: "#8e2c39" }}>
+          The checking layer for AI-built apps
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      ...(koFont ? { fonts: [{ name: "Pretendard", data: koFont, weight: 600, style: "normal" }] } : {}),
+    },
+  );
+}


### PR DESCRIPTION
KakaoTalk/Threads link previews (KO-first channels) now show the brand instead of a bare URL. One shared card — parchment bg, the oxblood **seal** (inline data-URI SVG), **"Simsa"** wordmark, tagline — rendered by **next/og** at the edge, added to all three apps (landing, dashboard, simsa-dev) via the app-router `opengraph-image` convention. `metadataBase` set on each so the `og:image` URL resolves absolute.

**Robustness:** the KO tagline ("AI로 만든 앱을 위한 확인 레이어") renders only when the Pretendard font loads (fetched at render, wrapped in try/catch); otherwise it falls back to the English line — a missing font can never ship tofu (□) or break the build. The wordmark + EN line always render.

No dark mode, no emoji, no gradients — brand oxblood / parchment / ink only (§6).

## Gates
typecheck + lint (no warnings) + build green for all 3 apps; each emits the `/opengraph-image` route. (The `.next/types` TS6053 the earlier attempt hit is a Turbo ordering quirk — run `build` before `typecheck` locally; CI's typecheck-build handles it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)