### PR TITLE
Prep layer (deploy A): in-Simsa guided MCP connect — lead the setup, hold no tokens

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -7,6 +7,8 @@ import { useParams } from "next/navigation";
 import { getProject } from "@/lib/mock-data";
 import { detectServices, hasAnyValue } from "@/lib/service-catalog.mjs";
 import type { CatalogService } from "@/lib/service-catalog.mjs";
+import { detectMcpTools } from "@/lib/mcp-catalog.mjs";
+import type { McpTool } from "@/lib/mcp-catalog.mjs";
 import {
   getLocalProject,
   loadExtendedProjectData,
@@ -172,6 +174,9 @@ export default function ExportPage() {
       ),
     );
   }
+
+  // Deploy tools (option A) — pure guidance, no state, no tokens collected.
+  const deployTools: McpTool[] = detectMcpTools();
 
   // ── Derived ──────────────────────────────────────────────────────────────
   const ext = loadExtendedProjectData(id);
@@ -385,6 +390,9 @@ export default function ExportPage() {
         onApply={handleGenerate}
         applying={phase === "loading"}
       />
+
+      {/* ── Prep: connect deploy tools (option A) — guidance only, no tokens ── */}
+      <McpSetupPanel tools={deployTools} />
 
       {/* ── Config: target + selection mode ── */}
       <div className="bg-white rounded-xl border border-gray-200 p-5">
@@ -614,6 +622,47 @@ export default function ExportPage() {
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
+
+function McpSetupPanel({ tools }: { tools: McpTool[] }) {
+  const { t } = useI18n();
+  const d = t.exportPage.deployTools;
+
+  if (tools.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-5">
+      <h2 className="text-sm font-semibold text-gray-800 mb-1">{d.title}</h2>
+      <p className="text-sm text-gray-500 mb-4">{d.intro}</p>
+
+      <div className="space-y-3">
+        {tools.map((tool) => (
+          <div key={tool.id} className="border border-gray-200 rounded-xl p-4">
+            <div className="flex items-center justify-between gap-3 mb-2">
+              <span className="text-sm font-medium text-gray-800">{tool.label}</span>
+              {tool.docsUrl && (
+                <a href={tool.docsUrl} target="_blank" rel="noopener noreferrer"
+                  className="text-xs px-3 py-1 rounded-lg font-medium bg-white text-brand-700 border border-brand-200 hover:bg-brand-50 transition-colors flex-shrink-0">
+                  {d.docsLabel} ↗
+                </a>
+              )}
+            </div>
+            <p className="text-xs text-gray-500 mb-3">{tool.purpose}</p>
+            <div className="space-y-2">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-0.5">{d.connectLabel}</p>
+                <p className="text-xs text-gray-600">{tool.connectHint}</p>
+              </div>
+              <div className="bg-brand-50 border border-brand-100 rounded-lg px-3 py-2">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-brand-600 mb-0.5">{d.safetyLabel}</p>
+                <p className="text-xs text-brand-700">{tool.authNote}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 function ServiceSetupPanel({
   services,

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -556,6 +556,13 @@ export type Dictionary = {
       siteDesc: string;
       siteCta: string;
     };
+    deployTools: {
+      title: string;
+      intro: string;
+      connectLabel: string;
+      safetyLabel: string;
+      docsLabel: string;
+    };
   };
   adminUsage: {
     title: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -629,6 +629,13 @@ const EN = {
       siteDesc: "Add your live app URL to run a visual check of the finished screens.",
       siteCta: "Connect app URL",
     },
+    deployTools: {
+      title: "Let your AI deploy it in one shot",
+      intro: "Connect these tools once in your editor. Then your dev AI can push the code and put the app online by itself — no copy-pasting keys, and Simsa never sees your tokens.",
+      connectLabel: "How to connect",
+      safetyLabel: "Your keys stay with you",
+      docsLabel: "Official guide",
+    },
   },
   adminUsage: {
     title: "Admin — Usage",
@@ -2886,6 +2893,13 @@ const KO = {
       siteTitle: "배포된 웹사이트 연결",
       siteDesc: "배포된 앱 주소를 넣어 완성된 화면을 시각 검수합니다.",
       siteCta: "앱 주소 연결하기",
+    },
+    deployTools: {
+      title: "AI가 한 번에 배포까지 하도록",
+      intro: "아래 도구를 에디터에서 한 번만 연결해 두세요. 그러면 개발 AI가 코드를 올리고 앱을 인터넷에 배포하는 것까지 알아서 합니다 — 키를 복사해 붙일 필요 없고, Simsa는 토큰을 절대 보지 않습니다.",
+      connectLabel: "연결 방법",
+      safetyLabel: "키는 사용자에게만",
+      docsLabel: "공식 안내",
     },
   },
   adminUsage: {

--- a/apps/dashboard/src/lib/mcp-catalog.d.mts
+++ b/apps/dashboard/src/lib/mcp-catalog.d.mts
@@ -1,0 +1,17 @@
+export interface McpTool {
+  id: string;
+  label: string;
+  /** why a non-dev needs this, one plain sentence */
+  purpose: string;
+  /** how to connect it once, in their editor */
+  connectHint: string;
+  /** the "we never see your token" reassurance */
+  authNote: string;
+  docsUrl?: string;
+}
+
+export declare const MCP_CATALOG: McpTool[];
+
+export declare function mcpToolById(id: string): McpTool | null;
+
+export declare function detectMcpTools(): McpTool[];

--- a/apps/dashboard/src/lib/mcp-catalog.mjs
+++ b/apps/dashboard/src/lib/mcp-catalog.mjs
@@ -1,0 +1,69 @@
+/**
+ * mcp-catalog.mjs
+ *
+ * Prep layer — deploy option A: the user's building agent deploys in one shot
+ * using its OWN connected tools (Vercel/GitHub MCP or CLI). Simsa's job is only
+ * to LEAD the one-time connect, never to hold a token.
+ *
+ * Unlike service-catalog.mjs (which collects runtime env values in the browser),
+ * this catalog is PURE GUIDANCE: there are no key inputs, no `value` fields, and
+ * nothing is ever sent to the server. The one-time auth happens in the user's
+ * editor (OAuth/login there), so the deploy token stays on their machine and
+ * never reaches Simsa. That invariant is the whole point of option A.
+ */
+
+/**
+ * @typedef {Object} McpTool
+ * @property {string} id
+ * @property {string} label
+ * @property {string} purpose      // why a non-dev needs this, one plain sentence
+ * @property {string} connectHint  // how to connect it once, in their editor
+ * @property {string} authNote     // the "we never see your token" reassurance
+ * @property {string} [docsUrl]
+ */
+
+/** @type {McpTool[]} */
+export const MCP_CATALOG = [
+  {
+    id: "github",
+    label: "GitHub — 코드 저장소",
+    purpose: "만든 코드를 저장하고 올려두는 곳입니다. 개발 AI가 여기에 코드를 올려야 나중에 Simsa에서 확인할 수 있어요.",
+    connectHint: "에디터(Claude Code·Cursor 등)에서 GitHub를 한 번 연결(로그인)해 두세요. 그러면 개발 AI가 코드를 알아서 올립니다.",
+    authNote: "로그인은 에디터에서 한 번만 하면 됩니다. 토큰이나 비밀번호를 Simsa에 넣지 마세요 — 저희는 받지도, 저장하지도 않습니다.",
+    docsUrl: "https://docs.github.com/en/get-started/getting-started-with-git/set-up-git",
+  },
+  {
+    id: "vercel",
+    label: "Vercel — 인터넷에 배포",
+    purpose: "만든 앱을 인터넷에 올려 접속 주소(URL)를 만드는 곳입니다. 개발 AI가 여기로 배포하면 바로 주소가 나와요.",
+    connectHint: "에디터에서 Vercel을 한 번 연결(로그인)해 두세요. 그러면 개발 AI에게 \"배포해줘\" 한 번으로 배포까지 끝납니다.",
+    authNote: "로그인은 에디터에서 한 번만. 배포 토큰을 Simsa에 넣지 마세요 — 저희는 받지도, 저장하지도 않습니다.",
+    docsUrl: "https://vercel.com/docs/cli",
+  },
+];
+
+/**
+ * Return a fresh clone of a tool entry by id (so callers never mutate the
+ * shared catalog).
+ * @param {string} id
+ * @returns {McpTool | null}
+ */
+export function mcpToolById(id) {
+  const found = MCP_CATALOG.find((t) => t.id === id);
+  if (!found) return null;
+  return { ...found };
+}
+
+/**
+ * The deploy tools a "build it and put it live" project needs. Any web app the
+ * user wants online needs a code repo (GitHub) and a host (Vercel), so this is
+ * deterministic and spec-independent for now — returned in connect order
+ * (repo first, then deploy). The `spec` parameter is accepted for future
+ * refinement (e.g. skipping the repo tool for a throwaway prototype) but is not
+ * used today.
+ *
+ * @returns {McpTool[]}
+ */
+export function detectMcpTools() {
+  return MCP_CATALOG.map((t) => ({ ...t }));
+}

--- a/apps/dashboard/test/mcp-catalog.test.mjs
+++ b/apps/dashboard/test/mcp-catalog.test.mjs
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { MCP_CATALOG, mcpToolById, detectMcpTools } from "../src/lib/mcp-catalog.mjs";
+
+describe("mcp-catalog", () => {
+  it("every tool has id, label, purpose, connectHint, authNote", () => {
+    assert.ok(MCP_CATALOG.length > 0);
+    for (const t of MCP_CATALOG) {
+      for (const field of ["id", "label", "purpose", "connectHint", "authNote"]) {
+        assert.ok(typeof t[field] === "string" && t[field].length > 0, `${t.id} missing ${field}`);
+      }
+    }
+  });
+
+  it("collects NO tokens — no key/value/secret/env fields anywhere", () => {
+    // Option A invariant: this catalog is pure guidance. If a token-input field
+    // ever leaks in, that's a security regression (we'd be collecting secrets).
+    for (const t of MCP_CATALOG) {
+      for (const banned of ["value", "secret", "envVars", "key", "token"]) {
+        assert.ok(!(banned in t), `${t.id} must not carry a "${banned}" field`);
+      }
+    }
+  });
+
+  it("every authNote reassures the token never goes to Simsa", () => {
+    for (const t of MCP_CATALOG) {
+      assert.ok(t.authNote.includes("Simsa"), `${t.id} authNote should mention Simsa`);
+      assert.ok(
+        t.authNote.includes("저장하지") || t.authNote.includes("받지"),
+        `${t.id} authNote should say we don't receive/store it`,
+      );
+    }
+  });
+
+  it("detectMcpTools returns github then vercel (connect order)", () => {
+    const tools = detectMcpTools();
+    assert.deepEqual(
+      tools.map((t) => t.id),
+      ["github", "vercel"],
+    );
+  });
+
+  it("detectMcpTools returns fresh clones (no shared mutation)", () => {
+    const a = detectMcpTools();
+    a[0].label = "mutated";
+    const b = detectMcpTools();
+    assert.notEqual(b[0].label, "mutated");
+    assert.notEqual(MCP_CATALOG[0].label, "mutated");
+  });
+
+  it("mcpToolById returns a clone or null", () => {
+    const gh = mcpToolById("github");
+    assert.ok(gh && gh.id === "github");
+    gh.label = "mutated";
+    assert.notEqual(MCP_CATALOG.find((t) => t.id === "github").label, "mutated");
+    assert.equal(mcpToolById("nope"), null);
+  });
+});


### PR DESCRIPTION
The **dashboard half** of option A (pairs with the pack prompt directive, #262). At the builder-pack step Simsa now **leads** the user through connecting their deploy tools once — so their building agent can push + deploy in one shot — while **never asking for or holding a token**.

- **`lib/mcp-catalog.mjs`** (+ `.d.mts` + 6 tests): pure-guidance catalog. GitHub (repo) + Vercel (deploy), each with purpose, a one-time connect hint, and a "your keys stay with you — Simsa never receives or stores them" note. Unlike the service (env) catalog there are **no key inputs and no `value`/`secret`/`token` fields at all** — a test asserts that invariant so a token field can never sneak in.
- **Export page**: an `McpSetupPanel` right below the service setup — per-tool cards with purpose, how-to-connect, the no-store safety note, and a docs link. **No inputs, no API calls**: the actual auth is a one-time OAuth/login in the user's editor, so the token never reaches Simsa.
- i18n `exportPage.deployTools.*` (EN + KO), parity preserved.

Nothing is collected or sent — the panel is instructional only, the strongest form of the no-store invariant for deploy credentials.

Dashboard **474/474**, typecheck + build + lint clean.

**Stacked on #261** (base will retarget to main once #261 merges). Pairs with **#262** (pack prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)