### PR TITLE
fix(recommend): Korean prompt caused haiku to hallucinate a refusal

### DIFF
--- a/apps/central-plane/src/workspace/recommend.ts
+++ b/apps/central-plane/src/workspace/recommend.ts
@@ -46,28 +46,47 @@ function buildRecommendPrompt(req: WorkspaceRecommendAnswerRequest): string {
   if (req.targetUsers && req.targetUsers.length > 0) ctx.push(`대상 사용자: ${req.targetUsers.join(", ")}`);
   const context = ctx.length > 0 ? ctx.join("\n") : "(추가 맥락 없음)";
 
-  // The instruction is deterministic; only the decision + context vary. Ask for
-  // a concrete, non-developer-friendly default the user can accept in one click.
+  // The instruction is deterministic; only the decision + context vary. A filled
+  // few-shot example anchors the format AND stops small models (haiku) from
+  // hallucinating a "can't read the input" refusal on the Korean prompt — an
+  // earlier version without the example produced exactly that. The KO rules are
+  // kept parallel to the EN ones (the EN path was reliable); the extra
+  // "실제 값을 지어내지 말고" line that pushed the model toward refusing is gone.
+  const example = ko
+    ? [
+        "예시 (형식 참고용):",
+        "질문: 사용자 파일 업로드 최대 크기를 얼마로 할지",
+        '{ "recommendation": "10MB", "reason": "대부분의 문서·이미지에 충분하면서 서버 부담이 적어요.", "options": ["5MB", "10MB", "50MB"] }',
+      ].join("\n")
+    : [
+        "Example (format only):",
+        "Question: What should the max file upload size be?",
+        '{ "recommendation": "10MB", "reason": "Enough for most documents and images without straining the server.", "options": ["5MB", "10MB", "50MB"] }',
+      ].join("\n");
+
   return [
     ko
       ? "너는 비개발자가 만드는 앱의 제품 결정을 돕는 조력자다. 아래 '아직 결정하지 못한 사항' 하나에 대해, 대부분의 경우에 무난한 기본값을 하나 추천하라."
       : "You help a non-developer decide one open product question. Recommend one sensible default that works for most cases.",
     "",
-    "제품 맥락:",
+    example,
+    "",
+    ko ? "이제 아래 실제 질문에 같은 형식으로 답하라." : "Now answer the real question below in the same format.",
+    "",
+    ko ? "제품 맥락:" : "Product context:",
     context,
     "",
-    "아직 결정하지 못한 사항:",
+    ko ? "아직 결정하지 못한 사항:" : "Open question:",
     req.question,
     "",
     ko
       ? [
           "규칙:",
-          "- recommendation: 사용자가 그대로 채택할 수 있는 짧고 구체적인 답 (예: \"30일\", \"무료로 제공\").",
+          "- recommendation: 사용자가 그대로 채택할 수 있는 짧고 구체적인 답.",
           "- reason: 왜 이게 무난한지 한 줄, 전문용어 없이.",
           "- options: 사용자가 대신 고를 수 있는 구체적 대안 2~4개.",
-          "- 개발/기술 용어를 쓰지 마라. 실제 값을 지어내지 말고, 결정의 성격에 맞는 합리적 기본을 제시하라.",
           "",
-          "아래 JSON 형식으로만 답하라(설명 문장 없이):",
+          "위 예시처럼 JSON만 출력하라(설명 문장 없이):",
         ].join("\n")
       : [
           "Rules:",
@@ -75,7 +94,7 @@ function buildRecommendPrompt(req: WorkspaceRecommendAnswerRequest): string {
           "- reason: one line, no jargon, why it is sensible.",
           "- options: 2–4 concrete alternatives.",
           "",
-          "Reply with ONLY this JSON (no prose):",
+          "Reply with ONLY this JSON, like the example (no prose):",
         ].join("\n"),
     '{ "recommendation": "...", "reason": "...", "options": ["...", "..."] }',
   ].join("\n");


### PR DESCRIPTION
## C2 라이브 검증 중 발견한 한국어 전용 버그

recommend-answer 배포 후 실호출 검증에서 **영어는 완벽**(`"90 days"` + 합리적 대안), **한국어만 실패** — haiku가 "입력된 내용을 확인할 수 없습니다 / 텍스트가 깨져서 읽을 수 없습니다"라는 **환각성 거부**를 냈습니다. 전송된 프롬프트는 캡처로 확인 결과 **완벽하게 정상인 UTF-8 + context 전부 포함**.

### 원인
- 한국어 rules에만 있던 `"실제 값을 지어내지 말고..."` 줄이 작은 모델을 "값을 주면 안 됨 → 못 읽겠다"로 몰아감(EN엔 이 줄 없이 완벽 작동).

### 수정 (검증된 EN 구조 유지)
- **채워진 few-shot 예시**(EN/KO 둘 다) + `"이제 아래 실제 질문에 같은 형식으로 답하라"` → 모델이 입력을 못 읽겠다고 할 수 없게 anchor.
- 혼란 유발 줄 제거, KO rules를 EN과 평행하게 정렬.

### 참고
- 게이트웨이 경유 + 정직 503 경로는 **이미 라이브 검증 완료**(EN 200 source:llm, 간헐 실패 → clean 503, 지어낸 기본값 없음). 이번 수정은 Korean-first 제품의 출력 품질 격차를 닫는 것.
- 6/6 단위테스트 green.

머지 후 central-plane 재배포 → 한국어 라이브 재확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)