### PR TITLE
Prep A1: expand service catalog (Resend, Sentry) + "why" + service picker

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -5,7 +5,7 @@ import { ProjectNotFound } from "@/components/ProjectNotFound";
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
 import { getProject } from "@/lib/mock-data";
-import { detectServices, hasAnyValue } from "@/lib/service-catalog.mjs";
+import { detectServices, hasAnyValue, allCatalogServices, catalogServiceById } from "@/lib/service-catalog.mjs";
 import type { CatalogService } from "@/lib/service-catalog.mjs";
 import { detectMcpTools } from "@/lib/mcp-catalog.mjs";
 import type { McpTool } from "@/lib/mcp-catalog.mjs";
@@ -175,6 +175,20 @@ export default function ExportPage() {
       ),
     );
   }
+
+  function addService(serviceId: string) {
+    setServices((prev) => {
+      if (prev.some((s) => s.id === serviceId)) return prev;
+      const svc = catalogServiceById(serviceId);
+      return svc ? [...prev, svc] : prev;
+    });
+  }
+  function removeService(serviceId: string) {
+    setServices((prev) => prev.filter((s) => s.id !== serviceId));
+  }
+  const addableServices = allCatalogServices().filter(
+    (c) => !services.some((s) => s.id === c.id),
+  );
 
   // Deploy tools (option A) — pure guidance, no state, no tokens collected.
   const deployTools: McpTool[] = detectMcpTools();
