### PR TITLE
Prep C: "잘 모르겠어요, 추천대로 할게요" — one-click accept the recommendation

### DIFF
--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -834,10 +834,24 @@ function ApiQuestionCard({
         {answer === "defer" && <span className="text-xs text-gray-500">{t.np.decideLater}</span>}
       </div>
       <p className="mb-4 text-base font-medium leading-snug text-gray-900">{question.question}</p>
-      <div className="mb-5 rounded-lg bg-brand-50 px-4 py-3">
+      <div className="mb-3 rounded-lg bg-brand-50 px-4 py-3">
         <p className="mb-0.5 text-xs font-semibold text-brand-700">{t.np.recommended}: {question.recommendation}</p>
         <p className="text-xs leading-relaxed text-brand-600">{question.reason}</p>
       </div>
+      {/* One-click accept of the already-generated recommendation — no new LLM
+          call, no failure mode; the recommendation came honestly with the question. */}
+      {question.recommendation && (
+        <button
+          onClick={() => onAnswer(question.recommendation)}
+          className={`mb-5 w-full rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
+            answer === question.recommendation
+              ? "border-brand-600 bg-brand-600 text-white"
+              : "border-brand-200 bg-white text-brand-700 hover:bg-brand-50"
+          }`}
+        >
+          {t.np.useRecommendation}
+        </button>
+      )}
       <div className="flex flex-wrap gap-2">
         {question.options.map((opt, i) => (
           <button

--- a/apps/dashboard/src/components/QuestionCard.tsx
+++ b/apps/dashboard/src/components/QuestionCard.tsx
@@ -31,7 +31,7 @@ export function QuestionCard({ question, index, total, answer, onAnswer }: Props
         {question.question}
       </p>
 
-      <div className="bg-brand-50 rounded-lg px-4 py-3 mb-5">
+      <div className="bg-brand-50 rounded-lg px-4 py-3 mb-3">
         <p className="text-xs font-semibold text-brand-700 mb-0.5">
           {t.np.recommended}: {question.recommendation}
         </p>
@@ -39,6 +39,22 @@ export function QuestionCard({ question, index, total, answer, onAnswer }: Props
           {question.recommendationReason}
         </p>
       </div>
+
+      {/* "Not sure — use the recommendation": one-click accept of the already-
+          generated recommendation. No new LLM call (and so no failure mode) —
+          the recommendation was produced honestly with the question. */}
+      {question.recommendation && (
+        <button
+          onClick={() => onAnswer(question.recommendation)}
+          className={`mb-5 w-full text-sm px-4 py-2 rounded-lg border font-medium transition-all ${
+            answer === question.recommendation
+              ? "bg-brand-600 text-white border-brand-600"
+              : "bg-white text-brand-700 border-brand-200 hover:bg-brand-50"
+          }`}
+        >
+          {t.np.useRecommendation}
+        </button>
+      )}
 
       <div className="flex flex-wrap gap-2">
         {question.options.map((opt) => (

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -347,6 +347,7 @@ export type Dictionary = {
     editQuestions: string;
     saveNote: string;
     customInput: string;
+    useRecommendation: string;
   };
   spec: {
     emptyBody: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -420,6 +420,7 @@ const EN = {
     editQuestions: "Edit answers",
     saveNote: "Once saved, you can revisit it any time from the project page.",
     customInput: "Custom",
+    useRecommendation: "Not sure — use the recommendation",
   },
   spec: {
     emptyBody: "No plan yet — this project started from code. Reviews use your checking items, so you can keep going from the overview.",
@@ -2704,6 +2705,7 @@ const KO = {
     editQuestions: "질문 수정",
     saveNote: "저장하면 프로젝트 페이지에서 언제든 확인할 수 있습니다.",
     customInput: "직접 입력",
+    useRecommendation: "잘 모르겠어요, 추천대로 할게요",
   },
   spec: {
     emptyBody: "아직 기획 내용이 없어요 — 이 프로젝트는 코드에서 시작했어요. 검수는 확인 항목 기준으로 진행되니, 개요에서 계속 진행하시면 돼요.",


### PR DESCRIPTION
Every spec-building question already ships a generated recommendation (the "추천:" block). Add a one-click button that fills the answer with it, so a non-dev who doesn't know how to answer can move forward without guessing.

- **QuestionCard + ApiQuestionCard**: a "not sure — use the recommendation" button → sets the answer to `question.recommendation`; highlights when chosen.
- i18n `np.useRecommendation` (EN + KO).

**Honesty (Bae's condition):** this is **not** a new LLM path. The recommendation was generated honestly **with** the question (that generation already routes through the AI gateway), so the button fills a real value **instantly** — no extra call, no failure mode to leak a fake default. Better than an LLM round-trip. A separate follow-up (turning the spec's `openQuestions`, which have no recommendation, into answerable questions) is where an LLM "recommend" endpoint would be needed — that path would be gateway-routed with an honest "couldn't fetch" on failure.

Dashboard **498/498**, typecheck + build + lint clean. Base = main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)