### PR TITLE
P0 fix(pack): conclave-*-pack → simsa-*-pack rename + honest README (B0-3/B0-6)

### DIFF
--- a/apps/central-plane/src/workspace/export.ts
+++ b/apps/central-plane/src/workspace/export.ts
@@ -164,7 +164,7 @@ function genReadme(
   const lines = [
     `# 만들기 패키지 — ${title}`,
     "",
-    "이 패키지는 Simsa에서 내보낸 제품 설명서와 개발 지시서입니다. 개발 AI에게 프롬프트 하나만 넘기면, 구현부터 서비스 설정·실행 확인·인터넷 배포·접속 주소 전달까지 **한 번에 알아서** 끝냅니다.",
+    "이 패키지는 Simsa에서 내보낸 제품 설명서와 개발 지시서입니다. 개발 AI에게 프롬프트를 넘기면 구현과 실행 확인까지 진행하도록 지시합니다. **인터넷 배포까지 자동으로 이어지려면 개발 AI에 배포 도구(예: Vercel·GitHub의 MCP 또는 CLI)가 연결돼 있어야 하고**, 연결돼 있지 않으면 개발 AI가 배포 방법을 단계별로 안내하는 방식으로 대신합니다.",
     "",
   ];
 
@@ -211,6 +211,11 @@ function genReadme(
     "- 범위를 벗어난 기능은 구현하지 마세요.",
     "- 확인 결과는 제품 설명서 기준의 사전 점검입니다. 실제 코드나 GitHub PR을 확인한 결과가 아닙니다.",
     "- 애매한 점이 있으면 구현 전에 질문하세요.",
+    "",
+    "## 이 패키지가 보장하지 않는 것",
+    "",
+    "- **배포 자동 완료**: 개발 AI에 배포 도구가 연결돼 있지 않으면 배포는 수동 안내로 진행됩니다. 개발 AI의 안내를 따라 마무리해주세요.",
+    "- **결과 검증**: Simsa는 개발 AI가 실제로 무엇을 만들었는지 직접 확인하지 않습니다. 완성되면 배포된 주소(또는 프로젝트 파일)를 Simsa에 다시 넣어 확인받으세요.",
   );
 
   return lines.join("\n");
@@ -492,7 +497,7 @@ const RETURN_TO_SIMSA_GUIDANCE: string = [
 const ONE_SHOT_RUNBOOK: string = [
   "## 이 지시 하나로 끝까지 — 사용자는 개발자가 아니다",
   "",
-  "너는 이 사용자를 대신해 **처음부터 끝까지 한 번에** 진행한다. 목표는 '항목 구현'이 아니라 **실제로 돌아가는, 인터넷에 배포된 앱과 그 접속 주소(URL)를 사용자 손에 쥐여주는 것**이다. 아래 순서를 스스로 끝까지 밟아라. 중간에 개발 절차를 사용자에게 되묻지 말고, 배포된 결과가 나올 때까지 멈추지 마라.",
+  "너는 이 사용자를 대신해 **처음부터 끝까지 한 번에** 진행한다. 목표는 '항목 구현'이 아니라 **실제로 돌아가는, 인터넷에 배포된 앱과 그 접속 주소(URL)를 사용자 손에 쥐여주는 것**이다. 아래 순서를 스스로 끝까지 밟아라. 중간에 개발 절차를 사용자에게 되묻지 말고, 배포된 결과가 나올 때까지 멈추지 마라. 단, **네게 배포·저장소 도구가 연결돼 있지 않아 자동 배포가 불가능하면** 그 사실을 사용자에게 솔직히 알리고 아래 '한 번에 배포'의 대체 절차(수동 안내)로 전환하라 — 되는 척하지 마라.",
   "",
   "1. **이해** — 이 폴더의 파일을 모두 읽는다(`product.md`·`items.md`·`checks.md`·`fixes.md`, 그리고 있으면 `SETUP.md`·`.env.example`).",
   "2. **구현** — 짧은 계획을 세우고, 이번 패키지에 포함된 항목만 구현한다.",
@@ -882,23 +887,23 @@ export function generateBuilderPack(
   // ── Generate files ────────────────────────────────────────────────────────
   const baseFiles: ExportFile[] = [
     {
-      path: "conclave-build-pack/README.md",
+      path: "simsa-build-pack/README.md",
       content: genReadme(title, target, allItems.length, effectiveItems.length) + hookSuffix,
     },
     {
-      path: "conclave-build-pack/product.md",
+      path: "simsa-build-pack/product.md",
       content: genProductMd(productSpec), // always full context
     },
     {
-      path: "conclave-build-pack/items.md",
+      path: "simsa-build-pack/items.md",
       content: genItemsMd(effectiveItems, allItems.length),
     },
     {
-      path: "conclave-build-pack/checks.md",
+      path: "simsa-build-pack/checks.md",
       content: genChecksMd(effectiveCheckResults, allItems.length),
     },
     {
-      path: "conclave-build-pack/fixes.md",
+      path: "simsa-build-pack/fixes.md",
       content: genFixesMd(effectiveItems, effectiveFixSuggestions),
     },
   ];
@@ -907,28 +912,28 @@ export function generateBuilderPack(
   const services = req.services ?? [];
   if (services.length > 0) {
     baseFiles.push({
-      path: "conclave-build-pack/.env.example",
+      path: "simsa-build-pack/.env.example",
       content: genEnvExample(services),
     });
     const envLocal = genEnvLocal(services);
     if (envLocal) {
-      baseFiles.push({ path: "conclave-build-pack/.env.local", content: envLocal });
+      baseFiles.push({ path: "simsa-build-pack/.env.local", content: envLocal });
     }
     baseFiles.push({
-      path: "conclave-build-pack/SETUP.md",
+      path: "simsa-build-pack/SETUP.md",
       content: genSetupMd(services, envLocal !== null),
     });
   }
 
   if (target !== "codex") {
     baseFiles.push({
-      path: "conclave-build-pack/CLAUDE_CODE_PROMPT.md",
+      path: "simsa-build-pack/CLAUDE_CODE_PROMPT.md",
       content: genClaudeCodePrompt(title, effectiveItems, allItems.length, services) + hookSuffix,
     });
   }
   if (target !== "claude_code") {
     baseFiles.push({
-      path: "conclave-build-pack/CODEX_PROMPT.md",
+      path: "simsa-build-pack/CODEX_PROMPT.md",
       content:
         genCodexPrompt(title, productSpec, effectiveItems, allItems.length, effectiveFixSuggestions, services) +
         hookSuffix,

--- a/apps/central-plane/src/workspace/pr-fix-brief.ts
+++ b/apps/central-plane/src/workspace/pr-fix-brief.ts
@@ -494,7 +494,7 @@ export function generatePRFixBrief(req: FixBriefRequest): FixBriefResponse {
     })
     .filter((i) => fixableStatuses().includes(i.status));
 
-  const root = "conclave-pr-fix-pack";
+  const root = "simsa-pr-fix-pack";
   const files: FixBriefFile[] = [];
 
   files.push({ path: `${root}/README.md`, content: genReadme(req.productSpec.productName, req.prMeta, req.repoFullName, req.target, selectedItems.length) });

--- a/apps/central-plane/test/workspace-export.test.mjs
+++ b/apps/central-plane/test/workspace-export.test.mjs
@@ -172,11 +172,28 @@ describe("workspace export-builder-pack", () => {
     assert.ok(fixFile.content.includes("완성 기준을 추가하면 됩니다"), "fix summary not in fixes.md");
   });
 
-  it("all files use conclave-build-pack/ path prefix", () => {
+  it("all files use simsa-build-pack/ path prefix", () => {
     const res = generateBuilderPack(makeReq("both"));
     for (const f of res.bundle.files) {
-      assert.ok(f.path.startsWith("conclave-build-pack/"), `${f.path} does not start with conclave-build-pack/`);
+      assert.ok(f.path.startsWith("simsa-build-pack/"), `${f.path} does not start with simsa-build-pack/`);
     }
+  });
+
+  it("no 'conclave' string anywhere in pack paths or content (Stage 84/85 rename regression)", () => {
+    const res = generateBuilderPack(makeReq("both", { checkResults: MOCK_CHECK_RESULTS, fixSuggestions: MOCK_FIX }));
+    for (const f of res.bundle.files) {
+      assert.ok(!f.path.toLowerCase().includes("conclave"), `old brand in path: ${f.path}`);
+      assert.ok(!f.content.toLowerCase().includes("conclave"), `old brand in content of ${f.path}`);
+    }
+  });
+
+  it("README does not overclaim one-shot deploy and states the deploy-tool condition", () => {
+    const res = generateBuilderPack(makeReq("both"));
+    const readme = res.bundle.files.find((f) => f.path.endsWith("README.md"));
+    assert.ok(readme, "README.md missing");
+    assert.ok(!readme.content.includes("한 번에 알아서"), "overclaim copy still in README");
+    assert.ok(readme.content.includes("배포 도구"), "deploy-tool condition not stated in README");
+    assert.ok(readme.content.includes("보장하지 않는 것"), "honesty section missing in README");
   });
 
   it("no banned developer terms in generated file content", () => {

--- a/apps/central-plane/test/workspace-pr-fix-brief.test.mjs
+++ b/apps/central-plane/test/workspace-pr-fix-brief.test.mjs
@@ -100,11 +100,12 @@ describe("generatePRFixBrief — basic shape", () => {
     assert.ok(paths.some((p) => p.includes("CODEX_FIX_PROMPT.md")));
   });
 
-  it("all files are under conclave-pr-fix-pack/ root", () => {
+  it("all files are under simsa-pr-fix-pack/ root", () => {
     const res = generatePRFixBrief(buildReq());
     assert.ok(res.ok);
     for (const f of res.brief.files) {
-      assert.ok(f.path.startsWith("conclave-pr-fix-pack/"), `unexpected path: ${f.path}`);
+      assert.ok(f.path.startsWith("simsa-pr-fix-pack/"), `unexpected path: ${f.path}`);
+      assert.ok(!f.path.toLowerCase().includes("conclave"), `old brand in path: ${f.path}`);
     }
   });
 });

--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -101,7 +101,7 @@ function downloadMarkdownBundle(files: ExportFile[], projectTitle: string): void
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `conclave-build-pack-${projectTitle.replace(/[^a-zA-Z0-9가-힣]/g, "-").slice(0, 40)}.md`;
+  a.download = `simsa-build-pack-${projectTitle.replace(/[^a-zA-Z0-9가-힣]/g, "-").slice(0, 40)}.md`;
   a.click();
   URL.revokeObjectURL(url);
 }

--- a/apps/dashboard/src/lib/zip-utils.ts
+++ b/apps/dashboard/src/lib/zip-utils.ts
@@ -9,7 +9,7 @@ import type { ExportFile } from "./workspace-export-api";
 
 /**
  * Generate a zip Blob from the export bundle files.
- * File paths are used as-is within the zip (includes the conclave-build-pack/ prefix).
+ * File paths are used as-is within the zip (includes the simsa-build-pack/ prefix).
  */
 export async function buildPackToZip(files: ExportFile[]): Promise<Blob> {
   const JSZip = (await import("jszip")).default;
@@ -26,7 +26,7 @@ export async function downloadBuildPackZip(files: ExportFile[], projectTitle: st
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `conclave-build-pack.zip`;
+  a.download = `simsa-build-pack.zip`;
   a.click();
   URL.revokeObjectURL(url);
 }

--- a/apps/dashboard/test/pack-bundle.test.mjs
+++ b/apps/dashboard/test/pack-bundle.test.mjs
@@ -10,10 +10,10 @@ import { isSecretFile, filesForTextBundle, hasSecretFiles } from "../src/lib/pac
 const SECRET = "SUPABASE_SERVICE_ROLE_KEY=eyJZQX-REAL-SECRET-do-not-leak-42";
 
 const PACK = [
-  { path: "conclave-build-pack/README.md", content: "readme" },
-  { path: "conclave-build-pack/.env.example", content: "SUPABASE_SERVICE_ROLE_KEY=" }, // placeholder → safe
-  { path: "conclave-build-pack/.env.local", content: `# secrets\n${SECRET}\n` },
-  { path: "conclave-build-pack/CLAUDE_CODE_PROMPT.md", content: "prompt" },
+  { path: "simsa-build-pack/README.md", content: "readme" },
+  { path: "simsa-build-pack/.env.example", content: "SUPABASE_SERVICE_ROLE_KEY=" }, // placeholder → safe
+  { path: "simsa-build-pack/.env.local", content: `# secrets\n${SECRET}\n` },
+  { path: "simsa-build-pack/CLAUDE_CODE_PROMPT.md", content: "prompt" },
 ];
 
 describe("pack text bundles never contain the real .env.local secret", () => {


### PR DESCRIPTION
## P0 (Group A): 팩 브랜드 rename + README 정직화 — 감사 v2 B0-3 · B0-6

한 PR인 이유: 두 P0가 같은 파일(`export.ts`·`zip-utils.ts`·`export/page.tsx`)을 만짐 (핸드오프 #301 Group A).

### 바뀐 것
- **rename (P0-clarity, Stage 84/85 파일명 miss의 후속):**
  - 팩 내부 폴더 prefix `conclave-build-pack/` → `simsa-build-pack/` (export.ts 9곳)
  - PR fix 팩 루트 `conclave-pr-fix-pack` → `simsa-pr-fix-pack`
  - 다운로드 파일명 `conclave-build-pack.zip` → `simsa-build-pack.zip`, `.md` 번들 → `simsa-build-pack-<제목>.md`
- **README 정직화 (P0-honesty, 감사 4.1 BLOCKER):**
  - "한 번에 알아서 끝냅니다" 폐기 → 배포 도구(MCP/CLI) 연결 조건 명시 + 미연결 시 수동 안내로 대체됨을 고지
  - "이 패키지가 보장하지 않는 것" 섹션 신설 (배포 자동 완료 X · Simsa가 결과 직접 확인 X)
  - ONE_SHOT_RUNBOOK에 "자동 배포 불가 시 솔직히 알리고 수동 안내로 전환 — 되는 척 금지" 추가
- **회귀 테스트:** 팩 path/content 어디에도 `conclave` 문자열 금지 + README 정직 카피 pin (문자열 grep과 파일명 grep 둘 다)

### 수동 검증 체크리스트 (실행 완료)
- [x] dist에서 **실제 팩 생성** → 10개 파일 전부 `simsa-build-pack/` prefix, ZIP 파일명 `simsa-build-pack.zip`
- [x] 생성물 전체 `grep -i conclave` → **0건** (path + content)
- [x] 생성된 README **육안 확인** — "한 번에 알아서" 없음, 배포 도구 조건 명시, "보장하지 않는 것" 섹션 존재
- [x] `git grep "conclave-build-pack|conclave-pr-fix"` → 코드 0건 (남은 2건은 `packages/mcp-workspace/README.md`의 내부 stage-docs 폴더 참조 = 대상 아님)
- [x] 테스트: central-plane 1642 pass · dashboard 507 pass · pre-push `pnpm verify` 통과
- [ ] (사람 확인) 배포 후 실제 브라우저에서 export → ZIP 다운로드 파일명 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
