### PR TITLE
Repo public face: Simsa README + badge → live site (before #274's star button ships)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,42 @@
-# Conclave Claude Code Builder Pack
+# Simsa
 
-이 묶음은 Conclave를 **개발자용 CLI/PR 리뷰 툴**에서 **일반 유저가 아이디어가 제품으로 만들어지는 과정을 시각적으로 확인하는 작업공간**으로 확장하기 위한 Claude Code용 작업 문서입니다.
+**The acceptance layer for AI-built software.**
 
-## 목표
+You built something with AI. Simsa helps you make sure it's actually what you
+asked for — turn your idea into a clear product spec, check what was built
+against it, and get a plain-language brief of what to fix. For everyone who ships
+with AI, not just developers.
 
-사용자에게는 어려운 개발자 용어를 숨기고, 다음 흐름을 앱 안에서 쉽게 보여줍니다.
+→ **Learn more: [simsa.dev](https://simsa.dev)** · **Open the app: [app.trysimsa.com](https://app.trysimsa.com)**
 
-```text
-아이디어 입력
-→ Conclave가 이해한 내용
-→ 맞춤 질문
-→ 제품 설명서
-→ 꼭 들어가야 할 항목
-→ 만들기 진행상황
-→ 확인 결과
-→ 고쳐야 할 것
-→ 다시 확인
-```
+## What it does
 
-내부적으로는 PRD, requirements, verification, autofix 같은 구조를 쓰더라도, 사용자 화면에는 다음 표현을 우선 사용합니다.
+1. **Idea → spec.** Describe your app in plain language. Simsa asks a few
+   questions and writes a product spec plus a checklist of what must be true.
+2. **Build pack.** Export a package your AI coding agent (Claude Code, Codex, …)
+   can build from end to end — including service setup and deploy.
+3. **Review.** Point Simsa at your repo or your deployed app. It checks each item
+   — passed / issue found / not verified — with evidence, not vibes.
+4. **Fix brief.** Get a plain-language brief of exactly what to change, ready to
+   hand back to your agent.
 
-```text
-제품 설명서
-꼭 들어가야 할 항목
-완성 기준
-확인 결과
-안 맞음
-확인 부족
-결정 필요
-고쳐보기
-```
+No developer jargon required. Simsa keeps the PRD / requirements / verification
+machinery behind a workspace anyone can follow.
 
-## 적용 방법
+## Who it's for
 
-1. 이 폴더의 내용을 Conclave 레포 루트에 복사합니다.
-2. 이미 `CLAUDE.md`가 있다면 덮어쓰지 말고 내용을 병합합니다.
-3. Claude Code를 레포 루트에서 실행합니다.
-4. 먼저 `.conclave/prompts/00-start-here-for-claude-code.md` 내용을 붙여 넣습니다.
-5. 첫 단계는 **탐색만** 합니다. 코드 수정은 하지 않습니다.
-6. Claude Code가 작성한 진행 결과를 사용자에게 보고하고 다음 단계를 진행합니다.
+People who build apps with AI tools (v0, Lovable, Bolt, Cursor, Claude Code,
+Codex, Replit, Windsurf, …) and want confidence that what shipped matches what
+they meant — before real users see it.
 
-## 절대 처음부터 전체 구현하지 않기
+## Status
 
-이 기능은 크고 실패 가능성이 높습니다. 반드시 단계별로 나눕니다.
+Simsa is in open beta. Star this repo to follow along, and try it at
+[simsa.dev](https://simsa.dev).
 
-```text
-Stage 0: 레포 탐색, 구현 위치 파악, 계획 작성
-Stage 1: 일반 유저용 언어/정보 구조 정리
-Stage 2: 아이디어 입력 + 제품 설명서 초안 화면
-Stage 3: 맞춤 질문 생성 엔진
-Stage 4: 꼭 들어가야 할 항목 카드 모델
-Stage 5: 확인 결과 + 고쳐보기 2단계 루프
-Stage 6: Claude/Codex용 만들기 패키지 내보내기
-Stage 7: 기존 Conclave review/autofix job과 연결
-```
+---
 
-## 현재 할 일
-
-처음에는 `.conclave/current-task.md`가 Stage 0으로 설정되어 있습니다. Claude Code에게 먼저 탐색과 계획만 시키세요.
-
-## MCP — AI 코딩 에이전트에서 직접 호출
-
-`@simsa/mcp-workspace` ([`packages/mcp-workspace`](packages/mcp-workspace/README.md))는 Conclave의 acceptance/PR-review 워크플로를 **MCP 도구(stdio)**로 노출합니다. Claude Code / Cursor / Codex-like 에이전트가 코딩 환경을 떠나지 않고 PR 확인·Fix 지시서·비교·코멘트 미리보기를 호출할 수 있습니다. 설정·과금 의미·안전 모델은 패키지 README와 `conclave-builder-pack/out/stage-62-mcp-packaging-billing-docs.md` 참고. (raw GitHub 토큰 불필요 — 연결된 계정을 central-plane 통해 사용.)
+**한국어** — Simsa(심사)는 **AI로 만든 소프트웨어를 검수하고 수락하는 레이어**입니다.
+아이디어를 제품 설명서로 바꾸고, AI가 실제로 만든 결과물을 그 기준으로 확인하고,
+무엇을 고쳐야 하는지 쉬운 말로 알려줍니다. 개발자가 아니어도 됩니다.
+→ [simsa.dev](https://simsa.dev) · 앱 열기 [app.trysimsa.com](https://app.trysimsa.com)

--- a/apps/dashboard/src/lib/simsa-share.mjs
+++ b/apps/dashboard/src/lib/simsa-share.mjs
@@ -14,8 +14,9 @@ import { BRAND } from "./brand.mjs";
 /** The public GitHub repository users can star. */
 export const SIMSA_REPO_URL = "https://github.com/3SVS/simsa";
 
-/** The public marketing site the badge links to. */
-export const SIMSA_SITE_URL = `https://${BRAND.primaryDomain}`;
+/** The public site the badge links to. Uses the developer domain (simsa.dev),
+ *  which is the live public landing; the trysimsa.com apex is not serving yet. */
+export const SIMSA_SITE_URL = `https://${BRAND.developerDomain}`;
 
 /** shields.io static badge — "Reviewed with · Simsa" in brand oxblood (#8e2c39)
  *  on a zinc label. Agent-agnostic, nothing to host. */

--- a/apps/dashboard/test/simsa-share.test.mjs
+++ b/apps/dashboard/test/simsa-share.test.mjs
@@ -14,7 +14,8 @@ describe("simsa-share", () => {
       assert.match(u, /^https:\/\/\S+$/);
     }
     assert.ok(SIMSA_REPO_URL.includes("github.com/3SVS/simsa"));
-    assert.ok(SIMSA_SITE_URL.includes("trysimsa.com"));
+    // Links to the live public landing (simsa.dev). trysimsa.com apex 403s.
+    assert.ok(SIMSA_SITE_URL.includes("simsa.dev"));
   });
 
   it("badge uses the brand oxblood and links back to Simsa", () => {


### PR DESCRIPTION
The public repo still wore its old **Conclave** face — a developer CLI/PR pitch — which the new **"Star on GitHub"** button (#274) sends users straight to. Bae flagged the ordering: fix the face **before** that button goes live, or we send star-seekers to "what is this? an internal doc?".

- **README.md**: replaced the stale internal "Conclave Claude Code Builder Pack" work doc with a public **Simsa** README — what it is, who it's for, how it works (idea → spec → build pack → review → fix brief), links to simsa.dev + the app.
- **simsa-share**: the "Reviewed with Simsa" badge linked to `trysimsa.com`, whose apex currently **403s**. Point it at `simsa.dev` (live, 200).
- **Description + homepage** were updated via the GitHub API (Simsa pitch + simsa.dev) — already live (metadata, not in this diff).

Badge wording stays **"Reviewed with Simsa"** — a usage mark, **not** a "passed" verification (reserved for a future server-verified badge, per Bae).

Dashboard build/test green. Base = main.

★ **Merge this BEFORE the dashboard deploy that makes #274's star button live.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)