### PR TITLE
fix(flow): new projects show in sidebar + forward exits from dead-ends (④⑥⑨)

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -394,6 +394,15 @@ export default function GitHubPage() {
               {t.github.goConnectRepo}
             </Link>
           </div>
+          {/* Forward exit so a user who hasn't built yet isn't trapped bouncing
+              between this card, settings, and the PR screens (Bae's loop). Their
+              real next action is to get the pack and build. */}
+          <p className="mx-auto mt-5 max-w-md border-t border-gray-100 pt-4 text-xs text-gray-500">
+            {t.github.noRepoBuildHint}{" "}
+            <Link href={`/projects/${id}/export`} className="font-medium text-brand-600 hover:text-brand-700">
+              {t.github.getPack} →
+            </Link>
+          </p>
         </div>
       )}
 

--- a/apps/dashboard/src/components/ServiceMcpSetup.tsx
+++ b/apps/dashboard/src/components/ServiceMcpSetup.tsx
@@ -8,6 +8,7 @@
 // ever go to a server here.
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { hasAnyValue, allCatalogServices, catalogServiceById } from "@/lib/service-catalog.mjs";
 import type { CatalogService } from "@/lib/service-catalog.mjs";
 import { detectMcpTools } from "@/lib/mcp-catalog.mjs";
@@ -95,12 +96,20 @@ export function ServiceMcpSetup({ projectId, spec }: { projectId: string; spec: 
         onRemove={removeService}
       />
       <McpSetupPanel tools={deployTools} agentId={agentId} onAgentChange={setAgentId} />
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <button onClick={handleSave} className="btn btn-md btn-primary">
           {t.exportPage.prep.save}
         </button>
         <span className="text-xs text-gray-400">{t.exportPage.prep.savedHint}</span>
       </div>
+      {/* Forward exit: saving used to dead-end with just a toast (Bae). Point at
+          the builder pack — that's where these values are consumed next. */}
+      <Link
+        href={`/projects/${projectId}/export`}
+        className="inline-flex text-sm font-medium text-brand-600 hover:text-brand-700"
+      >
+        {t.exportPage.prep.next}
+      </Link>
     </div>
   );
 }

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -574,6 +574,7 @@ export type Dictionary = {
       save: string;
       saved: string;
       savedHint: string;
+      next: string;
     };
     returnStep: {
       title: string;
@@ -965,6 +966,8 @@ export type Dictionary = {
     goConnectRepo: string;
     bridgeTitle: string;
     bridgeBody: string;
+    noRepoBuildHint: string;
+    getPack: string;
     loadPulls: string;
     pullsLoadError: string;
     openPulls: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -647,6 +647,7 @@ const EN = {
       save: "Save setup",
       saved: "Setup saved. It'll be in the pack you download.",
       savedHint: "Saved as you type — this just confirms it.",
+      next: "Next: get the builder pack for your AI →",
     },
     returnStep: {
       title: "Built it? Come back and connect it",
@@ -1063,6 +1064,8 @@ const EN = {
     goConnectRepo: "Connect a repository",
     bridgeTitle: "Why connect a code repo here?",
     bridgeBody: "So far you've shaped your idea and checking items. Now connect the GitHub repository your AI actually built into — Simsa then checks that real code against your items, instead of the plan alone.",
+    noRepoBuildHint: "Haven't built the app yet? Get the builder pack first and make it with your AI, then come back to connect it.",
+    getPack: "Get the builder pack",
     loadPulls: "Load code changes (PRs)",
     pullsLoadError: "We could not load the code changes.",
     openPulls: "open code changes (PRs)",
@@ -2974,6 +2977,7 @@ const KO = {
       save: "작성하고 저장하기",
       saved: "저장했어요. 다운로드하는 팩에 함께 들어갑니다.",
       savedHint: "입력하는 대로 저장돼요 — 이 버튼은 확인용이에요.",
+      next: "다음: 빌더팩을 받아 개발 AI에게 주세요 →",
     },
     returnStep: {
       title: "다 만드셨나요? 돌아와서 연결하세요",
@@ -3390,6 +3394,8 @@ const KO = {
     goConnectRepo: "저장소 연결하러 가기",
     bridgeTitle: "왜 여기서 코드 저장소를 연결하나요?",
     bridgeBody: "지금까지는 아이디어와 검수 항목을 정리했어요. 이제 AI가 실제로 만든 코드를 GitHub 저장소에 연결하면, 계획이 아니라 그 진짜 코드를 검수 항목 기준으로 확인해 드립니다.",
+    noRepoBuildHint: "아직 앱을 안 만드셨나요? 먼저 빌더팩을 받아 개발 AI로 만든 뒤, 돌아와서 연결하세요.",
+    getPack: "빌더팩 받기",
     loadPulls: "코드 변경(PR) 목록 불러오기",
     pullsLoadError: "코드 변경 목록을 불러오지 못했습니다.",
     openPulls: "개 열려 있는 코드 변경(PR)",


### PR DESCRIPTION
배님이 플로우를 걸으며 나온 끊김 3건:

- **④ 사이드바**: 방금 만든 프로젝트가 좌측 네비에 안 뜸 → 목록을 mount 때만 읽어서 새 id가 null로 풀리고 전체목록으로 폴백. **pathname 변경 시 재읽기**로 즉시 표시(편집 반영도 됨).
- **⑥ 저장 dead-end**: '작성하고 저장하기'가 토스트만 → **빌더팩으로 가는 forward 링크** 추가(값이 쓰이는 다음 단계).
- **⑨ no_repo 루프**: repo/PR 없는 유저가 연결카드↔설정↔PR 화면 뺑뺑이 → **'아직 안 만드셨다면 빌더팩 받기'** 출구 추가.

i18n EN/KO parity 15/15, typecheck·build green. (근본 문제 ①⑤ 플랫폼 하드코딩은 별도 큰 작업으로 진행 예정.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)