@@ -387,7 +401,10 @@ export default function ExportPage() {
       {/* ── Prep: detected services + in-browser key entry ── */}
       <ServiceSetupPanel
         services={services}
+        addable={addableServices}
         onEnvChange={setEnvValue}
+        onAdd={addService}
+        onRemove={removeService}
         onApply={handleGenerate}
         applying={phase === "loading"}
       />
@@ -700,12 +717,18 @@ function McpSetupPanel({ tools, agentId }: { tools: McpTool[]; agentId: string }
 
 function ServiceSetupPanel({
   services,
+  addable,
   onEnvChange,
+  onAdd,
+  onRemove,
   onApply,
   applying,
 }: {
   services: CatalogService[];
+  addable: CatalogService[];
   onEnvChange: (serviceId: string, key: string, value: string) => void;
+  onAdd: (serviceId: string) => void;
+  onRemove: (serviceId: string) => void;
   onApply: () => void;
   applying: boolean;
 }) {
@@ -713,7 +736,7 @@ function ServiceSetupPanel({
   const p = t.exportPage.prep;
   const [openSteps, setOpenSteps] = useState<Set<string>>(new Set());
 
-  if (services.length === 0) return null;
+  if (services.length === 0 && addable.length === 0) return null;
   const anyValue = hasAnyValue(services);
 
   function toggleSteps(sid: string) {
@@ -751,8 +774,13 @@ function ServiceSetupPanel({
                     {openSteps.has(s.id) ? p.stepsHide : p.stepsShow}
                   </button>
                 )}
+                <button onClick={() => onRemove(s.id)} title={p.remove} aria-label={p.remove}
+                  className="text-xs px-2 py-1 rounded-lg font-medium text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors">
+                  ✕
+                </button>
               </div>
             </div>
+            {s.why && <p className="text-xs text-gray-500 mb-2">{s.why}</p>}
             {openSteps.has(s.id) && s.setupSteps && (
               <ol className="space-y-1 text-xs text-gray-600 mb-3 pl-1">
                 {s.setupSteps.map((step, i) => (
@@ -788,6 +816,19 @@ function ServiceSetupPanel({
           </div>
         ))}
       </div>
+
+      {/* Picker: let the user add services beyond what we detected */}
+      {addable.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <span className="text-xs text-gray-400">{p.addMore}:</span>
+          {addable.map((c) => (
+            <button key={c.id} onClick={() => onAdd(c.id)}
+              className="text-xs px-3 py-1 rounded-lg font-medium bg-white text-brand-700 border border-brand-200 hover:bg-brand-50 transition-colors">
+              + {c.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       <p className="text-xs text-gray-500 mt-4">{p.note}</p>
       {anyValue && (

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -545,6 +545,8 @@ export type Dictionary = {
       secretBadge: string;
       valuePlaceholder: string;
       note: string;
+      addMore: string;
+      remove: string;
     };
     returnStep: {
       title: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -618,6 +618,8 @@ const EN = {
       secretBadge: "Server-only",
       valuePlaceholder: "Paste the value here",
       note: "Fill in any values and they'll be written to .env.local in the pack (kept out of git). Leave them blank to still get a .env.example template plus a setup guide.",
+      addMore: "Add a service",
+      remove: "Remove",
     },
     returnStep: {
       title: "Built it? Come back and connect it",
@@ -2891,6 +2893,8 @@ const KO = {
       secretBadge: "서버 전용",
       valuePlaceholder: "여기에 값을 붙여넣으세요",
       note: "값을 입력하면 팩의 .env.local 에 기록됩니다(깃에는 올라가지 않습니다). 비워 두면 .env.example 템플릿과 설정 안내서만 만들어집니다.",
+      addMore: "서비스 추가",
+      remove: "제거",
     },
     returnStep: {
       title: "다 만드셨나요? 돌아와서 연결하세요",

--- a/apps/dashboard/src/lib/service-catalog.d.mts
+++ b/apps/dashboard/src/lib/service-catalog.d.mts
@@ -12,6 +12,8 @@ export interface CatalogEnvVar {
 export interface CatalogService {
   id: string;
   label: string;
+  /** why a non-dev might need this, one plain sentence */
+  why?: string;
   setupUrl?: string;
   setupSteps?: string[];
   envVars: CatalogEnvVar[];
@@ -35,3 +37,5 @@ export declare function detectServices(
 ): CatalogService[];
 
 export declare function hasAnyValue(services: CatalogService[]): boolean;
+
+export declare function allCatalogServices(): CatalogService[];

--- a/apps/dashboard/src/lib/service-catalog.mjs
+++ b/apps/dashboard/src/lib/service-catalog.mjs
@@ -29,6 +29,7 @@
  * @typedef {Object} CatalogService
  * @property {string} id
  * @property {string} label
+ * @property {string} why           // why a non-dev might need this, one plain sentence
  * @property {string} [setupUrl]
  * @property {string[]} [setupSteps]
  * @property {CatalogEnvVar[]} envVars
@@ -39,6 +40,7 @@ export const SERVICE_CATALOG = [
   {
     id: "app-url",
     label: "앱 주소",
+    why: "앱이 자기 주소를 알아야 공유 링크·리디렉션이 깨지지 않습니다. 가입 없이 값만 넣으면 됩니다.",
     setupSteps: [
       "가입이 필요 없는 항목입니다.",
       "만드는 동안에는 http://localhost:3000 을 그대로 두세요.",
@@ -56,6 +58,7 @@ export const SERVICE_CATALOG = [
   {
     id: "supabase",
     label: "Supabase (데이터 저장·로그인)",
+    why: "회원가입·로그인이나 글·기록 같은 데이터를 저장하려면 데이터베이스가 필요합니다. Supabase는 무료로 시작할 수 있습니다.",
     setupUrl: "https://supabase.com",
     setupSteps: [
       "https://supabase.com 에 접속해 GitHub 계정으로 가입합니다.",
@@ -83,6 +86,44 @@ export const SERVICE_CATALOG = [
           "관리자 권한 키(service_role)입니다. 절대 브라우저/프론트엔드에 넣지 말고 서버에서만 쓰세요.",
         secret: true,
         example: "eyJhbGciOiJI...(service_role · 서버 전용)",
+      },
+    ],
+  },
+  {
+    id: "resend",
+    label: "Resend (이메일 보내기)",
+    why: "가입 확인·비밀번호 재설정·알림 메일을 보내려면 이메일 발송 서비스가 필요합니다. Resend는 무료 한도로 시작할 수 있습니다.",
+    setupUrl: "https://resend.com",
+    setupSteps: [
+      "https://resend.com 에 가입합니다(GitHub 계정으로 가능).",
+      "왼쪽 메뉴의 API Keys → Create API Key 를 누릅니다.",
+      "만들어진 키(re_ 로 시작)를 복사해 RESEND_API_KEY 에 넣습니다. 이 키는 서버에서만 씁니다.",
+      "메일을 실제로 보내려면 나중에 도메인 인증이 필요할 수 있습니다(테스트는 인증 없이 가능).",
+    ],
+    envVars: [
+      {
+        key: "RESEND_API_KEY",
+        description: "이메일을 보낼 때 쓰는 Resend API 키입니다. 서버 전용이라 프론트엔드에 넣지 마세요.",
+        secret: true,
+        example: "re_xxxxxxxx (서버 전용)",
+      },
+    ],
+  },
+  {
+    id: "sentry",
+    label: "Sentry (오류 추적)",
+    why: "앱에서 나는 오류를 자동으로 모아 알려줍니다. 사용자가 겪은 문제를 놓치지 않고 고칠 수 있어요. 무료 한도로 시작할 수 있습니다.",
+    setupUrl: "https://sentry.io",
+    setupSteps: [
+      "https://sentry.io 에 가입하고 프로젝트를 하나 만듭니다(플랫폼은 만드는 앱에 맞게 선택).",
+      "프로젝트 설정(Settings) → Client Keys (DSN) 로 이동합니다.",
+      "DSN 주소를 복사해 NEXT_PUBLIC_SENTRY_DSN 에 넣습니다. DSN은 공개돼도 되는 값입니다.",
+    ],
+    envVars: [
+      {
+        key: "NEXT_PUBLIC_SENTRY_DSN",
+        description: "오류를 Sentry로 보내는 주소(DSN)입니다. 공개돼도 되는 값이라 프론트에 넣어도 됩니다.",
+        example: "https://xxxx@oyyy.ingest.sentry.io/zzzz",
       },
     ],
   },
@@ -137,11 +178,17 @@ export function catalogServiceById(id) {
   return {
     id: found.id,
     label: found.label,
+    why: found.why,
     ...(found.setupUrl ? { setupUrl: found.setupUrl } : {}),
     ...(found.setupSteps ? { setupSteps: [...found.setupSteps] } : {}),
     envVars: found.envVars.map((v) => ({ ...v })),
   };
 }
+
+/** Email-sending keywords → Resend. */
+const EMAIL_KEYWORDS = ["이메일", "메일", "알림 메일", "발송", "비밀번호 재설정", "인증 메일", "email", "e-mail", "notification email", "verify email", "password reset"];
+/** Error-monitoring keywords → Sentry. */
+const ERROR_KEYWORDS = ["오류", "에러", "버그", "모니터링", "예외", "error", "bug", "monitoring", "crash", "exception"];
 
 /**
  * Read the product spec and return the services this project probably needs.
@@ -175,8 +222,21 @@ export function detectServices(spec) {
     const supabase = catalogServiceById("supabase");
     if (supabase) out.push(supabase);
   }
+  if (EMAIL_KEYWORDS.some((k) => text.includes(k.toLowerCase()))) {
+    const resend = catalogServiceById("resend");
+    if (resend) out.push(resend);
+  }
+  if (ERROR_KEYWORDS.some((k) => text.includes(k.toLowerCase()))) {
+    const sentry = catalogServiceById("sentry");
+    if (sentry) out.push(sentry);
+  }
 
   return out;
+}
+
+/** All services a user can add from the picker (full catalog, cloned). */
+export function allCatalogServices() {
+  return SERVICE_CATALOG.map((s) => catalogServiceById(s.id)).filter(Boolean);
 }
 
 /**

--- a/apps/dashboard/test/service-catalog.test.mjs
+++ b/apps/dashboard/test/service-catalog.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { allCatalogServices } from "../src/lib/service-catalog.mjs";
 import {
   SERVICE_CATALOG,
   catalogServiceById,
@@ -111,5 +112,38 @@ describe("service-catalog", () => {
     const services = detectServices({ oneLine: "글을 저장하는 앱" });
     services[1].envVars[0].value = "   ";
     assert.equal(hasAnyValue(services), false);
+  });
+
+  it("every service carries a plain-language 'why'", () => {
+    for (const s of SERVICE_CATALOG) {
+      assert.ok(typeof s.why === "string" && s.why.length > 0, `${s.id} missing why`);
+    }
+    // clones carry it too
+    assert.ok(catalogServiceById("supabase").why.length > 0);
+  });
+
+  it("catalog includes resend (email) and sentry (error tracking)", () => {
+    assert.ok(catalogServiceById("resend"));
+    assert.ok(catalogServiceById("sentry"));
+    // RESEND_API_KEY is server-only secret; SENTRY DSN is public
+    assert.equal(catalogServiceById("resend").envVars.find((v) => v.key === "RESEND_API_KEY").secret, true);
+    assert.notEqual(catalogServiceById("sentry").envVars.find((v) => v.key === "NEXT_PUBLIC_SENTRY_DSN").secret, true);
+  });
+
+  it("detectServices suggests resend on email keywords, sentry on error keywords", () => {
+    const email = detectServices({ oneLine: "가입하면 인증 메일을 보내는 앱" });
+    assert.ok(email.some((s) => s.id === "resend"));
+    const err = detectServices({ oneLine: "an app with error monitoring" });
+    assert.ok(err.some((s) => s.id === "sentry"));
+    // a plain calculator triggers neither
+    const plain = detectServices({ oneLine: "간단한 계산기" });
+    assert.ok(!plain.some((s) => s.id === "resend" || s.id === "sentry"));
+  });
+
+  it("allCatalogServices returns every service as a fresh clone", () => {
+    const all = allCatalogServices();
+    assert.deepEqual(all.map((s) => s.id).sort(), ["app-url", "resend", "sentry", "supabase"]);
+    all[0].label = "mutated";
+    assert.notEqual(SERVICE_CATALOG[0].label, "mutated");
   });
 });


### PR DESCRIPTION
Redesign step **A, part 1** — the prep service setup now covers more of what an app needs, explains **why**, and lets the user pick services beyond what we detected.

- **service-catalog**: added **Resend** (email, `RESEND_API_KEY` secret) and **Sentry** (error tracking, `NEXT_PUBLIC_SENTRY_DSN` public), each with signup URL + exact key-finding steps. Every service now carries a plain-language **`why`**.
- **detectServices**: suggests Resend on email keywords, Sentry on error/monitoring keywords (ko + en), alongside Supabase-on-data-keywords.
- **ServiceSetupPanel**: shows each service's `why`, a **✕ remove** per service, and an **"Add a service"** picker for anything not detected — the user chooses what to set up. Still browser-only, no-store.
- i18n `exportPage.prep.{addMore,remove}` (EN + KO).

**Next (A2):** move this panel + the MCP panel from the builder-pack page to the prep (settings) step and persist the collected values in the browser so export reads them.

Dashboard **490/490**, typecheck + build + lint clean. Base = main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)