### PR TITLE
Gateway audit close: guard PR review (5th LLM call site)

### DIFF
--- a/apps/central-plane/test/llm-routes-gateway.test.mjs
+++ b/apps/central-plane/test/llm-routes-gateway.test.mjs
@@ -17,6 +17,10 @@ const docSrc = readFileSync(
   fileURLToPath(new URL("../src/routes/workspace-document-intake.ts", import.meta.url)),
   "utf8",
 );
+const githubSrc = readFileSync(
+  fileURLToPath(new URL("../src/routes/workspace-github.ts", import.meta.url)),
+  "utf8",
+);
 
 const GENERATORS = [
   "generateIdeaToSpecDraft",
@@ -48,5 +52,20 @@ describe("every LLM route goes through the AI Gateway", () => {
     for (const l of callLines) {
       assert.ok(l.includes("CF_AI_GATEWAY_ANTHROPIC_URL"), `document-intake bypasses the gateway: ${l.trim()}`);
     }
+  });
+
+  it("PR review (reviewPRAgainstItems) routes through the gateway", () => {
+    // reviewPRAgainstItems is a multi-line call; assert the gateway URL appears
+    // within the call region (from the call to its closing `);`). This was the
+    // 5th Worker-side callAnthropic site audited after check-draft was found
+    // bypassing the gateway.
+    const idx = githubSrc.indexOf("await reviewPRAgainstItems(");
+    assert.ok(idx !== -1, "reviewPRAgainstItems call not found in workspace-github.ts");
+    const end = githubSrc.indexOf(");", idx);
+    const region = githubSrc.slice(idx, end === -1 ? idx + 600 : end);
+    assert.ok(
+      region.includes("CF_AI_GATEWAY_ANTHROPIC_URL"),
+      "PR review bypasses the AI Gateway",
+    );
   });
 });


### PR DESCRIPTION
Full audit of every Worker-side Anthropic call site (callers of `callAnthropic`) — all 5 route through the AI Gateway; check-draft was the only bypass (fixed #270).

| Call site | File | Via route | Gateway? |
|---|---|---|---|
| idea→spec | generate.ts | workspace.ts:230 + document-intake:180 | ✅ |
| check-draft | check.ts | workspace.ts:432 (fixed #270) | ✅ |
| fix-suggestion | fix.ts | workspace.ts:501 | ✅ |
| PR review | pr-review.ts | workspace-github.ts:963 | ✅ |

The regression test covered the first four; this extends it to assert **PR review** also passes `CF_AI_GATEWAY_ANTHROPIC_URL`.

Note: `packages/agent-{claude,design,worker}` call `@anthropic-ai/sdk` directly, but run in the Cloudflare **Container** (autofix/deep-review) — a separate egress, not the Worker→Anthropic 403 path. Flagged as follow-up, not a cause of the '확인 오류'.

central-plane **5/5**. Base = main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)