### PR TITLE
Restyle polish: seal favicon (landing + simsa-dev) + fix chooser progress sliver

### DIFF
--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -387,13 +387,17 @@ function NewProjectInner() {
 
   return (
     <div className="flex flex-col">
-      {showStepper ? (
-        <WizardStepper t={t} step={step} />
-      ) : (
-        <div className="h-0.5 bg-gray-100">
-          <div className="h-0.5 bg-brand-600 transition-all duration-500" style={{ width: progressWidth }} />
-        </div>
-      )}
+      {/* Progress only after a branch is chosen — on the chooser step (step 0)
+          the hairline bar rendered a stray oxblood sliver top-left (no progress
+          to show yet). */}
+      {entryPath !== null &&
+        (showStepper ? (
+          <WizardStepper t={t} step={step} />
+        ) : (
+          <div className="h-0.5 bg-gray-100">
+            <div className="h-0.5 bg-brand-600 transition-all duration-500" style={{ width: progressWidth }} />
+          </div>
+        ))}
 
       <main className="flex flex-1 justify-center px-4 py-12">
         <div className="w-full max-w-2xl">

--- a/apps/simsa-dev/src/app/icon.svg
+++ b/apps/simsa-dev/src/app/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="2" y="2" width="60" height="60" rx="9" fill="#8e2c39"/>
+  <g stroke="#faf6ee" fill="none" stroke-width="5" stroke-linecap="square">
+    <path d="M17 8 V16 M12 16 H22 M12 16 V27 M22 16 V27"/>
+    <path d="M28 8 V27"/>
+    <path d="M12 35 H28 V55 M12 35 V55 M12 55 H28"/>
+    <path d="M41 8 V21 M36 21 H46 M36 21 V41 M46 21 V41 M36 41 V55 M46 41 V55"/>
+    <path d="M53 8 V55 M53 29 H57"/>
+  </g>
+</svg>

--- a/apps/simsa-landing/src/app/icon.svg
+++ b/apps/simsa-landing/src/app/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="2" y="2" width="60" height="60" rx="9" fill="#8e2c39"/>
+  <g stroke="#faf6ee" fill="none" stroke-width="5" stroke-linecap="square">
+    <path d="M17 8 V16 M12 16 H22 M12 16 V27 M22 16 V27"/>
+    <path d="M28 8 V27"/>
+    <path d="M12 35 H28 V55 M12 35 V55 M12 55 H28"/>
+    <path d="M41 8 V21 M36 21 H46 M36 21 V41 M46 21 V41 M36 41 V55 M46 41 V55"/>
+    <path d="M53 8 V55 M53 29 H57"/>
+  </g>
+</svg>


### PR DESCRIPTION
The last two restyle items.

- **Favicon (§4-b common assets):** landing and simsa-dev now share the same seal `app/icon.svg` as the dashboard (added in #247) — all three apps carry the oxblood seal favicon.
- **P0-③ (`/projects/new`):** the hairline progress bar rendered on the branch-**chooser** step too, showing a stray **25% oxblood sliver top-left** before any branch is picked (the reported scroll artifact). Gated the progress indicator (labeled stepper + hairline) behind `entryPath !== null`, so it only appears once a branch is chosen.

## Gates
dashboard **456/456**, typecheck + lint (no warnings) + build green for dashboard, landing, and simsa-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)