### PR TITLE
B: inject service facts into builder-pack prompts (keys only, never values)

### DIFF
--- a/apps/central-plane/src/workspace/export.ts
+++ b/apps/central-plane/src/workspace/export.ts
@@ -504,10 +504,49 @@ const ONE_SHOT_RUNBOOK: string = [
   "**멈추지 않기:** 각 단계에서 막히면 스스로 해결을 시도하라. 정말 사용자만 할 수 있는 것(가입·키 입력, 도구 최초 연결)만 콕 집어 부탁하고 곧바로 이어간다. '어떻게 마무리할까요(병합/PR/브랜치)?' 같은 선택지로 끝내지 마라 — 끝은 언제나 '배포된 URL + 다음 한 가지 행동'이다.",
 ].join("\n");
 
+/**
+ * "이미 준비된 서비스" — a prompt-facing REFERENCE block for the services the
+ * user set up in Simsa. Lists service names + env var KEYS + where the value
+ * lives (`.env.local`), and points the agent at code-side `process.env` access.
+ *
+ * SECURITY (B): this string must NEVER contain a real secret value. Only
+ * `v.key`, `v.description`, `v.secret`, `svc.label`, `svc.setupUrl` are read —
+ * `v.value` is deliberately untouched. The pasted-into-chat prompt is a leak
+ * surface; values live only in the gitignored `.env.local`. Enforced by
+ * builder-pack-prompt-no-secret.test.mjs (the prompt version of the #271 guard).
+ */
+function genServicesContext(services: BuilderPackService[]): string {
+  if (services.length === 0) return "";
+  const lines: string[] = [
+    "## 이미 준비된 서비스 (키 값은 지시서에 없음)",
+    "",
+    "사용자가 Simsa에서 아래 서비스를 미리 설정했다. **실제 키 값은 이 지시서에 들어있지 않다** — 팩의 `.env.local` 파일에 이미 채워져 있고(gitignore됨), 이 대화창에도 절대 붙지 않는다.",
+    "- 코드에서는 값을 하드코딩하지 말고 `process.env.<KEY>`(또는 프레임워크 규칙)로 읽어라.",
+    "- 실제 키 값을 이 대화, 코드, 커밋, 로그 어디에도 노출하지 마라.",
+    "",
+  ];
+  for (const svc of services) {
+    lines.push(`### ${svc.label}`);
+    if (svc.setupUrl) lines.push(`- 서비스: ${svc.setupUrl}`);
+    lines.push("- 사용할 환경변수 (값은 `.env.local`에서 읽음):");
+    for (const v of svc.envVars) {
+      const secret = v.secret ? " · 서버 전용(프론트/브라우저 금지)" : "";
+      lines.push(`  - \`${v.key}\` — ${v.description}${secret}`);
+    }
+    lines.push("");
+  }
+  lines.push(
+    "- 자세한 설정과 아직 비어 있는 값을 채우는 법은 `SETUP.md`를 참고하라.",
+    "- 값이 비어 있는 키가 있으면 `SETUP.md`/`.env.example` 안내대로 사용자에게 발급을 부탁하고 곧바로 이어가라.",
+  );
+  return lines.join("\n");
+}
+
 function genClaudeCodePrompt(
   title: string,
   effectiveItems: ExportItem[],
   totalItems: number,
+  services: BuilderPackService[] = [],
 ): string {
   const isFiltered = effectiveItems.length < totalItems;
   const itemList = effectiveItems.map((i) => `- [ ] ${i.title}`).join("\n");
@@ -546,6 +585,7 @@ function genClaudeCodePrompt(
     "- `product.md`의 '이번 버전에서 제외' 항목은 절대 구현하지 않는다.",
     "- 전체 제품을 한 번에 만들지 않는다. 이번 패키지 범위만 구현한다.",
     "- 애매한 점이 있으면 코드 작성 전에 질문한다.",
+    ...(services.length > 0 ? ["", genServicesContext(services)] : []),
     "",
     BEGINNER_SETUP_GUIDANCE,
     "",
@@ -567,6 +607,7 @@ function genCodexPrompt(
   effectiveItems: ExportItem[],
   totalItems: number,
   fixSuggestions?: Record<string, ExportFixSuggestion>,
+  services: BuilderPackService[] = [],
 ): string {
   const isFiltered = effectiveItems.length < totalItems;
 
@@ -626,6 +667,7 @@ function genCodexPrompt(
     "",
     "이번 버전에 포함할 기능:",
     ...spec.included.map((i) => `- ${i}`),
+    ...(services.length > 0 ? ["", genServicesContext(services)] : []),
     "",
     "## Selected tasks",
     "",
@@ -881,14 +923,14 @@ export function generateBuilderPack(
   if (target !== "codex") {
     baseFiles.push({
       path: "conclave-build-pack/CLAUDE_CODE_PROMPT.md",
-      content: genClaudeCodePrompt(title, effectiveItems, allItems.length) + hookSuffix,
+      content: genClaudeCodePrompt(title, effectiveItems, allItems.length, services) + hookSuffix,
     });
   }
   if (target !== "claude_code") {
     baseFiles.push({
       path: "conclave-build-pack/CODEX_PROMPT.md",
       content:
-        genCodexPrompt(title, productSpec, effectiveItems, allItems.length, effectiveFixSuggestions) +
+        genCodexPrompt(title, productSpec, effectiveItems, allItems.length, effectiveFixSuggestions, services) +
         hookSuffix,
     });
   }

--- a/apps/central-plane/test/builder-pack-prompt-no-secret.test.mjs
+++ b/apps/central-plane/test/builder-pack-prompt-no-secret.test.mjs
@@ -1,0 +1,145 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// B guard (prompt version of the #271 no-store guard).
+//
+// The builder-pack prompts (CLAUDE_CODE_PROMPT.md / CODEX_PROMPT.md) are pasted
+// verbatim into an AI chat window — a secret-leak surface. When the user set up
+// services in Simsa, the prompt must inject FACTS (which services exist, which
+// env var KEYS to read) but NEVER a real secret VALUE. Values live only in the
+// gitignored `.env.local`. This test bakes distinctive sentinel values into the
+// service inputs and asserts they appear in `.env.local` but in NO prompt text.
+
+const { generateBuilderPack } = await import("../dist/workspace/export.js");
+
+// Distinctive sentinels — highly unlikely to occur by chance in prompt boilerplate.
+const SENTINELS = {
+  supabaseUrl: "https://ZQXSENTINEL9projref.supabase.co",
+  anonKey: "eyJZQX-ANON-SENTINEL-abc123-do-not-leak",
+  serviceKey: "eyJZQX-SERVICE-ROLE-SENTINEL-xyz789-server-only",
+};
+
+const MOCK_SPEC = {
+  productName: "회의록 요약 앱",
+  oneLine: "회의를 녹음하면 요약과 할 일이 정리됩니다",
+  targetUsers: ["회의 많은 팀"],
+  problem: "정리에 시간이 오래 걸립니다.",
+  included: ["녹음 업로드", "요약 생성"],
+  excluded: ["실시간 녹음"],
+  userFlow: ["업로드", "요약", "확인"],
+  decisions: [],
+  openQuestions: [],
+};
+
+const MOCK_ITEMS = [
+  { id: "req_001", title: "녹음 파일 업로드", status: "not_started", criteria: ["mp3 지원"] },
+];
+
+// Services carrying REAL values (as the setup UI would supply). The prompt must
+// reference the keys/labels but never echo these values.
+const SERVICES = [
+  {
+    id: "supabase",
+    label: "Supabase (데이터베이스·인증)",
+    setupUrl: "https://supabase.com",
+    envVars: [
+      {
+        key: "NEXT_PUBLIC_SUPABASE_URL",
+        description: "프로젝트 URL",
+        example: "https://xxxx.supabase.co",
+        secret: false,
+        value: SENTINELS.supabaseUrl,
+      },
+      {
+        key: "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        description: "공개 anon 키",
+        example: "eyJ...",
+        secret: false,
+        value: SENTINELS.anonKey,
+      },
+      {
+        key: "SUPABASE_SERVICE_ROLE_KEY",
+        description: "관리자 키",
+        example: "eyJ...",
+        secret: true,
+        value: SENTINELS.serviceKey,
+      },
+    ],
+  },
+];
+
+function makeReq(target) {
+  return {
+    project: { title: MOCK_SPEC.productName, productSpec: MOCK_SPEC, items: MOCK_ITEMS },
+    target,
+    format: "json",
+    locale: "ko",
+    services: SERVICES,
+  };
+}
+
+function fileByPath(res, suffix) {
+  return res.bundle.files.find((f) => f.path.endsWith(suffix));
+}
+
+const ALL_VALUES = Object.values(SENTINELS);
+const PROMPT_FILES = ["CLAUDE_CODE_PROMPT.md", "CODEX_PROMPT.md"];
+
+describe("builder-pack prompt never contains a real secret value (B)", () => {
+  it("both prompts inject the service KEYS but no VALUES", () => {
+    const res = generateBuilderPack(makeReq("both"));
+    for (const suffix of PROMPT_FILES) {
+      const file = fileByPath(res, suffix);
+      assert.ok(file, `${suffix} should be generated`);
+      const text = file.content;
+      // Reference present: keys + label appear so the agent knows what's wired.
+      assert.ok(text.includes("NEXT_PUBLIC_SUPABASE_URL"), `${suffix} should reference the env var key`);
+      assert.ok(text.includes("Supabase"), `${suffix} should name the service`);
+      assert.ok(text.includes(".env.local"), `${suffix} should point at .env.local for values`);
+      // No value leaks — the core assertion.
+      for (const value of ALL_VALUES) {
+        assert.ok(
+          !text.includes(value),
+          `${suffix} leaked a secret value into the prompt: ${value}`,
+        );
+      }
+    }
+  });
+
+  it("values DO land in .env.local (proof they went to the right place)", () => {
+    const res = generateBuilderPack(makeReq("both"));
+    const envLocal = fileByPath(res, ".env.local");
+    assert.ok(envLocal, ".env.local should be generated when values are supplied");
+    for (const value of ALL_VALUES) {
+      assert.ok(envLocal.content.includes(value), `.env.local should hold the value: ${value}`);
+    }
+  });
+
+  it("no value leaks into ANY committed pack file (only .env.local, which is gitignored)", () => {
+    const res = generateBuilderPack(makeReq("both"));
+    for (const file of res.bundle.files) {
+      if (file.path.endsWith(".env.local")) continue; // gitignored secret store
+      for (const value of ALL_VALUES) {
+        assert.ok(
+          !file.content.includes(value),
+          `${file.path} leaked a secret value: ${value}`,
+        );
+      }
+    }
+  });
+
+  it("prompt reference block is omitted when no services are supplied", () => {
+    const res = generateBuilderPack({
+      project: { title: MOCK_SPEC.productName, productSpec: MOCK_SPEC, items: MOCK_ITEMS },
+      target: "both",
+      format: "json",
+      locale: "ko",
+    });
+    const claude = fileByPath(res, "CLAUDE_CODE_PROMPT.md");
+    assert.ok(claude);
+    assert.ok(
+      !claude.content.includes("이미 준비된 서비스"),
+      "services block should not appear when no services are set up",
+    );
+  });
+});


### PR DESCRIPTION
## B — 수집한 서비스 정보를 팩/프롬프트에 주입 (병렬 C·B·D 중 B)

유저가 Simsa에서 준비한 서비스(DB·배포·키)를 빌더팩 프롬프트가 **개발 에이전트에게 사실로 알려줍니다** — "이 유저는 Supabase를 쓴다, 이 키들이 있다, `.env.local`에서 읽어라". 단, **주입되는 건 키가 아니라 사실**입니다.

### 배님 필수 조건 반영
- 프롬프트 텍스트(채팅창에 붙는 = 시크릿 누출 표면)에 **실제 키 값 절대 금지** → 참조만(`SUPABASE_URL은 .env.local에 있다`)
- 실제 값은 gitignore된 `.env.local`에만 (기존 동작 유지, 검증됨)

### 변경
- `genServicesContext(services)`: "이미 준비된 서비스" 블록. `label/setupUrl/key/description/secret`만 읽음 — `v.value`는 의도적으로 미접근. 두 프롬프트(CLAUDE_CODE/CODEX) 모두 주입, 서비스 없으면 생략.
- **B 필수 테스트** `builder-pack-prompt-no-secret.test.mjs` (#271 무저장 가드의 프롬프트 버전): 서비스 입력에 sentinel 값을 심고 → `.env.local`엔 들어가되 **어떤 프롬프트/커밋 파일에도 등장하지 않음**을 assert. 4 tests.

### 검증
- 라우트가 `req.services`를 Zod strip 없이 순수 generator로 전달, usage event엔 `{target}`만 → end-to-end 무저장 유지
- 38/38 export + 14/14 (no-store·gateway·B) green, `pnpm verify` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)