### PR TITLE
fix(ux): block Backspace from discarding typed input (no more lost work)

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { ToastProvider } from "@/components/Toast";
 import { AppSidebar } from "@/components/AppSidebar";
 import { GlobalDropZone } from "@/components/GlobalDropZone";
 import { ImproveSimsaPrompt } from "@/components/ImproveSimsaPrompt";
+import { BackspaceNavGuard } from "@/components/BackspaceNavGuard";
 import { LanguageToggle } from "@/components/LanguageToggle";
 import { BRAND } from "@/lib/brand.mjs";
 
@@ -36,6 +37,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <I18nProvider>
           <ToastProvider>
             <GlobalDropZone />
+            <BackspaceNavGuard />
             <ImproveSimsaPrompt />
             {/* App shell: slim left sidebar (like an AI-platform workspace) + spacious main */}
             <div className="flex min-h-screen">

--- a/apps/dashboard/src/components/BackspaceNavGuard.tsx
+++ b/apps/dashboard/src/components/BackspaceNavGuard.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+// Backspace pressed OUTSIDE a text field navigates the browser back in some
+// setups (older engines, certain keyboards/extensions), silently discarding
+// everything typed on the current screen — e.g. a half-written idea in the new
+// project wizard (Bae's report: "백스페이스 누르면 입력된 게 다 사라진 채로 처음으로").
+// Backspace has no legitimate action outside an editable element, so we block it
+// there and let it delete characters normally inside inputs. App-wide, mounted
+// once in the root layout.
+
+import { useEffect } from "react";
+
+export function BackspaceNavGuard() {
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== "Backspace") return;
+      const el = e.target as HTMLElement | null;
+      const tag = el?.tagName;
+      const editable =
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        (el?.isContentEditable ?? false);
+      if (!editable) e.preventDefault();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+  return null;
+}


### PR DESCRIPTION
배님 피드백: 뒤로가기 버튼이 안 보여 백스페이스를 누르면 입력한 게 다 사라진 채 처음으로 돌아감.

편집 필드 밖에서 백스페이스는 일부 환경에서 브라우저 뒤로가기를 유발 → 화면의 입력 상태(위저드의 아이디어, items/spec 편집, 서비스 키)를 조용히 날림.

**전역 BackspaceNavGuard**를 root layout에 1회 마운트: input/textarea/select/contentEditable 안에서는 정상 삭제, 그 밖에서는 차단(그곳에선 파괴적 뒤로가기밖에 안 하므로). 앱 전역, i18n 없음, typecheck·build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)