### PR TITLE
Prep A2b: move service/deploy-tool setup from builder pack → prep (settings) step

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -2,15 +2,10 @@
 
 import { ProjectNotFound } from "@/components/ProjectNotFound";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import { getProject } from "@/lib/mock-data";
-import { detectServices, hasAnyValue, allCatalogServices, catalogServiceById } from "@/lib/service-catalog.mjs";
-import { loadServiceValues, saveServiceValues } from "@/lib/service-values-store.mjs";
-import type { CatalogService } from "@/lib/service-catalog.mjs";
-import { detectMcpTools } from "@/lib/mcp-catalog.mjs";
-import type { McpTool } from "@/lib/mcp-catalog.mjs";
-import { primaryAgentForTarget, agentLabel, resolveMcpConnect } from "@/lib/agent-registry.mjs";
+import { loadServiceValues } from "@/lib/service-values-store.mjs";
 import {
   getLocalProject,
   loadExtendedProjectData,
@@ -26,6 +21,7 @@ import {
   callSaveOutcomeApi,
   callListOutcomesApi,
   type ExportBuilderPackResponse,
+  type ExportBuilderPackInput,
   type ExportFile,
   type ExportTarget,
   type RemoteOutcome,
@@ -152,53 +148,9 @@ export default function ExportPage() {
   const [outcomeNote, setOutcomeNote] = useState("");
   const [outcomeSavePhase, setOutcomeSavePhase] = useState<"idle" | "saving" | "saved_remote" | "saved_local">("idle");
 
-  // ── Prep layer: detected services + in-browser key values ─────────────────
-  // Values are sent per-export and never persisted server-side (no-store, Rule 3).
-  // They ARE kept in browser sessionStorage so they survive navigation to/from
-  // the prep step (A2) and a refresh — cleared when the tab closes.
-  const [services, setServices] = useState<CatalogService[]>(() => {
-    const stored = loadServiceValues(id) as CatalogService[] | null;
-    if (stored && stored.length > 0) return stored;
-    const e = loadExtendedProjectData(id);
-    return detectServices({
-      oneLine: e?.productSpec?.oneLine ?? project?.description,
-      problem: e?.productSpec?.problem ?? project?.spec?.goal,
-      productName: e?.productSpec?.productName ?? project?.name,
-      included: e?.productSpec?.included ?? project?.spec?.included,
-      userFlow: e?.productSpec?.userFlow,
-    });
-  });
-  const servicesRef = useRef<CatalogService[]>(services);
-  useEffect(() => { servicesRef.current = services; }, [services]);
-  // Persist collected values (browser-only) so they carry across the prep flow.
-  useEffect(() => { saveServiceValues(id, services); }, [id, services]);
-
-  function setEnvValue(serviceId: string, key: string, value: string) {
-    setServices((prev) =>
-      prev.map((s) =>
-        s.id === serviceId
-          ? { ...s, envVars: s.envVars.map((v) => (v.key === key ? { ...v, value } : v)) }
-          : s,
-      ),
-    );
-  }
-
-  function addService(serviceId: string) {
-    setServices((prev) => {
-      if (prev.some((s) => s.id === serviceId)) return prev;
-      const svc = catalogServiceById(serviceId);
-      return svc ? [...prev, svc] : prev;
-    });
-  }
-  function removeService(serviceId: string) {
-    setServices((prev) => prev.filter((s) => s.id !== serviceId));
-  }
-  const addableServices = allCatalogServices().filter(
-    (c) => !services.some((s) => s.id === c.id),
-  );
-
-  // Deploy tools (option A) — pure guidance, no state, no tokens collected.
-  const deployTools: McpTool[] = detectMcpTools();
+  // Prep layer: the service/key + deploy-tool setup lives on the prep (settings)
+  // step now. The values the user entered there are read from the browser-only
+  // store at export time (see generate()); this page only points there.
 
   // ── Derived ──────────────────────────────────────────────────────────────
   const ext = loadExtendedProjectData(id);
@@ -277,9 +229,15 @@ export default function ExportPage() {
           fixSuggestions: Object.keys(fixSuggestions).length > 0 ? fixSuggestions : undefined,
         },
         selectedItemIds: sel && sel.size > 0 ? Array.from(sel) : undefined,
-        // Prep layer: detected services + any keys the user pasted in the browser.
-        // Sent per-export so the pack can bake .env; never stored server-side.
-        services: servicesRef.current.length > 0 ? servicesRef.current : undefined,
+        // Prep layer: the services + keys the user entered on the prep step live
+        // in the browser-only store; read them here and send per-export so the
+        // pack can bake .env. Never stored server-side.
+        services: (() => {
+          const svcs = loadServiceValues(id);
+          return Array.isArray(svcs) && svcs.length > 0
+            ? (svcs as ExportBuilderPackInput["services"])
+            : undefined;
+        })(),
         target: t,
       });
 
@@ -405,19 +363,12 @@ export default function ExportPage() {
         <p className="text-sm text-gray-500">{t.exportPage.intro}</p>
       </div>
 
-      {/* ── Prep: detected services + in-browser key entry ── */}
-      <ServiceSetupPanel
-        services={services}
-        addable={addableServices}
-        onEnvChange={setEnvValue}
-        onAdd={addService}
-        onRemove={removeService}
-        onApply={handleGenerate}
-        applying={phase === "loading"}
-      />
-
-      {/* ── Prep: connect deploy tools (option A) — guidance only, no tokens ── */}
-      <McpSetupPanel tools={deployTools} agentId={primaryAgentForTarget(target)} />
+      {/* Service/key + deploy-tool setup moved to the prep step. Leave a pointer
+          so anyone who remembers the old location isn't left wondering. */}
+      <Link href={`/projects/${id}/settings`}
+        className="block bg-brand-50 border border-brand-100 rounded-xl px-4 py-3 text-sm text-brand-800 hover:bg-brand-100 transition-colors">
+        {t.exportPage.prepMoved} →
+      </Link>
 
       {/* ── Config: target + selection mode ── */}
       <div className="bg-white rounded-xl border border-gray-200 p-5">
@@ -691,207 +642,6 @@ function SimsaBadgePanel() {
           </div>
         </div>
       ))}
