### PR TITLE
UIUX #5 (structural): demote flow "다음 →" so each screen has one hero primary

### DIFF
--- a/apps/dashboard/src/components/StepNextButton.tsx
+++ b/apps/dashboard/src/components/StepNextButton.tsx
@@ -30,11 +30,15 @@ export function StepNextButton() {
     fixes: t.nav.fixes,
   };
 
+  // Secondary weight on purpose: this is the flow "next" nav, not the screen's
+  // hero action. Each step screen's own key action (connect repo, generate
+  // items, run review, …) is the single filled primary; "다음 →" recedes so it
+  // never competes with — or outshouts — that primary (UIUX #5).
   return (
     <div className="mt-10 flex justify-end border-t border-gray-100 pt-4">
       <Link
         href={`/projects/${seg[1]}/${next}`}
-        className="btn btn-md btn-primary"
+        className="btn btn-md btn-secondary"
       >
         {t.stepsNav.next}: {labels[next] ?? next} →
       </Link>


### PR DESCRIPTION
First, structural part of **#5 (per-screen primary CTA hierarchy)**. The most common conflict across step screens: the shared bottom **"다음 →"** (StepNextButton) was `btn-primary` while the screen also had its own hero (connect repo, generate items, …) — two filled primaries competing.

- **StepNextButton → `btn-secondary`**. It's flow-navigation, not the screen's hero action; it now recedes so the screen's own key action is the sole filled primary. Fixes the double-primary on **settings, items, spec** (and every step screen) at once.

Per Bae's trap warning, this is contrast, not size. The screens needing visual-contrast judgment (checks double-primary, github multi-primary) fold into **#2 (요약재배치)** and Bae's eye-check (criterion 2). See the per-screen table in the session report.

Dashboard **498/498**, typecheck + build + lint clean. Base = main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)