### PR TITLE
fix(recommend): mirror check-draft's proven Korean framing

### DIFF
--- a/apps/central-plane/src/workspace/recommend.ts
+++ b/apps/central-plane/src/workspace/recommend.ts
@@ -46,58 +46,46 @@ function buildRecommendPrompt(req: WorkspaceRecommendAnswerRequest): string {
   if (req.targetUsers && req.targetUsers.length > 0) ctx.push(`대상 사용자: ${req.targetUsers.join(", ")}`);
   const context = ctx.length > 0 ? ctx.join("\n") : "(추가 맥락 없음)";
 
-  // The instruction is deterministic; only the decision + context vary. A filled
-  // few-shot example anchors the format AND stops small models (haiku) from
-  // hallucinating a "can't read the input" refusal on the Korean prompt — an
-  // earlier version without the example produced exactly that. The KO rules are
-  // kept parallel to the EN ones (the EN path was reliable); the extra
-  // "실제 값을 지어내지 말고" line that pushed the model toward refusing is gone.
-  const example = ko
-    ? [
-        "예시 (형식 참고용):",
-        "질문: 사용자 파일 업로드 최대 크기를 얼마로 할지",
-        '{ "recommendation": "10MB", "reason": "대부분의 문서·이미지에 충분하면서 서버 부담이 적어요.", "options": ["5MB", "10MB", "50MB"] }',
-      ].join("\n")
-    : [
-        "Example (format only):",
-        "Question: What should the max file upload size be?",
-        '{ "recommendation": "10MB", "reason": "Enough for most documents and images without straining the server.", "options": ["5MB", "10MB", "50MB"] }',
-      ].join("\n");
+  // Framing mirrors check-draft's prompt, which is the ONE workspace generator
+  // proven reliable in Korean with this same model (haiku-4-5). Earlier recommend
+  // prompts (반말 command + loose "제품 맥락:" labels, with and without a few-shot
+  // example) made haiku hallucinate an "인코딩 오류로 읽을 수 없습니다" refusal in
+  // Korean while English worked. The winning pattern, copied here: polite framing
+  // (~해주세요), bracketed [섹션] delimiters so the model reads the Korean as data,
+  // and "마크다운·설명 없이" before a JSON template.
+  if (ko) {
+    return `아직 결정하지 못한 제품 사항 하나에 대해, 비개발자가 그대로 채택할 수 있는 무난한 기본값을 추천해주세요.
 
-  return [
-    ko
-      ? "너는 비개발자가 만드는 앱의 제품 결정을 돕는 조력자다. 아래 '아직 결정하지 못한 사항' 하나에 대해, 대부분의 경우에 무난한 기본값을 하나 추천하라."
-      : "You help a non-developer decide one open product question. Recommend one sensible default that works for most cases.",
-    "",
-    example,
-    "",
-    ko ? "이제 아래 실제 질문에 같은 형식으로 답하라." : "Now answer the real question below in the same format.",
-    "",
-    ko ? "제품 맥락:" : "Product context:",
-    context,
-    "",
-    ko ? "아직 결정하지 못한 사항:" : "Open question:",
-    req.question,
-    "",
-    ko
-      ? [
-          "규칙:",
-          "- recommendation: 사용자가 그대로 채택할 수 있는 짧고 구체적인 답.",
-          "- reason: 왜 이게 무난한지 한 줄, 전문용어 없이.",
-          "- options: 사용자가 대신 고를 수 있는 구체적 대안 2~4개.",
-          "",
-          "위 예시처럼 JSON만 출력하라(설명 문장 없이):",
-        ].join("\n")
-      : [
-          "Rules:",
-          "- recommendation: a short concrete answer the user can accept as-is.",
-          "- reason: one line, no jargon, why it is sensible.",
-          "- options: 2–4 concrete alternatives.",
-          "",
-          "Reply with ONLY this JSON, like the example (no prose):",
-        ].join("\n"),
-    '{ "recommendation": "...", "reason": "...", "options": ["...", "..."] }',
-  ].join("\n");
+[제품 맥락]
+${context}
+
+[결정할 질문]
+${req.question}
+
+규칙:
+- recommendation: 그대로 채택할 수 있는 짧고 구체적인 답 (예: "30일", "무료로 제공")
+- reason: 왜 이게 무난한지 한국어 1문장, 전문용어 없이
+- options: 사용자가 대신 고를 수 있는 구체적 대안 2~4개
+
+다음 JSON 형식으로만 응답 (마크다운·설명 없이):
+{ "recommendation": "...", "reason": "...", "options": ["...", "..."] }`;
+  }
+
+  return `Recommend one sensible default a non-developer can accept as-is for a single undecided product question.
+
+[Product context]
+${context}
+
+[Question to decide]
+${req.question}
+
+Rules:
+- recommendation: a short concrete answer the user can accept as-is (e.g. "30 days")
+- reason: one sentence, no jargon, why it is sensible
+- options: 2-4 concrete alternatives
+
+Reply with ONLY this JSON (no markdown, no prose):
+{ "recommendation": "...", "reason": "...", "options": ["...", "..."] }`;
 }
 
 async function callAnthropic(


### PR DESCRIPTION
## recommend-answer 한국어 실패 — 근본 수정 (라이브 로그로 원인 확정)

`wrangler tail`로 실제 모델 출력 확보: haiku-4-5가 **"죄송하지만 질문 내용이 인코딩 오류로 표시되어 읽을 수 없습니다"** — 한국어 입력을 인코딩 손상으로 **환각·거부**. (전송 프롬프트는 캡처로 정상 UTF-8 확인. 영어는 항상 정상. 앞선 few-shot 예시 수정은 bad-200 → 503으로 바뀌기만 함.)

### 원인 = 프롬프트 프레이밍
check-draft는 **동일 모델·게이트웨이로 한국어가 안정적으로 작동**하는 유일한 generator. recommend가 그 구조와 달랐던 것.

### 수정 = check-draft 검증 패턴 이식
- 반말 명령 → **존댓말(~추천해주세요)**
- **`[제품 맥락]` / `[결정할 질문]` 대괄호 구분자** (모델이 한국어를 데이터로 인식)
- **"마크다운·설명 없이"** + JSON 템플릿
- few-shot 예시 제거(check-draft엔 없고 잘 됨)

모델/게이트웨이/정직 503 경로 동일 — 프롬프트 문자열만 변경. 6/6 단위테스트 green. 배포 후 `wrangler tail`로 라이브 재확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)