### PR TITLE
Builder pack: hand-hold beginners through service setup + return-to-Simsa

### DIFF
--- a/apps/central-plane/src/workspace/export.ts
+++ b/apps/central-plane/src/workspace/export.ts
@@ -385,6 +385,32 @@ const BEGINNER_SETUP_GUIDANCE: string = [
   "- **Supabase (데이터베이스)**: https://supabase.com 가입 → `New project` 생성 → 왼쪽 하단 `Project Settings`(톱니바퀴) → `API` → `Project URL`과 `anon public` 키를 복사. 관리자 키가 필요하면 `API Keys` 탭 → `service_role` → `Reveal` 클릭 → 복사. **`service_role` 키는 관리자용이라 절대 프론트엔드/브라우저에 넣지 말라고 사용자에게 경고**하고, 서버 환경변수로만 쓰게 한다.",
   "- **Vercel (배포)**: https://vercel.com 에 GitHub 계정으로 로그인 → `Add New → Project` → 저장소 선택 → `Environment Variables`에 위에서 복사한 키를 이름 그대로 추가 → `Deploy`. 배포가 끝나면 나오는 URL을 사용자에게 그대로 알려준다.",
   "- 그 외 서비스(이메일·결제 등)도 같은 순서로: **가입 URL → 키를 찾는 정확한 위치 → 붙여넣을 곳** 순으로 상세히 안내한다.",
+  "",
+  "**배포 대응(중요):** 앱이 스스로를 가리키는 주소 — 짧은 링크의 앞부분, 공유 URL, 리다이렉트 대상, API 주소 등 — 를 절대 `http://localhost:3000` 같은 개발용 주소로 하드코딩하지 마라. 런타임 origin에서 가져와라(브라우저는 `window.location.origin`, 서버는 요청 host 또는 `NEXT_PUBLIC_APP_URL` 같은 환경변수). 그래야 로컬에서도, 배포 후에도 주소가 자동으로 맞는다. 이걸 안 하면 배포했을 때 사용자에게 보이는 링크가 `localhost`로 깨진다.",
+].join("\n");
+
+/**
+ * "Build like it's for a non-developer, and finish with a RESULT" directive.
+ * From dogfooding: the agent dragged the user through developer ceremony
+ * (branches, migrations, TDD) and ended by ASKING "merge to master / open a PR /
+ * discard?" instead of delivering a working app. A non-dev can't answer those
+ * and just wants the outcome.
+ */
+const NONDEV_WORKFLOW_GUIDANCE: string = [
+  "## 작업 방식 — 비개발자 우선",
+  "",
+  "이 사용자는 개발자가 아니다. 개발 절차 자체를 사용자에게 결정하게 하지 마라:",
+  "- **묻지 말 것**: 브랜치를 딸지, 커밋을 어떻게 나눌지, main/master에 병합할지, PR을 만들지 같은 개발 프로세스 선택. 이런 건 네가 알아서 처리하거나 생략하라. 사용자에게 이런 선택 메뉴를 던지면 막힌다.",
+  "- **손잡고 안내할 것은 딱 하나**: 외부 서비스 가입·키처럼 사용자만 할 수 있는 일. 위 '초보자 안내' 방식으로 단계별로.",
+  "- 진행 상황은 개발 용어 없이 '지금 무엇을 만들고 있고, 다음에 무엇이 필요한지'로만 알린다.",
+  "",
+  "## 마무리 — 질문이 아니라 결과물",
+  "",
+  "다 만들었으면 절대 '어떻게 마무리할까요(병합/PR/브랜치/폐기)?'처럼 개발 절차를 나열해 묻지 마라. 대신 이렇게 끝맺어라:",
+  "1. 앱을 실제로 **실행해서 동작하는 모습을 보여준다** (예: 개발 서버를 켠 뒤 접속할 로컬 주소를 알려준다).",
+  "2. 실제로 쓰려면 어떻게 **배포**하는지 위 '초보자 안내' 방식으로 단계별 안내한다(Vercel 등).",
+  "3. 배포된 URL(또는 프로젝트 파일)을 **Simsa에 다시 넣어 확인받게** 안내한다(아래 참고).",
+  "끝은 언제나 '완성된 결과물 + 다음에 할 한 가지 행동'이어야 한다. 개발 절차 선택 메뉴로 끝내지 마라.",
 ].join("\n");
 
 /**
@@ -441,6 +467,8 @@ function genClaudeCodePrompt(
     "- 애매한 점이 있으면 코드 작성 전에 질문한다.",
     "",
     BEGINNER_SETUP_GUIDANCE,
+    "",
+    NONDEV_WORKFLOW_GUIDANCE,
     "",
     RETURN_TO_SIMSA_GUIDANCE,
     "",
@@ -548,6 +576,8 @@ function genCodexPrompt(
     "## Final response format",
     "",
     BEGINNER_SETUP_GUIDANCE,
+    "",
+    NONDEV_WORKFLOW_GUIDANCE,
     "",
     RETURN_TO_SIMSA_GUIDANCE,
     "",

--- a/apps/central-plane/src/workspace/export.ts
+++ b/apps/central-plane/src/workspace/export.ts
@@ -361,6 +361,46 @@ function genFixesMd(
   return lines.join("\n");
 }
 
+/**
+ * Beginner hand-holding directive shared by both agent prompts. The end user may
+ * be a complete non-developer, so the building agent must never say "set this up
+ * yourself" for external services / API keys / env vars — it walks them through
+ * signup URLs and exact click-paths, one step at a time. Korean, matching the
+ * surrounding prompt and the KO-first audience.
+ */
+const BEGINNER_SETUP_GUIDANCE: string = [
+  "## 사용자 안내 원칙 — 완전 초보자 가정",
+  "",
+  "이 프로젝트의 사용자는 개발 경험이 전혀 없는 비개발자일 수 있다. 외부 서비스(데이터베이스·호스팅·인증·결제 등)나 API 키, 환경변수, 터미널 명령이 필요한 순간에는 절대 \"알아서 준비하세요\"라고 넘기지 말고, 다음처럼 손을 잡고 안내하라:",
+  "",
+  "- 왜 필요한지 한 문장으로 쉽게 설명한다. (예: \"데이터를 저장하려면 무료 데이터베이스가 필요해요.\")",
+  "- 가입·설정 URL을 전체 주소 그대로 준다.",
+  "- 화면에서 **어디를 눌러야 하는지 단계별로, 한 번에 하나씩** 안내한다. 전문용어(API 키, 환경변수, .env 등)는 그때그때 한 줄로 풀어 설명한다.",
+  "- 복사한 값을 **어디에 붙여넣는지(예: `.env` 파일의 어떤 줄)**까지 알려주고, 사용자가 \"했어요\"라고 확인하면 다음 단계로 넘어간다.",
+  "- 키·비밀번호는 절대 코드나 로그에 하드코딩하지 말고 환경변수로만 안내한다.",
+  "- 사용자가 막히면 \"지금 화면에 뭐가 보이세요?\"라고 묻거나 스크린샷을 요청해 다음 단계를 맞춘다.",
+  "",
+  "자주 쓰는 서비스 예시 (UI가 바뀌었으면 현재 화면에 맞게 조정하되, 이 정도로 상세하게):",
+  "",
+  "- **Supabase (데이터베이스)**: https://supabase.com 가입 → `New project` 생성 → 왼쪽 하단 `Project Settings`(톱니바퀴) → `API` → `Project URL`과 `anon public` 키를 복사. 관리자 키가 필요하면 `API Keys` 탭 → `service_role` → `Reveal` 클릭 → 복사. **`service_role` 키는 관리자용이라 절대 프론트엔드/브라우저에 넣지 말라고 사용자에게 경고**하고, 서버 환경변수로만 쓰게 한다.",
+  "- **Vercel (배포)**: https://vercel.com 에 GitHub 계정으로 로그인 → `Add New → Project` → 저장소 선택 → `Environment Variables`에 위에서 복사한 키를 이름 그대로 추가 → `Deploy`. 배포가 끝나면 나오는 URL을 사용자에게 그대로 알려준다.",
+  "- 그 외 서비스(이메일·결제 등)도 같은 순서로: **가입 URL → 키를 찾는 정확한 위치 → 붙여넣을 곳** 순으로 상세히 안내한다.",
+].join("\n");
+
+/**
+ * Closing "bring it back to Simsa" guidance, appended after the beginner setup
+ * block. Broader than the deep-link hook: reminds the agent that the user can
+ * return with a deployed URL OR the project files/spec for another review.
+ */
+const RETURN_TO_SIMSA_GUIDANCE: string = [
+  "## 완성한 뒤 — Simsa로 다시 확인받기",
+  "",
+  "구현·자가 점검이 끝나면 사용자에게 이렇게 안내하라:",
+  "- **배포까지 했다면**: 배포된 앱 URL을 Simsa에 다시 넣어 라이브 화면을 검수받게 한다.",
+  "- **아직 배포 전이라면**: 프로젝트 파일(또는 기획서)을 Simsa에 다시 넣어 이번 결과를 재확인받게 한다.",
+  "이렇게 하면 남은 문제를 Simsa가 다시 잡아주고, 다음 패키지로 이어갈 수 있다.",
+].join("\n");
+
 function genClaudeCodePrompt(
   title: string,
   effectiveItems: ExportItem[],
@@ -399,6 +439,10 @@ function genClaudeCodePrompt(
     "- `product.md`의 '이번 버전에서 제외' 항목은 절대 구현하지 않는다.",
     "- 전체 제품을 한 번에 만들지 않는다. 이번 패키지 범위만 구현한다.",
     "- 애매한 점이 있으면 코드 작성 전에 질문한다.",
+    "",
+    BEGINNER_SETUP_GUIDANCE,
+    "",
+    RETURN_TO_SIMSA_GUIDANCE,
     "",
     "## 포함된 항목 목록",
     "",
@@ -502,6 +546,10 @@ function genCodexPrompt(
     "- 아직 결정이 필요한 사항(product.md)이 구현에 영향을 미치지 않았는지 확인한다.",
     "",
     "## Final response format",
+    "",
+    BEGINNER_SETUP_GUIDANCE,
+    "",
+    RETURN_TO_SIMSA_GUIDANCE,
     "",
     "완료 시 다음 형식으로 보고하라:",
     "",

--- a/apps/central-plane/test/workspace-export.test.mjs
+++ b/apps/central-plane/test/workspace-export.test.mjs
@@ -101,6 +101,13 @@ describe("workspace export-builder-pack", () => {
       // return-to-Simsa: either the deployed URL or the project files
       assert.match(p, /Simsa로 다시 확인받기/);
       assert.ok(p.includes("배포된 앱 URL") && p.includes("프로젝트 파일"), "URL or files re-entry");
+      // deploy hygiene: never hardcode localhost; derive from runtime origin
+      assert.ok(p.includes("localhost") && p.includes("window.location.origin"), "no-hardcoded-localhost directive");
+      // non-dev workflow: don't ask dev-ceremony questions
+      assert.match(p, /작업 방식 — 비개발자 우선/);
+      assert.ok(p.includes("병합") && p.includes("PR"), "no branch/merge/PR questions");
+      // finish = a running result, not a git-strategy menu
+      assert.match(p, /마무리 — 질문이 아니라 결과물/);
     }
   });
 

--- a/apps/central-plane/test/workspace-export.test.mjs
+++ b/apps/central-plane/test/workspace-export.test.mjs
@@ -85,6 +85,25 @@ describe("workspace export-builder-pack", () => {
     assert.ok(!paths.some((p) => p.endsWith("CLAUDE_CODE_PROMPT.md")), "CLAUDE_CODE_PROMPT.md should not be present");
   });
 
+  it("both prompts hand-hold a beginner through external-service setup + return-to-Simsa", () => {
+    const res = generateBuilderPack(makeReq("both"));
+    const prompts = res.bundle.files
+      .filter((f) => f.path.endsWith("CLAUDE_CODE_PROMPT.md") || f.path.endsWith("CODEX_PROMPT.md"))
+      .map((f) => f.content);
+    assert.equal(prompts.length, 2);
+    for (const p of prompts) {
+      // beginner setup guidance: signup URLs + exact key-finding path + warning
+      assert.match(p, /완전 초보자 가정/);
+      assert.ok(p.includes("https://supabase.com"), "Supabase signup URL");
+      assert.ok(p.includes("service_role") && p.includes("Reveal"), "exact service_role key path");
+      assert.ok(p.includes("https://vercel.com"), "Vercel signup URL");
+      assert.match(p, /환경변수/); // don't hardcode keys
+      // return-to-Simsa: either the deployed URL or the project files
+      assert.match(p, /Simsa로 다시 확인받기/);
+      assert.ok(p.includes("배포된 앱 URL") && p.includes("프로젝트 파일"), "URL or files re-entry");
+    }
+  });
+
   it("both target includes both prompt files", () => {
     const res = generateBuilderPack(makeReq("both"));
     const paths = res.bundle.files.map((f) => f.path);


### PR DESCRIPTION
From dogfooding the pack in Claude Code — a complete-beginner non-developer hits a wall the moment the agent needs an external service (Supabase, Vercel, API keys, env vars). The pack said nothing, so the agent assumed knowledge. Both these gaps are now in the generated agent prompts.

Both `CLAUDE_CODE_PROMPT.md` + `CODEX_PROMPT.md` now carry two shared directives:

- **BEGINNER_SETUP_GUIDANCE** — assume zero technical knowledge; **never say "set it up yourself."** Give the exact signup URL, walk the exact click-path **one step at a time**, translate jargon (API key / env var / .env), say precisely where to paste each value, wait for confirmation. Seeded with the real paths for the common services:
  - **Supabase**: sign up → New project → Project Settings → API → Project URL + `anon`; for admin: API Keys → `service_role` → **Reveal** → copy — with a **"never put service_role in the frontend"** warning.
  - **Vercel**: sign in with GitHub → Add New Project → Environment Variables → Deploy.
- **RETURN_TO_SIMSA_GUIDANCE** — after building, guide the user back to Simsa with **either the deployed URL** (live review) **OR the project files/spec** (re-check). Complements the D1-b deep-link hook (#243), which stays for the concrete `/p/{id}/connect` link.

Deterministic (no LLM). **1 new test** asserts both prompts include the signup URLs, the exact `service_role` Reveal path, and the URL-or-files return line. central-plane **1614/1614**, typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)