### PR TITLE
Prep layer: copyable MCP connect commands (+ recover orphaned #263)

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -626,13 +626,21 @@ export default function ExportPage() {
 function McpSetupPanel({ tools }: { tools: McpTool[] }) {
   const { t } = useI18n();
   const d = t.exportPage.deployTools;
+  const [copiedCmd, setCopiedCmd] = useState<string | null>(null);
 
   if (tools.length === 0) return null;
+
+  async function copyCommand(id: string, command: string) {
+    await copyText(command);
+    setCopiedCmd(id);
+    setTimeout(() => setCopiedCmd(null), 2000);
+  }
 
   return (
     <div className="bg-white rounded-xl border border-gray-200 p-5">
       <h2 className="text-sm font-semibold text-gray-800 mb-1">{d.title}</h2>
-      <p className="text-sm text-gray-500 mb-4">{d.intro}</p>
+      <p className="text-sm text-gray-500 mb-3">{d.intro}</p>
+      <p className="text-xs text-brand-700 bg-brand-50 border border-brand-100 rounded-lg px-3 py-2 mb-4">{d.whatIsMcp}</p>
 
       <div className="space-y-3">
         {tools.map((tool) => (
@@ -647,15 +655,27 @@ function McpSetupPanel({ tools }: { tools: McpTool[] }) {
               )}
             </div>
             <p className="text-xs text-gray-500 mb-3">{tool.purpose}</p>
-            <div className="space-y-2">
-              <div>
-                <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-0.5">{d.connectLabel}</p>
-                <p className="text-xs text-gray-600">{tool.connectHint}</p>
+
+            {/* The exact connect command the user pastes into Claude Code */}
+            <div className="mb-3">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">{d.commandLabel}</p>
+              <div className="flex items-stretch gap-2">
+                <code className="flex-1 min-w-0 overflow-x-auto whitespace-nowrap bg-gray-900 text-gray-100 rounded-lg px-3 py-2 text-xs font-mono">
+                  {tool.connectCommand}
+                </code>
+                <button onClick={() => copyCommand(tool.id, tool.connectCommand)}
+                  className="flex-shrink-0 text-xs px-3 rounded-lg font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors">
+                  {copiedCmd === tool.id ? t.exportPage.copied : t.exportPage.copy}
+                </button>
               </div>
-              <div className="bg-brand-50 border border-brand-100 rounded-lg px-3 py-2">
-                <p className="text-[11px] font-semibold uppercase tracking-wide text-brand-600 mb-0.5">{d.safetyLabel}</p>
-                <p className="text-xs text-brand-700">{tool.authNote}</p>
-              </div>
+              <p className="mt-1.5 text-xs text-gray-600">
+                <span className="font-medium text-gray-700">{d.authStepLabel}:</span> {tool.authStep}
+              </p>
+            </div>
+
+            <div className="bg-brand-50 border border-brand-100 rounded-lg px-3 py-2">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-brand-600 mb-0.5">{d.safetyLabel}</p>
+              <p className="text-xs text-brand-700">{tool.authNote}</p>
             </div>
           </div>
         ))}

--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -7,6 +7,8 @@ import { useParams } from "next/navigation";
 import { getProject } from "@/lib/mock-data";
 import { detectServices, hasAnyValue } from "@/lib/service-catalog.mjs";
 import type { CatalogService } from "@/lib/service-catalog.mjs";
+import { detectMcpTools } from "@/lib/mcp-catalog.mjs";
+import type { McpTool } from "@/lib/mcp-catalog.mjs";
 import {
   getLocalProject,
   loadExtendedProjectData,
@@ -172,6 +174,9 @@ export default function ExportPage() {
       ),
     );
   }
+
+  // Deploy tools (option A) — pure guidance, no state, no tokens collected.
+  const deployTools: McpTool[] = detectMcpTools();
 
   // ── Derived ──────────────────────────────────────────────────────────────
   const ext = loadExtendedProjectData(id);
@@ -385,6 +390,9 @@ export default function ExportPage() {
         onApply={handleGenerate}
         applying={phase === "loading"}
       />
+
+      {/* ── Prep: connect deploy tools (option A) — guidance only, no tokens ── */}
+      <McpSetupPanel tools={deployTools} />
 
       {/* ── Config: target + selection mode ── */}
       <div className="bg-white rounded-xl border border-gray-200 p-5">
@@ -614,6 +622,47 @@ export default function ExportPage() {
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
+
+function McpSetupPanel({ tools }: { tools: McpTool[] }) {
+  const { t } = useI18n();
+  const d = t.exportPage.deployTools;
+
+  if (tools.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-5">
+      <h2 className="text-sm font-semibold text-gray-800 mb-1">{d.title}</h2>
+      <p className="text-sm text-gray-500 mb-4">{d.intro}</p>
+
+      <div className="space-y-3">
+        {tools.map((tool) => (
+          <div key={tool.id} className="border border-gray-200 rounded-xl p-4">
+            <div className="flex items-center justify-between gap-3 mb-2">
+              <span className="text-sm font-medium text-gray-800">{tool.label}</span>
+              {tool.docsUrl && (
+                <a href={tool.docsUrl} target="_blank" rel="noopener noreferrer"
+                  className="text-xs px-3 py-1 rounded-lg font-medium bg-white text-brand-700 border border-brand-200 hover:bg-brand-50 transition-colors flex-shrink-0">
+                  {d.docsLabel} ↗
+                </a>
+              )}
+            </div>
+            <p className="text-xs text-gray-500 mb-3">{tool.purpose}</p>
+            <div className="space-y-2">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-0.5">{d.connectLabel}</p>
+                <p className="text-xs text-gray-600">{tool.connectHint}</p>
+              </div>
+              <div className="bg-brand-50 border border-brand-100 rounded-lg px-3 py-2">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-brand-600 mb-0.5">{d.safetyLabel}</p>
+                <p className="text-xs text-brand-700">{tool.authNote}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 function ServiceSetupPanel({
   services,

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -559,6 +559,9 @@ export type Dictionary = {
     deployTools: {
       title: string;
       intro: string;
+      whatIsMcp: string;
+      commandLabel: string;
+      authStepLabel: string;
       connectLabel: string;
       safetyLabel: string;
       docsLabel: string;

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -556,6 +556,13 @@ export type Dictionary = {
       siteDesc: string;
       siteCta: string;
     };
+    deployTools: {
+      title: string;
+      intro: string;
+      connectLabel: string;
+      safetyLabel: string;
+      docsLabel: string;
+    };
   };
   adminUsage: {
     title: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -632,6 +632,9 @@ const EN = {
     deployTools: {
       title: "Let your AI deploy it in one shot",
       intro: "Connect these tools once in your editor. Then your dev AI can push the code and put the app online by itself — no copy-pasting keys, and Simsa never sees your tokens.",
+      whatIsMcp: "MCP is how you connect a tool to your dev AI. Paste each command below into Claude Code once and sign in when the browser opens — then paste the builder pack prompt and your AI can deploy on its own.",
+      commandLabel: "Connect command",
+      authStepLabel: "Sign in",
       connectLabel: "How to connect",
       safetyLabel: "Your keys stay with you",
       docsLabel: "Official guide",
@@ -2897,6 +2900,9 @@ const KO = {
     deployTools: {
       title: "AI가 한 번에 배포까지 하도록",
       intro: "아래 도구를 에디터에서 한 번만 연결해 두세요. 그러면 개발 AI가 코드를 올리고 앱을 인터넷에 배포하는 것까지 알아서 합니다 — 키를 복사해 붙일 필요 없고, Simsa는 토큰을 절대 보지 않습니다.",
+      whatIsMcp: "MCP는 개발 AI에 '도구'를 연결하는 방법입니다. 아래 명령을 Claude Code에 한 번씩 붙여넣고, 브라우저가 열리면 로그인만 하세요. 그다음 빌더팩 프롬프트를 붙여넣으면 개발 AI가 알아서 배포까지 합니다.",
+      commandLabel: "연결 명령",
+      authStepLabel: "로그인",
       connectLabel: "연결 방법",
       safetyLabel: "키는 사용자에게만",
       docsLabel: "공식 안내",

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -629,6 +629,13 @@ const EN = {
       siteDesc: "Add your live app URL to run a visual check of the finished screens.",
       siteCta: "Connect app URL",
     },
+    deployTools: {
+      title: "Let your AI deploy it in one shot",
+      intro: "Connect these tools once in your editor. Then your dev AI can push the code and put the app online by itself — no copy-pasting keys, and Simsa never sees your tokens.",
+      connectLabel: "How to connect",
+      safetyLabel: "Your keys stay with you",
+      docsLabel: "Official guide",
+    },
   },
   adminUsage: {
     title: "Admin — Usage",
@@ -2886,6 +2893,13 @@ const KO = {
       siteTitle: "배포된 웹사이트 연결",
       siteDesc: "배포된 앱 주소를 넣어 완성된 화면을 시각 검수합니다.",
       siteCta: "앱 주소 연결하기",
+    },
+    deployTools: {
+      title: "AI가 한 번에 배포까지 하도록",
+      intro: "아래 도구를 에디터에서 한 번만 연결해 두세요. 그러면 개발 AI가 코드를 올리고 앱을 인터넷에 배포하는 것까지 알아서 합니다 — 키를 복사해 붙일 필요 없고, Simsa는 토큰을 절대 보지 않습니다.",
+      connectLabel: "연결 방법",
+      safetyLabel: "키는 사용자에게만",
+      docsLabel: "공식 안내",
     },
   },
   adminUsage: {

--- a/apps/dashboard/src/lib/mcp-catalog.d.mts
+++ b/apps/dashboard/src/lib/mcp-catalog.d.mts
@@ -7,6 +7,10 @@ export interface McpTool {
   connectHint: string;
   /** the "we never see your token" reassurance */
   authNote: string;
+  /** the exact CLI command the user pastes to connect the tool (Claude Code) */
+  connectCommand: string;
+  /** the one-time login step after running connectCommand */
+  authStep: string;
   docsUrl?: string;
 }
 

--- a/apps/dashboard/src/lib/mcp-catalog.d.mts
+++ b/apps/dashboard/src/lib/mcp-catalog.d.mts
@@ -1,0 +1,17 @@
+export interface McpTool {
+  id: string;
+  label: string;
+  /** why a non-dev needs this, one plain sentence */
+  purpose: string;
+  /** how to connect it once, in their editor */
+  connectHint: string;
+  /** the "we never see your token" reassurance */
+  authNote: string;
+  docsUrl?: string;
+}
+
+export declare const MCP_CATALOG: McpTool[];
+
+export declare function mcpToolById(id: string): McpTool | null;
+
+export declare function detectMcpTools(): McpTool[];

--- a/apps/dashboard/src/lib/mcp-catalog.mjs
+++ b/apps/dashboard/src/lib/mcp-catalog.mjs
@@ -1,0 +1,69 @@
+/**
+ * mcp-catalog.mjs
+ *
+ * Prep layer — deploy option A: the user's building agent deploys in one shot
+ * using its OWN connected tools (Vercel/GitHub MCP or CLI). Simsa's job is only
+ * to LEAD the one-time connect, never to hold a token.
+ *
+ * Unlike service-catalog.mjs (which collects runtime env values in the browser),
+ * this catalog is PURE GUIDANCE: there are no key inputs, no `value` fields, and
+ * nothing is ever sent to the server. The one-time auth happens in the user's
+ * editor (OAuth/login there), so the deploy token stays on their machine and
+ * never reaches Simsa. That invariant is the whole point of option A.
+ */
+
+/**
+ * @typedef {Object} McpTool
+ * @property {string} id
+ * @property {string} label
+ * @property {string} purpose      // why a non-dev needs this, one plain sentence
+ * @property {string} connectHint  // how to connect it once, in their editor
+ * @property {string} authNote     // the "we never see your token" reassurance
+ * @property {string} [docsUrl]
+ */
+
+/** @type {McpTool[]} */
+export const MCP_CATALOG = [
+  {
+    id: "github",
+    label: "GitHub — 코드 저장소",
+    purpose: "만든 코드를 저장하고 올려두는 곳입니다. 개발 AI가 여기에 코드를 올려야 나중에 Simsa에서 확인할 수 있어요.",
+    connectHint: "에디터(Claude Code·Cursor 등)에서 GitHub를 한 번 연결(로그인)해 두세요. 그러면 개발 AI가 코드를 알아서 올립니다.",
+    authNote: "로그인은 에디터에서 한 번만 하면 됩니다. 토큰이나 비밀번호를 Simsa에 넣지 마세요 — 저희는 받지도, 저장하지도 않습니다.",
+    docsUrl: "https://docs.github.com/en/get-started/getting-started-with-git/set-up-git",
+  },
+  {
+    id: "vercel",
+    label: "Vercel — 인터넷에 배포",
+    purpose: "만든 앱을 인터넷에 올려 접속 주소(URL)를 만드는 곳입니다. 개발 AI가 여기로 배포하면 바로 주소가 나와요.",
+    connectHint: "에디터에서 Vercel을 한 번 연결(로그인)해 두세요. 그러면 개발 AI에게 \"배포해줘\" 한 번으로 배포까지 끝납니다.",
+    authNote: "로그인은 에디터에서 한 번만. 배포 토큰을 Simsa에 넣지 마세요 — 저희는 받지도, 저장하지도 않습니다.",
+    docsUrl: "https://vercel.com/docs/cli",
+  },
+];
+
+/**
+ * Return a fresh clone of a tool entry by id (so callers never mutate the
+ * shared catalog).
+ * @param {string} id
+ * @returns {McpTool | null}
+ */
+export function mcpToolById(id) {
+  const found = MCP_CATALOG.find((t) => t.id === id);
+  if (!found) return null;
+  return { ...found };
+}
+
+/**
+ * The deploy tools a "build it and put it live" project needs. Any web app the
+ * user wants online needs a code repo (GitHub) and a host (Vercel), so this is
+ * deterministic and spec-independent for now — returned in connect order
+ * (repo first, then deploy). The `spec` parameter is accepted for future
+ * refinement (e.g. skipping the repo tool for a throwaway prototype) but is not
+ * used today.
+ *
+ * @returns {McpTool[]}
+ */
+export function detectMcpTools() {
+  return MCP_CATALOG.map((t) => ({ ...t }));
+}

--- a/apps/dashboard/src/lib/mcp-catalog.mjs
+++ b/apps/dashboard/src/lib/mcp-catalog.mjs
@@ -19,6 +19,8 @@
  * @property {string} purpose      // why a non-dev needs this, one plain sentence
  * @property {string} connectHint  // how to connect it once, in their editor
  * @property {string} authNote     // the "we never see your token" reassurance
+ * @property {string} connectCommand // the exact CLI command the user pastes to connect (Claude Code)
+ * @property {string} authStep     // the one-time login step after running connectCommand
  * @property {string} [docsUrl]
  */
 
@@ -28,17 +30,23 @@ export const MCP_CATALOG = [
     id: "github",
     label: "GitHub — 코드 저장소",
     purpose: "만든 코드를 저장하고 올려두는 곳입니다. 개발 AI가 여기에 코드를 올려야 나중에 Simsa에서 확인할 수 있어요.",
-    connectHint: "에디터(Claude Code·Cursor 등)에서 GitHub를 한 번 연결(로그인)해 두세요. 그러면 개발 AI가 코드를 알아서 올립니다.",
+    connectHint: "아래 명령을 개발 AI(Claude Code)에 한 번 붙여넣어 GitHub를 연결하세요. 그러면 개발 AI가 코드를 알아서 올립니다.",
+    // Official GitHub remote MCP server (OAuth). Verified 2026-07.
+    connectCommand: "claude mcp add --transport http github https://api.githubcopilot.com/mcp/",
+    authStep: "명령을 실행한 뒤 Claude Code에서 `/mcp` 를 입력하면 GitHub 로그인 창이 열립니다. 한 번만 로그인하면 됩니다.",
     authNote: "로그인은 에디터에서 한 번만 하면 됩니다. 토큰이나 비밀번호를 Simsa에 넣지 마세요 — 저희는 받지도, 저장하지도 않습니다.",
-    docsUrl: "https://docs.github.com/en/get-started/getting-started-with-git/set-up-git",
+    docsUrl: "https://github.com/github/github-mcp-server",
   },
   {
     id: "vercel",
     label: "Vercel — 인터넷에 배포",
     purpose: "만든 앱을 인터넷에 올려 접속 주소(URL)를 만드는 곳입니다. 개발 AI가 여기로 배포하면 바로 주소가 나와요.",
-    connectHint: "에디터에서 Vercel을 한 번 연결(로그인)해 두세요. 그러면 개발 AI에게 \"배포해줘\" 한 번으로 배포까지 끝납니다.",
+    connectHint: "아래 명령을 개발 AI(Claude Code)에 한 번 붙여넣어 Vercel을 연결하세요. 그러면 \"배포해줘\" 한 번으로 배포까지 끝납니다.",
+    // Official Vercel remote MCP server (OAuth, public beta). Verified 2026-07.
+    connectCommand: "claude mcp add --transport http vercel https://mcp.vercel.com",
+    authStep: "명령을 실행한 뒤 Claude Code에서 `/mcp` 를 입력하면 Vercel 로그인 창이 열립니다. 한 번만 로그인하면 됩니다.",
     authNote: "로그인은 에디터에서 한 번만. 배포 토큰을 Simsa에 넣지 마세요 — 저희는 받지도, 저장하지도 않습니다.",
-    docsUrl: "https://vercel.com/docs/cli",
+    docsUrl: "https://vercel.com/docs/mcp/vercel-mcp",
   },
 ];
 

--- a/apps/dashboard/test/mcp-catalog.test.mjs
+++ b/apps/dashboard/test/mcp-catalog.test.mjs
@@ -3,12 +3,25 @@ import assert from "node:assert/strict";
 import { MCP_CATALOG, mcpToolById, detectMcpTools } from "../src/lib/mcp-catalog.mjs";
 
 describe("mcp-catalog", () => {
-  it("every tool has id, label, purpose, connectHint, authNote", () => {
+  it("every tool has id, label, purpose, connectHint, authNote, connectCommand, authStep", () => {
     assert.ok(MCP_CATALOG.length > 0);
     for (const t of MCP_CATALOG) {
-      for (const field of ["id", "label", "purpose", "connectHint", "authNote"]) {
+      for (const field of ["id", "label", "purpose", "connectHint", "authNote", "connectCommand", "authStep"]) {
         assert.ok(typeof t[field] === "string" && t[field].length > 0, `${t.id} missing ${field}`);
       }
+    }
+  });
+
+  it("connectCommand is a real 'claude mcp add' command and authStep points to /mcp", () => {
+    for (const t of MCP_CATALOG) {
+      assert.ok(
+        t.connectCommand.startsWith("claude mcp add "),
+        `${t.id} connectCommand should be a claude mcp add command`,
+      );
+      // the command carries a public https server URL, never a secret
+      assert.match(t.connectCommand, /https:\/\/\S+/);
+      assert.ok(!/ghp_|sk-|Bearer /.test(t.connectCommand), `${t.id} command must not embed a secret`);
+      assert.ok(t.authStep.includes("/mcp"), `${t.id} authStep should tell the user to run /mcp`);
     }
   });
 

--- a/apps/dashboard/test/mcp-catalog.test.mjs
+++ b/apps/dashboard/test/mcp-catalog.test.mjs
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { MCP_CATALOG, mcpToolById, detectMcpTools } from "../src/lib/mcp-catalog.mjs";
+
+describe("mcp-catalog", () => {
+  it("every tool has id, label, purpose, connectHint, authNote", () => {
+    assert.ok(MCP_CATALOG.length > 0);
+    for (const t of MCP_CATALOG) {
+      for (const field of ["id", "label", "purpose", "connectHint", "authNote"]) {
+        assert.ok(typeof t[field] === "string" && t[field].length > 0, `${t.id} missing ${field}`);
+      }
+    }
+  });
+
+  it("collects NO tokens — no key/value/secret/env fields anywhere", () => {
+    // Option A invariant: this catalog is pure guidance. If a token-input field
+    // ever leaks in, that's a security regression (we'd be collecting secrets).
+    for (const t of MCP_CATALOG) {
+      for (const banned of ["value", "secret", "envVars", "key", "token"]) {
+        assert.ok(!(banned in t), `${t.id} must not carry a "${banned}" field`);
+      }
+    }
+  });
+
+  it("every authNote reassures the token never goes to Simsa", () => {
+    for (const t of MCP_CATALOG) {
+      assert.ok(t.authNote.includes("Simsa"), `${t.id} authNote should mention Simsa`);
+      assert.ok(
+        t.authNote.includes("저장하지") || t.authNote.includes("받지"),
+        `${t.id} authNote should say we don't receive/store it`,
+      );
+    }
+  });
+
+  it("detectMcpTools returns github then vercel (connect order)", () => {
+    const tools = detectMcpTools();
+    assert.deepEqual(
+      tools.map((t) => t.id),
+      ["github", "vercel"],
+    );
+  });
+
+  it("detectMcpTools returns fresh clones (no shared mutation)", () => {
+    const a = detectMcpTools();
+    a[0].label = "mutated";
+    const b = detectMcpTools();
+    assert.notEqual(b[0].label, "mutated");
+    assert.notEqual(MCP_CATALOG[0].label, "mutated");
+  });
+
+  it("mcpToolById returns a clone or null", () => {
+    const gh = mcpToolById("github");
+    assert.ok(gh && gh.id === "github");
+    gh.label = "mutated";
+    assert.notEqual(MCP_CATALOG.find((t) => t.id === "github").label, "mutated");
+    assert.equal(mcpToolById("nope"), null);
+  });
+});


### PR DESCRIPTION
### Two things

**1. Recover #263.** That PR merged into its stacked base `service-catalog`, not main — and since #261 (service-catalog) had already merged to main, **#263's content never reached production**: `mcp-catalog`, the `McpSetupPanel`, and the `deployTools` i18n were silently orphaned. This branch cherry-picks it back onto main.

**2. The user-facing connect commands Bae asked for.** The panel was prose-only ("connect it in your editor"). Now each tool shows the **exact copyable command**:
- **GitHub** — `claude mcp add --transport http github https://api.githubcopilot.com/mcp/`
- **Vercel** — `claude mcp add --transport http vercel https://mcp.vercel.com`

…plus a "what is MCP + do this **before** the pack" explainer and the one-time **`/mcp` sign-in** step. The command sits in a dark copy-to-clipboard code block.

Official remote MCP servers (OAuth), verified 2026-07:
- Vercel MCP → [vercel.com/docs/mcp/vercel-mcp](https://vercel.com/docs/agent-resources/vercel-mcp)
- GitHub MCP → [github/github-mcp-server](https://github.com/github/github-mcp-server)

### Still zero token collection
The commands only add a **public** MCP server URL; auth is a one-time OAuth in the user's editor. A test asserts each command is a real `claude mcp add …` with a public https URL and **no embedded secret**.

Dashboard **475/475**, typecheck + build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)