### PR TITLE
Key no-store guard: user service keys never touch server storage or logs

### DIFF
--- a/apps/central-plane/test/export-key-no-store.test.mjs
+++ b/apps/central-plane/test/export-key-no-store.test.mjs
@@ -1,0 +1,78 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// KEY NO-STORE — same grade of irreversible surface as the secret scrub (#201).
+//
+// The export route receives the user's real service keys in the request body
+// (req.services[].envVars[].value) so it can bake them into the pack's local,
+// gitignored .env.local. Those values must NEVER be recorded server-side:
+//   ① never written to D1 / R2 / a usage-event's metadata,
+//   ② never logged — including on the error path (console.* must not carry the
+//      raw body/req or the services array).
+// This is a source-level guard so a future edit can't silently reintroduce a
+// leak. The value-only-in-.env.local guarantee is asserted separately in
+// workspace-export.test.mjs.
+
+const src = readFileSync(
+  fileURLToPath(new URL("../src/routes/workspace.ts", import.meta.url)),
+  "utf8",
+);
+const lines = src.split("\n");
+
+const consoleLines = lines.filter((l) => /console\.(log|warn|error|info|debug)\(/.test(l));
+
+describe("export route never records service keys server-side", () => {
+  it("no console.* statement references the services payload", () => {
+    for (const l of consoleLines) {
+      assert.ok(
+        !l.includes("services"),
+        `a log statement references the services payload (potential key leak): ${l.trim()}`,
+      );
+    }
+  });
+
+  it("no console.* logs the raw request body/req object wholesale", () => {
+    // Logging req.projectId etc. is fine; logging the whole `body`/`req` (which
+    // carries services[].value) is not.
+    for (const l of consoleLines) {
+      assert.ok(
+        !/[(,]\s*(body|req)\s*[,)]/.test(l),
+        `a log statement dumps the raw request object (carries keys): ${l.trim()}`,
+      );
+    }
+  });
+
+  it("no insertUsageEvent(...) call carries services in its metadata", () => {
+    // Grab each insertUsageEvent(...) call region (up to its closing "});") and
+    // assert the recorded payload never includes the services array.
+    let idx = src.indexOf("insertUsageEvent(");
+    let found = 0;
+    while (idx !== -1) {
+      const end = src.indexOf("});", idx);
+      const region = src.slice(idx, end === -1 ? idx + 400 : end);
+      assert.ok(!region.includes("services"), `insertUsageEvent records services: ...${region.slice(0, 120)}...`);
+      found++;
+      idx = src.indexOf("insertUsageEvent(", idx + 1);
+    }
+    assert.ok(found > 0, "expected at least one insertUsageEvent call to guard");
+  });
+
+  it("the export usage event records only the target (no user data)", () => {
+    // Positive assertion: the builder-pack export's usage event is target-only.
+    assert.ok(
+      src.includes("metadata: { target: req.target }"),
+      "export usage event should record metadata: { target: req.target } only",
+    );
+  });
+
+  it("no D1/R2 write in the file binds or stores the services payload", () => {
+    const writeLines = lines.filter(
+      (l) => /\.bind\(|INSERT\s+INTO|EVIDENCE\.put|\.put\(/.test(l),
+    );
+    for (const l of writeLines) {
+      assert.ok(!l.includes("services"), `a persistence call references services: ${l.trim()}`);
+    }
+  });
+});

--- a/apps/central-plane/test/workspace-export.test.mjs
+++ b/apps/central-plane/test/workspace-export.test.mjs
@@ -244,6 +244,25 @@ describe("workspace export-builder-pack", () => {
     assert.ok(!paths.some((p) => p.endsWith(".env.local")), "no .env.local without values");
   });
 
+  it("KEY NO-STORE: a real secret value lands ONLY in .env.local, in NO other pack file", () => {
+    // The single most important guarantee of the prep layer: a user's real key
+    // is baked into the local, gitignored .env.local and appears NOWHERE else —
+    // not the committable .env.example, not SETUP.md, not the prompts/README,
+    // not product/items/checks/fixes. If it leaks into any other file it would
+    // be committed or handed to the agent verbatim.
+    const SECRET_URL = "https://real.supabase.co";
+    const SECRET_KEY = "svc_real_key";
+    const res = generateBuilderPack(makeReq("both", {}, { services: MOCK_SERVICES }));
+    const envLocal = res.bundle.files.find((f) => f.path.endsWith(".env.local"));
+    assert.ok(envLocal, ".env.local generated");
+    assert.ok(envLocal.content.includes(SECRET_KEY) && envLocal.content.includes(SECRET_URL), "values ARE in .env.local");
+    for (const f of res.bundle.files) {
+      if (f.path.endsWith(".env.local")) continue;
+      assert.ok(!f.content.includes(SECRET_KEY), `secret key leaked into ${f.path}`);
+      assert.ok(!f.content.includes(SECRET_URL), `secret url leaked into ${f.path}`);
+    }
+  });
+
   it("returns empty files when no project provided", () => {
     const res = generateBuilderPack({ target: "both", format: "json" });
     assert.equal(res.ok, true);


### PR DESCRIPTION
Bae flagged this as a **mandatory** test for the prep layer's B work — same grade of irreversible surface as the secret scrub (#201).

The export route receives real service keys in the request body (`req.services[].envVars[].value`) to bake them into the pack's gitignored `.env.local`. Those values must **never** be recorded server-side.

**Audit result: the current code is safe** — the export usage event records `metadata:{ target }` only, `onError` logs `err` (not the body), no telemetry on the route. These tests lock that in so a future edit can't silently reintroduce a leak:

- **`workspace-export.test.mjs`**: a real secret value lands **only** in `.env.local` and appears in **no other** pack file (`.env.example` / `SETUP.md` / README / prompts / product / items / checks / fixes).
- **`export-key-no-store.test.mjs`** (new source guard on `workspace.ts`):
  1. no `console.*` references the services payload,
  2. no `console.*` logs the raw `body`/`req` object wholesale — **covers the error path** (③ in Bae's ask),
  3. no `insertUsageEvent(...)` carries services in metadata (① D1/telemetry),
  4. the export usage event is target-only,
  5. no D1/R2 write binds the services payload.

central-plane **1628/1628**. Base = main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)