### PR TITLE
D: 'Simsa 개선 참여' one-time opt-in popup (surfaces existing consent)

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { I18nProvider } from "@/i18n/I18nProvider";
 import { ToastProvider } from "@/components/Toast";
 import { AppSidebar } from "@/components/AppSidebar";
 import { GlobalDropZone } from "@/components/GlobalDropZone";
+import { ImproveSimsaPrompt } from "@/components/ImproveSimsaPrompt";
 import { LanguageToggle } from "@/components/LanguageToggle";
 import { BRAND } from "@/lib/brand.mjs";
 
@@ -35,6 +36,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <I18nProvider>
           <ToastProvider>
             <GlobalDropZone />
+            <ImproveSimsaPrompt />
             {/* App shell: slim left sidebar (like an AI-platform workspace) + spacious main */}
             <div className="flex min-h-screen">
               <AppSidebar />

--- a/apps/dashboard/src/components/ImproveSimsaPrompt.tsx
+++ b/apps/dashboard/src/components/ImproveSimsaPrompt.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+// D ("Simsa 개선 참여" popup): surfaces the EXISTING training-data consent as a
+// one-time, opt-in invitation instead of leaving it buried in Settings. Honest
+// by design — off is the default, the two choices are symmetrical, dismissing is
+// one click, and it never reappears once decided (server) or dismissed (browser).
+//
+// Shows ONLY when the user has never decided (server consentVersion === null)
+// AND hasn't dismissed the invite in this browser. A previous "no" (version set)
+// is respected — we never nag.
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { getUserKey } from "@/lib/workflow-store";
+import { fetchTrainingConsent, saveTrainingConsent } from "@/lib/workspace-training-consent-api";
+import { useI18n } from "@/i18n/I18nProvider";
+import { useToast } from "@/components/Toast";
+
+const DISMISS_KEY = "simsa:improve-prompt-dismissed";
+
+export function ImproveSimsaPrompt() {
+  const { t } = useI18n();
+  const toast = useToast();
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    // Never re-invite once dismissed in this browser.
+    try {
+      if (window.localStorage.getItem(DISMISS_KEY)) return;
+    } catch {
+      /* storage unavailable — fall through, the server check still gates it */
+    }
+    (async () => {
+      const res = await fetchTrainingConsent(getUserKey());
+      // Only invite when the user has never decided (version null). A prior
+      // yes/no (version set) or a failed fetch → stay silent.
+      if (!cancelled && res.ok && res.consentVersion === null && !res.active) {
+        // Small delay so it doesn't jar on first paint.
+        setTimeout(() => {
+          if (!cancelled) setOpen(true);
+        }, 1500);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function dismiss() {
+    try {
+      window.localStorage.setItem(DISMISS_KEY, "1");
+    } catch {
+      /* ignore */
+    }
+    setOpen(false);
+  }
+
+  async function join() {
+    setSaving(true);
+    const res = await saveTrainingConsent(getUserKey(), true);
+    setSaving(false);
+    if (res.ok && res.active) {
+      toast.success(t.trainingConsent.savedOn);
+      dismiss();
+    } else {
+      toast.error(t.trainingConsent.saveError);
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 w-[calc(100%-2rem)] max-w-sm">
+      <div className="card border border-gray-200 bg-white p-5 shadow-lg">
+        <div className="mb-2 flex items-start justify-between gap-3">
+          <h2 className="text-sm font-semibold text-gray-900">{t.trainingConsent.title}</h2>
+          <button
+            onClick={dismiss}
+            aria-label={t.common.dismiss}
+            className="-mt-1 text-gray-400 hover:text-gray-600"
+          >
+            ✕
+          </button>
+        </div>
+        <p className="mb-3 text-xs leading-relaxed text-gray-600">{t.trainingConsent.desc}</p>
+        <ul className="mb-4 space-y-1 text-xs text-gray-500">
+          <li>• {t.trainingConsent.point1}</li>
+          <li>• {t.trainingConsent.point2}</li>
+          <li>• {t.trainingConsent.point3}</li>
+        </ul>
+        <div className="flex items-center gap-2">
+          <button onClick={join} disabled={saving} className="btn btn-sm btn-primary">
+            {t.trainingConsent.joinCta}
+          </button>
+          <button onClick={dismiss} disabled={saving} className="btn btn-sm btn-ghost">
+            {t.trainingConsent.laterCta}
+          </button>
+        </div>
+        <p className="mt-3 text-[11px] text-gray-400">
+          <Link href="/settings" className="underline hover:text-gray-600">
+            {t.trainingConsent.manageInSettings}
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -883,6 +883,9 @@ export type Dictionary = {
     savedOn: string;
     savedOff: string;
     saveError: string;
+    joinCta: string;
+    laterCta: string;
+    manageInSettings: string;
   };
   github: {
     connectTitle: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -981,6 +981,9 @@ const EN = {
     savedOn: "Thanks — your reviews will help improve Simsa.",
     savedOff: "Turned off. New reviews won't be kept.",
     saveError: "Could not save your choice. Please try again.",
+    joinCta: "Join in",
+    laterCta: "Maybe later",
+    manageInSettings: "Change anytime in Settings",
   },
   github: {
     connectTitle: "Connect your code",
@@ -3265,6 +3268,9 @@ const KO = {
     savedOn: "감사합니다 — 보내주신 확인이 Simsa 개선에 도움이 돼요.",
     savedOff: "껐어요. 이후 확인은 보관되지 않아요.",
     saveError: "선택을 저장하지 못했어요. 잠시 후 다시 시도해주세요.",
+    joinCta: "참여하기",
+    laterCta: "나중에",
+    manageInSettings: "설정에서 언제든 바꿀 수 있어요",
   },
   github: {
     connectTitle: "코드 저장소 연결",


### PR DESCRIPTION
## D — "Simsa 개선 참여" 팝업 (병렬 C·B·D 중 D)

training-data consent는 이미 있었지만 **Settings에 묻혀 있어 유저가 초대를 못 봤습니다**. 이걸 1회성·정직한 팝업으로 표면화합니다.

### 동작 (Rule 2 full picture)
- **시점:** 유저가 **한 번도 결정 안 했을 때만**(서버 `consentVersion === null && !active`) + 이 브라우저에서 dismiss 안 했을 때. 이전에 예/아니오를 골랐으면 **다시 안 띄움**(nag 금지).
- **정직:** 우하단 카드, 기존 trainingConsent copy 재사용(desc + point1-3), **대칭 버튼 "참여하기"/"나중에"**, ✕ 한 번에 닫힘, Settings 링크로 언제든 변경. **기본 OFF·명시적 opt-in** (다크패턴 없음).
- **참여하기** → `saveTrainingConsent(true)` + 성공 토스트.

### 구현
- 기존 `fetchTrainingConsent`/`saveTrainingConsent` 재사용 — **새 엔드포인트 없음**.
- app shell(layout)에 `<ImproveSimsaPrompt />` 마운트 (GlobalDropZone 옆).
- `trainingConsent.joinCta`/`laterCta`/`manageInSettings` i18n (EN+KO), parity 15/15.
- 빌드 + typecheck + `pnpm verify` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)