### PR TITLE
Align landing subpages (/demo, /privacy, /terms) with the main landing (§4-b)

### DIFF
--- a/apps/simsa-landing/src/app/demo/page.tsx
+++ b/apps/simsa-landing/src/app/demo/page.tsx
@@ -3,6 +3,7 @@
 // backend). It shows the transformation: AI-built draft -> staged acceptance.
 import type { Metadata } from "next";
 import Link from "next/link";
+import { StampMark } from "../../components/StampMark";
 
 const APP_URL = "https://app.trysimsa.com";
 const CONTACT_EMAIL = "seunghunbae@b2w.kr";
@@ -46,10 +47,24 @@ const OUTPUT = [
 export default function Demo() {
   return (
     <main>
+      <header className="nav">
+        <div className="container nav-inner">
+          <Link className="nav-brand" href="/">
+            <StampMark size={26} id="nav" />
+            Simsa
+          </Link>
+          <div className="nav-actions">
+            <a className="nav-cta" href={APP_URL}>
+              Open Simsa
+            </a>
+          </div>
+        </div>
+      </header>
+
       <section className="hero">
         <div className="container">
           <span className="demo-label">Public demo · Fictional example</span>
-          <h1 className="tagline">
+          <h1 className="demo-title">
             From AI-built draft to staged acceptance workflow.
           </h1>
           <p className="lede">
@@ -193,6 +208,9 @@ export default function Demo() {
 
       <footer className="foot">
         <div className="container">
+          <div className="foot-mark" aria-hidden>
+            <StampMark size={36} rough id="foot" />
+          </div>
           <nav className="foot-links">
             <Link href="/">Home</Link>
             <Link href="/privacy">Privacy</Link>

--- a/apps/simsa-landing/src/app/globals.css
+++ b/apps/simsa-landing/src/app/globals.css
@@ -1068,6 +1068,37 @@ body::after {
   margin-bottom: 1rem;
 }
 
+/* Demo intro heading — section-scale, NOT the marketing hero .tagline scale */
+.demo-title {
+  font-size: clamp(1.9rem, 4.6vw, 2.9rem);
+  line-height: 1.08;
+  font-weight: 800;
+  letter-spacing: -0.035em;
+  margin: 0 auto 1.1rem;
+  max-width: 16em;
+  word-break: keep-all;
+  text-wrap: balance;
+  color: var(--fg);
+}
+
+/* Demo list blocks (acceptance items / Simsa output) — quiet card rows */
+.outputs {
+  list-style: none;
+  margin: 1.1rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.outputs li {
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  box-shadow: var(--shadow-card);
+  font-size: 0.97rem;
+  color: var(--fg);
+}
+
 .demo-card {
   border: none;
   border-radius: var(--radius-md);
@@ -1145,13 +1176,15 @@ body::after {
   padding: 3rem 0 4rem;
 }
 
+/* Quiet text-link back to the landing (matches footer link treatment) */
 .back {
   display: inline-block;
   margin-bottom: 1.5rem;
   font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--muted);
+  font-weight: 500;
+  color: var(--faint);
   text-decoration: none;
+  transition: color 120ms ease;
 }
 
 .back:hover {

--- a/apps/simsa-landing/src/app/page.tsx
+++ b/apps/simsa-landing/src/app/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 import { LANDING_DICT, LANG_STORAGE_KEY, resolveInitialLang } from "../lib/dictionary.mjs";
+import { StampMark } from "../components/StampMark";
 
 const APP_URL = "https://app.trysimsa.com";
 // Partnership / contact mailbox — 3SVS (operator's company). No trysimsa.com
@@ -28,72 +29,6 @@ const FEEDBACK_MAILTO = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
 )}&body=${encodeURIComponent(FEEDBACK_BODY)}`;
 
 type Lang = "en" | "ko";
-
-// Simsa seal mark (전각 인장) — solid oxblood square with "심사" carved in
-// right-angle seal-script strokes (절곡 인장체: vertical/horizontal only,
-// maze-like, square caps). 심 left / 사 right so it reads 심사 left-to-right.
-// `rough` adds an 인주(ink-pad) texture for large hero/footer sizes.
-const SEAL_STROKES = [
-  // 심: ㅅ (squared Y)
-  "M17 8 V16 M12 16 H22 M12 16 V27 M22 16 V27",
-  // 심: ㅣ
-  "M28 8 V27",
-  // 심: ㅁ
-  "M12 35 H28 V55 M12 35 V55 M12 55 H28",
-  // 사: ㅅ (tall squared Y)
-  "M41 8 V21 M36 21 H46 M36 21 V41 M46 21 V41 M36 41 V55 M46 41 V55",
-  // 사: ㅏ
-  "M53 8 V55 M53 29 H57",
-];
-
-function StampMark({
-  size = 24,
-  rough = false,
-  id = "s",
-  className,
-}: {
-  size?: number;
-  rough?: boolean;
-  id?: string;
-  className?: string;
-}) {
-  const fid = `seal-ink-${id}`;
-  const strokeW = size <= 28 ? 5 : 4;
-  const body = (
-    <>
-      <rect x="2" y="2" width="60" height="60" rx="7" fill="#8e2c39" />
-      <g stroke="#faf6ee" fill="none" strokeWidth={strokeW} strokeLinecap="square">
-        {SEAL_STROKES.map((d) => (
-          <path key={d} d={d} />
-        ))}
-      </g>
-    </>
-  );
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 64 64"
-      className={className}
-      aria-hidden
-      focusable="false"
-    >
-      {rough ? (
-        <>
-          <defs>
-            <filter id={fid} x="-6%" y="-6%" width="112%" height="112%">
-              <feTurbulence type="fractalNoise" baseFrequency="0.35 0.4" numOctaves="2" seed="5" result="n" />
-              <feDisplacementMap in="SourceGraphic" in2="n" scale="1.4" />
-            </filter>
-          </defs>
-          <g filter={`url(#${fid})`}>{body}</g>
-        </>
-      ) : (
-        body
-      )}
-    </svg>
-  );
-}
 
 // Inline line-glyphs for the "start from anything" cards (decorative, aria-hidden).
 const GLYPHS = [

--- a/apps/simsa-landing/src/app/privacy/page.tsx
+++ b/apps/simsa-landing/src/app/privacy/page.tsx
@@ -2,7 +2,9 @@
 // Not a final/lawyer-reviewed policy; no legal entity invented.
 import type { Metadata } from "next";
 import Link from "next/link";
+import { StampMark } from "../../components/StampMark";
 
+const APP_URL = "https://app.trysimsa.com";
 const CONTACT_EMAIL = "seunghunbae@b2w.kr";
 
 export const metadata: Metadata = {
@@ -13,6 +15,20 @@ export const metadata: Metadata = {
 export default function Privacy() {
   return (
     <main>
+      <header className="nav">
+        <div className="container nav-inner">
+          <Link className="nav-brand" href="/">
+            <StampMark size={26} id="nav" />
+            Simsa
+          </Link>
+          <div className="nav-actions">
+            <a className="nav-cta" href={APP_URL}>
+              Open Simsa
+            </a>
+          </div>
+        </div>
+      </header>
+
       <article className="legal container">
         <Link className="back" href="/">
           ← Simsa
@@ -65,6 +81,9 @@ export default function Privacy() {
 
       <footer className="foot">
         <div className="container">
+          <div className="foot-mark" aria-hidden>
+            <StampMark size={36} rough id="foot" />
+          </div>
           <nav className="foot-links">
             <Link href="/privacy">Privacy</Link>
             <Link href="/terms">Terms</Link>

--- a/apps/simsa-landing/src/app/terms/page.tsx
+++ b/apps/simsa-landing/src/app/terms/page.tsx
@@ -2,7 +2,9 @@
 // Not a final/lawyer-reviewed agreement; no paid plans or billing terms.
 import type { Metadata } from "next";
 import Link from "next/link";
+import { StampMark } from "../../components/StampMark";
 
+const APP_URL = "https://app.trysimsa.com";
 const CONTACT_EMAIL = "seunghunbae@b2w.kr";
 
 export const metadata: Metadata = {
@@ -13,6 +15,20 @@ export const metadata: Metadata = {
 export default function Terms() {
   return (
     <main>
+      <header className="nav">
+        <div className="container nav-inner">
+          <Link className="nav-brand" href="/">
+            <StampMark size={26} id="nav" />
+            Simsa
+          </Link>
+          <div className="nav-actions">
+            <a className="nav-cta" href={APP_URL}>
+              Open Simsa
+            </a>
+          </div>
+        </div>
+      </header>
+
       <article className="legal container">
         <Link className="back" href="/">
           ← Simsa
@@ -60,6 +76,9 @@ export default function Terms() {
 
       <footer className="foot">
         <div className="container">
+          <div className="foot-mark" aria-hidden>
+            <StampMark size={36} rough id="foot" />
+          </div>
           <nav className="foot-links">
             <Link href="/privacy">Privacy</Link>
             <Link href="/terms">Terms</Link>

--- a/apps/simsa-landing/src/components/StampMark.tsx
+++ b/apps/simsa-landing/src/components/StampMark.tsx
@@ -1,0 +1,69 @@
+// Shared Simsa seal mark (전각 인장) — solid oxblood square with "심사" carved in
+// right-angle seal-script strokes (절곡 인장체: vertical/horizontal only,
+// maze-like, square caps). 심 left / 사 right so it reads 심사 left-to-right.
+// `rough` adds an 인주(ink-pad) texture for large hero/footer sizes.
+//
+// Pure presentational SVG (no hooks) so it works in both server and client
+// components. Used by the landing page and the /demo, /privacy, /terms subpages
+// so the brand mark is defined exactly once.
+const SEAL_STROKES = [
+  // 심: ㅅ (squared Y)
+  "M17 8 V16 M12 16 H22 M12 16 V27 M22 16 V27",
+  // 심: ㅣ
+  "M28 8 V27",
+  // 심: ㅁ
+  "M12 35 H28 V55 M12 35 V55 M12 55 H28",
+  // 사: ㅅ (tall squared Y)
+  "M41 8 V21 M36 21 H46 M36 21 V41 M46 21 V41 M36 41 V55 M46 41 V55",
+  // 사: ㅏ
+  "M53 8 V55 M53 29 H57",
+];
+
+export function StampMark({
+  size = 24,
+  rough = false,
+  id = "s",
+  className,
+}: {
+  size?: number;
+  rough?: boolean;
+  id?: string;
+  className?: string;
+}) {
+  const fid = `seal-ink-${id}`;
+  const strokeW = size <= 28 ? 5 : 4;
+  const body = (
+    <>
+      <rect x="2" y="2" width="60" height="60" rx="7" fill="#8e2c39" />
+      <g stroke="#faf6ee" fill="none" strokeWidth={strokeW} strokeLinecap="square">
+        {SEAL_STROKES.map((d) => (
+          <path key={d} d={d} />
+        ))}
+      </g>
+    </>
+  );
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      className={className}
+      aria-hidden
+      focusable="false"
+    >
+      {rough ? (
+        <>
+          <defs>
+            <filter id={fid} x="-6%" y="-6%" width="112%" height="112%">
+              <feTurbulence type="fractalNoise" baseFrequency="0.35 0.4" numOctaves="2" seed="5" result="n" />
+              <feDisplacementMap in="SourceGraphic" in2="n" scale="1.4" />
+            </filter>
+          </defs>
+          <g filter={`url(#${fid})`}>{body}</g>
+        </>
+      ) : (
+        body
+      )}
+    </svg>
+  );
+}


### PR DESCRIPTION
The main Simsa landing was recently redesigned (seal brand, floating-glass nav, oxblood, Pretendard, card shadows). The subpages lagged behind — no nav, seal-less footer, and `/demo` used the full marketing hero scale. This aligns all three to the same design language. **Skin only — no copy, route, or IA changes.**

## Shared brand mark
- Extracted `StampMark` (+ `SEAL_STROKES`) once to `src/components/StampMark.tsx` and import it from `page.tsx` and all three subpages. The SVG seal is no longer duplicated. Pure presentational component (no hooks) so it works in both server and client components.

## Per subpage
- **/demo** — added the floating-glass nav + seal footer (`foot-mark`). Dialed the intro heading from the marketing `.tagline` scale down to a section-scale `.demo-title` (no hero scale). Gave the acceptance/output lists (`.outputs`, previously unstyled) quiet card rows so they match the `.demo-card`/`.kv`/`.ev-*`/`.decision` blocks (already on `--shadow-card`).
- **/privacy** + **/terms** — added the same nav + seal footer; restyled the `.back` link to the landing's quiet text-link treatment. Document-page density kept — no hero-scale type. Pretendard inherits from `layout.tsx`.

## Constraints (§6)
No dark mode, emoji, gradient text, or new colors — palette limited to existing brand/gold/parchment tokens. Pages stay CSS/SVG only (no `<img>`, no `no-img-element`).

## Gate
`pnpm turbo run typecheck lint build --filter @simsa/simsa-landing` — all 3 green. `/demo`, `/privacy`, `/terms` all prerender as static content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)