### PR TITLE
UIUX #2: single state-driven primary on check-results (closes checks' #5 CTA)

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/checks/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/checks/page.tsx
@@ -24,6 +24,7 @@ import {
   type LinkedPull,
 } from "@/lib/workspace-github-api";
 import { StatusBadge } from "@/components/StatusBadge";
+import { checksPrimaryCta } from "@/lib/checks-cta.mjs";
 import { StatCard } from "@/components/StatCard";
 import type { ItemStatus } from "@/lib/labels";
 import {
@@ -160,6 +161,16 @@ export default function ChecksPage() {
     ? linkedPulls.find((lp) => lp.number === latestPrReview.prNumber)
     : undefined;
 
+  // Exactly ONE filled primary on the page (UIUX #5 / #2), state-driven — see
+  // checksPrimaryCta. The real code review outranks the draft spec pre-check.
+  const primaryCta = checksPrimaryCta({
+    prReviewLoaded: prLoadPhase === "done",
+    hasPrReview: Boolean(latestPrReview),
+    prNeedsAction,
+    draftNeedsAction: needsAction,
+  });
+  const btnClass = (isPrimary: boolean) => (isPrimary ? "btn btn-md btn-primary" : "btn btn-md btn-secondary");
+
   return (
     <div className="max-w-3xl space-y-10">
       <div>
@@ -231,7 +242,7 @@ export default function ChecksPage() {
         {results && needsAction > 0 && (
           <div className="mb-6 flex items-center justify-between rounded-lg border border-brand-100 bg-brand-50 px-5 py-4">
             <p className="text-sm text-brand-800">{needsAction} {t.checks.needsAction}</p>
-            <Link href={`/projects/${id}/fixes`} className="btn btn-md btn-primary">
+            <Link href={`/projects/${id}/fixes`} className={btnClass(primaryCta === "draft_fix")}>
               {t.checks.viewRemaining} →
             </Link>
           </div>
@@ -305,7 +316,7 @@ export default function ChecksPage() {
           <div className="card p-8 text-center">
             <p className="mb-1 text-sm text-gray-600">{t.checks.noPrReview}</p>
             <p className="mb-4 text-xs text-gray-500">{t.checks.noPrReviewDesc}</p>
-            <Link href={`/projects/${id}/github`} className="btn btn-md btn-primary">
+            <Link href={`/projects/${id}/github`} className={btnClass(primaryCta === "connect_pr")}>
               {t.checks.connectPr} →
             </Link>
           </div>
@@ -362,7 +373,7 @@ export default function ChecksPage() {
             {/* CTA */}
             <div className="flex flex-wrap items-center gap-3">
               {prNeedsAction > 0 && (
-                <Link href={`/projects/${id}/github`} className="btn btn-md btn-primary">
+                <Link href={`/projects/${id}/github`} className={btnClass(primaryCta === "pr_fix")}>
                   {t.github.createFixInstructions} →
                 </Link>
               )}

--- a/apps/dashboard/src/lib/checks-cta.d.mts
+++ b/apps/dashboard/src/lib/checks-cta.d.mts
@@ -1,0 +1,6 @@
+export declare function checksPrimaryCta(facts: {
+  prReviewLoaded: boolean;
+  hasPrReview: boolean;
+  prNeedsAction: number;
+  draftNeedsAction: number;
+}): "connect_pr" | "pr_fix" | "draft_fix" | "none";

--- a/apps/dashboard/src/lib/checks-cta.mjs
+++ b/apps/dashboard/src/lib/checks-cta.mjs
@@ -1,0 +1,21 @@
+/**
+ * checks-cta.mjs
+ *
+ * The single filled primary on the check-results screen (UIUX #5 / #2). The
+ * screen has two result sections — the draft spec pre-check and the real PR/code
+ * review — each with its own forward action, which used to render as competing
+ * primaries. This picks EXACTLY ONE, state-driven (not hand-chosen per button):
+ * the most-forward actionable step, with the real code review outranking the
+ * draft pre-check. Everything else recedes to secondary.
+ *
+ * Pure, no I/O.
+ *
+ * @param {{ prReviewLoaded: boolean, hasPrReview: boolean, prNeedsAction: number, draftNeedsAction: number }} facts
+ * @returns {"connect_pr" | "pr_fix" | "draft_fix" | "none"}
+ */
+export function checksPrimaryCta({ prReviewLoaded, hasPrReview, prNeedsAction, draftNeedsAction }) {
+  if (prReviewLoaded && !hasPrReview) return "connect_pr"; // no real review yet → get one
+  if (hasPrReview && prNeedsAction > 0) return "pr_fix"; // real review has issues → fix them
+  if (draftNeedsAction > 0) return "draft_fix"; // only the pre-check has issues
+  return "none";
+}

--- a/apps/dashboard/test/checks-cta.test.mjs
+++ b/apps/dashboard/test/checks-cta.test.mjs
@@ -1,0 +1,51 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { checksPrimaryCta } from "../src/lib/checks-cta.mjs";
+
+describe("checks-cta: exactly one state-driven primary", () => {
+  it("no PR review yet → connect_pr (get the real review)", () => {
+    assert.equal(
+      checksPrimaryCta({ prReviewLoaded: true, hasPrReview: false, prNeedsAction: 0, draftNeedsAction: 5 }),
+      "connect_pr",
+    );
+  });
+
+  it("real PR review with issues → pr_fix (outranks the draft pre-check)", () => {
+    assert.equal(
+      checksPrimaryCta({ prReviewLoaded: true, hasPrReview: true, prNeedsAction: 2, draftNeedsAction: 3 }),
+      "pr_fix",
+    );
+  });
+
+  it("PR review all passed but draft has issues → draft_fix", () => {
+    assert.equal(
+      checksPrimaryCta({ prReviewLoaded: true, hasPrReview: true, prNeedsAction: 0, draftNeedsAction: 3 }),
+      "draft_fix",
+    );
+  });
+
+  it("nothing actionable → none (no filled primary)", () => {
+    assert.equal(
+      checksPrimaryCta({ prReviewLoaded: true, hasPrReview: true, prNeedsAction: 0, draftNeedsAction: 0 }),
+      "none",
+    );
+  });
+
+  it("PR still loading → not connect_pr; falls back to draft state", () => {
+    assert.equal(
+      checksPrimaryCta({ prReviewLoaded: false, hasPrReview: false, prNeedsAction: 0, draftNeedsAction: 4 }),
+      "draft_fix",
+    );
+  });
+
+  it("never returns two primaries — the result is a single tag", () => {
+    // Exhaustive-ish: every combination yields exactly one of the four tags.
+    const tags = new Set();
+    for (const prReviewLoaded of [true, false])
+      for (const hasPrReview of [true, false])
+        for (const prNeedsAction of [0, 2])
+          for (const draftNeedsAction of [0, 3])
+            tags.add(checksPrimaryCta({ prReviewLoaded, hasPrReview, prNeedsAction, draftNeedsAction }));
+    for (const tag of tags) assert.ok(["connect_pr", "pr_fix", "draft_fix", "none"].includes(tag));
+  });
+});


### PR DESCRIPTION
The check-results screen has two result sections — the **draft spec pre-check** and the **real PR/code review** — each with a forward action that rendered as a competing `btn-primary` ("view remaining", "create fix instructions", "connect PR"). Up to two/three filled primaries at once → no clear "press this".

- **`lib/checks-cta.mjs`** (+6 tests): `checksPrimaryCta(facts)` picks **exactly one** primary, **state-driven** — the most-forward actionable step, real code review outranking the draft pre-check (`connect_pr → pr_fix → draft_fix → none`). Tested to **never yield two primaries**.
- **checks page**: the three CTAs render primary only when they are THE chosen action; the rest recede to `btn-secondary`. This is the checks half of **#5**, driven by state — not hand-picked per button.

Summary layout is already "3-second" (VerdictBanner + stat cards + next-action directly under the verdict, details collapsed below) from prior work; this closes the remaining gap — the competing primaries.

Bundles with **#280** for Bae's single eye-check (settings/items/spec + checks).

Dashboard **504/504**, typecheck + build + lint clean. Base = main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)