### PR TITLE
Fix the repo-connect infinite loop (무한 도돌이표)

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -146,15 +146,21 @@ export default function GitHubPage() {
 
   const loadInitial = useCallback(async () => {
     setLoadPhase("loading");
-    const [repoRes, linkedRes] = await Promise.all([
-      fetchProjectRepo(id, getUserKey()),
-      fetchLinkedPulls(id, getUserKey()),
-    ]);
+    // Read-after-write: a just-linked repo can briefly read back as null while
+    // D1 propagates. Retry a few times before concluding "no repo" — otherwise a
+    // user who just connected gets funneled back to /settings to reconnect what
+    // is already connected, which reads as an infinite loop (무한 도돌이표).
+    let repoRes = await fetchProjectRepo(id, getUserKey());
+    for (let attempt = 0; attempt < 3 && repoRes.ok && !repoRes.repo; attempt++) {
+      await new Promise((r) => setTimeout(r, 700));
+      repoRes = await fetchProjectRepo(id, getUserKey());
+    }
+    const linkedRes = await fetchLinkedPulls(id, getUserKey());
     if (repoRes.ok && repoRes.repo) {
       setRepo(repoRes.repo);
       setLoadPhase("ready");
     } else if (repoRes.ok) {
-      // Confirmed: genuinely no repo linked.
+      // Confirmed after retries: genuinely no repo linked.
       setLoadPhase("no_repo");
     } else {
       // Transient fetch failure ≠ "not connected" — a user WITH a linked repo
@@ -341,12 +347,16 @@ export default function GitHubPage() {
         <div className="card p-8 text-center">
           <p className="mb-4 text-sm text-gray-600">{t.github.connectRepoFirst}</p>
           <div className="flex items-center justify-center gap-2">
-            <Link href={`/projects/${id}/settings`} className="btn btn-md btn-primary">
-              {t.github.goConnectRepo}
-            </Link>
-            <button onClick={() => void loadInitial()} className="btn btn-md btn-secondary">
+            {/* Retry is PRIMARY: if the repo was just connected and briefly read
+                as null, one re-check recovers it — so the reflexive click keeps
+                the user here instead of looping back to reconnect. Connecting is
+                the secondary path for a genuinely un-linked project. */}
+            <button onClick={() => void loadInitial()} className="btn btn-md btn-primary">
               {t.common.retry}
             </button>
+            <Link href={`/projects/${id}/settings`} className="btn btn-md btn-secondary">
+              {t.github.goConnectRepo}
+            </Link>
           </div>
         </div>
       )}

--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -340,7 +340,7 @@ function NewProjectInner() {
     router.push(`/projects/${id}/settings`);
   }
 
-  function handleSave() {
+  async function handleSave() {
     const spec = specResult ?? result;
     if (!spec) return;
     const id = generateProjectId();
@@ -369,7 +369,12 @@ function NewProjectInner() {
       itemCriteria: Object.fromEntries(spec.items.map((i) => [i.id, i.criteria ?? []])),
       entryPath: entryPath ?? "idea",
     });
-    saveProjectToDb({
+    // Await the D1 persist BEFORE navigating (was fire-and-forget). Same race
+    // #258 fixed on the code branch: navigating first leaves the project row
+    // uncommitted, so a later repo-link (ownership-gated) 404s forever and the
+    // user hits the reconnect loop. Awaiting means the row is in D1 by the time
+    // they reach settings to connect a repo.
+    const saveRes = await saveProjectToDb({
       id,
       userKey: getUserKey(),
       title: spec.productSpec.productName,
@@ -383,9 +388,8 @@ function NewProjectInner() {
           : undefined,
       // The branch the user chose at the single entry (idea/code/spec).
       entryPath: entryPath ?? "idea",
-    })
-      .then((res) => { if (!res || res.ok !== true) { markProjectSyncFailed(id); toast.error(t.interaction.syncFailedSaved); } })
-      .catch(() => { markProjectSyncFailed(id); toast.error(t.interaction.syncFailedSaved); });
+    }).catch(() => null);
+    if (!saveRes || saveRes.ok !== true) { markProjectSyncFailed(id); toast.error(t.interaction.syncFailedSaved); }
     router.push(`/projects/${id}`);
   }
 


### PR DESCRIPTION
**The bug Bae hit:** connect a repo → click 코드 변경 again → "저장소 연결하기" shows again (repo reads as unlinked) → clicking connect goes back to the connect page → infinite loop.

**Root cause (flow trace):** after linking, `/projects/[id]/github` can transiently read `repo:null` while D1 propagates (read-after-write). The `no_repo` card's **primary** button sent the user to `/settings` to reconnect an already-connected repo; #258 added a Retry but left it **secondary**, so the reflex click looped.

**Fixes:**
- `github` `loadInitial`: retry `fetchProjectRepo` up to 3× (700ms backoff) on the ok-but-null case before concluding `no_repo` — recovers a just-linked repo.
- `no_repo` card: **Retry is now primary**, "저장소 연결하러 가기" secondary — the reflexive click re-checks and lands on the connected view.
- idea/spec `handleSave`: **await** the D1 persist before navigating (was fire-and-forget) — closes the same race #258 fixed only on the code branch (uncommitted project row → ownership-gated repo link 404s forever).

Dashboard **475/475**, typecheck + build + lint clean. Base = main.

**Remaining (follow-up):** if the initial `saveProjectToDb` genuinely fails (offline/5xx), nothing re-persists → link 404s. Fix = re-persist on settings mount before `linkProjectRepo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)