### PR TITLE
Prep A2a: persist collected service values in the browser (survive the prep flow)

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
 import { getProject } from "@/lib/mock-data";
 import { detectServices, hasAnyValue, allCatalogServices, catalogServiceById } from "@/lib/service-catalog.mjs";
+import { loadServiceValues, saveServiceValues } from "@/lib/service-values-store.mjs";
 import type { CatalogService } from "@/lib/service-catalog.mjs";
 import { detectMcpTools } from "@/lib/mcp-catalog.mjs";
 import type { McpTool } from "@/lib/mcp-catalog.mjs";
@@ -152,9 +153,12 @@ export default function ExportPage() {
   const [outcomeSavePhase, setOutcomeSavePhase] = useState<"idle" | "saving" | "saved_remote" | "saved_local">("idle");
 
   // ── Prep layer: detected services + in-browser key values ─────────────────
-  // Values live only in this component's state and are sent per-export; they are
-  // never persisted server-side (no-store, Rule 3).
+  // Values are sent per-export and never persisted server-side (no-store, Rule 3).
+  // They ARE kept in browser sessionStorage so they survive navigation to/from
+  // the prep step (A2) and a refresh — cleared when the tab closes.
   const [services, setServices] = useState<CatalogService[]>(() => {
+    const stored = loadServiceValues(id) as CatalogService[] | null;
+    if (stored && stored.length > 0) return stored;
     const e = loadExtendedProjectData(id);
     return detectServices({
       oneLine: e?.productSpec?.oneLine ?? project?.description,
@@ -166,6 +170,8 @@ export default function ExportPage() {
   });
   const servicesRef = useRef<CatalogService[]>(services);
   useEffect(() => { servicesRef.current = services; }, [services]);
+  // Persist collected values (browser-only) so they carry across the prep flow.
+  useEffect(() => { saveServiceValues(id, services); }, [id, services]);
 
   function setEnvValue(serviceId: string, key: string, value: string) {
     setServices((prev) =>

--- a/apps/dashboard/src/lib/service-values-store.d.mts
+++ b/apps/dashboard/src/lib/service-values-store.d.mts
@@ -1,0 +1,3 @@
+export declare function saveServiceValues(projectId: string, services: unknown[]): void;
+export declare function loadServiceValues(projectId: string): unknown[] | null;
+export declare function clearServiceValues(projectId: string): void;

--- a/apps/dashboard/src/lib/service-values-store.mjs
+++ b/apps/dashboard/src/lib/service-values-store.mjs
@@ -1,0 +1,70 @@
+/**
+ * service-values-store.mjs
+ *
+ * Prep layer A2: the service/MCP setup moves to the prep (settings) step, so the
+ * keys a user enters there must survive the walk to the builder-pack (export)
+ * screen. This is a BROWSER-ONLY store — the values never go to a server here
+ * (they're sent only at export time, baked into the pack's .env.local).
+ *
+ * Uses sessionStorage, not localStorage, on purpose: these values include real
+ * secrets (service_role, API keys). sessionStorage survives navigation within
+ * the tab (settings → export) but is cleared when the tab closes, so a secret
+ * never lingers on the device indefinitely. Keyed per project.
+ */
+
+const KEY_PREFIX = "conclave:service-values:";
+
+function storage() {
+  try {
+    return typeof window !== "undefined" && window.sessionStorage ? window.sessionStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the collected services (with values) for a project, browser-only.
+ * @param {string} projectId
+ * @param {unknown[]} services
+ */
+export function saveServiceValues(projectId, services) {
+  const s = storage();
+  if (!s || !projectId) return;
+  try {
+    s.setItem(KEY_PREFIX + projectId, JSON.stringify(services ?? []));
+  } catch {
+    /* quota / disabled storage — non-fatal */
+  }
+}
+
+/**
+ * Load the collected services for a project, or null if none stored.
+ * @param {string} projectId
+ * @returns {unknown[] | null}
+ */
+export function loadServiceValues(projectId) {
+  const s = storage();
+  if (!s || !projectId) return null;
+  try {
+    const raw = s.getItem(KEY_PREFIX + projectId);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove a project's stored service values (e.g. after the user is done).
+ * @param {string} projectId
+ */
+export function clearServiceValues(projectId) {
+  const s = storage();
+  if (!s || !projectId) return;
+  try {
+    s.removeItem(KEY_PREFIX + projectId);
+  } catch {
+    /* non-fatal */
+  }
+}

--- a/apps/dashboard/test/service-values-store.test.mjs
+++ b/apps/dashboard/test/service-values-store.test.mjs
@@ -1,0 +1,59 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  saveServiceValues,
+  loadServiceValues,
+  clearServiceValues,
+} from "../src/lib/service-values-store.mjs";
+
+// Minimal sessionStorage mock on globalThis.window.
+function installStorage() {
+  const map = new Map();
+  globalThis.window = {
+    sessionStorage: {
+      getItem: (k) => (map.has(k) ? map.get(k) : null),
+      setItem: (k, v) => map.set(k, String(v)),
+      removeItem: (k) => map.delete(k),
+    },
+  };
+  return map;
+}
+
+describe("service-values-store (browser-only, sessionStorage)", () => {
+  beforeEach(() => installStorage());
+
+  it("round-trips services for a project", () => {
+    const services = [{ id: "supabase", envVars: [{ key: "K", value: "secret_v" }] }];
+    saveServiceValues("proj_1", services);
+    assert.deepEqual(loadServiceValues("proj_1"), services);
+  });
+
+  it("is scoped per project", () => {
+    saveServiceValues("proj_a", [{ id: "a" }]);
+    saveServiceValues("proj_b", [{ id: "b" }]);
+    assert.equal(loadServiceValues("proj_a")[0].id, "a");
+    assert.equal(loadServiceValues("proj_b")[0].id, "b");
+  });
+
+  it("returns null for an unknown project", () => {
+    assert.equal(loadServiceValues("nope"), null);
+  });
+
+  it("clear removes the stored values", () => {
+    saveServiceValues("proj_1", [{ id: "x" }]);
+    clearServiceValues("proj_1");
+    assert.equal(loadServiceValues("proj_1"), null);
+  });
+
+  it("no-ops gracefully without window/storage (SSR)", () => {
+    delete globalThis.window;
+    assert.doesNotThrow(() => saveServiceValues("p", [{ id: "x" }]));
+    assert.equal(loadServiceValues("p"), null);
+    assert.doesNotThrow(() => clearServiceValues("p"));
+  });
+
+  it("survives corrupt stored JSON (returns null, no throw)", () => {
+    globalThis.window.sessionStorage.setItem("conclave:service-values:proj_1", "{not json");
+    assert.equal(loadServiceValues("proj_1"), null);
+  });
+});


### PR DESCRIPTION
Foundation for moving the service/MCP setup to the prep step (A2b): the keys a user enters must survive navigation between prep and the builder pack, and a refresh.

- **`lib/service-values-store.mjs`** (+6 tests): save/load/clear collected services per project. Uses **sessionStorage, not localStorage** — the values include real secrets, so they survive the tab session (settings → export) but clear when the tab closes; **never stored server-side** (no-store).
- **Export page**: initializes services from the store (falling back to detection) and persists on every change.

**Next (A2b):** render the ServiceSetupPanel + McpSetupPanel on the prep (settings) step reading this store, and drop them from the builder-pack page.

Dashboard **496/496**, typecheck + build + lint clean. Base = main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)