### PR TITLE
P0 fix(generate): stop fabricating a meeting/Linear app from a common word

### DIFF
--- a/apps/central-plane/src/workspace/generate.ts
+++ b/apps/central-plane/src/workspace/generate.ts
@@ -332,7 +332,15 @@ function gateDraftOf(res: IdeaToSpecDraftResponse): unknown {
 }
 
 function buildMockFallback(req: IdeaToSpecDraftRequest): IdeaToSpecDraftResponse {
-  const isMeeting = /회의|녹음|요약|linear|미팅/i.test(req.idea);
+  // Honesty guard: this LLM-unavailable fallback must NOT fabricate a specific,
+  // unrelated product from a single common word. The old trigger
+  // (/회의|녹음|요약|linear|미팅/) fired on "요약" or "linear" ALONE, so "리뷰를
+  // 요약하는 앱" or "회의실 예약 앱" got a canned "회의록 → Linear 전송" spec that
+  // had nothing to do with the user's idea. Now it only fires for a genuine
+  // meeting-NOTES idea: a meeting-context word (회의/미팅/녹음) AND a
+  // summarize/tasks word. Everything else gets the generic, idea-echoing draft.
+  const isMeeting =
+    /회의|미팅|녹음/i.test(req.idea) && /요약|할\s*일|정리|linear/i.test(req.idea);
   const flags = extractAnswerFlags(req.answers);
 
   if (isMeeting) {

--- a/apps/central-plane/test/generate-no-fabrication.test.mjs
+++ b/apps/central-plane/test/generate-no-fabrication.test.mjs
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// P0 honesty guard: the LLM-unavailable mock fallback must never fabricate a
+// specific unrelated product from a single common word. The old trigger fired on
+// "요약" or "linear" ALONE, so a review-summary app or a meeting-ROOM booking app
+// got a canned "회의록 → Linear 전송" spec. This locks the narrowed trigger.
+
+const { generateIdeaToSpecDraft } = await import("../dist/workspace/generate.js");
+
+function specText(res) {
+  return JSON.stringify(res.productSpec) + " " + JSON.stringify(res.items);
+}
+
+describe("mock fallback never fabricates an unrelated meeting/Linear product", () => {
+  it("a review-summary idea (요약, no meeting context) is NOT turned into a 회의록/Linear app", async () => {
+    const res = await generateIdeaToSpecDraft(
+      { idea: "고객 리뷰를 요약해서 한눈에 정리해주는 앱", answers: [] },
+      undefined, // no key → mock fallback
+    );
+    assert.equal(res.source, "mock-fallback");
+    const text = specText(res);
+    assert.ok(!/회의록|Linear/i.test(text), `should not fabricate a meeting/Linear spec, got: ${text.slice(0, 200)}`);
+    // It should echo the actual idea instead.
+    assert.ok(res.productSpec.oneLine.includes("리뷰") || res.productSpec.productName.includes("리뷰"), "should reflect the real idea");
+  });
+
+  it("a meeting-ROOM booking idea (회의 but no 요약/할일) is NOT turned into a 회의록/Linear app", async () => {
+    const res = await generateIdeaToSpecDraft(
+      { idea: "회의실을 예약하고 시간표를 관리하는 앱", answers: [] },
+      undefined,
+    );
+    assert.equal(res.source, "mock-fallback");
+    assert.ok(!/회의록|Linear/i.test(specText(res)), "meeting-room booking must not become meeting-notes");
+  });
+
+  it("a genuine meeting-notes idea (회의 + 요약) still gets the meeting spec (feature preserved)", async () => {
+    const res = await generateIdeaToSpecDraft(
+      { idea: "회의를 녹음하면 요약하고 할 일을 정리해주는 앱", answers: [] },
+      undefined,
+    );
+    assert.equal(res.source, "mock-fallback");
+    assert.ok(/회의|요약/.test(specText(res)), "genuine meeting idea should still produce a meeting-shaped draft");
+  });
+});


### PR DESCRIPTION
감사보고서 BLOCKER 2.1 수정 — 첫 P0.

mock 폴백이 아이디어에 **"요약"이나 "linear" 단어 하나만** 있어도 "회의록→Linear 전송" 스펙을 통째로 날조했습니다("고객 리뷰를 요약"·"회의실 예약"도 회의록 앱이 됨). ok:true로 나가서 유저에 도달.

트리거를 **진짜 회의노트 신호**(회의/미팅/녹음 **AND** 요약/할일/정리/linear)로 좁힘. 나머지는 아이디어를 그대로 반영하는 제네릭 초안. 진짜 회의앱 + answers-reflection 기능/테스트 유지.

회귀 테스트 3개(리뷰요약·회의실예약 → 회의록 아님, 진짜 회의앱 → 유지). 기존 39/39 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)