### PR TITLE
Canary: flag "merged but never deployed" (deploy-freshness check)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Probe production
         id: probe
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
           fails=""
@@ -58,6 +60,29 @@ jobs:
           err=$(printf '%s' "$gen" | sed -n 's/.*"error":"\([^"]*\)".*/\1/p')
           if [ "$src" != "llm" ]; then
             fails="$fails\n- generation NOT real: source=${src:-none} error=${err:-none}"
+          fi
+
+          # 5. Deploy freshness — "merged but never deployed" has bitten us twice
+          #    (deploy-central-plane is manual). Flag when main is ahead of the
+          #    deployed Worker AND the oldest undeployed commit is >12h old.
+          #    Fail-safe: any ambiguity (unknown sha / API hiccup) → no alert.
+          deployed=$(curl -sS --max-time 20 "$BASE/healthz" | sed -n 's/.*"deployedSha":"\([^"]*\)".*/\1/p')
+          if [ -n "$deployed" ] && [ "$deployed" != "unknown" ]; then
+            head=$(curl -sS --max-time 20 -H "Authorization: Bearer $GH_TOKEN" \
+                  "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/main" | jq -r '.sha // empty')
+            if [ -n "$head" ] && [ "$head" != "$deployed" ]; then
+              cmp=$(curl -sS --max-time 20 -H "Authorization: Bearer $GH_TOKEN" \
+                   "https://api.github.com/repos/${GITHUB_REPOSITORY}/compare/${deployed}...${head}")
+              ahead=$(printf '%s' "$cmp" | jq -r '.ahead_by // 0')
+              oldest=$(printf '%s' "$cmp" | jq -r '.commits[0].commit.committer.date // empty')
+              if [ "${ahead:-0}" -gt 0 ] && [ -n "$oldest" ]; then
+                age=$(( $(date -u +%s) - $(date -u -d "$oldest" +%s) ))
+                if [ "$age" -gt 43200 ]; then
+                  hrs=$(( age / 3600 ))
+                  fails="$fails\n- deploy stale: main is ${ahead} commit(s) ahead of the deployed Worker (oldest undeployed ~${hrs}h old). Run deploy-central-plane."
+                fi
+              fi
+            fi
           fi
 
           if [ -n "$fails" ]; then

--- a/.github/workflows/deploy-central-plane.yml
+++ b/.github/workflows/deploy-central-plane.yml
@@ -88,7 +88,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npx wrangler deploy
+          # Stamp the deployed commit into the Worker so /healthz can report it
+          # and the canary can flag "main merged but never deployed".
+          npx wrangler deploy --var DEPLOYED_SHA:"${GITHUB_SHA}"
 
       - name: Smoke test deployed endpoints
         run: |

--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -7,6 +7,14 @@ export interface Env {
   DB: D1Database;
   ENVIRONMENT: string;
   /**
+   * Git commit SHA this Worker was deployed from. Injected at deploy time by
+   * deploy-central-plane.yml (`wrangler deploy --var DEPLOYED_SHA:$GITHUB_SHA`)
+   * and surfaced on /healthz so the canary can flag "main is ahead of the
+   * deployed Worker" — i.e. catch a merge that never got deployed. Absent on
+   * local dev and on any deploy predating this var.
+   */
+  DEPLOYED_SHA?: string;
+  /**
    * Public GitHub OAuth App client_id (vars, not secret — it's public by nature).
    * Required by the /oauth/device/* routes. Leave empty / set to placeholder
    * while the central plane is run without OAuth integration.

--- a/apps/central-plane/src/routes/health.ts
+++ b/apps/central-plane/src/routes/health.ts
@@ -61,6 +61,9 @@ healthRoutes.get("/healthz", async (c) => {
     ok: dbStatus !== "down",
     service: "conclave-central-plane",
     version: "0.13.15",
+    // Commit this Worker was deployed from — the canary compares it to main
+    // HEAD to catch "merged but never deployed" (see canary.yml freshness step).
+    deployedSha: c.env.DEPLOYED_SHA ?? "unknown",
     environment: c.env.ENVIRONMENT ?? "unknown",
     db: dbStatus,
     time: new Date().toISOString(),


### PR DESCRIPTION
"main에 있음 ≠ worker 배포됨" has bitten us **twice** (deploy-central-plane is manual `workflow_dispatch`). Make the machine catch the third — as Bae directed.

- **Worker stamps its deployed commit**: `wrangler deploy --var DEPLOYED_SHA:$GITHUB_SHA` in `deploy-central-plane.yml` → `env.DEPLOYED_SHA` → surfaced on **`/healthz`** as `deployedSha`.
- **Canary check #5** (every 15 min): read `/healthz` `deployedSha`, compare to `main` HEAD via the GitHub compare API. If main is ahead **AND** the oldest undeployed commit is **>12h old**, fail the job → GitHub email + Telegram alert (reuses the existing fail path).
- **Fail-safe**: unknown sha / API hiccup / <12h ahead → no alert. No false positives, 12h grace so a normal merge→deploy gap doesn't page.

`deployedSha` populates on the first deploy that uses the updated workflow (older deploys report `"unknown"` → check skips).

central-plane typecheck + build green. Base = main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)