### PR TITLE
feat(edit): make idea and product spec editable — go back and correct (item 1)

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/idea/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/idea/page.tsx
@@ -2,15 +2,30 @@
 
 import { ProjectNotFound } from "@/components/ProjectNotFound";
 
+import { useState } from "react";
 import { useParams } from "next/navigation";
 import { getProject } from "@/lib/mock-data";
-import { getLocalProject } from "@/lib/workflow-store";
+import type { Project } from "@/lib/mock-data";
+import {
+  getLocalProject,
+  getUserKey,
+  saveProject,
+  loadExtendedProjectData,
+  markProjectSyncFailed,
+} from "@/lib/workflow-store";
+import { saveProjectToDb } from "@/lib/workspace-check-api";
 import { useI18n } from "@/i18n/I18nProvider";
+import { useToast } from "@/components/Toast";
 import { StepNextButton } from "@/components/StepNextButton";
 
 export default function IdeaPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useI18n();
+  const toast = useToast();
+  const [, forceRefresh] = useState(0);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+
   // Read on the client so locally-created (localStorage) projects resolve,
   // not just the bundled mock demos.
   const project = getLocalProject(id) ?? getProject(id);
@@ -19,6 +34,42 @@ export default function IdeaPage() {
   // Code-branch projects legitimately start without a worked-up idea/spec —
   // show a guiding empty state instead of blank cards.
   const isEmpty = !project.spec.goal && project.spec.included.length === 0 && !project.description;
+
+  function startEdit() {
+    setDraft(project!.description ?? "");
+    setEditing(true);
+  }
+
+  // Persist an edited idea text: local-first (what every page reads) + a
+  // best-effort server sync that preserves items/criteria (sticky upsert), the
+  // same payload shape items/page.tsx uses so nothing is wiped.
+  function saveIdea() {
+    const nextProject: Project = { ...project!, description: draft };
+    saveProject(nextProject);
+    const ext = loadExtendedProjectData(id);
+    saveProjectToDb({
+      id,
+      userKey: getUserKey(),
+      title: nextProject.name,
+      idea: draft,
+      understood: {},
+      productSpec: ext?.productSpec ?? {},
+      items: nextProject.requirements.map((r) => ({
+        id: r.id,
+        title: r.title,
+        status: r.status,
+        criteria: ext?.itemCriteria?.[r.id] ?? [],
+        note: ext?.itemNotes?.[r.id] || undefined,
+      })),
+    })
+      .then((res) => {
+        if (!res || res.ok !== true) markProjectSyncFailed(id);
+      })
+      .catch(() => markProjectSyncFailed(id));
+    setEditing(false);
+    forceRefresh((v) => v + 1);
+    toast.success(t.common.saved);
+  }
 
   return (
     <div className="max-w-2xl">
@@ -37,10 +88,33 @@ export default function IdeaPage() {
       {!isEmpty && (
       <>
       <div className="card mb-6 p-6">
-        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
-          {t.idea.yourInput}
-        </h2>
-        <p className="text-sm leading-relaxed text-gray-800">{project.description}</p>
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+            {t.idea.yourInput}
+          </h2>
+          {!editing && (
+            <button onClick={startEdit} className="text-xs font-medium text-brand-600 hover:text-brand-700">
+              {t.common.edit}
+            </button>
+          )}
+        </div>
+        {editing ? (
+          <div>
+            <textarea
+              autoFocus
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              rows={5}
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-brand-300"
+            />
+            <div className="mt-3 flex items-center gap-2">
+              <button onClick={saveIdea} className="btn btn-sm btn-primary">{t.common.save}</button>
+              <button onClick={() => setEditing(false)} className="btn btn-sm btn-ghost">{t.common.cancel}</button>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm leading-relaxed text-gray-800 whitespace-pre-wrap">{project.description}</p>
+        )}
       </div>
 
       <div className="card mb-6 p-6">

--- a/apps/dashboard/src/app/projects/[id]/spec/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/spec/page.tsx
@@ -5,21 +5,29 @@ import { ProjectNotFound } from "@/components/ProjectNotFound";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { getProject } from "@/lib/mock-data";
+import type { Project } from "@/lib/mock-data";
 import {
   getLocalProject,
   getUserKey,
+  saveProject,
   loadExtendedProjectData,
   saveExtendedProjectData,
+  markProjectSyncFailed,
 } from "@/lib/workflow-store";
+import type { WorkspaceProductSpec } from "@/lib/workspace-types";
+import { saveProjectToDb } from "@/lib/workspace-check-api";
 import { SpecCompleteness } from "@/components/SpecCompleteness";
 import { OpenQuestionCard } from "@/components/OpenQuestionCard";
 import { useI18n } from "@/i18n/I18nProvider";
+import { useToast } from "@/components/Toast";
 import { StepNextButton } from "@/components/StepNextButton";
 
 export default function SpecPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useI18n();
+  const toast = useToast();
   const project = getLocalProject(id) ?? getProject(id);
+  const [, forceRefresh] = useState(0);
 
   // C2: answers the user settled for open decisions (kept in extended data, not
   // the core spec, so example projects aren't mutated). Hydrated client-side.
@@ -27,6 +35,15 @@ export default function SpecPage() {
   useEffect(() => {
     setResolved(loadExtendedProjectData(id)?.resolvedOpenDecisions ?? {});
   }, [id]);
+
+  // Edit mode for the core spec (goal / included / excluded). Persists to BOTH
+  // representations: project.spec (what these pages render) and the extended
+  // productSpec (what checks/export read), so an edit actually reaches the
+  // acceptance pipeline. openDecisions stays owned by the C2 cards below.
+  const [editing, setEditing] = useState(false);
+  const [dGoal, setDGoal] = useState("");
+  const [dIncluded, setDIncluded] = useState<string[]>([]);
+  const [dExcluded, setDExcluded] = useState<string[]>([]);
 
   function resolveOpenDecision(question: string, answer: string) {
     setResolved((prev) => {
@@ -41,6 +58,66 @@ export default function SpecPage() {
   if (!project) return <ProjectNotFound />;
 
   const { spec } = project;
+
+  function startEdit() {
+    setDGoal(spec.goal);
+    setDIncluded([...spec.included]);
+    setDExcluded([...spec.excluded]);
+    setEditing(true);
+  }
+
+  function saveSpec() {
+    const included = dIncluded.map((s) => s.trim()).filter(Boolean);
+    const excluded = dExcluded.map((s) => s.trim()).filter(Boolean);
+    const goal = dGoal.trim();
+    // 1) local project.spec — the source these pages render.
+    const nextProject: Project = {
+      ...project!,
+      spec: { ...spec, goal, included, excluded },
+    };
+    saveProject(nextProject);
+    // 2) extended productSpec — the source checks/export read. goal → oneLine
+    //    (the one-line product description); included/excluded map 1:1.
+    const ext = loadExtendedProjectData(id);
+    const base = ext?.productSpec;
+    const nextProductSpec: WorkspaceProductSpec = base
+      ? { ...base, oneLine: goal, included, excluded }
+      : {
+          productName: project!.name,
+          oneLine: goal,
+          targetUsers: [],
+          problem: "",
+          included,
+          excluded,
+          userFlow: [],
+          decisions: [],
+          openQuestions: spec.openDecisions ?? [],
+        };
+    saveExtendedProjectData(id, { productSpec: nextProductSpec });
+    // 3) best-effort server sync (sticky upsert preserves items/criteria).
+    saveProjectToDb({
+      id,
+      userKey: getUserKey(),
+      title: nextProject.name,
+      idea: nextProject.description ?? "",
+      understood: {},
+      productSpec: nextProductSpec,
+      items: nextProject.requirements.map((r) => ({
+        id: r.id,
+        title: r.title,
+        status: r.status,
+        criteria: ext?.itemCriteria?.[r.id] ?? [],
+        note: ext?.itemNotes?.[r.id] || undefined,
+      })),
+    })
+      .then((res) => {
+        if (!res || res.ok !== true) markProjectSyncFailed(id);
+      })
+      .catch(() => markProjectSyncFailed(id));
+    setEditing(false);
+    forceRefresh((v) => v + 1);
+    toast.success(t.common.saved);
+  }
 
   return (
     <div className="max-w-2xl">
@@ -60,8 +137,35 @@ export default function SpecPage() {
             {t.common.goOverview}
           </a>
         </div>
+      ) : editing ? (
+      <div className="space-y-5">
+        <Section title={t.spec.goal}>
+          <textarea
+            autoFocus
+            value={dGoal}
+            onChange={(e) => setDGoal(e.target.value)}
+            rows={2}
+            className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-brand-300"
+          />
+        </Section>
+        <Section title={t.spec.included}>
+          <ListEditor items={dIncluded} onChange={setDIncluded} addLabel={t.common.addLine} removeLabel={t.common.removeLine} />
+        </Section>
+        <Section title={t.spec.excluded}>
+          <ListEditor items={dExcluded} onChange={setDExcluded} addLabel={t.common.addLine} removeLabel={t.common.removeLine} />
+        </Section>
+        <div className="flex items-center gap-2">
+          <button onClick={saveSpec} className="btn btn-md btn-primary">{t.common.save}</button>
+          <button onClick={() => setEditing(false)} className="btn btn-md btn-ghost">{t.common.cancel}</button>
+        </div>
+      </div>
       ) : (
       <div className="space-y-5">
+        <div className="flex justify-end">
+          <button onClick={startEdit} className="text-xs font-medium text-brand-600 hover:text-brand-700">
+            {t.common.edit}
+          </button>
+        </div>
         <Section title={t.spec.goal}>
           <p className="text-sm leading-relaxed text-gray-700">{spec.goal}</p>
         </Section>
@@ -119,6 +223,52 @@ function Section({ title, children }: { title: string; children: React.ReactNode
     <div className="card p-5">
       <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">{title}</h2>
       {children}
+    </div>
+  );
+}
+
+/** Inline editor for a list of short strings (included / excluded lines). */
+function ListEditor({
+  items,
+  onChange,
+  addLabel,
+  removeLabel,
+}: {
+  items: string[];
+  onChange: (next: string[]) => void;
+  addLabel: string;
+  removeLabel: string;
+}) {
+  function setAt(i: number, value: string) {
+    onChange(items.map((it, idx) => (idx === i ? value : it)));
+  }
+  function removeAt(i: number) {
+    onChange(items.filter((_, idx) => idx !== i));
+  }
+  return (
+    <div className="space-y-2">
+      {items.map((item, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <input
+            value={item}
+            onChange={(e) => setAt(i, e.target.value)}
+            className="flex-1 rounded-lg border border-gray-200 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
+          />
+          <button
+            onClick={() => removeAt(i)}
+            aria-label={removeLabel}
+            className="flex-shrink-0 rounded-lg px-2 py-1 text-xs text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+      <button
+        onClick={() => onChange([...items, ""])}
+        className="text-xs font-medium text-brand-600 hover:text-brand-700"
+      >
+        ＋ {addLabel}
+      </button>
     </div>
   );
 }

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -185,6 +185,10 @@ export type Dictionary = {
     viewAll: string;
     more: string;
     rateLimited: string;
+    edit: string;
+    saved: string;
+    addLine: string;
+    removeLine: string;
   };
   errors: {
     llmUnavailable: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -247,6 +247,10 @@ const EN = {
     viewAll: "View all",
     more: "more",
     rateLimited: "Too many requests. Please wait a moment and try again.",
+    edit: "Edit",
+    saved: "Saved.",
+    addLine: "Add",
+    removeLine: "Remove",
   },
   // Friendly, localized messages for backend error codes. Non-developers must
   // never see a raw code like "db_error" or "HTTP 500". Map at the render site
@@ -2545,6 +2549,10 @@ const KO = {
     viewAll: "전체 보기",
     more: "개 더",
     rateLimited: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
+    edit: "수정",
+    saved: "저장했어요.",
+    addLine: "추가",
+    removeLine: "삭제",
   },
   errors: {
     llmUnavailable: "지금 AI 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요 — 입력하신 내용은 그대로 남아 있어요.",


### PR DESCRIPTION
배님 피드백 item 1: "아이디어, 제품설명서, 확인 항목 등도 다시 돌아가서 수정을 할 수 있는 기능이 필요해."

**확인 항목(items)은 이미 편집 가능**했고, 읽기 전용이던 **아이디어·제품설명서**를 편집 가능하게 만듭니다.

- **아이디어 페이지**: 원문 아이디어(`project.description`) 수정 → 로컬 저장 + 서버 sticky sync(항목/기준 보존).
- **제품설명서 페이지**: goal/포함/제외를 수정 토글 + ListEditor로 편집. **두 표현 동시 갱신**으로 편집이 검수 파이프라인까지 도달: `project.spec`(페이지 표시) + 확장 `productSpec`(checks/export가 읽음) — goal→oneLine, 포함/제외 1:1. C2 미결정 카드는 그대로.
- `common.edit/saved/addLine/removeLine` i18n(EN+KO), parity 15/15, typecheck·build green.

> item 2(검수→저장소 전환 브릿지)·item 4(옛 프로젝트 재시도 잔상)는 별도. item 4는 배님 새 프로젝트 재테스트 결과 대기 중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)