### PR TITLE
docs(recommend): correct prompt comment to true mojibake root cause (keep #288)

### DIFF
--- a/apps/central-plane/src/workspace/recommend.ts
+++ b/apps/central-plane/src/workspace/recommend.ts
@@ -48,15 +48,23 @@ function buildRecommendPrompt(req: WorkspaceRecommendAnswerRequest): string {
   if (req.targetUsers && req.targetUsers.length > 0) ctx.push(`Target users: ${req.targetUsers.join(", ")}`);
   const context = ctx.length > 0 ? ctx.join("\n") : "(no extra context)";
 
-  // English scaffolding is DELIBERATE even when the answer must be Korean.
-  // Verified live via `wrangler tail`: a fully-Korean prompt makes
-  // claude-haiku-4-5 hallucinate an "인코딩 오류로 읽을 수 없습니다" refusal, but
-  // mixing English framing with Korean content reliably engages it
-  // (KO-template+EN-content and EN-template+KO-content both returned 200 while
-  // KO-template+KO-content failed 3/3). So we always frame in English and just
-  // require the OUTPUT values in the user's language. Earlier attempts (반말
-  // command, check-draft-style 존댓말 + brackets, a few-shot example) all still
-  // triggered the refusal because the prompt was fully Korean.
+  // Why the scaffolding is English while the output is Korean:
+  //
+  // HONEST HISTORY (do not "fix" this back to a fully-Korean prompt without
+  // reading this). During live verification the Korean path appeared to fail —
+  // the model reported the input as "corrupted/인코딩 오류". That was NOT a real
+  // model or prompt bug: the manual test harness (Windows Git Bash `curl -d`)
+  // was sending the Korean body as mojibake, and the model correctly reported
+  // the garbled bytes. With a proper UTF-8 payload every prompt variant works.
+  // Three prompt PRs (#286 few-shot, #287 check-draft-style, #288 this English
+  // scaffold) were merged chasing that phantom before it was isolated.
+  //
+  // We KEEP the English scaffold (decision, 2026-07-07): it is verified live to
+  // produce high-quality Korean ("90일" + sensible reason + options), and
+  // English framing + localized output is a standard, defensible technique. A
+  // pure-Korean prompt would also work now — this is a preference, not a fix.
+  // The context labels are English; the VALUES stay in the user's language, and
+  // langLine forces the OUTPUT into it. See gotcha-windows-gitbash-curl-utf8.
   const langLine = ko
     ? "Write recommendation, reason, and every option value in natural Korean (한국어)."
     : "Write recommendation, reason, and options in English.";


### PR DESCRIPTION
배님 결정 1 반영: **#288(영어 스캐폴딩) 유지**, 단 repo에 "왜 영어지"의 정직한 답을 남김.

기존 주석은 틀린 원인(모델이 완전 한국어 프롬프트를 거부)을 사실처럼 적고 있었습니다. 실제론 **Windows Git Bash curl이 한국어를 모지바케로 전송**한 테스트 하네스 문제였고, 모델은 깨진 바이트를 정확히 보고한 것. 주석을 진실로 교정:
- #286~288은 모지바케 오진에서 나온 변경
- 영어 스캐폴딩은 라이브 검증(고품질 한국어)으로 **유지 결정** — fix가 아니라 preference
- 순수 한국어 프롬프트도 지금은 정상 작동

주석 전용, 런타임 무영향 → 재배포 불필요. 관련 메모리: gotcha-windows-gitbash-curl-utf8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)