### PR TITLE
Restyle §6: indigo purge (→ brand oxblood) + unify contact email to 3svs.com

### DIFF
--- a/apps/dashboard/src/app/admin/credits/page.tsx
+++ b/apps/dashboard/src/app/admin/credits/page.tsx
@@ -114,7 +114,7 @@ function BalanceTable({ balances }: { balances: CreditBalance[] }) {
         {balances.map((b) => (
           <tr key={b.creditType} className="border-b last:border-0">
             <td className="py-1">{creditTypeLabel(t, b.creditType)}</td>
-            <td className="py-1 text-right font-mono font-bold text-indigo-700">{b.balance}</td>
+            <td className="py-1 text-right font-mono font-bold text-brand-700">{b.balance}</td>
             <td className="py-1 text-right text-gray-500">{b.updatedAt.slice(0, 10)}</td>
           </tr>
         ))}
@@ -395,10 +395,10 @@ function PreviewTable({ preview }: { preview: PreviewResult }) {
       )}
 
       {preview.allowanceSummary && (
-        <div className="bg-indigo-50 border border-indigo-200 rounded-lg px-4 py-2 text-xs text-indigo-700 flex gap-6">
+        <div className="bg-brand-50 border border-brand-200 rounded-lg px-4 py-2 text-xs text-brand-700 flex gap-6">
           <span>{t.adminCredits.allowanceFreeCover}<strong>{preview.allowanceSummary.totalCoveredByAllowance}</strong>{t.adminCredits.allowanceFreeCoverSuffix.replace("{n}", "")}</span>
           <span>{t.adminCredits.allowanceBillableCandidate}<strong>{preview.allowanceSummary.totalBillableAfterAllowance}</strong>{t.adminCredits.allowanceBillableCandidateSuffix.replace("{n}", "")}</span>
-          <span className="text-indigo-500">{preview.allowanceSummary.rule}</span>
+          <span className="text-brand-500">{preview.allowanceSummary.rule}</span>
         </div>
       )}
 
