### PR TITLE
Growth: Star-on-GitHub CTA + copyable "Reviewed with Simsa" badge

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -33,6 +33,7 @@ import { downloadBuildPackZip } from "@/lib/zip-utils";
 import { StatusBadge } from "@/components/StatusBadge";
 import type { ItemStatus } from "@/lib/labels";
 import Link from "next/link";
+import { buildSimsaBadgeMarkdown, buildSimsaBadgeHtml, SIMSA_BADGE_IMG } from "@/lib/simsa-share.mjs";
 import { useI18n } from "@/i18n/I18nProvider";
 import { statusLabel } from "@/i18n/dictionary.mjs";
 import type { Dictionary } from "@/i18n/dictionary.mjs";
@@ -616,6 +617,9 @@ export default function ExportPage() {
 
           {/* ── Past outcomes ── */}
           {outcomes.length > 0 && <OutcomeHistory outcomes={outcomes} projectId={id} />}
+
+          {/* ── Show you reviewed with Simsa (repo badge) ── */}
+          <SimsaBadgePanel />
         </>
       )}
     </div>
@@ -623,6 +627,50 @@ export default function ExportPage() {
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
+
+function SimsaBadgePanel() {
+  const { t } = useI18n();
+  const [copied, setCopied] = useState<"md" | "html" | null>(null);
+  const md = buildSimsaBadgeMarkdown();
+  const html = buildSimsaBadgeHtml();
+
+  async function copy(which: "md" | "html", text: string) {
+    await copyText(text);
+    setCopied(which);
+    setTimeout(() => setCopied(null), 2000);
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-5">
+      <h2 className="text-sm font-semibold text-gray-800 mb-1">{t.share.badgeTitle}</h2>
+      <p className="text-sm text-gray-500 mb-3">{t.share.badgeIntro}</p>
+
+      <div className="mb-3">
+        <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">{t.share.previewLabel}</p>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={SIMSA_BADGE_IMG} alt="Reviewed with Simsa" className="h-5" />
+      </div>
+
+      {([
+        { which: "md" as const, label: t.share.markdownLabel, value: md },
+        { which: "html" as const, label: t.share.htmlLabel, value: html },
+      ]).map(({ which, label, value }) => (
+        <div key={which} className="mb-2">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">{label}</p>
+          <div className="flex items-stretch gap-2">
+            <code className="flex-1 min-w-0 overflow-x-auto whitespace-nowrap bg-gray-900 text-gray-100 rounded-lg px-3 py-2 text-xs font-mono">
+              {value}
+            </code>
+            <button onClick={() => copy(which, value)}
+              className="flex-shrink-0 text-xs px-3 rounded-lg font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors">
+              {copied === which ? t.exportPage.copied : t.exportPage.copy}
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 function McpSetupPanel({ tools, agentId }: { tools: McpTool[]; agentId: string }) {
   const { t } = useI18n();

--- a/apps/dashboard/src/components/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar.tsx
@@ -12,6 +12,7 @@ import { Tooltip } from "@/components/Tooltip";
 import { getAuthSession, signOutAuth } from "@/lib/auth-client.mjs";
 import { computeProjectSteps } from "@/lib/project-steps.mjs";
 import { fetchProjectRepo, listProjectReviewHistory } from "@/lib/workspace-github-api";
+import { SIMSA_REPO_URL } from "@/lib/simsa-share.mjs";
 
 const MOCK_IDS = new Set(MOCK_PROJECTS.map((p) => p.id));
 
@@ -381,6 +382,17 @@ export function AppSidebar() {
         >
           {t.nav.feedback}
         </button>
+        <a
+          href={SIMSA_REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mb-1 flex w-full items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700"
+        >
+          <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3.5 w-3.5 flex-shrink-0" fill="currentColor">
+            <path d="M8 .25l2.06 4.17 4.6.67-3.33 3.24.79 4.58L8 10.94l-4.12 2.17.79-4.58L1.34 5.09l4.6-.67L8 .25z" />
+          </svg>
+          {t.share.starGithub}
+        </a>
         <div ref={accountMenuRef} className="relative">
           <button
             type="button"

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -570,6 +570,14 @@ export type Dictionary = {
       docsLabel: string;
     };
   };
+  share: {
+    starGithub: string;
+    badgeTitle: string;
+    badgeIntro: string;
+    markdownLabel: string;
+    htmlLabel: string;
+    previewLabel: string;
+  };
   adminUsage: {
     title: string;
     viewCreditPreview: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -643,6 +643,14 @@ const EN = {
       docsLabel: "Official guide",
     },
   },
+  share: {
+    starGithub: "Star on GitHub",
+    badgeTitle: "Show you reviewed with Simsa",
+    badgeIntro: "Add this badge to your repo's README — it shows visitors your app was reviewed with Simsa and links back here.",
+    markdownLabel: "Markdown",
+    htmlLabel: "HTML",
+    previewLabel: "Preview",
+  },
   adminUsage: {
     title: "Admin — Usage",
     viewCreditPreview: "View credit preview →",
@@ -2915,6 +2923,14 @@ const KO = {
       safetyLabel: "키는 사용자에게만",
       docsLabel: "공식 안내",
     },
+  },
+  share: {
+    starGithub: "GitHub에서 별 주기",
+    badgeTitle: "Simsa로 검수했다고 알리기",
+    badgeIntro: "저장소 README에 이 뱃지를 붙이세요 — 방문자에게 이 앱이 Simsa로 검수됐음을 보여주고 여기로 연결됩니다.",
+    markdownLabel: "Markdown",
+    htmlLabel: "HTML",
+    previewLabel: "미리보기",
   },
   adminUsage: {
     title: "Admin — 사용 현황",

--- a/apps/dashboard/src/lib/simsa-share.d.mts
+++ b/apps/dashboard/src/lib/simsa-share.d.mts
@@ -1,0 +1,5 @@
+export declare const SIMSA_REPO_URL: string;
+export declare const SIMSA_SITE_URL: string;
+export declare const SIMSA_BADGE_IMG: string;
+export declare function buildSimsaBadgeMarkdown(): string;
+export declare function buildSimsaBadgeHtml(): string;

--- a/apps/dashboard/src/lib/simsa-share.mjs
+++ b/apps/dashboard/src/lib/simsa-share.mjs
@@ -1,0 +1,41 @@
+/**
+ * simsa-share.mjs
+ *
+ * Community / growth surface: let users (a) star the public repo and (b) add a
+ * "Reviewed with Simsa" badge to their own repo README that links back to Simsa.
+ *
+ * Pure, no I/O. The badge uses a shields.io static badge in the brand oxblood so
+ * there's nothing to host; the copy snippets are plain markdown/HTML the user
+ * pastes into their README.
+ */
+
+import { BRAND } from "./brand.mjs";
+
+/** The public GitHub repository users can star. */
+export const SIMSA_REPO_URL = "https://github.com/3SVS/simsa";
+
+/** The public marketing site the badge links to. */
+export const SIMSA_SITE_URL = `https://${BRAND.primaryDomain}`;
+
+/** shields.io static badge — "Reviewed with · Simsa" in brand oxblood (#8e2c39)
+ *  on a zinc label. Agent-agnostic, nothing to host. */
+export const SIMSA_BADGE_IMG =
+  "https://img.shields.io/badge/Reviewed_with-Simsa-8e2c39?labelColor=27272a";
+
+const BADGE_ALT = "Reviewed with Simsa";
+
+/**
+ * The markdown snippet a user pastes into their repo README.
+ * @returns {string}
+ */
+export function buildSimsaBadgeMarkdown() {
+  return `[![${BADGE_ALT}](${SIMSA_BADGE_IMG})](${SIMSA_SITE_URL})`;
+}
+
+/**
+ * The HTML snippet (for READMEs / sites that don't render markdown).
+ * @returns {string}
+ */
+export function buildSimsaBadgeHtml() {
+  return `<a href="${SIMSA_SITE_URL}"><img src="${SIMSA_BADGE_IMG}" alt="${BADGE_ALT}" /></a>`;
+}

--- a/apps/dashboard/test/simsa-share.test.mjs
+++ b/apps/dashboard/test/simsa-share.test.mjs
@@ -1,0 +1,39 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  SIMSA_REPO_URL,
+  SIMSA_SITE_URL,
+  SIMSA_BADGE_IMG,
+  buildSimsaBadgeMarkdown,
+  buildSimsaBadgeHtml,
+} from "../src/lib/simsa-share.mjs";
+
+describe("simsa-share", () => {
+  it("repo + site + badge are absolute https URLs", () => {
+    for (const u of [SIMSA_REPO_URL, SIMSA_SITE_URL, SIMSA_BADGE_IMG]) {
+      assert.match(u, /^https:\/\/\S+$/);
+    }
+    assert.ok(SIMSA_REPO_URL.includes("github.com/3SVS/simsa"));
+    assert.ok(SIMSA_SITE_URL.includes("trysimsa.com"));
+  });
+
+  it("badge uses the brand oxblood and links back to Simsa", () => {
+    assert.ok(SIMSA_BADGE_IMG.includes("8e2c39"), "oxblood brand color");
+    const md = buildSimsaBadgeMarkdown();
+    assert.equal(md, `[![Reviewed with Simsa](${SIMSA_BADGE_IMG})](${SIMSA_SITE_URL})`);
+    assert.ok(md.includes(SIMSA_SITE_URL), "markdown links to the site");
+  });
+
+  it("html snippet embeds the badge image with alt text", () => {
+    const html = buildSimsaBadgeHtml();
+    assert.ok(html.includes(`href="${SIMSA_SITE_URL}"`));
+    assert.ok(html.includes(`src="${SIMSA_BADGE_IMG}"`));
+    assert.ok(html.includes('alt="Reviewed with Simsa"'));
+  });
+
+  it("badge snippets carry no secret / no user data", () => {
+    for (const s of [buildSimsaBadgeMarkdown(), buildSimsaBadgeHtml()]) {
+      assert.ok(!/ghp_|sk-|Bearer |userKey/.test(s));
+    }
+  });
+});


### PR DESCRIPTION
Two community/growth surfaces Bae asked for.

- **Sidebar "Star on GitHub"** link → [github.com/3SVS/simsa](https://github.com/3SVS/simsa) (public, new tab). Inline SVG star (no emoji, per design rule).
- **`SimsaBadgePanel`** on the builder-pack results: a shields.io **"Reviewed with Simsa"** badge in brand oxblood (#8e2c39) linking back to the site, with copyable **Markdown + HTML** snippets the user pastes into their repo README — awareness + backlinks.

- **`lib/simsa-share.mjs`** (+4 tests): repo/site/badge URLs + `buildSimsaBadgeMarkdown/Html`; tested to carry no secret / no user data.
- i18n `share.*` (EN + KO).

Dashboard **486/486**, typecheck + build + lint clean. Base = main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)