### PR TITLE
Restyle §4 P0: first-impression screens (chooser, home, login, intake)

### DIFF
--- a/apps/dashboard/src/app/login/page.tsx
+++ b/apps/dashboard/src/app/login/page.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { useI18n } from "@/i18n/I18nProvider";
 import { getUserKey, setActiveAccountNamespace } from "@/lib/workflow-store";
 import { isPlausibleEmail } from "@/lib/email-validate.mjs";
+import { StampMark } from "@/components/brand/StampMark";
 import {
   getAuthSession,
   signInEmail,
@@ -135,8 +136,9 @@ function LoginInner() {
   }
 
   return (
-    <main className="flex flex-1 justify-center px-4 py-16">
-      <div className="w-full max-w-sm">
+    <main className="flex flex-1 items-center justify-center px-4 py-16">
+      <div className="card w-full max-w-sm p-8">
+        <StampMark size={30} className="mb-4" />
         <h1 className="text-2xl font-semibold tracking-tight text-gray-900">{t.login.title}</h1>
         <p className="mb-8 mt-2 text-sm text-gray-500">{t.login.subtitle}</p>
 
@@ -186,7 +188,7 @@ function LoginInner() {
             <input type="password" required minLength={8} value={password} onChange={(e) => setPassword(e.target.value)} className="input" />
           </div>
           {errorMsg && <p className="text-xs text-red-600">{errorMsg}</p>}
-          <button type="submit" disabled={phase !== "idle"} className="btn btn-secondary w-full py-2.5">
+          <button type="submit" disabled={phase !== "idle"} className="btn btn-primary w-full py-2.5">
             {phase === "claiming"
               ? t.login.linking
               : phase === "working"

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -394,7 +394,7 @@ export default function IntakePage() {
       <div className="w-full max-w-2xl">
         <Link
           href="/projects/new"
-          className="mb-6 inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:border-gray-300 hover:text-gray-900"
+          className="mb-6 inline-flex items-center gap-1 text-sm text-gray-500 transition-colors hover:text-gray-800"
         >
           <span aria-hidden>←</span> {tr.branch.backToChooser}
         </Link>
@@ -564,6 +564,10 @@ export default function IntakePage() {
                 </button>
               )}
             </div>
+            {/* Disabled-reason helper (§1-3): say WHY the primary is inert. */}
+            {!rawInput.trim() && (
+              <p className="mt-1.5 text-xs text-gray-400">{ic.createDisabledHint}</p>
+            )}
           </div>
         )}
 

--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -401,7 +401,7 @@ function NewProjectInner() {
               Asks the user's situation, not a "type" — no jargon. The choice
               sets entry_path (idea/code/spec) which persists to the P1 envelope. */}
           {entryPath === null && (
-            <div>
+            <div className="mx-auto flex min-h-[60vh] max-w-[34rem] flex-col justify-center">
               <Link href="/projects" className="mb-4 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800">
                 <span aria-hidden>←</span> {t.nav.allProjects}
               </Link>

--- a/apps/dashboard/src/app/projects/page.tsx
+++ b/apps/dashboard/src/app/projects/page.tsx
@@ -8,6 +8,7 @@ import { SpecCompleteness } from "@/components/SpecCompleteness";
 import { useI18n } from "@/i18n/I18nProvider";
 import { statusLabel } from "@/i18n/dictionary.mjs";
 import type { Dictionary } from "@/i18n/dictionary.mjs";
+import { StampMark } from "@/components/brand/StampMark";
 
 export default function ProjectsPage() {
   const { t } = useI18n();
@@ -36,13 +37,11 @@ export default function ProjectsPage() {
           ))}
         </div>
       ) : localProjects.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-300 bg-white px-6 py-16 text-center">
+        <div className="card flex flex-col items-center px-6 py-16 text-center">
+          <StampMark size={40} className="mb-4 opacity-90" />
           <h2 className="text-base font-semibold text-gray-900">{t.projects.emptyTitle}</h2>
           <p className="mx-auto mt-2 max-w-md text-sm text-gray-500">{t.projects.emptyBody}</p>
-          <Link
-            href="/projects/new"
-            className="mt-5 inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
-          >
+          <Link href="/projects/new" className="btn btn-primary btn-md mt-5">
             + {t.projects.newProject}
           </Link>
         </div>
@@ -82,7 +81,7 @@ function ProjectCard({
   return (
     <Link
       href={`/projects/${project.id}`}
-      className="block rounded-xl border border-gray-200 bg-white p-6 transition-all hover:border-indigo-300 hover:shadow-sm"
+      className="card card-select block p-6"
     >
       <div className="mb-4 flex items-start justify-between gap-4">
         <div>

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -1607,6 +1607,7 @@ export type Dictionary = {
     };
     page: {
       createDraftButton: string;
+      createDisabledHint: string;
       useExampleUrl: string;
       useExampleRepo: string;
       useExampleApp: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -1719,6 +1719,7 @@ const EN = {
     // Non-developer copy pass — plain-language strings for the intake workflow page.
     page: {
       createDraftButton: "Create draft plan",
+      createDisabledHint: "Type or paste something above to begin.",
       useExampleUrl: "Use an example link",
       useExampleRepo: "Use an example repository",
       useExampleApp: "Use an example app",
@@ -3943,6 +3944,7 @@ const KO = {
     // Non-developer copy pass — 인테이크 워크플로우 페이지 일반 사용자용 문구.
     page: {
       createDraftButton: "초안 만들기",
+      createDisabledHint: "위에 내용을 입력하면 시작할 수 있어요.",
       useExampleUrl: "예시 링크 사용",
       useExampleRepo: "예시 저장소 사용",
       useExampleApp: "예시 앱 사용",


### PR DESCRIPTION
Restyle §4 **P0 first-impression path**, on #247's pill / `.card-select` / `StampMark` primitives. Skin + state only; no copy/route changes (§6).

- **`/projects/new`** (branch chooser): narrowed to `max-w-[34rem]` + **vertically centered** (was top-piled with a big bottom gap). Cards already got glyph+tint+lift in #247.
- **`/projects`** (home): removed **INDIGO** (unauthorized color, §6) — the empty-state CTA and example-card hover were indigo → **oxblood**. Example cards now use `.card` + `.card-select` (contact shadow + hover lift + press). Empty state: dashed box → a real `.card` with the **seal mark** + oxblood pill CTA.
- **`/login`**: the email "sign in" submit was a weak white secondary → **oxblood primary pill** (Google stays the top social primary — two auth methods, each its own action). Added the **seal mark** + a focused `.card` layout, vertically centered.
- **`/projects/new/intake`**: boxed "back to the three choices" → **quiet text link**; added a **disabled-reason helper** under the primary CTA (§1-3 "왜 안 눌리는지"). The CTA's disabled oxblood-at-0.45 + not-allowed cursor already came from #247.

### Deferred
A full **indigo→brand purge** (132 occurrences, mostly `/admin/credits` + `QuestionCard`) is a separate §6 follow-up; this PR fixes only the indigo on the P0 path.

## Gates
dashboard **456/456**, typecheck + lint (no warnings) + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)