### PR TITLE
Fix: document→spec wait hint says 30s–1min (not 20–30s) — recovers #266 race

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/sources/[sourceId]/draft/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/sources/[sourceId]/draft/page.tsx
@@ -162,7 +162,7 @@ export default function DocumentDraftPage() {
           variant="panel"
           stepLabels={loadingSteps}
           label={t.sources.draft.generating}
-          hint={t.loading.waitHint}
+          hint={t.loading.waitHintLong}
         />
       )}
 

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -1826,6 +1826,7 @@ export type Dictionary = {
     saving: string;
     refreshing: string;
     waitHint: string;
+    waitHintLong: string;
   };
   planMap: {
     title: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -1940,6 +1940,7 @@ const EN = {
     saving: "Saving…",
     refreshing: "Refreshing…",
     waitHint: "Usually 20–30 seconds — keep this window open.",
+    waitHintLong: "Usually 30 seconds to a minute — keep this window open.",
   },
   // Stage 183 — Plan Map ("심사 지도") read-only preview copy. Honest, generated, no
   // multi-user / certification claims.
@@ -4202,6 +4203,7 @@ const KO = {
     saving: "저장하는 중…",
     refreshing: "새로고침하는 중…",
     waitHint: "보통 20~30초 걸려요 — 창을 닫지 마세요.",
+    waitHintLong: "보통 30초~1분 걸려요 — 창을 닫지 마세요.",
   },
   // Stage 183 — Plan Map (심사 지도) 읽기 전용 미리보기 카피.
   planMap: {


### PR DESCRIPTION
**Recovery.** #266 was merged (380cbe9) from the pre-fix commit `5bd9037` while the one-line fix commit `f6da6a6` was still landing — a merge/push race. So `waitHintLong` never reached main and the document path currently claims "20–30s" for a ~45s generation. This cherry-picks the fix onto main.

Measured: idea→spec ~22–25s, document→spec ~45–47s. A single "20–30s" hint on the document path sets an expectation it then breaks — worse than none.

- New `t.loading.waitHintLong` = "보통 30초~1분 걸려요 …" (EN: "Usually 30 seconds to a minute …").
- document→spec draft panel uses `waitHintLong`; idea→spec keeps `waitHint` (20–30s).

Note: the wait-hint feature is **not live yet** — the last dashboard deploy predated #266's merge — so this fix will go live with the next dashboard deploy, correct from the start.

i18n parity preserved. Dashboard build + i18n green. Base = main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)