### PR TITLE
Flow IA: move builder pack up to step 2, drop fix brief from results (design P1a)

### DIFF
--- a/apps/dashboard/src/components/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar.tsx
@@ -175,11 +175,15 @@ export function AppSidebar() {
     },
     review: {
       label: t.stepsNav.review,
-      items: [["github", t.nav.github]],
+      // 검수·준비 단계: 저장소 연결 + 빌더팩 다운로드(위로 올림). 서비스/키·알림은
+      // 준비 계층(P1)에서 이 단계에 추가된다.
+      items: [["github", t.nav.github], ["export", t.nav.export]],
     },
     results: {
       label: t.stepsNav.results,
-      items: [["checks", t.nav.checks], ["visual-checks", t.nav.visualChecks], ["fixes", t.nav.fixes], ["export", t.nav.export]],
+      // 결과·수정: 사전확인/검수 결과. 수정지시서(fixes)는 빌더팩에 포함되어 중복이라
+      // 여기서 제거(설계 2026-07-06). /fixes 라우트 자체는 유지(직접 접근·이력용).
+      items: [["checks", t.nav.checks], ["visual-checks", t.nav.visualChecks]],
     },
   };
   const lockHint = (reason: "need_items" | "need_code" | "need_build" | null) =>


### PR DESCRIPTION
First slice of the approved flow redesign (#257). **Sidebar step map only** — routes unchanged, no behavior change beyond nav placement.

- **Builder pack (export) moved from step 3 (결과·수정) → step 2 (검수·준비)**, next to 저장소 연결 — you connect + get the pack *before* building. Services/keys + notifications join this step in the prep-layer PR.
- **Fix brief (fixes) removed from the step-3 nav** — it's already in the builder pack, so it was redundant there (per Bae, 2026-07-06). The `/fixes` route itself stays (direct access / history).

dashboard **456/456**, typecheck + lint + build green.

Next (P1b): the prep layer — in-Simsa guided service setup + bake `.env` into the pack (no-store), and the fuller step-machine wiring for the connect→pack→build→return loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)