### PR TITLE
feat(prep): explicit '작성하고 저장하기' button on service setup panel (item 3)

### DIFF
--- a/apps/dashboard/src/components/ServiceMcpSetup.tsx
+++ b/apps/dashboard/src/components/ServiceMcpSetup.tsx
@@ -15,6 +15,7 @@ import type { McpTool } from "@/lib/mcp-catalog.mjs";
 import { agentLabel, resolveMcpConnect, DEV_AGENTS } from "@/lib/agent-registry.mjs";
 import { seedServiceSetup, saveServiceValues } from "@/lib/service-values-store.mjs";
 import { useI18n } from "@/i18n/I18nProvider";
+import { useToast } from "@/components/Toast";
 
 async function copyText(text: string): Promise<void> {
   try {
@@ -39,6 +40,8 @@ type SpecLike = {
 };
 
 export function ServiceMcpSetup({ projectId, spec }: { projectId: string; spec: SpecLike }) {
+  const { t } = useI18n();
+  const toast = useToast();
   // Seed from the store (values entered earlier) or fresh detection from the
   // spec — the single shared seed both this panel and export use.
   const [services, setServices] = useState<CatalogService[]>(
@@ -46,6 +49,14 @@ export function ServiceMcpSetup({ projectId, spec }: { projectId: string; spec: 
   );
   // Persist every change (browser-only) so the values reach the builder pack.
   useEffect(() => { saveServiceValues(projectId, services); }, [projectId, services]);
+
+  // Explicit save: the panel already auto-persists on every keystroke, but users
+  // had no signal it was saved (Bae's feedback). This button makes the save
+  // tangible — a confirmed write + toast — without changing the storage path.
+  function handleSave() {
+    saveServiceValues(projectId, services);
+    toast.success(t.exportPage.prep.saved);
+  }
 
   // Which agent's MCP connect steps to show (settings has no target selector).
   const [agentId, setAgentId] = useState<string>("claude_code");
@@ -84,6 +95,12 @@ export function ServiceMcpSetup({ projectId, spec }: { projectId: string; spec: 
         onRemove={removeService}
       />
       <McpSetupPanel tools={deployTools} agentId={agentId} onAgentChange={setAgentId} />
+      <div className="flex items-center gap-3">
+        <button onClick={handleSave} className="btn btn-md btn-primary">
+          {t.exportPage.prep.save}
+        </button>
+        <span className="text-xs text-gray-400">{t.exportPage.prep.savedHint}</span>
+      </div>
     </div>
   );
 }

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -556,6 +556,9 @@ export type Dictionary = {
       note: string;
       addMore: string;
       remove: string;
+      save: string;
+      saved: string;
+      savedHint: string;
     };
     returnStep: {
       title: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -629,6 +629,9 @@ const EN = {
       note: "Fill in any values and they'll be written to .env.local in the pack (kept out of git). Leave them blank to still get a .env.example template plus a setup guide.",
       addMore: "Add a service",
       remove: "Remove",
+      save: "Save setup",
+      saved: "Setup saved. It'll be in the pack you download.",
+      savedHint: "Saved as you type — this just confirms it.",
     },
     returnStep: {
       title: "Built it? Come back and connect it",
@@ -2924,6 +2927,9 @@ const KO = {
       note: "값을 입력하면 팩의 .env.local 에 기록됩니다(깃에는 올라가지 않습니다). 비워 두면 .env.example 템플릿과 설정 안내서만 만들어집니다.",
       addMore: "서비스 추가",
       remove: "제거",
+      save: "작성하고 저장하기",
+      saved: "저장했어요. 다운로드하는 팩에 함께 들어갑니다.",
+      savedHint: "입력하는 대로 저장돼요 — 이 버튼은 확인용이에요.",
     },
     returnStep: {
       title: "다 만드셨나요? 돌아와서 연결하세요",


### PR DESCRIPTION
배님 피드백 item 3: "앱에 필요한 서비스 준비하기도 작성하고 저장하기 버튼이 필요해."

서비스 준비 패널은 키 입력마다 브라우저 저장소에 **조용히 자동저장**만 하고 저장됐다는 신호가 없어, 유저가 저장 여부를 확신할 수 없었습니다.

- **"작성하고 저장하기" 버튼** + 저장 확인 토스트 추가 (재저장 + `저장했어요` 토스트)
- "입력하는 대로 저장돼요 — 이 버튼은 확인용" 힌트
- 저장 경로 불변(브라우저 전용·서버 무저장) — 순수 확신 affordance
- i18n EN/KO parity 15/15, typecheck·build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)