### PR TITLE
Fix code-check 'connection lost' — await project persist + recoverable no-repo card

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -334,13 +334,20 @@ export default function GitHubPage() {
         </div>
       )}
 
-      {/* No repo */}
+      {/* No repo. The reload button recovers a just-connected repo that a
+          persistence race briefly reported as null — so a real connection is
+          never lost behind a terminal "connect again" card. */}
       {loadPhase === "no_repo" && (
         <div className="card p-8 text-center">
           <p className="mb-4 text-sm text-gray-600">{t.github.connectRepoFirst}</p>
-          <Link href={`/projects/${id}/settings`} className="btn btn-md btn-primary">
-            {t.github.goConnectRepo}
-          </Link>
+          <div className="flex items-center justify-center gap-2">
+            <Link href={`/projects/${id}/settings`} className="btn btn-md btn-primary">
+              {t.github.goConnectRepo}
+            </Link>
+            <button onClick={() => void loadInitial()} className="btn btn-md btn-secondary">
+              {t.common.retry}
+            </button>
+          </div>
         </div>
       )}
 

--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -311,7 +311,13 @@ function NewProjectInner() {
         : {}),
       entryPath: "code",
     });
-    saveProjectToDb({
+    // Persist the project server-side BEFORE navigating to connect a repo.
+    // This was fire-and-forget + an immediate router.push, so the project row
+    // could still be uncommitted when the user linked a repo on the next screen
+    // — orphaning the link and later showing the "connect a repo again" card
+    // (the reported bug). Await it; on failure still navigate (local-first) and
+    // mark the sync so settings can surface it.
+    const saveRes = await saveProjectToDb({
       id,
       userKey: getUserKey(),
       title: name,
@@ -324,9 +330,11 @@ function NewProjectInner() {
           ? { tools: builtWithTools, other: builtWithOther.trim() || undefined }
           : undefined,
       entryPath: "code",
-    })
-      .then((res) => { if (!res || res.ok !== true) { markProjectSyncFailed(id); toast.error(t.interaction.syncFailedSaved); } })
-      .catch(() => { markProjectSyncFailed(id); toast.error(t.interaction.syncFailedSaved); });
+    }).catch(() => null);
+    if (!saveRes || saveRes.ok !== true) {
+      markProjectSyncFailed(id);
+      toast.error(t.interaction.syncFailedSaved);
+    }
     // Straight to code connect — that IS this branch's step 1.
     router.push(`/projects/${id}/settings`);
   }


### PR DESCRIPTION
**Reported:** on the code-check (코드 변경) screen, after connecting a repo and pressing 확인하기, the "connect a repo first" card shows again and the connection looks gone.

**Trace (it's not real data loss):** the repo row is never deleted server-side — the review route only reads repo/PR + writes a review run; there's no unlink anywhere. The github page has **no router** (nothing navigates/unlinks on 확인하기). The "connect again" card is `loadPhase="no_repo"`, reachable only when `fetchProjectRepo` returns `{ok:true, repo:null}` on a **remount**. Root cause: the CODE-branch project was persisted with a **fire-and-forget `saveProjectToDb` + an immediate `router.push(/settings)`** — so the project row could still be uncommitted when the user linked a repo on the next screen, **orphaning the link**.

**Fix:**
- `new/page.tsx` (`handleCreateCodeProject`): **await** `saveProjectToDb` before navigating to `/settings`, so the project exists server-side before a repo is connected to it. On failure still navigate (local-first) + mark the sync.
- `github/page.tsx`: the `no_repo` card gets a **retry** button (re-runs `loadInitial`) so a repo that a race briefly reported null **recovers** instead of stranding the user behind a terminal "connect again" card.

dashboard **456/456**, typecheck + lint + build green.

**Note:** the static trace couldn't dynamically reproduce the exact trigger, so this targets the most-likely root cause (the persist race) + adds a hard recovery path. If it recurs after this, the exact repro steps (which screen, before/after which click) would pin any remaining trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)