@@ -476,11 +476,11 @@ function MonthlyPreviewSection({ data }: { data: MonthlyCreditPreviewResult }) {
   const { t } = useI18n();
   return (
     <div className="space-y-4">
-      <div className="bg-indigo-50 border border-indigo-200 rounded-lg px-4 py-3">
-        <p className="text-sm font-semibold text-indigo-800">
+      <div className="bg-brand-50 border border-brand-200 rounded-lg px-4 py-3">
+        <p className="text-sm font-semibold text-brand-800">
           {t.adminCredits.monthlySimNotice}
         </p>
-        <p className="text-xs text-indigo-600 mt-0.5">
+        <p className="text-xs text-brand-600 mt-0.5">
           {data.month} · {t.adminCredits.monthlyFreePerUser.replace("{n}", String(data.allowanceRule.includedRuns))} · actualDebitsEnabled: false
         </p>
       </div>
@@ -885,7 +885,7 @@ export default function AdminCreditsPage() {
             placeholder={t.adminCredits.adminKeyPlaceholder}
             value={adminKey}
             onChange={(e) => setAdminKey(e.target.value)}
-            className="flex-1 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="flex-1 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
         </div>
       </SectionCard>
@@ -916,19 +916,19 @@ export default function AdminCreditsPage() {
               </div>
               {/* Stage 31: limited rollout allowlist */}
               {creditConfig.limitedRollout !== undefined && (
-                <div className={`text-xs font-mono px-2 py-1 rounded ${creditConfig.limitedRollout.allowedUserKeyCount > 0 ? "bg-indigo-50 text-indigo-700" : "bg-gray-100 text-gray-600"}`}>
+                <div className={`text-xs font-mono px-2 py-1 rounded ${creditConfig.limitedRollout.allowedUserKeyCount > 0 ? "bg-brand-50 text-brand-700" : "bg-gray-100 text-gray-600"}`}>
                   <div>
                     ACTUAL_DEBIT_ALLOWED_USER_KEYS: {creditConfig.envFlags.ACTUAL_DEBIT_ALLOWED_USER_KEYS ?? "(unset)"}
                     {" "}→ {t.adminCredits.rolloutRegistered.replace("{n}", String(creditConfig.limitedRollout.allowedUserKeyCount))}
                   </div>
                   {creditConfig.limitedRollout.allowedUserKeysPreview.length > 0 && (
-                    <div className="mt-1 text-indigo-600">
+                    <div className="mt-1 text-brand-600">
                       {t.adminCredits.rolloutPreview}{creditConfig.limitedRollout.allowedUserKeysPreview.join(", ")}
                       {creditConfig.limitedRollout.allowedUserKeyCount > 5 ? " ..." : ""}
                     </div>
                   )}
                   {creditConfig.limitedRollout.enabled ? (
-                    <div className="mt-1 text-indigo-700 font-semibold">{t.adminCredits.rolloutLimitedActive}</div>
+                    <div className="mt-1 text-brand-700 font-semibold">{t.adminCredits.rolloutLimitedActive}</div>
                   ) : creditConfig.actualDebitsEnabled && creditConfig.limitedRollout.allowedUserKeyCount === 0 ? (
                     <div className="mt-1 text-amber-600 font-semibold">{t.adminCredits.rolloutWarningEmptyAllowlist}</div>
                   ) : null}
@@ -968,14 +968,14 @@ export default function AdminCreditsPage() {
               placeholder={t.adminCredits.userKeyPlaceholder}
               value={userKey}
               onChange={(e) => setUserKey(e.target.value)}
-              className="flex-1 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="flex-1 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
           </div>
           <div className="flex gap-2">
             <button
               onClick={handleFetchBalances}
               disabled={loading}
-              className="bg-indigo-600 text-white px-4 py-2 rounded text-sm hover:bg-indigo-700 disabled:opacity-50"
+              className="bg-brand-600 text-white px-4 py-2 rounded text-sm hover:bg-brand-700 disabled:opacity-50"
             >
               {t.adminCredits.fetchBalance}
             </button>
@@ -1011,12 +1011,12 @@ export default function AdminCreditsPage() {
               placeholder={t.adminCredits.grantUserKeyPlaceholder}
               value={grantUserKey}
               onChange={(e) => setGrantUserKey(e.target.value)}
-              className="flex-1 min-w-40 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="flex-1 min-w-40 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
             <select
               value={grantType}
               onChange={(e) => setGrantType(e.target.value as CreditType)}
-              className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <option value="review">{t.adminCredits.creditTypeReview}</option>
               <option value="fix">{t.adminCredits.creditTypeFix}</option>
@@ -1029,7 +1029,7 @@ export default function AdminCreditsPage() {
               placeholder={t.adminCredits.amountPlaceholder}
               value={grantAmount}
               onChange={(e) => setGrantAmount(e.target.value)}
-              className="w-24 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="w-24 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
           </div>
           <div className="flex gap-2">
@@ -1038,7 +1038,7 @@ export default function AdminCreditsPage() {
               placeholder={t.adminCredits.grantReasonPlaceholder}
               value={grantReason}
               onChange={(e) => setGrantReason(e.target.value)}
-              className="flex-1 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="flex-1 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
             <button
               onClick={handleGrant}
@@ -1061,7 +1061,7 @@ export default function AdminCreditsPage() {
             <select
               value={range}
               onChange={(e) => setRange(e.target.value as UsageRange)}
-              className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               {(["24h", "7d", "30d"] as UsageRange[]).map((r) => (
                 <option key={r} value={r}>{rangeLabel(t, r)}</option>
@@ -1072,7 +1072,7 @@ export default function AdminCreditsPage() {
               placeholder={t.adminCredits.userKeyFilterOptional}
               value={userKey}
               onChange={(e) => setUserKey(e.target.value)}
-              className="flex-1 min-w-40 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="flex-1 min-w-40 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
             <button
               onClick={handlePreview}
@@ -1098,19 +1098,19 @@ export default function AdminCreditsPage() {
               placeholder={t.adminCredits.monthPlaceholder}
               value={monthInput}
               onChange={(e) => setMonthInput(e.target.value)}
-              className="w-40 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="w-40 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
             <input
               type="text"
               placeholder={t.adminCredits.userKeyFilterOptional}
               value={monthlyUserKey}
               onChange={(e) => setMonthlyUserKey(e.target.value)}
-              className="flex-1 min-w-40 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="flex-1 min-w-40 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
             <button
               onClick={handleMonthlyPreview}
               disabled={loading}
-              className="bg-indigo-600 text-white px-4 py-2 rounded text-sm hover:bg-indigo-700 disabled:opacity-50 whitespace-nowrap"
+              className="bg-brand-600 text-white px-4 py-2 rounded text-sm hover:bg-brand-700 disabled:opacity-50 whitespace-nowrap"
             >
               {t.adminCredits.monthlyLookup}
             </button>
@@ -1231,7 +1231,7 @@ export default function AdminCreditsPage() {
             <button
               onClick={handleFetchTopUpRequests}
               disabled={loading}
-              className="bg-indigo-600 text-white px-4 py-2 rounded text-sm hover:bg-indigo-700 disabled:opacity-50"
+              className="bg-brand-600 text-white px-4 py-2 rounded text-sm hover:bg-brand-700 disabled:opacity-50"
             >
               {t.adminCredits.fetchTopUpList}
             </button>
@@ -1252,7 +1252,7 @@ export default function AdminCreditsPage() {
                       <div>
                         <div className="flex items-center gap-2 text-sm">
                           <span className="font-mono text-gray-700">{req.userKey}</span>
-                          <span className="font-bold text-indigo-700">+{req.requestedAmount}</span>
+                          <span className="font-bold text-brand-700">+{req.requestedAmount}</span>
                           <span className="text-gray-500 text-xs">{req.creditType}</span>
                           <span className={`text-xs px-1.5 py-0.5 rounded border ${
                             req.status === "requested"
@@ -1268,7 +1268,7 @@ export default function AdminCreditsPage() {
                           <p className="text-xs text-gray-500 mt-1">{t.adminCredits.topUpNoteLabel}{req.note}</p>
                         )}
                         {req.adminNote && (
-                          <p className="text-xs text-indigo-600 mt-0.5">{t.adminCredits.topUpAdminNoteLabel}{req.adminNote}</p>
+                          <p className="text-xs text-brand-600 mt-0.5">{t.adminCredits.topUpAdminNoteLabel}{req.adminNote}</p>
                         )}
                         <p className="text-xs text-gray-500 mt-1">
                           {t.adminCredits.topUpRequestedAt}{req.createdAt.slice(0, 10)}
@@ -1327,9 +1327,9 @@ export default function AdminCreditsPage() {
       </SectionCard>
 
       {/* Free allowance policy notice */}
-      <div className="bg-indigo-50 border border-indigo-200 rounded-lg px-4 py-3">
-        <p className="text-sm font-medium text-indigo-700 mb-1">{t.adminCredits.allowanceNoticeTitle}</p>
-        <ul className="text-xs text-indigo-600 space-y-0.5 list-disc list-inside">
+      <div className="bg-brand-50 border border-brand-200 rounded-lg px-4 py-3">
+        <p className="text-sm font-medium text-brand-700 mb-1">{t.adminCredits.allowanceNoticeTitle}</p>
+        <ul className="text-xs text-brand-600 space-y-0.5 list-disc list-inside">
           <li>{t.adminCredits.allowanceNotice1}</li>
           <li>{t.adminCredits.allowanceNotice2}</li>
           <li>{t.adminCredits.allowanceNotice3}</li>

--- a/apps/dashboard/src/app/admin/usage/page.tsx
+++ b/apps/dashboard/src/app/admin/usage/page.tsx
@@ -27,7 +27,7 @@ function billingStatusLabel(t: Dictionary, s: BillingStatus): string {
 const BILLING_STATUS_COLORS: Record<BillingStatus, string> = {
   billable_candidate: "bg-amber-100 text-amber-700",
   included: "bg-green-100 text-green-700",
-  future_billable: "bg-indigo-100 text-indigo-700",
+  future_billable: "bg-brand-100 text-brand-700",
   ignored: "bg-gray-100 text-gray-500",
 };
 
@@ -80,7 +80,7 @@ export default function AdminUsagePage() {
           <h1 className="text-2xl font-bold text-gray-900">{t.adminUsage.title}</h1>
           <a
             href="/admin/credits"
-            className="text-xs text-indigo-600 hover:underline whitespace-nowrap mt-1"
+            className="text-xs text-brand-600 hover:underline whitespace-nowrap mt-1"
           >
             {t.adminUsage.viewCreditPreview}
           </a>
@@ -99,7 +99,7 @@ export default function AdminUsagePage() {
               onChange={(e) => setAdminKey(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleLoad()}
               placeholder={t.adminUsage.adminKeyPlaceholder}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
           </div>
           <div>
@@ -107,7 +107,7 @@ export default function AdminUsagePage() {
             <select
               value={range}
               onChange={(e) => setRange(e.target.value as UsageRange)}
-              className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               {(["24h", "7d", "30d"] as UsageRange[]).map((r) => (
                 <option key={r} value={r}>{rangeLabel(t, r)}</option>
@@ -117,7 +117,7 @@ export default function AdminUsagePage() {
           <button
             onClick={handleLoad}
             disabled={loading}
-            className="px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+            className="px-5 py-2 bg-brand-600 text-white text-sm font-medium rounded-lg hover:bg-brand-700 disabled:opacity-50 transition-colors"
           >
             {loading ? t.adminUsage.loading : t.adminUsage.load}
           </button>

--- a/apps/dashboard/src/app/projects/[id]/benchmark/[benchmarkId]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/benchmark/[benchmarkId]/page.tsx
@@ -145,7 +145,7 @@ export default function BenchmarkDetailPage() {
   if (phase === "not_found" || phase === "error" || !data) {
     return (
       <div className="max-w-3xl space-y-4">
-        <Link href={backUrl} className="text-xs text-gray-500 hover:text-indigo-600">{t.benchmark.detailBack}</Link>
+        <Link href={backUrl} className="text-xs text-gray-500 hover:text-brand-600">{t.benchmark.detailBack}</Link>
         <div className="rounded-xl border border-gray-200 bg-white px-4 py-6 text-center text-sm text-gray-500">
           {phase === "not_found" ? t.benchmark.notFoundDetail : t.benchmark.loadErrorDetail}
         </div>
@@ -306,7 +306,7 @@ export default function BenchmarkDetailPage() {
     <div className="max-w-4xl space-y-6">
       {/* Header */}
       <div>
-        <Link href={backUrl} className="text-xs text-gray-500 hover:text-indigo-600">{t.benchmark.detailBack}</Link>
+        <Link href={backUrl} className="text-xs text-gray-500 hover:text-brand-600">{t.benchmark.detailBack}</Link>
         <div className="mt-2 flex items-start justify-between gap-3">
           <div>
             <h2 className="text-lg font-semibold tracking-tight text-gray-900">{t.benchmark.detailTitle}</h2>
@@ -327,7 +327,7 @@ export default function BenchmarkDetailPage() {
         <span>{t.benchmark.createdLabel}: {formatDate(data.createdAt, locale)}</span>
         <span>{t.benchmark.detailCandidates}: {data.candidateCount}</span>
         {data.sourceExperimentId && (
-          <Link href={`/projects/${id}/experiment?experiment=${encodeURIComponent(data.sourceExperimentId)}`} className="text-indigo-600 hover:underline">
+          <Link href={`/projects/${id}/experiment?experiment=${encodeURIComponent(data.sourceExperimentId)}`} className="text-brand-600 hover:underline">
             {t.benchmark.sourceExperiment}: {t.benchmark.openExperiment}
           </Link>
         )}
@@ -346,14 +346,14 @@ export default function BenchmarkDetailPage() {
 
       {/* Ready to decide? (Stage 74) */}
       {data.sourceExperimentId && (
-        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-indigo-200 bg-indigo-50 px-4 py-3">
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-brand-200 bg-brand-50 px-4 py-3">
           <div>
-            <p className="text-sm font-semibold text-indigo-800">{t.benchmark.readyToDecide}</p>
-            <p className="mt-0.5 text-xs text-indigo-600">{t.benchmark.readyToDecideDesc}</p>
+            <p className="text-sm font-semibold text-brand-800">{t.benchmark.readyToDecide}</p>
+            <p className="mt-0.5 text-xs text-brand-600">{t.benchmark.readyToDecideDesc}</p>
           </div>
           <Link
             href={`/projects/${id}/experiment?experiment=${encodeURIComponent(data.sourceExperimentId)}`}
-            className="flex-shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-indigo-700"
+            className="flex-shrink-0 rounded-lg bg-brand-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-brand-700"
           >
             {t.benchmark.recordDecision}
           </Link>
@@ -362,11 +362,11 @@ export default function BenchmarkDetailPage() {
 
       {/* Recommendation */}
       <section className="rounded-xl border border-gray-200 bg-white p-5">
-        <p className="rounded-lg bg-indigo-50 px-3 py-2 text-xs text-indigo-700">{t.benchmark.intro}</p>
+        <p className="rounded-lg bg-brand-50 px-3 py-2 text-xs text-brand-700">{t.benchmark.intro}</p>
         {winner ? (
           <>
             <h3 className="mt-3 text-sm font-semibold text-gray-800">{t.benchmark.recommendedCandidate}</h3>
-            <p className="mt-1 text-sm font-semibold text-indigo-700">{winner.label}</p>
+            <p className="mt-1 text-sm font-semibold text-brand-700">{winner.label}</p>
             <p className="mt-1 text-xs text-gray-500">{t.benchmark.recommendedBody}</p>
             {winner.reviewRunId && (
               <Link
@@ -419,7 +419,7 @@ export default function BenchmarkDetailPage() {
             </thead>
             <tbody>
               {ranked.map(({ candidate, metrics }) => (
-                <tr key={candidate.id} className={`border-t border-gray-100 ${candidate.id === winnerId ? "bg-indigo-50/40" : ""}`}>
+                <tr key={candidate.id} className={`border-t border-gray-100 ${candidate.id === winnerId ? "bg-brand-50/40" : ""}`}>
                   <td className="px-4 py-2.5 font-medium text-gray-800">{candidate.label}</td>
                   <td className="px-4 py-2.5 text-gray-600">{modeLabel(t, candidate.mode)}</td>
                   <td className="px-4 py-2.5 text-gray-600">{sourceLabel(t, candidate.source)}</td>
@@ -429,7 +429,7 @@ export default function BenchmarkDetailPage() {
                   <td className="px-4 py-2.5 text-right font-semibold text-gray-900">{metrics.score}</td>
                   <td className="px-4 py-2.5 text-right">
                     {candidate.reviewRunId ? (
-                      <Link href={`/projects/${id}/github/history/${candidate.reviewRunId}`} className="text-xs text-indigo-600 hover:underline">
+                      <Link href={`/projects/${id}/github/history/${candidate.reviewRunId}`} className="text-xs text-brand-600 hover:underline">
                         {candidate.pullRequestNumber ? `PR #${candidate.pullRequestNumber}` : t.benchmark.openReviewRun}
                       </Link>
                     ) : (
@@ -448,7 +448,7 @@ export default function BenchmarkDetailPage() {
         <h3 className="mb-3 text-sm font-semibold text-gray-700">{t.benchmark.metricsTitle}</h3>
         <div className="grid gap-3 sm:grid-cols-2">
           {ranked.map(({ candidate, metrics }) => (
-            <div key={candidate.id} className={`rounded-xl border p-4 ${candidate.id === winnerId ? "border-indigo-300 bg-indigo-50/40" : "border-gray-200 bg-white"}`}>
+            <div key={candidate.id} className={`rounded-xl border p-4 ${candidate.id === winnerId ? "border-brand-300 bg-brand-50/40" : "border-gray-200 bg-white"}`}>
               <p className="mb-2 text-sm font-semibold text-gray-800">{candidate.label}</p>
               <div className="grid grid-cols-2 gap-2 text-xs">
                 <Stat label={t.benchmark.acceptancePassRate} value={pct(metrics.acceptancePassRate)} strong />
@@ -530,7 +530,7 @@ export default function BenchmarkDetailPage() {
                 {c.pullRequestNumber ? ` · PR #${c.pullRequestNumber}` : ""}
               </span>
               {c.reviewRunId && (
-                <Link href={`/projects/${id}/github/history/${c.reviewRunId}`} className="flex-shrink-0 text-indigo-600 hover:underline">
+                <Link href={`/projects/${id}/github/history/${c.reviewRunId}`} className="flex-shrink-0 text-brand-600 hover:underline">
                   {t.benchmark.openReviewRun}
                 </Link>
               )}
@@ -626,7 +626,7 @@ function MatrixSection({
               type="checkbox"
               checked={differentOnly}
               onChange={(e) => setDifferentOnly(e.target.checked)}
-              className="accent-indigo-600"
+              className="accent-brand-600"
             />
             {t.benchmark.showDifferentOnly}
           </label>
@@ -662,7 +662,7 @@ function MatrixSection({
                       </div>
                       <button
                         onClick={() => setExpanded(expanded === row.itemId ? null : row.itemId)}
-                        className="mt-0.5 text-[11px] text-indigo-600 hover:underline"
+                        className="mt-0.5 text-[11px] text-brand-600 hover:underline"
                       >
                         {expanded === row.itemId ? t.benchmark.hideEvidence : t.benchmark.viewEvidence}
                       </button>

--- a/apps/dashboard/src/app/projects/[id]/benchmark/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/benchmark/page.tsx
@@ -215,7 +215,7 @@ export default function BenchmarkPage() {
       <div>
         <h2 className="text-lg font-semibold tracking-tight text-gray-900">{t.benchmark.title}</h2>
         <p className="mt-0.5 text-sm text-gray-500">{t.benchmark.subtitle}</p>
-        <p className="mt-2 rounded-lg bg-indigo-50 px-3 py-2 text-xs text-indigo-700">{t.benchmark.intro}</p>
+        <p className="mt-2 rounded-lg bg-brand-50 px-3 py-2 text-xs text-brand-700">{t.benchmark.intro}</p>
       </div>
 
       {phase === "loading" && (
@@ -270,7 +270,7 @@ export default function BenchmarkPage() {
                         </div>
                         <button
                           onClick={() => addCandidate(run)}
-                          className="flex-shrink-0 rounded-lg border border-indigo-200 bg-indigo-50 px-2.5 py-1 text-[11px] font-medium text-indigo-700 transition-colors hover:bg-indigo-100"
+                          className="flex-shrink-0 rounded-lg border border-brand-200 bg-brand-50 px-2.5 py-1 text-[11px] font-medium text-brand-700 transition-colors hover:bg-brand-100"
                         >
                           {t.benchmark.addCandidate}
                         </button>
@@ -302,14 +302,14 @@ export default function BenchmarkPage() {
                             value={c.label}
                             onChange={(e) => updateCandidate(c.runId, { label: e.target.value })}
                             aria-label={t.benchmark.labelField}
-                            className="mb-2 w-full rounded-md border border-gray-200 px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                            className="mb-2 w-full rounded-md border border-gray-200 px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-brand-300"
                           />
                           <div className="flex gap-2">
                             <select
                               value={c.mode}
                               onChange={(e) => updateCandidate(c.runId, { mode: e.target.value as CandidateMode })}
                               aria-label={t.benchmark.modeField}
-                              className="flex-1 rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                              className="flex-1 rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-brand-300"
                             >
                               {CANDIDATE_MODES.map((m) => (
                                 <option key={m} value={m}>{modeLabel(t, m)}</option>
@@ -319,7 +319,7 @@ export default function BenchmarkPage() {
                               value={c.source}
                               onChange={(e) => updateCandidate(c.runId, { source: e.target.value as CandidateSource })}
                               aria-label={t.benchmark.sourceField}
-                              className="flex-1 rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                              className="flex-1 rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-brand-300"
                             >
                               {CANDIDATE_SOURCES.map((s) => (
                                 <option key={s} value={s}>{sourceLabel(t, s)}</option>
@@ -360,7 +360,7 @@ export default function BenchmarkPage() {
                   {ranked.map(({ candidate, metrics }) => (
                     <div
                       key={candidate.id}
-                      className={`rounded-xl border p-4 ${candidate.id === winnerId ? "border-indigo-300 bg-indigo-50/40" : "border-gray-200 bg-white"}`}
+                      className={`rounded-xl border p-4 ${candidate.id === winnerId ? "border-brand-300 bg-brand-50/40" : "border-gray-200 bg-white"}`}
                     >
                       <div className="mb-2 flex items-center justify-between">
                         <p className="text-sm font-semibold text-gray-800">{candidate.label}</p>
@@ -396,7 +396,7 @@ export default function BenchmarkPage() {
                   </thead>
                   <tbody>
                     {ranked.map(({ candidate, metrics }) => (
-                      <tr key={candidate.id} className={`border-t border-gray-100 ${candidate.id === winnerId ? "bg-indigo-50/40" : ""}`}>
+                      <tr key={candidate.id} className={`border-t border-gray-100 ${candidate.id === winnerId ? "bg-brand-50/40" : ""}`}>
                         <td className="px-4 py-2.5 font-medium text-gray-800">{candidate.label}</td>
                         <td className="px-4 py-2.5 text-right text-gray-700">{pct(metrics.acceptancePassRate)}</td>
                         <td className="px-4 py-2.5 text-right text-gray-700">{metrics.passed} / {metrics.totalItems}</td>
@@ -414,7 +414,7 @@ export default function BenchmarkPage() {
                 <h3 className="text-sm font-semibold text-gray-800">{t.benchmark.recommendationTitle}</h3>
                 {winnerId ? (
                   <>
-                    <p className="mt-1 text-sm font-semibold text-indigo-700">
+                    <p className="mt-1 text-sm font-semibold text-brand-700">
                       {t.benchmark.winnerLabel.replace("{label}", candidates.find((c) => c.id === winnerId)?.label ?? "")}
                     </p>
                     <ul className="mt-2 space-y-1">
@@ -467,12 +467,12 @@ export default function BenchmarkPage() {
                     onChange={(e) => setTitle(e.target.value)}
                     placeholder={t.benchmark.titlePlaceholder}
                     maxLength={120}
-                    className="flex-1 rounded-md border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                    className="flex-1 rounded-md border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
                   />
                   <button
                     onClick={handleSave}
                     disabled={!canSaveBenchmark(configs.length) || savePhase === "saving"}
-                    className="flex-shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700 disabled:opacity-40"
+                    className="flex-shrink-0 rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-700 disabled:opacity-40"
                   >
                     {savePhase === "saving" ? t.benchmark.saving : t.benchmark.save}
                   </button>

--- a/apps/dashboard/src/app/projects/[id]/credits/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/credits/page.tsx
@@ -118,7 +118,7 @@ export default function CreditsPage() {
     <div className="max-w-2xl mx-auto px-4 py-8 space-y-6">
       {/* Back link */}
       <div className="flex items-center gap-2">
-        <Link href={`/projects/${id}/github`} className="text-sm text-indigo-600 hover:underline">
+        <Link href={`/projects/${id}/github`} className="text-sm text-brand-600 hover:underline">
           {t.creditsPage.back}
         </Link>
       </div>
@@ -149,7 +149,7 @@ export default function CreditsPage() {
           {creditsPhase === "done" && credits && (
             <div className="space-y-4">
               <div className="flex items-baseline gap-3">
-                <span className="text-4xl font-bold text-indigo-700">{reviewBalance}</span>
+                <span className="text-4xl font-bold text-brand-700">{reviewBalance}</span>
                 <span className="text-sm text-gray-500">{t.creditsPage.reviewCredit}</span>
               </div>
 
@@ -165,7 +165,7 @@ export default function CreditsPage() {
                   </div>
                   <div className="w-full bg-gray-200 rounded-full h-2">
                     <div
-                      className="bg-indigo-500 h-2 rounded-full transition-all"
+                      className="bg-brand-500 h-2 rounded-full transition-all"
                       style={{ width: `${Math.min(100, (allowance.usedThisPeriod / allowance.includedRuns) * 100)}%` }}
                     />
                   </div>
@@ -187,7 +187,7 @@ export default function CreditsPage() {
               )}
 
               {credits.actualDebitsEnabled && (
-                <p className="text-xs text-indigo-600">
+                <p className="text-xs text-brand-600">
                   {credits.actualDebitAllowedForUser
                     ? t.creditsPage.actualDebitOn
                     : t.creditsPage.dryRunMode}
@@ -212,8 +212,8 @@ export default function CreditsPage() {
           )}
 
           {openRequests >= 3 ? (
-            <div className="border border-indigo-200 bg-indigo-50 rounded-lg px-4 py-3">
-              <p className="text-sm text-indigo-700">
+            <div className="border border-brand-200 bg-brand-50 rounded-lg px-4 py-3">
+              <p className="text-sm text-brand-700">
                 {t.creditsPage.pendingRequests.replace("{n}", String(openRequests))}
               </p>
             </div>
@@ -258,7 +258,7 @@ export default function CreditsPage() {
               <button
                 type="submit"
                 disabled={submitPhase === "submitting"}
-                className="bg-indigo-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50"
+                className="bg-brand-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
               >
                 {submitPhase === "submitting" ? t.creditsPage.submitting : t.creditsPage.submit}
               </button>
@@ -273,7 +273,7 @@ export default function CreditsPage() {
           <h2 className="font-semibold text-gray-700 text-sm">{t.creditsPage.historyTitle}</h2>
           <button
             onClick={loadRequests}
-            className="text-xs text-indigo-600 hover:underline"
+            className="text-xs text-brand-600 hover:underline"
           >
             {t.creditsPage.refresh}
           </button>
@@ -302,7 +302,7 @@ export default function CreditsPage() {
                 >
                   <div className="flex items-center justify-between mb-1">
                     <div className="flex items-center gap-2">
-                      <span className="font-mono text-sm font-semibold text-indigo-700">
+                      <span className="font-mono text-sm font-semibold text-brand-700">
                         +{req.requestedAmount}
                       </span>
                       <span className="text-xs text-gray-500">{t.creditsPage.reviewCredit}</span>
@@ -313,7 +313,7 @@ export default function CreditsPage() {
                     <p className="text-xs text-gray-500 mt-1">{req.note}</p>
                   )}
                   {req.adminNote && (
-                    <p className="text-xs text-indigo-600 mt-1">{t.creditsPage.adminNote} {req.adminNote}</p>
+                    <p className="text-xs text-brand-600 mt-1">{t.creditsPage.adminNote} {req.adminNote}</p>
                   )}
                   <p className="text-xs text-gray-500 mt-1">
                     {req.createdAt.slice(0, 10)}

--- a/apps/dashboard/src/app/projects/[id]/experiment/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/experiment/page.tsx
@@ -310,7 +310,7 @@ export default function ExperimentPage() {
       <div>
         <h2 className="text-lg font-semibold tracking-tight text-gray-900">{t.experiment.title}</h2>
         <p className="mt-0.5 text-sm text-gray-500">{t.experiment.subtitle}</p>
-        <p className="mt-2 rounded-lg bg-indigo-50 px-3 py-2 text-xs text-indigo-700">{t.experiment.purposeNote}</p>
+        <p className="mt-2 rounded-lg bg-brand-50 px-3 py-2 text-xs text-brand-700">{t.experiment.purposeNote}</p>
       </div>
 
       {/* Template selector */}
@@ -321,7 +321,7 @@ export default function ExperimentPage() {
             <button
               key={tpl.id}
               onClick={() => setSelectedId(tpl.id)}
-              className={`rounded-xl border p-4 text-left transition-colors ${tpl.id === selectedId ? "border-indigo-300 bg-indigo-50/50" : "border-gray-200 bg-white hover:border-indigo-200"}`}
+              className={`rounded-xl border p-4 text-left transition-colors ${tpl.id === selectedId ? "border-brand-300 bg-brand-50/50" : "border-gray-200 bg-white hover:border-brand-200"}`}
             >
               <p className="text-sm font-semibold text-gray-800">{templateTitle(t, tpl.id)}</p>
               <p className="mt-1 text-xs text-gray-500">{templateDesc(t, tpl.id)}</p>
@@ -357,7 +357,7 @@ export default function ExperimentPage() {
               </div>
               <button
                 onClick={() => copy(c.id, c.prompt)}
-                className="flex-shrink-0 rounded-lg border border-indigo-200 bg-indigo-50 px-2.5 py-1 text-[11px] font-medium text-indigo-700 transition-colors hover:bg-indigo-100"
+                className="flex-shrink-0 rounded-lg border border-brand-200 bg-brand-50 px-2.5 py-1 text-[11px] font-medium text-brand-700 transition-colors hover:bg-brand-100"
               >
                 {copiedKey === c.id ? t.experiment.copied : t.experiment.copyPrompt}
               </button>
@@ -383,12 +383,12 @@ export default function ExperimentPage() {
             onChange={(e) => setTitleInput(e.target.value)}
             placeholder={t.experiment.titlePlaceholder}
             maxLength={120}
-            className="flex-1 rounded-md border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            className="flex-1 rounded-md border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
           />
           <button
             onClick={handleSaveExperiment}
             disabled={!canSaveExperiment(titleInput, template.id) || savePhase === "saving"}
-            className="flex-shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700 disabled:opacity-40"
+            className="flex-shrink-0 rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-700 disabled:opacity-40"
           >
             {savePhase === "saving" ? t.experiment.saving : t.experiment.saveExperiment}
           </button>
@@ -421,7 +421,7 @@ export default function ExperimentPage() {
 
       {/* Candidate linking for the opened experiment */}
       {openExp && (
-        <section className="rounded-xl border border-indigo-200 bg-white p-5">
+        <section className="rounded-xl border border-brand-200 bg-white p-5">
           <h3 className="text-sm font-semibold text-gray-800">{openExp.title}</h3>
           <p className="mt-0.5 text-xs text-gray-500">{templateTitle(t, openExp.templateId)}</p>
           <div className="mt-3 space-y-3">
@@ -450,7 +450,7 @@ export default function ExperimentPage() {
                     <button
                       onClick={handleCreateBenchmark}
                       disabled={benchPhase === "creating"}
-                      className="rounded-lg bg-indigo-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-indigo-700 disabled:opacity-40"
+                      className="rounded-lg bg-brand-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-brand-700 disabled:opacity-40"
                     >
                       {benchPhase === "creating" ? t.experiment.creatingBenchmark : t.experiment.createBenchmarkFromExperiment}
                     </button>
@@ -491,7 +491,7 @@ export default function ExperimentPage() {
         <ol className="mt-2 space-y-1.5 text-sm text-gray-600">
           {steps.map((step, i) => (
             <li key={i} className="flex gap-2.5">
-              <span className="flex-shrink-0 font-semibold text-indigo-500">{i + 1}.</span>
+              <span className="flex-shrink-0 font-semibold text-brand-500">{i + 1}.</span>
               <span>{step}</span>
             </li>
           ))}
@@ -504,7 +504,7 @@ export default function ExperimentPage() {
         <p className="mt-0.5 text-xs text-gray-500">{t.experiment.benchmarkHint}</p>
         <Link
           href={`/projects/${id}/benchmark`}
-          className="mt-2 inline-block rounded-lg bg-indigo-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-indigo-700"
+          className="mt-2 inline-block rounded-lg bg-brand-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-brand-700"
         >
           {t.experiment.openBenchmark}
         </Link>
@@ -601,7 +601,7 @@ function DecisionSection({
               onChange={(e) => setNotes((p) => ({ ...p, [c.candidateId]: e.target.value }))}
               placeholder={t.experiment.candidateNotePlaceholder}
               maxLength={300}
-              className="mt-2 w-full rounded-md border border-gray-200 px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-300"
+              className="mt-2 w-full rounded-md border border-gray-200 px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-brand-300"
             />
           </div>
         ))}
@@ -612,13 +612,13 @@ function DecisionSection({
         onChange={(e) => setDecisionNote(e.target.value)}
         rows={2}
         maxLength={1000}
-        className="mt-0.5 w-full resize-none rounded-md border border-gray-200 px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-300"
+        className="mt-0.5 w-full resize-none rounded-md border border-gray-200 px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-brand-300"
       />
       <div className="mt-2 flex items-center gap-2">
         <button
           onClick={save}
           disabled={phase === "saving"}
-          className="rounded-lg bg-indigo-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-indigo-700 disabled:opacity-40"
+          className="rounded-lg bg-brand-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-brand-700 disabled:opacity-40"
         >
           {phase === "saving" ? t.experiment.savingDecision : t.experiment.saveDecision}
         </button>
@@ -674,7 +674,7 @@ function CandidateLinkCard({
             min={1}
             value={pr}
             onChange={(e) => setPr(e.target.value)}
-            className="w-full rounded-md border border-gray-200 px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            className="w-full rounded-md border border-gray-200 px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-brand-300"
           />
         </div>
         <div className="flex-1">
@@ -682,7 +682,7 @@ function CandidateLinkCard({
           <select
             value={runId}
             onChange={(e) => setRunId(e.target.value)}
-            className="w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            className="w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-brand-300"
           >
             <option value="">{t.experiment.selectReviewRun}</option>
             {reviewRuns.map((r) => (
@@ -1114,7 +1114,7 @@ function OutcomeQualitySection({
                 type="button"
                 onClick={handleGenerate}
                 disabled={packPhase === "generating"}
-                className="rounded-lg bg-indigo-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-indigo-700 disabled:opacity-40"
+                className="rounded-lg bg-brand-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-brand-700 disabled:opacity-40"
               >
                 {t.evolution.generate}
               </button>
@@ -1131,7 +1131,7 @@ function OutcomeQualitySection({
                 type="button"
                 onClick={handleSave}
                 disabled={savePhase === "saving"}
-                className="rounded-lg border border-indigo-200 bg-white px-3 py-1.5 text-xs font-medium text-indigo-700 transition-colors hover:bg-indigo-50 disabled:opacity-40"
+                className="rounded-lg border border-brand-200 bg-white px-3 py-1.5 text-xs font-medium text-brand-700 transition-colors hover:bg-brand-50 disabled:opacity-40"
               >
                 {savePhase === "saving"
                   ? t.evolution.saving
@@ -1152,7 +1152,7 @@ function OutcomeQualitySection({
               <div className="mt-3 space-y-3">
                 <div className="flex flex-wrap items-center gap-2 text-xs">
                   <span className="font-medium text-gray-500">{t.evolution.recommendedAction}:</span>
-                  <span className="rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold text-indigo-700">
+                  <span className="rounded-full border border-brand-200 bg-brand-50 px-2 py-0.5 text-[11px] font-semibold text-brand-700">
                     {pack.title}
                   </span>
                   {pack.targetCandidateId && (
@@ -1328,7 +1328,7 @@ function OutcomeQualitySection({
                                   ? "border-gray-200 bg-gray-50 text-gray-500"
                                   : p.followupStatus === "not_started"
                                     ? "border-gray-200 bg-white text-gray-500"
-                                    : "border-indigo-200 bg-indigo-50 text-indigo-700"
+                                    : "border-brand-200 bg-brand-50 text-brand-700"
                             }`}
                           >
                             {t.evolution[followupStatusLabelKey(p.followupStatus) as keyof typeof t.evolution]}
@@ -1356,7 +1356,7 @@ function OutcomeQualitySection({
 
             {/* Stage 77 + Stage 78: opened saved pack detail with follow-up tracking */}
             {openedPack && openPhase === "ready" && (
-              <div className="mt-4 rounded-lg border border-indigo-100 bg-white p-3">
+              <div className="mt-4 rounded-lg border border-brand-100 bg-white p-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
                     <p className="text-xs font-semibold text-gray-800">{t.evolution.serverGenerated}</p>
@@ -1367,7 +1367,7 @@ function OutcomeQualitySection({
                       type="button"
                       onClick={handleMarkCopied}
                       disabled={followupPhase === "saving"}
-                      className="rounded-lg border border-indigo-200 bg-white px-3 py-1.5 text-xs font-medium text-indigo-700 transition-colors hover:bg-indigo-50 disabled:opacity-40"
+                      className="rounded-lg border border-brand-200 bg-white px-3 py-1.5 text-xs font-medium text-brand-700 transition-colors hover:bg-brand-50 disabled:opacity-40"
                     >
                       {t.evolution.markCopied}
                     </button>
@@ -1382,7 +1382,7 @@ function OutcomeQualitySection({
                 </div>
                 <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
                   <span className="font-medium text-gray-500">{t.evolution.recommendedAction}:</span>
-                  <span className="rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold text-indigo-700">
+                  <span className="rounded-full border border-brand-200 bg-brand-50 px-2 py-0.5 text-[11px] font-semibold text-brand-700">
                     {openedPack.title}
                   </span>
                   {openedPack.pack.targetCandidateId && (
@@ -1475,7 +1475,7 @@ function OutcomeQualitySection({
                       type="button"
                       onClick={handleSaveFollowup}
                       disabled={followupPhase === "saving"}
-                      className="rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-indigo-700 disabled:opacity-40"
+                      className="rounded-lg bg-brand-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-brand-700 disabled:opacity-40"
                     >
                       {followupPhase === "saving"
                         ? t.evolution.savingFollowup

--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -414,7 +414,7 @@ export default function ExportPage() {
             {filteredItems.map((item) => (
               <label key={item.id} className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-50 cursor-pointer group">
                 <input type="checkbox" checked={selectedIds.has(item.id)} onChange={() => toggleItem(item.id)}
-                  className="w-4 h-4 rounded accent-indigo-600 cursor-pointer flex-shrink-0" />
+                  className="w-4 h-4 rounded accent-brand-600 cursor-pointer flex-shrink-0" />
                 <span className="flex-1 text-sm text-gray-700">{item.title}</span>
                 <StatusBadge status={item.checkStatus} />
               </label>
@@ -435,7 +435,7 @@ export default function ExportPage() {
       {/* ── Loading / Error ── */}
       {phase === "loading" && (
         <div className="bg-white rounded-xl border border-gray-200 p-8 text-center">
-          <div className="w-5 h-5 border-2 border-indigo-300 border-t-indigo-600 rounded-full animate-spin mx-auto mb-3" />
+          <div className="w-5 h-5 border-2 border-brand-300 border-t-brand-600 rounded-full animate-spin mx-auto mb-3" />
           <p className="text-sm text-gray-500">{t.exportPage.generatingPack}</p>
         </div>
       )}
@@ -450,20 +450,20 @@ export default function ExportPage() {
       {phase === "done" && result && (
         <>
           {/* Summary bar */}
-          <div className="bg-indigo-50 border border-indigo-100 rounded-xl px-5 py-3 flex items-center justify-between flex-wrap gap-3">
+          <div className="bg-brand-50 border border-brand-100 rounded-xl px-5 py-3 flex items-center justify-between flex-wrap gap-3">
             <div className="flex items-center gap-4 flex-wrap text-sm">
-              <span className="font-medium text-indigo-900">{t.exportPage.filesGenerated.replace("{n}", String(result.summary.fileCount))}</span>
-              <span className="text-xs text-indigo-600">
+              <span className="font-medium text-brand-900">{t.exportPage.filesGenerated.replace("{n}", String(result.summary.fileCount))}</span>
+              <span className="text-xs text-brand-600">
                 {t.exportPage.includedItems.replace("{n}", String(result.summary.selectedItems))}
                 {result.summary.selectedItems < result.summary.totalItems
                   ? t.exportPage.ofTotal.replace("{total}", String(result.summary.totalItems))
                   : t.exportPage.ofTotalAll}
               </span>
               {result.bundle.files.some((f) => f.path.endsWith("CLAUDE_CODE_PROMPT.md")) && (
-                <span className="text-xs bg-white text-indigo-600 border border-indigo-200 rounded-full px-2 py-0.5">{t.exportPage.claudeInstr}</span>
+                <span className="text-xs bg-white text-brand-600 border border-brand-200 rounded-full px-2 py-0.5">{t.exportPage.claudeInstr}</span>
               )}
               {result.bundle.files.some((f) => f.path.endsWith("CODEX_PROMPT.md")) && (
-                <span className="text-xs bg-white text-indigo-600 border border-indigo-200 rounded-full px-2 py-0.5">{t.exportPage.codexInstr}</span>
+                <span className="text-xs bg-white text-brand-600 border border-brand-200 rounded-full px-2 py-0.5">{t.exportPage.codexInstr}</span>
               )}
             </div>
             <div className="flex gap-2 flex-wrap">
@@ -472,7 +472,7 @@ export default function ExportPage() {
                 {isZipping ? t.exportPage.zipping : t.exportPage.downloadZip}
               </button>
               <button onClick={handleCopyAll}
-                className="text-xs px-3 py-1.5 rounded-lg font-medium bg-white text-indigo-700 border border-indigo-200 hover:bg-indigo-50 transition-colors">
+                className="text-xs px-3 py-1.5 rounded-lg font-medium bg-white text-brand-700 border border-brand-200 hover:bg-brand-50 transition-colors">
                 {copiedPath === "__all__" ? t.exportPage.copiedAll : t.exportPage.copyAll}
               </button>
               <button onClick={() => downloadMarkdownBundle(result.bundle.files, project.name)}
@@ -486,11 +486,11 @@ export default function ExportPage() {
           <div className="bg-white border border-gray-200 rounded-xl p-5">
             <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">{t.exportPage.howToTitle}</p>
             <ol className="space-y-2 text-sm text-gray-600">
-              <li className="flex gap-2.5"><span className="text-indigo-500 font-semibold flex-shrink-0">1.</span><span>{t.exportPage.step1}</span></li>
-              <li className="flex gap-2.5"><span className="text-indigo-500 font-semibold flex-shrink-0">2.</span><span>{t.exportPage.step2}</span></li>
-              <li className="flex gap-2.5"><span className="text-indigo-500 font-semibold flex-shrink-0">3.</span><span>{t.exportPage.step3}</span></li>
-              <li className="flex gap-2.5"><span className="text-indigo-500 font-semibold flex-shrink-0">4.</span><span>{t.exportPage.step4}</span></li>
-              <li className="flex gap-2.5"><span className="text-indigo-500 font-semibold flex-shrink-0">5.</span><span>{t.exportPage.step5}</span></li>
+              <li className="flex gap-2.5"><span className="text-brand-500 font-semibold flex-shrink-0">1.</span><span>{t.exportPage.step1}</span></li>
+              <li className="flex gap-2.5"><span className="text-brand-500 font-semibold flex-shrink-0">2.</span><span>{t.exportPage.step2}</span></li>
+              <li className="flex gap-2.5"><span className="text-brand-500 font-semibold flex-shrink-0">3.</span><span>{t.exportPage.step3}</span></li>
+              <li className="flex gap-2.5"><span className="text-brand-500 font-semibold flex-shrink-0">4.</span><span>{t.exportPage.step4}</span></li>
+              <li className="flex gap-2.5"><span className="text-brand-500 font-semibold flex-shrink-0">5.</span><span>{t.exportPage.step5}</span></li>
             </ol>
           </div>
 
@@ -502,7 +502,7 @@ export default function ExportPage() {
                 {result.bundle.files.map((f) => (
                   <li key={f.path}>
                     <button onClick={() => setSelectedFile(f.path)}
-                      className={`w-full text-left px-4 py-2 text-xs transition-colors ${selectedFile === f.path ? "bg-indigo-50 text-indigo-700 font-medium" : "text-gray-600 hover:bg-gray-50"}`}>
+                      className={`w-full text-left px-4 py-2 text-xs transition-colors ${selectedFile === f.path ? "bg-brand-50 text-brand-700 font-medium" : "text-gray-600 hover:bg-gray-50"}`}>
                       {filename(f.path)}
                     </button>
                   </li>
@@ -613,7 +613,7 @@ function OutcomeRecorder({
             onChange={(e) => onNoteChange(e.target.value)}
             placeholder={t.exportPage.notePlaceholder}
             rows={2}
-            className="w-full text-sm border border-gray-200 rounded-xl px-4 py-3 mb-3 focus:outline-none focus:ring-2 focus:ring-indigo-300 resize-none"
+            className="w-full text-sm border border-gray-200 rounded-xl px-4 py-3 mb-3 focus:outline-none focus:ring-2 focus:ring-brand-300 resize-none"
           />
           <button onClick={onSave} disabled={!outcomeStatus || savePhase === "saving"}
             className="btn btn-md btn-secondary">
@@ -649,7 +649,7 @@ function OutcomeHistory({
             <Link
               href={`/projects/${projectId}/checks`}
               title={t.exportPage.recheckTooltip}
-              className="flex-shrink-0 text-indigo-500 hover:text-indigo-700 font-medium"
+              className="flex-shrink-0 text-brand-500 hover:text-brand-700 font-medium"
             >
               {t.exportPage.recheck}
             </Link>

--- a/apps/dashboard/src/app/projects/[id]/github/history/[runId]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/history/[runId]/page.tsx
@@ -145,7 +145,7 @@ function ResultCard({ item }: { item: ReviewResultItem }) {
         </div>
       )}
       {item.status !== "passed" && item.nextAction && (
-        <p className="text-xs text-indigo-600 bg-indigo-50 rounded-lg px-3 py-2">
+        <p className="text-xs text-brand-600 bg-brand-50 rounded-lg px-3 py-2">
           <span className="font-medium">{t.runDetail.nextStep}:</span> {item.nextAction}
         </p>
       )}
@@ -249,13 +249,13 @@ function FixPackPanel({
       <div className="bg-gray-50 border-b border-gray-200 px-4 py-3 flex items-center justify-between">
         <div>
           <p className="text-sm font-semibold text-gray-800">{t.runDetail.fpTitle}</p>
-          <p className="text-xs text-indigo-600 mt-0.5">
+          <p className="text-xs text-brand-600 mt-0.5">
             {t.runDetail.fpBuilt.replace("{n}", String(result.selectedItemIds.length))}
           </p>
         </div>
         <button
           onClick={copyAll}
-          className="text-xs text-indigo-600 hover:text-indigo-800 font-medium"
+          className="text-xs text-brand-600 hover:text-brand-800 font-medium"
         >
           {copied ? t.runDetail.copied : t.runDetail.fpCopyAll}
         </button>
@@ -275,7 +275,7 @@ function FixPackPanel({
               onClick={() => setSelectedFileIdx(i)}
               className={`text-xs px-3 py-2 flex-shrink-0 border-b-2 transition-colors ${
                 i === selectedFileIdx
-                  ? "border-indigo-500 text-indigo-700 font-medium"
+                  ? "border-brand-500 text-brand-700 font-medium"
                   : "border-transparent text-gray-500 hover:text-gray-700"
               }`}
             >
@@ -534,13 +534,13 @@ function ComparisonPanel({ cmp, newRunId, projectId, selectedCount }: {
         <div>
           <p className="text-sm font-semibold text-gray-800">{t.runDetail.cmpTitle}</p>
           {typeof selectedCount === "number" && selectedCount > 0 && (
-            <p className="text-xs text-indigo-600 mt-0.5">{t.runDetail.rerunDoneCount.replace("{n}", String(selectedCount))}</p>
+            <p className="text-xs text-brand-600 mt-0.5">{t.runDetail.rerunDoneCount.replace("{n}", String(selectedCount))}</p>
           )}
           <p className="text-xs text-gray-500 mt-0.5">{cmp.summaryText}</p>
         </div>
         <Link
           href={`/projects/${projectId}/github/history/${newRunId}`}
-          className="text-xs text-indigo-600 font-medium hover:text-indigo-800 flex-shrink-0"
+          className="text-xs text-brand-600 font-medium hover:text-brand-800 flex-shrink-0"
         >
           {t.runDetail.viewNewRun}
         </Link>
@@ -672,7 +672,7 @@ function AutoCompareGroup({ title, description, color, items }: {
               <p className="text-[11px] text-gray-500 mt-0.5 truncate">{t.runDetail.acCurrentEvidence}: {item.currentEvidence}</p>
             )}
             {item.currentNextAction && (
-              <p className="text-[11px] text-indigo-500 mt-0.5 truncate">{t.runDetail.acNextAction}: {item.currentNextAction}</p>
+              <p className="text-[11px] text-brand-500 mt-0.5 truncate">{t.runDetail.acNextAction}: {item.currentNextAction}</p>
             )}
           </div>
         ))}
@@ -752,7 +752,7 @@ function AutoComparisonPanel({ state, hasLineage, onSendToComment }: {
         {hasLineage && onSendToComment ? (
           <button
             onClick={onSendToComment}
-            className="text-xs font-medium border border-indigo-200 text-indigo-700 bg-indigo-50 rounded-lg px-3 py-1.5 hover:bg-indigo-100 transition-colors"
+            className="text-xs font-medium border border-brand-200 text-brand-700 bg-brand-50 rounded-lg px-3 py-1.5 hover:bg-brand-100 transition-colors"
           >
             {t.runDetail.acSendToComment}
           </button>
@@ -790,7 +790,7 @@ function RerunItemRow({ item, checked, onToggle }: {
         </div>
         {evidence && <p className="text-[11px] text-gray-500 mt-0.5 truncate">{evidence}</p>}
         {item.status !== "passed" && item.nextAction && (
-          <p className="text-[11px] text-indigo-500 mt-0.5 truncate">{t.runDetail.next}: {item.nextAction}</p>
+          <p className="text-[11px] text-brand-500 mt-0.5 truncate">{t.runDetail.next}: {item.nextAction}</p>
         )}
       </div>
     </label>
@@ -863,7 +863,7 @@ function ReviewItemSelectionPanel({
 
       <div className="border-t border-gray-100 bg-gray-50 px-4 py-2.5 flex items-center justify-between gap-2">
         {selectedItemIds.length > 0 ? (
-          <p className="text-xs text-indigo-600">{t.runDetail.selSelected.replace("{n}", String(selectedItemIds.length))}</p>
+          <p className="text-xs text-brand-600">{t.runDetail.selSelected.replace("{n}", String(selectedItemIds.length))}</p>
         ) : (
           <p className="text-xs text-amber-600">
             {t.runDetail.selHint}
@@ -1110,7 +1110,7 @@ export default function RunDetailPage() {
   if (phase === "not_found") {
     return (
       <div className="max-w-3xl space-y-4">
-        <Link href={historyUrl} className="text-xs text-gray-500 hover:text-indigo-600 inline-block">
+        <Link href={historyUrl} className="text-xs text-gray-500 hover:text-brand-600 inline-block">
           {t.runDetail.backToHistory}
         </Link>
         <div className="bg-white rounded-xl border border-gray-200 p-8 text-center">
@@ -1124,7 +1124,7 @@ export default function RunDetailPage() {
   if (phase === "error" || !detail) {
     return (
       <div className="max-w-3xl space-y-4">
-        <Link href={historyUrl} className="text-xs text-gray-500 hover:text-indigo-600 inline-block">
+        <Link href={historyUrl} className="text-xs text-gray-500 hover:text-brand-600 inline-block">
           {t.runDetail.backToHistory}
         </Link>
         <div className="bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700">
@@ -1155,7 +1155,7 @@ export default function RunDetailPage() {
       {/* ── Header ── */}
       <div className="flex items-start justify-between gap-4">
         <div>
-          <Link href={historyUrl} className="text-xs text-gray-500 hover:text-indigo-600 mb-2 inline-block">
+          <Link href={historyUrl} className="text-xs text-gray-500 hover:text-brand-600 mb-2 inline-block">
             {t.runDetail.backToHistory}
           </Link>
           <h2 className="text-lg font-bold text-gray-900">{t.runDetail.title}</h2>
@@ -1171,13 +1171,13 @@ export default function RunDetailPage() {
 
       {/* ── Lineage badge ── */}
       {run.rerunOfReviewRunId && (
-        <div className="flex items-center gap-2 bg-indigo-50 border border-indigo-100 rounded-xl px-4 py-2.5">
-          <span className="text-xs font-medium text-indigo-700 bg-indigo-100 border border-indigo-200 rounded-full px-2 py-0.5">
+        <div className="flex items-center gap-2 bg-brand-50 border border-brand-100 rounded-xl px-4 py-2.5">
+          <span className="text-xs font-medium text-brand-700 bg-brand-100 border border-brand-200 rounded-full px-2 py-0.5">
             {t.runDetail.rerunBadge}
           </span>
           <Link
             href={`/projects/${id}/github/history/${run.rerunOfReviewRunId}`}
-            className="text-xs text-indigo-600 hover:text-indigo-800"
+            className="text-xs text-brand-600 hover:text-brand-800"
           >
             {t.runDetail.viewPrevRun}
           </Link>

--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -518,7 +518,7 @@ export default function GitHubPage() {
                           {lp.selectedItemIds.map((itemId) => {
                             const item = allItems.find((i) => i.id === itemId);
                             return item ? (
-                              <span key={itemId} className="text-xs bg-indigo-50 text-indigo-700 border border-indigo-200 rounded-full px-2 py-0.5 truncate max-w-[200px]">
+                              <span key={itemId} className="text-xs bg-brand-50 text-brand-700 border border-brand-200 rounded-full px-2 py-0.5 truncate max-w-[200px]">
                                 {item.title}
                               </span>
                             ) : null;
@@ -683,7 +683,7 @@ function ReviewResultPanel({ run, onRerun }: { run: ReviewRun; onRerun: () => vo
                     </div>
                   )}
                   {r.nextAction && (
-                    <p className="text-xs text-indigo-700 bg-indigo-50 rounded px-2 py-1.5">
+                    <p className="text-xs text-brand-700 bg-brand-50 rounded px-2 py-1.5">
                       {t.review.nextLabel}: {r.nextAction}
                     </p>
                   )}

--- a/apps/dashboard/src/app/projects/[id]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/page.tsx
@@ -753,7 +753,7 @@ function badgeClassForEventType(type: string): string {
     case "impact_inconclusive":
       return "border-amber-200 bg-amber-50 text-amber-700";
     case "decision_recorded":
-      return "border-indigo-200 bg-indigo-50 text-indigo-700";
+      return "border-brand-200 bg-brand-50 text-brand-700";
     case "benchmark_created":
       return "border-blue-200 bg-blue-50 text-blue-700";
     case "experiment_created":

--- a/apps/dashboard/src/components/QuestionCard.tsx
+++ b/apps/dashboard/src/components/QuestionCard.tsx
@@ -31,11 +31,11 @@ export function QuestionCard({ question, index, total, answer, onAnswer }: Props
         {question.question}
       </p>
 
-      <div className="bg-indigo-50 rounded-lg px-4 py-3 mb-5">
-        <p className="text-xs font-semibold text-indigo-700 mb-0.5">
+      <div className="bg-brand-50 rounded-lg px-4 py-3 mb-5">
+        <p className="text-xs font-semibold text-brand-700 mb-0.5">
           {t.np.recommended}: {question.recommendation}
         </p>
-        <p className="text-xs text-indigo-600 leading-relaxed">
+        <p className="text-xs text-brand-600 leading-relaxed">
           {question.recommendationReason}
         </p>
       </div>
@@ -47,8 +47,8 @@ export function QuestionCard({ question, index, total, answer, onAnswer }: Props
             onClick={() => onAnswer(opt.value)}
             className={`text-sm px-4 py-2 rounded-lg border transition-all ${
               answer === opt.value
-                ? "bg-indigo-600 text-white border-indigo-600"
-                : "bg-white text-gray-700 border-gray-200 hover:border-indigo-300 hover:bg-indigo-50"
+                ? "bg-brand-600 text-white border-brand-600"
+                : "bg-white text-gray-700 border-gray-200 hover:border-brand-300 hover:bg-brand-50"
             }`}
           >
             {opt.label}
@@ -71,7 +71,7 @@ export function QuestionCard({ question, index, total, answer, onAnswer }: Props
           autoFocus
           type="text"
           placeholder={t.np.typeYourOwn}
-          className="mt-3 w-full text-sm border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+          className="mt-3 w-full text-sm border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-300"
           onBlur={(e) => e.target.value && onAnswer(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter") {

--- a/apps/dashboard/src/lib/beta-feedback.mjs
+++ b/apps/dashboard/src/lib/beta-feedback.mjs
@@ -8,7 +8,7 @@
 
 // Existing public contact email used across the product surfaces. Do NOT invent
 // hi@/support@/feedback@ addresses without explicit approval.
-const FEEDBACK_EMAIL = "seunghunbae@b2w.kr";
+const FEEDBACK_EMAIL = "seunghunbae@3svs.com";
 const DEFAULT_SUBJECT_PREFIX = "[Simsa beta feedback]";
 
 function str(x) {

--- a/apps/dashboard/test/beta-feedback.test.mjs
+++ b/apps/dashboard/test/beta-feedback.test.mjs
@@ -12,7 +12,7 @@ function decoded(url) {
 test("builds a mailto to the existing public contact email", () => {
   const url = buildBetaFeedbackMailto({});
   assert.ok(url.startsWith(`mailto:${FEEDBACK_EMAIL}?`));
-  assert.equal(FEEDBACK_EMAIL, "seunghunbae@b2w.kr");
+  assert.equal(FEEDBACK_EMAIL, "seunghunbae@3svs.com");
 });
 
 test("subject carries the Simsa beta feedback prefix", () => {

--- a/apps/simsa-dev/src/app/page.tsx
+++ b/apps/simsa-dev/src/app/page.tsx
@@ -5,7 +5,7 @@
 const APP_URL = "https://app.trysimsa.com";
 const REPO_URL = "https://github.com/3SVS/simsa"; // public repo
 // Real contact mailbox (operator-provided), shared with the trysimsa.com surface.
-const CONTACT_EMAIL = "seunghunbae@b2w.kr";
+const CONTACT_EMAIL = "seunghunbae@3svs.com";
 // Stage 97: mailto-based early access — no backend / DB / email provider.
 const EARLY_ACCESS_MAILTO = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
   "Simsa early access request",

--- a/apps/simsa-landing/src/app/demo/page.tsx
+++ b/apps/simsa-landing/src/app/demo/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { StampMark } from "../../components/StampMark";
 
 const APP_URL = "https://app.trysimsa.com";
-const CONTACT_EMAIL = "seunghunbae@b2w.kr";
+const CONTACT_EMAIL = "seunghunbae@3svs.com";
 const EARLY_ACCESS_MAILTO = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
   "Simsa early access request",
 )}`;

--- a/apps/simsa-landing/src/app/privacy/page.tsx
+++ b/apps/simsa-landing/src/app/privacy/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { StampMark } from "../../components/StampMark";
 
 const APP_URL = "https://app.trysimsa.com";
-const CONTACT_EMAIL = "seunghunbae@b2w.kr";
+const CONTACT_EMAIL = "seunghunbae@3svs.com";
 
 export const metadata: Metadata = {
   title: "Privacy Note — Simsa",

--- a/apps/simsa-landing/src/app/terms/page.tsx
+++ b/apps/simsa-landing/src/app/terms/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { StampMark } from "../../components/StampMark";
 
 const APP_URL = "https://app.trysimsa.com";
-const CONTACT_EMAIL = "seunghunbae@b2w.kr";
+const CONTACT_EMAIL = "seunghunbae@3svs.com";
 
 export const metadata: Metadata = {
   title: "Terms Note — Simsa",


### PR DESCRIPTION
Finishes the restyle program's §6 color-compliance + a contact-email tidy-up.

## Indigo purge (§6 — P1 absorbed)
Indigo was an unauthorized accent (§6: only brand/gold/status tokens). Purged **all 200 `indigo-*` occurrences across 11 dashboard screens** (admin/credits, admin/usage, QuestionCard, benchmark ×2, credits, experiment, export, github ×2, project overview) → the **same-numbered `brand-*` oxblood** shade. The brand scale (50–950) covers every shade indigo used, so the mapping is 1:1 and on-palette: fills land on `brand-600` (the existing `.btn-primary` color), tints on `brand-50/100`, focus rings on `brand-500`. This completes **P1** — the work screens now read in the brand palette, no stray indigo.

## Contact email unified → seunghunbae@3svs.com
The partnership move to `seunghunbae@3svs.com` (from the landing) hadn't reached the landing **subpages** (/demo, /privacy, /terms), **simsa-dev**, or the dashboard **beta-feedback** mailto — all still on the old `b2w.kr`. Unified to `seunghunbae@3svs.com` (same recipient, company-standard domain). beta-feedback test updated to match.

**0 `indigo-` and 0 `b2w.kr` remain** (outside tests).

## Gates
dashboard **456/456**, typecheck + lint (no warnings) + build green for dashboard, landing, and simsa-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)