-    </div>
-  );
-}
-
-function McpSetupPanel({ tools, agentId }: { tools: McpTool[]; agentId: string }) {
-  const { t } = useI18n();
-  const d = t.exportPage.deployTools;
-  const [copiedCmd, setCopiedCmd] = useState<string | null>(null);
-
-  if (tools.length === 0) return null;
-  const label = agentLabel(agentId);
-
-  async function copyCommand(id: string, text: string) {
-    await copyText(text);
-    setCopiedCmd(id);
-    setTimeout(() => setCopiedCmd(null), 2000);
-  }
-
-  return (
-    <div className="bg-white rounded-xl border border-gray-200 p-5">
-      <h2 className="text-sm font-semibold text-gray-800 mb-1">{d.title}</h2>
-      <p className="text-sm text-gray-500 mb-3">{d.intro}</p>
-      <p className="text-xs text-brand-700 bg-brand-50 border border-brand-100 rounded-lg px-3 py-2 mb-4">
-        {d.whatIsMcp.replace("{agent}", label)}
-      </p>
-
-      <div className="space-y-3">
-        {tools.map((tool) => {
-          // Connect instructions follow the agent the user picked: Claude Code
-          // gets the exact `claude mcp add` command; others get the server URL to
-          // add in their own MCP settings (never a wrong command).
-          const conn = resolveMcpConnect(agentId, { mcpName: tool.mcpName, serverUrl: tool.serverUrl });
-          const isCommand = conn.style === "command";
-          const copyValue = isCommand ? conn.command! : conn.serverUrl!;
-          const authStep = (isCommand ? d.authStepCommand : d.authStepSettings).replace("{agent}", label);
-          return (
-            <div key={tool.id} className="border border-gray-200 rounded-xl p-4">
-              <div className="flex items-center justify-between gap-3 mb-2">
-                <span className="text-sm font-medium text-gray-800">{tool.label}</span>
-                {tool.docsUrl && (
-                  <a href={tool.docsUrl} target="_blank" rel="noopener noreferrer"
-                    className="text-xs px-3 py-1 rounded-lg font-medium bg-white text-brand-700 border border-brand-200 hover:bg-brand-50 transition-colors flex-shrink-0">
-                    {d.docsLabel} ↗
-                  </a>
-                )}
-              </div>
-              <p className="text-xs text-gray-500 mb-3">{tool.purpose}</p>
-
-              <div className="mb-3">
-                <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">
-                  {isCommand ? d.commandLabel : d.serverUrlLabel}
-                </p>
-                <div className="flex items-stretch gap-2">
-                  <code className="flex-1 min-w-0 overflow-x-auto whitespace-nowrap bg-gray-900 text-gray-100 rounded-lg px-3 py-2 text-xs font-mono">
-                    {copyValue}
-                  </code>
-                  <button onClick={() => copyCommand(tool.id, copyValue)}
-                    className="flex-shrink-0 text-xs px-3 rounded-lg font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors">
-                    {copiedCmd === tool.id ? t.exportPage.copied : t.exportPage.copy}
-                  </button>
-                </div>
-                <p className="mt-1.5 text-xs text-gray-600">
-                  <span className="font-medium text-gray-700">{d.authStepLabel}:</span> {authStep}
-                </p>
-              </div>
-
-              <div className="bg-brand-50 border border-brand-100 rounded-lg px-3 py-2">
-                <p className="text-[11px] font-semibold uppercase tracking-wide text-brand-600 mb-0.5">{d.safetyLabel}</p>
-                <p className="text-xs text-brand-700">{tool.authNote}</p>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function ServiceSetupPanel({
-  services,
-  addable,
-  onEnvChange,
-  onAdd,
-  onRemove,
-  onApply,
-  applying,
-}: {
-  services: CatalogService[];
-  addable: CatalogService[];
-  onEnvChange: (serviceId: string, key: string, value: string) => void;
-  onAdd: (serviceId: string) => void;
-  onRemove: (serviceId: string) => void;
-  onApply: () => void;
-  applying: boolean;
-}) {
-  const { t } = useI18n();
-  const p = t.exportPage.prep;
-  const [openSteps, setOpenSteps] = useState<Set<string>>(new Set());
-
-  if (services.length === 0 && addable.length === 0) return null;
-  const anyValue = hasAnyValue(services);
-
-  function toggleSteps(sid: string) {
-    setOpenSteps((prev) => {
-      const next = new Set(prev);
-      if (next.has(sid)) next.delete(sid); else next.add(sid);
-      return next;
-    });
-  }
-
-  return (
-    <div className="bg-white rounded-xl border border-gray-200 p-5">
-      <div className="flex items-start justify-between gap-3 mb-1">
-        <h2 className="text-sm font-semibold text-gray-800">{p.title}</h2>
-        <span className="text-xs text-gray-400 flex-shrink-0">{p.optional}</span>
-      </div>
-      <p className="text-sm text-gray-500 mb-3">{p.intro}</p>
-      <p className="text-xs text-brand-700 bg-brand-50 border border-brand-100 rounded-lg px-3 py-2 mb-4">{p.noStore}</p>
-
-      <div className="space-y-3">
-        {services.map((s) => (
-          <div key={s.id} className="border border-gray-200 rounded-xl p-4">
-            <div className="flex items-center justify-between gap-3 mb-2">
-              <span className="text-sm font-medium text-gray-800">{s.label}</span>
-              <div className="flex items-center gap-2 flex-shrink-0">
-                {s.setupUrl && (
-                  <a href={s.setupUrl} target="_blank" rel="noopener noreferrer"
-                    className="text-xs px-3 py-1 rounded-lg font-medium bg-white text-brand-700 border border-brand-200 hover:bg-brand-50 transition-colors">
-                    {p.signup} ↗
-                  </a>
-                )}
-                {s.setupSteps && s.setupSteps.length > 0 && (
-                  <button onClick={() => toggleSteps(s.id)}
-                    className="text-xs px-3 py-1 rounded-lg font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors">
-                    {openSteps.has(s.id) ? p.stepsHide : p.stepsShow}
-                  </button>
-                )}
-                <button onClick={() => onRemove(s.id)} title={p.remove} aria-label={p.remove}
-                  className="text-xs px-2 py-1 rounded-lg font-medium text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors">
-                  ✕
-                </button>
-              </div>
-            </div>
-            {s.why && <p className="text-xs text-gray-500 mb-2">{s.why}</p>}
-            {openSteps.has(s.id) && s.setupSteps && (
-              <ol className="space-y-1 text-xs text-gray-600 mb-3 pl-1">
-                {s.setupSteps.map((step, i) => (
-                  <li key={i} className="flex gap-2">
-                    <span className="text-brand-500 font-semibold flex-shrink-0">{i + 1}.</span>
-                    <span>{step}</span>
-                  </li>
-                ))}
-              </ol>
-            )}
-            <div className="space-y-2.5">
-              {s.envVars.map((v) => (
-                <div key={v.key}>
-                  <div className="flex items-center gap-2 mb-1">
-                    <code className="text-xs font-mono text-gray-700">{v.key}</code>
-                    {v.secret && (
-                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200 font-medium">{p.secretBadge}</span>
-                    )}
-                  </div>
-                  <p className="text-xs text-gray-500 mb-1.5">{v.description}</p>
-                  <input
-                    type={v.secret ? "password" : "text"}
-                    value={v.value ?? ""}
-                    onChange={(e) => onEnvChange(s.id, v.key, e.target.value)}
-                    placeholder={v.example ?? p.valuePlaceholder}
-                    autoComplete="off"
-                    spellCheck={false}
-                    className="w-full text-sm border border-gray-200 rounded-lg px-3 py-2 font-mono focus:outline-none focus:ring-2 focus:ring-brand-300"
-                  />
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {/* Picker: let the user add services beyond what we detected */}
-      {addable.length > 0 && (
-        <div className="mt-3 flex flex-wrap items-center gap-2">
-          <span className="text-xs text-gray-400">{p.addMore}:</span>
-          {addable.map((c) => (
-            <button key={c.id} onClick={() => onAdd(c.id)}
-              className="text-xs px-3 py-1 rounded-lg font-medium bg-white text-brand-700 border border-brand-200 hover:bg-brand-50 transition-colors">
-              + {c.label}
-            </button>
-          ))}
-        </div>
-      )}
-
-      <p className="text-xs text-gray-500 mt-4">{p.note}</p>
-      {anyValue && (
-        <div className="mt-3 flex justify-end">
-          <button onClick={onApply} disabled={applying} className="btn btn-sm btn-primary">
-            {applying ? t.exportPage.generating : t.exportPage.generate}
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/dashboard/src/app/projects/[id]/settings/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/settings/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { getUserKey } from "@/lib/workflow-store";
+import { getUserKey, loadExtendedProjectData, getLocalProject } from "@/lib/workflow-store";
+import { ServiceMcpSetup } from "@/components/ServiceMcpSetup";
 import { useI18n } from "@/i18n/I18nProvider";
 import {
   fetchGitHubStatus,
@@ -594,6 +595,22 @@ export default function SettingsPage() {
       {linkPhase === "error" && (
         <p className="callout callout-error">{t.github.linkFailed}</p>
       )}
+
+      {/* ─── Services + deploy tools (prep layer A2) ──────────────────────── */}
+      <div className="mt-10">
+        {(() => {
+          const ext = loadExtendedProjectData(id);
+          const proj = getLocalProject(id);
+          const spec = {
+            oneLine: ext?.productSpec?.oneLine ?? proj?.description,
+            problem: ext?.productSpec?.problem ?? proj?.spec?.goal,
+            productName: ext?.productSpec?.productName ?? proj?.name,
+            included: ext?.productSpec?.included ?? proj?.spec?.included,
+            userFlow: ext?.productSpec?.userFlow,
+          };
+          return <ServiceMcpSetup projectId={id} spec={spec} />;
+        })()}
+      </div>
 
       {/* ─── Email notifications (simple default) ────────────────────────── */}
       <div className="mt-10">

--- a/apps/dashboard/src/components/ServiceMcpSetup.tsx
+++ b/apps/dashboard/src/components/ServiceMcpSetup.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+// Prep layer A2b: the self-contained "set up the services + deploy tools your
+// app needs" block. Moved out of the builder-pack (export) page so it lives on
+// the prep (settings) step instead. Holds its own state, seeds from the shared
+// store-or-detect helper, and persists every change to the browser-only store
+// (sessionStorage) so the values carry to the builder-pack export. No values
+// ever go to a server here.
+
+import { useEffect, useState } from "react";
+import { hasAnyValue, allCatalogServices, catalogServiceById } from "@/lib/service-catalog.mjs";
+import type { CatalogService } from "@/lib/service-catalog.mjs";
+import { detectMcpTools } from "@/lib/mcp-catalog.mjs";
+import type { McpTool } from "@/lib/mcp-catalog.mjs";
+import { agentLabel, resolveMcpConnect, DEV_AGENTS } from "@/lib/agent-registry.mjs";
+import { seedServiceSetup, saveServiceValues } from "@/lib/service-values-store.mjs";
+import { useI18n } from "@/i18n/I18nProvider";
+
+async function copyText(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.cssText = "position:fixed;opacity:0";
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand("copy");
+    document.body.removeChild(ta);
+  }
+}
+
+type SpecLike = {
+  oneLine?: string;
+  problem?: string;
+  included?: string[];
+  userFlow?: string[];
+  productName?: string;
+};
+
+export function ServiceMcpSetup({ projectId, spec }: { projectId: string; spec: SpecLike }) {
+  // Seed from the store (values entered earlier) or fresh detection from the
+  // spec — the single shared seed both this panel and export use.
+  const [services, setServices] = useState<CatalogService[]>(
+    () => seedServiceSetup(projectId, spec) as CatalogService[],
+  );
+  // Persist every change (browser-only) so the values reach the builder pack.
+  useEffect(() => { saveServiceValues(projectId, services); }, [projectId, services]);
+
+  // Which agent's MCP connect steps to show (settings has no target selector).
+  const [agentId, setAgentId] = useState<string>("claude_code");
+  const deployTools: McpTool[] = detectMcpTools();
+
+  function setEnvValue(serviceId: string, key: string, value: string) {
+    setServices((prev) =>
+      prev.map((s) =>
+        s.id === serviceId
+          ? { ...s, envVars: s.envVars.map((v) => (v.key === key ? { ...v, value } : v)) }
+          : s,
+      ),
+    );
+  }
+  function addService(serviceId: string) {
+    setServices((prev) => {
+      if (prev.some((s) => s.id === serviceId)) return prev;
+      const svc = catalogServiceById(serviceId);
+      return svc ? [...prev, svc] : prev;
+    });
+  }
+  function removeService(serviceId: string) {
+    setServices((prev) => prev.filter((s) => s.id !== serviceId));
+  }
+  const addableServices = allCatalogServices().filter(
+    (c) => !services.some((s) => s.id === c.id),
+  );
+
+  return (
+    <div className="space-y-4">
+      <ServiceSetupPanel
+        services={services}
+        addable={addableServices}
+        onEnvChange={setEnvValue}
+        onAdd={addService}
+        onRemove={removeService}
+      />
+      <McpSetupPanel tools={deployTools} agentId={agentId} onAgentChange={setAgentId} />
+    </div>
+  );
+}
+
+// ─── Panels (moved from the export page) ────────────────────────────────────
+
+function ServiceSetupPanel({
+  services,
+  addable,
+  onEnvChange,
+  onAdd,
+  onRemove,
+}: {
+  services: CatalogService[];
+  addable: CatalogService[];
+  onEnvChange: (serviceId: string, key: string, value: string) => void;
+  onAdd: (serviceId: string) => void;
+  onRemove: (serviceId: string) => void;
+}) {
+  const { t } = useI18n();
+  const p = t.exportPage.prep;
+  const [openSteps, setOpenSteps] = useState<Set<string>>(new Set());
+
+  if (services.length === 0 && addable.length === 0) return null;
+
+  function toggleSteps(sid: string) {
+    setOpenSteps((prev) => {
+      const next = new Set(prev);
+      if (next.has(sid)) next.delete(sid); else next.add(sid);
+      return next;
+    });
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-5">
+      <div className="flex items-start justify-between gap-3 mb-1">
+        <h2 className="text-sm font-semibold text-gray-800">{p.title}</h2>
+        <span className="text-xs text-gray-400 flex-shrink-0">{p.optional}</span>
+      </div>
+      <p className="text-sm text-gray-500 mb-3">{p.intro}</p>
+      <p className="text-xs text-brand-700 bg-brand-50 border border-brand-100 rounded-lg px-3 py-2 mb-4">{p.noStore}</p>
+
+      <div className="space-y-3">
+        {services.map((s) => (
+          <div key={s.id} className="border border-gray-200 rounded-xl p-4">
+            <div className="flex items-center justify-between gap-3 mb-2">
+              <span className="text-sm font-medium text-gray-800">{s.label}</span>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                {s.setupUrl && (
+                  <a href={s.setupUrl} target="_blank" rel="noopener noreferrer"
+                    className="text-xs px-3 py-1 rounded-lg font-medium bg-white text-brand-700 border border-brand-200 hover:bg-brand-50 transition-colors">
+                    {p.signup} ↗
+                  </a>
+                )}
+                {s.setupSteps && s.setupSteps.length > 0 && (
+                  <button onClick={() => toggleSteps(s.id)}
+                    className="text-xs px-3 py-1 rounded-lg font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors">
+                    {openSteps.has(s.id) ? p.stepsHide : p.stepsShow}
+                  </button>
+                )}
+                <button onClick={() => onRemove(s.id)} title={p.remove} aria-label={p.remove}
+                  className="text-xs px-2 py-1 rounded-lg font-medium text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors">
+                  ✕
+                </button>
+              </div>
+            </div>
+            {s.why && <p className="text-xs text-gray-500 mb-2">{s.why}</p>}
+            {openSteps.has(s.id) && s.setupSteps && (
+              <ol className="space-y-1 text-xs text-gray-600 mb-3 pl-1">
+                {s.setupSteps.map((step, i) => (
+                  <li key={i} className="flex gap-2">
+                    <span className="text-brand-500 font-semibold flex-shrink-0">{i + 1}.</span>
+                    <span>{step}</span>
+                  </li>
+                ))}
+              </ol>
+            )}
+            <div className="space-y-2.5">
+              {s.envVars.map((v) => (
+                <div key={v.key}>
+                  <div className="flex items-center gap-2 mb-1">
+                    <code className="text-xs font-mono text-gray-700">{v.key}</code>
+                    {v.secret && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200 font-medium">{p.secretBadge}</span>
+                    )}
+                  </div>
+                  <p className="text-xs text-gray-500 mb-1.5">{v.description}</p>
+                  <input
+                    type={v.secret ? "password" : "text"}
+                    value={v.value ?? ""}
+                    onChange={(e) => onEnvChange(s.id, v.key, e.target.value)}
+                    placeholder={v.example ?? p.valuePlaceholder}
+                    autoComplete="off"
+                    spellCheck={false}
+                    className="w-full text-sm border border-gray-200 rounded-lg px-3 py-2 font-mono focus:outline-none focus:ring-2 focus:ring-brand-300"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {addable.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <span className="text-xs text-gray-400">{p.addMore}:</span>
+          {addable.map((c) => (
+            <button key={c.id} onClick={() => onAdd(c.id)}
+              className="text-xs px-3 py-1 rounded-lg font-medium bg-white text-brand-700 border border-brand-200 hover:bg-brand-50 transition-colors">
+              + {c.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <p className="text-xs text-gray-500 mt-4">{p.note}</p>
+    </div>
+  );
+}
+
+function McpSetupPanel({
+  tools,
+  agentId,
+  onAgentChange,
+}: {
+  tools: McpTool[];
+  agentId: string;
+  onAgentChange: (id: string) => void;
+}) {
+  const { t } = useI18n();
+  const d = t.exportPage.deployTools;
+  const [copiedCmd, setCopiedCmd] = useState<string | null>(null);
+
+  if (tools.length === 0) return null;
+  const label = agentLabel(agentId);
+
+  async function copyCommand(id: string, text: string) {
+    await copyText(text);
+    setCopiedCmd(id);
+    setTimeout(() => setCopiedCmd(null), 2000);
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-5">
+      <h2 className="text-sm font-semibold text-gray-800 mb-1">{d.title}</h2>
+      <p className="text-sm text-gray-500 mb-3">{d.intro}</p>
+
+      {/* Agent picker — the connect steps follow the chosen dev AI. */}
+      <div className="flex gap-2 mb-3">
+        {DEV_AGENTS.map((a) => (
+          <button key={a.id} onClick={() => onAgentChange(a.id)}
+            className={`text-xs px-3 py-1.5 rounded-lg border font-medium transition-colors ${
+              agentId === a.id ? "bg-brand-600 text-white border-brand-600" : "bg-white text-gray-700 border-gray-200 hover:border-brand-300"
+            }`}>
+            {a.label}
+          </button>
+        ))}
+      </div>
+      <p className="text-xs text-brand-700 bg-brand-50 border border-brand-100 rounded-lg px-3 py-2 mb-4">
+        {d.whatIsMcp.replace("{agent}", label)}
+      </p>
+
+      <div className="space-y-3">
+        {tools.map((tool) => {
+          const conn = resolveMcpConnect(agentId, { mcpName: tool.mcpName, serverUrl: tool.serverUrl });
+          const isCommand = conn.style === "command";
+          const copyValue = isCommand ? conn.command! : conn.serverUrl!;
+          const authStep = (isCommand ? d.authStepCommand : d.authStepSettings).replace("{agent}", label);
+          return (
+            <div key={tool.id} className="border border-gray-200 rounded-xl p-4">
+              <div className="flex items-center justify-between gap-3 mb-2">
+                <span className="text-sm font-medium text-gray-800">{tool.label}</span>
+                {tool.docsUrl && (
+                  <a href={tool.docsUrl} target="_blank" rel="noopener noreferrer"
+                    className="text-xs px-3 py-1 rounded-lg font-medium bg-white text-brand-700 border border-brand-200 hover:bg-brand-50 transition-colors flex-shrink-0">
+                    {d.docsLabel} ↗
+                  </a>
+                )}
+              </div>
+              <p className="text-xs text-gray-500 mb-3">{tool.purpose}</p>
+
+              <div className="mb-3">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">
+                  {isCommand ? d.commandLabel : d.serverUrlLabel}
+                </p>
+                <div className="flex items-stretch gap-2">
+                  <code className="flex-1 min-w-0 overflow-x-auto whitespace-nowrap bg-gray-900 text-gray-100 rounded-lg px-3 py-2 text-xs font-mono">
+                    {copyValue}
+                  </code>
+                  <button onClick={() => copyCommand(tool.id, copyValue)}
+                    className="flex-shrink-0 text-xs px-3 rounded-lg font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors">
+                    {copiedCmd === tool.id ? t.exportPage.copied : t.exportPage.copy}
+                  </button>
+                </div>
+                <p className="mt-1.5 text-xs text-gray-600">
+                  <span className="font-medium text-gray-700">{d.authStepLabel}:</span> {authStep}
+                </p>
+              </div>
+
+              <div className="bg-brand-50 border border-brand-100 rounded-lg px-3 py-2">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-brand-600 mb-0.5">{d.safetyLabel}</p>
+                <p className="text-xs text-brand-700">{tool.authNote}</p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -477,6 +477,7 @@ export type Dictionary = {
   exportPage: {
     title: string;
     intro: string;
+    prepMoved: string;
     chooseAi: string;
     scope: string;
     targetClaude: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -550,6 +550,7 @@ const EN = {
   exportPage: {
     title: "Builder pack for your dev AI",
     intro: "Bundle the product brief, review results, and items to fix into files you can hand straight to Claude Code or Codex. (Fix instructions cover one review's remaining issues; this pack covers the whole product.)",
+    prepMoved: "Set up services + deploy tools in the Prep step",
     chooseAi: "Choose dev AI",
     scope: "Scope",
     targetClaude: "For Claude Code",
@@ -2833,6 +2834,7 @@ const KO = {
   exportPage: {
     title: "개발 AI에게 넘길 만들기 패키지",
     intro: "제품 설명서, 확인 결과, 고쳐야 할 항목을 Claude Code 또는 Codex에 바로 넘길 수 있는 파일로 만듭니다. (수정 지시서는 한 번의 확인에서 남은 문제만, 이 패키지는 제품 전체를 다룹니다.)",
+    prepMoved: "서비스·배포 도구 설정은 준비 단계에서",
     chooseAi: "개발 AI 선택",
     scope: "포함 범위",
     targetClaude: "Claude Code용",

--- a/apps/dashboard/src/lib/service-values-store.d.mts
+++ b/apps/dashboard/src/lib/service-values-store.d.mts
@@ -1,3 +1,10 @@
 export declare function saveServiceValues(projectId: string, services: unknown[]): void;
 export declare function loadServiceValues(projectId: string): unknown[] | null;
 export declare function clearServiceValues(projectId: string): void;
+export declare function seedServiceSetup(
+  projectId: string,
+  spec:
+    | { oneLine?: string; problem?: string; included?: string[]; userFlow?: string[]; productName?: string }
+    | null
+    | undefined,
+): unknown[];

--- a/apps/dashboard/src/lib/service-values-store.mjs
+++ b/apps/dashboard/src/lib/service-values-store.mjs
@@ -12,6 +12,8 @@
  * never lingers on the device indefinitely. Keyed per project.
  */
 
+import { detectServices } from "./service-catalog.mjs";
+
 const KEY_PREFIX = "conclave:service-values:";
 
 function storage() {
@@ -67,4 +69,23 @@ export function clearServiceValues(projectId) {
   } catch {
     /* non-fatal */
   }
+}
+
+/**
+ * The single seed used by BOTH the prep (settings) panel and the builder-pack
+ * export: reuse the user's stored values when present, otherwise fall back to
+ * fresh keyword detection from the product spec. Shared so moving the panel
+ * (A2b) can't drop the two things that break in a move:
+ *   1. values entered in prep survive to export (stored wins),
+ *   2. spec detection (email→Resend, error→Sentry, …) still reaches the panel
+ *      on its new screen (detection fallback).
+ *
+ * @param {string} projectId
+ * @param {Parameters<typeof detectServices>[0]} spec
+ * @returns {unknown[]}
+ */
+export function seedServiceSetup(projectId, spec) {
+  const stored = loadServiceValues(projectId);
+  if (Array.isArray(stored) && stored.length > 0) return stored;
+  return detectServices(spec);
 }

--- a/apps/dashboard/test/service-values-store.test.mjs
+++ b/apps/dashboard/test/service-values-store.test.mjs
@@ -4,6 +4,7 @@ import {
   saveServiceValues,
   loadServiceValues,
   clearServiceValues,
+  seedServiceSetup,
 } from "../src/lib/service-values-store.mjs";
 
 // Minimal sessionStorage mock on globalThis.window.
@@ -55,5 +56,21 @@ describe("service-values-store (browser-only, sessionStorage)", () => {
   it("survives corrupt stored JSON (returns null, no throw)", () => {
     globalThis.window.sessionStorage.setItem("conclave:service-values:proj_1", "{not json");
     assert.equal(loadServiceValues("proj_1"), null);
+  });
+
+  // A2b safety check 1: values entered in prep survive the move to export.
+  it("seedServiceSetup returns the STORED values when present (survives the move)", () => {
+    const stored = [{ id: "supabase", envVars: [{ key: "SUPABASE_SERVICE_ROLE_KEY", value: "svc_real" }] }];
+    saveServiceValues("proj_1", stored);
+    const seeded = seedServiceSetup("proj_1", { oneLine: "무엇이든" });
+    assert.deepEqual(seeded, stored);
+  });
+
+  // A2b safety check 2: spec detection still reaches the panel on its new screen.
+  it("seedServiceSetup falls back to spec detection when nothing is stored", () => {
+    const seeded = seedServiceSetup("proj_new", { oneLine: "가입하면 인증 메일을 보내는 앱" });
+    const ids = seeded.map((s) => s.id);
+    assert.ok(ids.includes("app-url"), "always detects app-url");
+    assert.ok(ids.includes("resend"), "email spec → Resend reaches the panel");
   });
 });


### PR DESCRIPTION
Consolidates where a user sets up services + connects deploy tools: now on the **prep (settings) step** next to repo connect + notifications, not on the builder-pack page. The pack just **reads** the collected values at export.

- **`components/ServiceMcpSetup.tsx`** (new): self-contained — holds services state, seeds via the shared `seedServiceSetup` (store-or-detect), persists every change to the browser-only store, renders the service-key panel + agent-aware MCP panel (own agent picker, since settings has no target).
- **settings**: renders `<ServiceMcpSetup>` below repo connect.
- **export**: dropped the two panels + their state/handlers; reads services from the store at export time; leaves a one-line pointer (`서비스·배포 도구 설정은 준비 단계에서 →`) so nobody who remembers the old location is stranded.

**Bae's two move-risk safety checks locked by tests** (`seedServiceSetup`):
1. values entered in prep survive to export (stored wins),
2. spec detection (email→Resend, …) still reaches the panel on its new screen.

i18n `exportPage.prepMoved` (EN + KO). Dashboard **498/498**, typecheck + build + lint clean. Base = main.

Next: **#5** (per-screen primary CTA hierarchy — highest P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)