### PR TITLE
Fix recurring "확인 중 오류" — check-draft bypassed the AI Gateway

### DIFF
--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -425,7 +425,11 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
 
     let result;
     try {
-      result = await generateCheckDraft({ productSpec: req.productSpec, items: req.items, projectId: req.projectId, locale: req.locale ?? "ko" }, c.env.ANTHROPIC_API_KEY);
+      // Route through the Cloudflare AI Gateway like every other LLM call —
+      // direct Worker→Anthropic egress ~90% 403s, which surfaced as the
+      // recurring "확인 중 오류가 발생했습니다". This was the ONE LLM route that
+      // omitted the gateway URL.
+      result = await generateCheckDraft({ productSpec: req.productSpec, items: req.items, projectId: req.projectId, locale: req.locale ?? "ko" }, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL);
     } catch (err) {
       console.error("[workspace/check-draft] error:", err);
       return new Response(JSON.stringify({ ok: false, error: "internal_error" }), { status: 500, headers: { "content-type": "application/json", ...headers } });

--- a/apps/central-plane/test/llm-routes-gateway.test.mjs
+++ b/apps/central-plane/test/llm-routes-gateway.test.mjs
@@ -1,0 +1,52 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Regression guard for the bug class where an LLM route silently bypassed the
+// Cloudflare AI Gateway. Direct Worker→Anthropic egress ~90% 403s, so every
+// generate*() call in the workspace routes MUST pass
+// c.env.CF_AI_GATEWAY_ANTHROPIC_URL. check-draft omitted it once and produced
+// the recurring "확인 중 오류가 발생했습니다" — this test would have caught it.
+
+const src = readFileSync(
+  fileURLToPath(new URL("../src/routes/workspace.ts", import.meta.url)),
+  "utf8",
+);
+const docSrc = readFileSync(
+  fileURLToPath(new URL("../src/routes/workspace-document-intake.ts", import.meta.url)),
+  "utf8",
+);
+
+const GENERATORS = [
+  "generateIdeaToSpecDraft",
+  "generateCheckDraft",
+  "generateFixSuggestion",
+];
+
+describe("every LLM route goes through the AI Gateway", () => {
+  for (const gen of GENERATORS) {
+    it(`${gen}(...) passes CF_AI_GATEWAY_ANTHROPIC_URL`, () => {
+      const callLines = src
+        .split("\n")
+        .filter((l) => l.includes(`${gen}(`) && !l.trimStart().startsWith("import"));
+      assert.ok(callLines.length > 0, `${gen} call not found in workspace.ts`);
+      for (const l of callLines) {
+        assert.ok(
+          l.includes("CF_AI_GATEWAY_ANTHROPIC_URL"),
+          `${gen} call bypasses the AI Gateway: ${l.trim()}`,
+        );
+      }
+    });
+  }
+
+  it("document-intake generation also routes through the gateway", () => {
+    const callLines = docSrc
+      .split("\n")
+      .filter((l) => l.includes("generateIdeaToSpecDraft(") && !l.trimStart().startsWith("import"));
+    assert.ok(callLines.length > 0);
+    for (const l of callLines) {
+      assert.ok(l.includes("CF_AI_GATEWAY_ANTHROPIC_URL"), `document-intake bypasses the gateway: ${l.trim()}`);
+    }
+  });
+});


### PR DESCRIPTION
**The bug Bae hit:** "확인 중 오류가 발생했습니다" keeps appearing on the check page.

**Root cause:** `POST /workspace/check-draft` called `generateCheckDraft()` with only two args — omitting `c.env.CF_AI_GATEWAY_ANTHROPIC_URL`. It was the **one** LLM route that bypassed the Cloudflare AI Gateway (idea-to-spec, fix-suggestion, document-intake all pass it). Direct Worker→Anthropic egress ~90% 403s → 503 `llm_unavailable` → `/checks` shows the error, and its Retry re-runs the identical failing call, so it **recurs ~90% of the time**.

- `workspace.ts:432`: pass the gateway URL as the third arg (`generateCheckDraft` already threads `anthropicBaseUrl` — one line).
- **New regression test** `llm-routes-gateway.test.mjs`: asserts every `generate*()` call in the workspace routes passes `CF_AI_GATEWAY_ANTHROPIC_URL` — so this exact bug class can't silently return.

Answers Bae's question: yes, `/checks` produces 통과 / 안맞음 / 확인 부족 — but only once this is deployed; right now it 90%-errors before it can.

central-plane **4/4** (new test) + typecheck + build green. Base = main.

★ **Live blocker** — needs a central-plane deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)