### PR TITLE
P0 fix(honesty): verify-against-user-words gate + C2 answers reach productSpec

### DIFF
--- a/apps/central-plane/src/workspace/generate.ts
+++ b/apps/central-plane/src/workspace/generate.ts
@@ -4,6 +4,7 @@
  * so the user-facing flow never breaks.
  */
 import { anthropicMessages, anthropicEndpoint } from "./anthropic-fetch.js";
+import { verifySpecAgainstUserWords, type SpecVerification } from "./verify-spec.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -55,6 +56,10 @@ export type IdeaToSpecDraftResponse = {
   productSpec: ProductSpec;
   items: RequirementItem[];
   warnings?: string[];
+  /** Deterministic verify-against-user-words result (audit v2 P0-honesty).
+   *  Present on every successful draft; ok:false means the draft did not
+   *  reflect enough of the user's own words and a loud warning was attached. */
+  specVerification?: SpecVerification;
 };
 
 // ─── Prompt ───────────────────────────────────────────────────────────────────
@@ -267,6 +272,16 @@ function extractAnswerFlags(answers: IdeaToSpecDraftRequest["answers"]): {
   };
 }
 
+/** Everything the user actually typed — the reference text for the gate. */
+function userWordsOf(req: IdeaToSpecDraftRequest): string {
+  return [req.idea, ...(req.answers ?? []).map((a) => a.answer)].join(" ");
+}
+
+/** The draft surfaces the gate inspects (title/spec/flow/items — what the user reads). */
+function gateDraftOf(res: IdeaToSpecDraftResponse): unknown {
+  return { understood: res.understood, productSpec: res.productSpec, items: res.items };
+}
+
 function buildMockFallback(req: IdeaToSpecDraftRequest): IdeaToSpecDraftResponse {
   const isMeeting = /회의|녹음|요약|linear|미팅/i.test(req.idea);
   const flags = extractAnswerFlags(req.answers);
@@ -302,7 +317,7 @@ function buildMockFallback(req: IdeaToSpecDraftRequest): IdeaToSpecDraftResponse
           ],
         };
 
-    return {
+    const meetingDraft: IdeaToSpecDraftResponse = {
       ok: true,
       source: "mock-fallback",
       understood: {
@@ -382,6 +397,16 @@ function buildMockFallback(req: IdeaToSpecDraftRequest): IdeaToSpecDraftResponse
       ],
       warnings: hasAnswers ? undefined : ["임시 초안입니다. 다시 시도하면 더 맞춤형 결과를 받을 수 있습니다."],
     };
+
+    // Verify-against-user-words gate (P0-honesty): the canned meeting draft is
+    // only allowed out when it actually reflects the user's own words. A common
+    // word alone ("요약" in "리뷰를 요약해줘") must NOT produce an unrelated
+    // meeting-notes product — fall through to the generic draft, which quotes
+    // the user's idea verbatim and fabricates nothing.
+    const meetingGate = verifySpecAgainstUserWords(userWordsOf(req), gateDraftOf(meetingDraft));
+    if (meetingGate.ok) {
+      return { ...meetingDraft, specVerification: meetingGate };
+    }
   }
 
   const shortIdea = req.idea.slice(0, 30).trim();
@@ -515,6 +540,32 @@ function buildMockFallback(req: IdeaToSpecDraftRequest): IdeaToSpecDraftResponse
 
 // ─── Main entry ───────────────────────────────────────────────────────────────
 
+/** Loud, non-silent notice attached whenever a draft fails the user-words gate. */
+function coverageWarning(v: SpecVerification, locale?: "ko" | "en"): string {
+  const pct = Math.round(v.coverage * 100);
+  const missing = v.missingWords.slice(0, 8).join(", ");
+  return locale === "en"
+    ? `This draft may not reflect what you typed — only ${pct}% of your words appear in it. Not reflected: ${missing}. Please review the draft carefully or try again.`
+    : `초안이 입력하신 내용을 충분히 반영하지 못했을 수 있어요 (입력하신 단어의 ${pct}%만 반영됨). 반영되지 않은 단어: ${missing}. 초안을 그대로 믿지 마시고 내용을 확인하거나 다시 시도해주세요.`;
+}
+
+/** Attach the gate result (and a loud warning on failure) to a finished draft. */
+function withVerification(
+  req: IdeaToSpecDraftRequest,
+  res: IdeaToSpecDraftResponse,
+): IdeaToSpecDraftResponse {
+  const v = res.specVerification ?? verifySpecAgainstUserWords(userWordsOf(req), gateDraftOf(res));
+  if (v.ok) return { ...res, specVerification: v };
+  console.warn(
+    `[workspace/generate] user-words gate failed: source=${res.source} coverage=${v.coverage.toFixed(2)} missing=${v.missingWords.slice(0, 8).join("|")}`,
+  );
+  return {
+    ...res,
+    specVerification: v,
+    warnings: [...(res.warnings ?? []), coverageWarning(v, req.locale)],
+  };
+}
+
 export async function generateIdeaToSpecDraft(
   req: IdeaToSpecDraftRequest,
   anthropicApiKey: string | undefined,
@@ -525,7 +576,7 @@ export async function generateIdeaToSpecDraft(
   }
   if (!anthropicApiKey) {
     console.warn("[workspace/generate] ANTHROPIC_API_KEY not set — using mock fallback");
-    return buildMockFallback(req);
+    return withVerification(req, buildMockFallback(req));
   }
 
   const prompt = buildPrompt(req);
@@ -563,5 +614,8 @@ export async function generateIdeaToSpecDraft(
   const data = parsed as Omit<IdeaToSpecDraftResponse, "ok" | "source">;
   data.items = data.items.map((item) => ({ ...item, status: "not_started" as const }));
 
-  return { ok: true, source: "llm", ...data };
+  // The LLM can fabricate too — same deterministic gate as the mock path.
+  // On failure the draft still ships, but with a loud "not reflected: …"
+  // warning (never a silent rejection, never silent fabrication).
+  return withVerification(req, { ok: true, source: "llm", ...data });
 }

--- a/apps/central-plane/src/workspace/verify-spec.ts
+++ b/apps/central-plane/src/workspace/verify-spec.ts
@@ -1,0 +1,121 @@
+/**
+ * workspace/verify-spec.ts
+ *
+ * Deterministic verify-against-user-words gate (audit v2 P0-honesty).
+ *
+ * The generation pipeline (mock OR LLM — both can fabricate) must produce a
+ * spec that actually reflects the user's own words. This is a pure, LLM-free
+ * check: take the content words of the user's idea (+ answers) and measure
+ * what fraction of them appear anywhere in the generated draft. A draft that
+ * misses most of the user's words is an unrelated product, not their product.
+ *
+ * Korean is agglutinative, so tokens are stemmed by stripping common particle
+ * and verb-ending suffixes (조사/어미) before matching. Matching is substring
+ * over the JSON-serialised draft, so "요약" matches "요약해서 보여줌".
+ */
+
+export type SpecVerification = {
+  /** true = the draft reflects enough of the user's words to trust. */
+  ok: boolean;
+  /** matched / total content words, 0..1. 1 when there are too few words to judge. */
+  coverage: number;
+  totalWords: number;
+  matchedWords: string[];
+  /** The user's words the draft never mentions — shown to the user on failure
+   *  so a rejection is never silent. */
+  missingWords: string[];
+};
+
+/** Minimum fraction of the user's content words the draft must contain. */
+export const MIN_USER_WORD_COVERAGE = 0.6;
+
+/** Generic words that carry no product meaning — never count them. */
+const STOPWORDS = new Set([
+  // Korean generic
+  "앱", "어플", "애플리케이션", "서비스", "웹", "웹사이트", "사이트", "홈페이지",
+  "프로그램", "플랫폼", "기능", "제품", "버전", "사용자", "유저",
+  "만들", "만드", "제작", "개발", "필요", "원해", "원합니다", "싶", "주세요",
+  "그리고", "그래서", "또는", "혹은", "같은", "위한", "통해", "있는", "없는",
+  "하는", "되는", "수", "것", "거", "게", "때", "등", "더", "잘", "좀",
+  "한다", "하다", "된다", "되다", "있다", "없다", "해준다", "해줘", "해요",
+  // English generic
+  "app", "apps", "application", "service", "web", "website", "site", "page",
+  "program", "platform", "feature", "features", "product", "version", "user", "users",
+  "make", "makes", "making", "build", "builds", "building", "create", "creating",
+  "want", "wants", "need", "needs", "would", "like", "please",
+  "a", "an", "the", "to", "for", "of", "in", "on", "with", "and", "or", "that",
+  "this", "it", "is", "are", "be", "can", "i", "my", "me", "we", "our", "you",
+]);
+
+/** Korean particles / verb endings stripped (longest first) to get a stem. */
+const KO_SUFFIXES = [
+  "하고싶어요", "하고싶어", "해주세요", "했으면", "싶어요", "입니다", "이에요",
+  "해주는", "해줘", "해요", "하는", "해서", "하기", "하면", "하고", "하며",
+  "해도", "해야", "한다", "하다", "합니다", "해주", "해",
+  "되는", "된다", "되다", "돼요", "면서", "다는", "주는", "아서", "어서",
+  "들이", "들을", "들은", "들의", "에서", "에게", "으로", "라는", "이라는",
+  "까지", "부터", "처럼", "마다", "이나", "든지",
+  "을", "를", "이", "가", "은", "는", "에", "로", "와", "과", "랑", "도",
+  "의", "만", "요", "들", "고", "서", "며", "면", "야", "지", "게", "다",
+].sort((a, b) => b.length - a.length);
+
+function stemToken(raw: string): string {
+  let t = raw;
+  let changed = true;
+  while (changed && t.length > 2) {
+    changed = false;
+    for (const suf of KO_SUFFIXES) {
+      if (t.length - suf.length >= 2 && t.endsWith(suf)) {
+        t = t.slice(0, t.length - suf.length);
+        changed = true;
+        break;
+      }
+    }
+  }
+  // English plural: "reviews" should match a draft that says "review".
+  if (/^[a-z]+s$/.test(t) && t.length > 3) t = t.slice(0, -1);
+  return t;
+}
+
+/** Extract deduplicated, stemmed content words from user text. Pure. */
+export function contentWords(text: string): string[] {
+  const tokens = text
+    .toLowerCase()
+    .split(/[\s.,!?;:"'“”‘’()\[\]{}<>/\\|@#$%^&*+=~`_—–-]+/)
+    .filter(Boolean);
+  const out: string[] = [];
+  for (const raw of tokens) {
+    if (STOPWORDS.has(raw)) continue;
+    const stem = stemToken(raw);
+    if (stem.length < 2) continue;
+    if (STOPWORDS.has(stem)) continue;
+    if (!out.includes(stem)) out.push(stem);
+  }
+  return out;
+}
+
+/**
+ * Measure how much of the user's own words the generated draft reflects. Pure
+ * and deterministic — applies equally to mock and LLM output.
+ *
+ * `draft` is anything JSON-serialisable (productSpec + understood + items).
+ * With fewer than 2 content words there is not enough signal to judge, so the
+ * gate passes (never block a one-word idea on a heuristic).
+ */
+export function verifySpecAgainstUserWords(userText: string, draft: unknown): SpecVerification {
+  const words = contentWords(userText);
+  if (words.length < 2) {
+    return { ok: true, coverage: 1, totalWords: words.length, matchedWords: words, missingWords: [] };
+  }
+  const hay = JSON.stringify(draft).toLowerCase();
+  const matchedWords = words.filter((w) => hay.includes(w));
+  const missingWords = words.filter((w) => !hay.includes(w));
+  const coverage = matchedWords.length / words.length;
+  return {
+    ok: coverage >= MIN_USER_WORD_COVERAGE,
+    coverage,
+    totalWords: words.length,
+    matchedWords,
+    missingWords,
+  };
+}

--- a/apps/central-plane/test/workspace-verify-spec.test.mjs
+++ b/apps/central-plane/test/workspace-verify-spec.test.mjs
@@ -1,0 +1,94 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// P0-honesty (audit v2): deterministic verify-against-user-words gate.
+// The generated draft (mock OR LLM) must reflect the user's own words —
+// a common word alone ("요약") must not fabricate an unrelated product.
+
+const { contentWords, verifySpecAgainstUserWords, MIN_USER_WORD_COVERAGE } =
+  await import("../dist/workspace/verify-spec.js");
+const { generateIdeaToSpecDraft } = await import("../dist/workspace/generate.js");
+
+describe("contentWords", () => {
+  it("stems Korean particles and verb endings", () => {
+    assert.deepEqual(contentWords("리뷰를 요약해줘"), ["리뷰", "요약"]);
+    assert.deepEqual(contentWords("linear에 보내는 앱"), ["linear", "보내"]);
+  });
+
+  it("drops stopwords and short fragments", () => {
+    // 앱/서비스/만들… carry no product meaning. Single-syllable ending strip is
+    // aggressive ("강아지" → "강아") — safe because matching is substring-based.
+    assert.deepEqual(contentWords("강아지 산책 앱 서비스"), ["강아", "산책"]);
+  });
+
+  it("dedupes and lowercases (English plural stem)", () => {
+    assert.deepEqual(contentWords("Reviews reviews REVIEW"), ["review"]);
+  });
+});
+
+describe("verifySpecAgainstUserWords", () => {
+  it("fails when the draft misses most of the user's words, and names them", () => {
+    const draft = { productSpec: { oneLine: "회의를 녹음하면 요약이 정리됩니다" } };
+    const v = verifySpecAgainstUserWords("리뷰를 요약해줘", draft);
+    assert.equal(v.ok, false, "half coverage must fail the gate");
+    assert.ok(v.coverage < MIN_USER_WORD_COVERAGE);
+    assert.deepEqual(v.missingWords, ["리뷰"], "rejection must say WHAT was missing (no silent gate)");
+    assert.deepEqual(v.matchedWords, ["요약"]);
+  });
+
+  it("passes when the draft reflects the user's words", () => {
+    const draft = { productSpec: { oneLine: "리뷰를 모아 요약해서 보여주는 앱" } };
+    const v = verifySpecAgainstUserWords("리뷰를 요약해줘", draft);
+    assert.equal(v.ok, true);
+    assert.equal(v.coverage, 1);
+  });
+
+  it("passes trivially when there is too little signal (single word)", () => {
+    const v = verifySpecAgainstUserWords("앱 요약", { productSpec: {} });
+    assert.equal(v.ok, true, "one content word is not enough to judge — never block on it");
+  });
+});
+
+describe("generate mock path behind the gate (no API key)", () => {
+  it('"리뷰를 요약해줘" must NOT fabricate the meeting-notes app', async () => {
+    const res = await generateIdeaToSpecDraft({ idea: "리뷰를 요약해줘", locale: "ko" }, undefined);
+    assert.equal(res.ok, true);
+    assert.notEqual(res.productSpec.productName, "회의록 자동 요약 앱", "fabricated meeting app leaked out");
+    assert.ok(
+      JSON.stringify(res.productSpec).includes("리뷰"),
+      "the draft must reflect the user's own words",
+    );
+    assert.ok(res.specVerification, "verification result must be attached");
+  });
+
+  it('a real meeting idea still gets the tailored meeting draft', async () => {
+    const res = await generateIdeaToSpecDraft(
+      { idea: "회의 내용을 요약해서 할 일을 linear로 보내는 앱", locale: "ko" },
+      undefined,
+    );
+    assert.equal(res.ok, true);
+    assert.equal(res.productSpec.productName, "회의록 자동 요약 앱");
+    assert.equal(res.specVerification?.ok, true);
+  });
+
+  it('"linear에 보내는 앱" passes — the user named linear themselves (not fabrication)', async () => {
+    const res = await generateIdeaToSpecDraft({ idea: "linear에 보내는 앱", locale: "ko" }, undefined);
+    assert.equal(res.ok, true);
+    assert.equal(res.specVerification?.ok, true);
+  });
+
+  it("a low-coverage draft ships with a loud warning, never silently", async () => {
+    // 30 unique pseudo-words (~135 chars) — the generic fallback only embeds the
+    // first 60 chars of the idea, so coverage lands well under the threshold.
+    const idea = Array.from({ length: 30 }, (_, i) => `단어${i}`).join(" ");
+    const res = await generateIdeaToSpecDraft({ idea, locale: "ko" }, undefined);
+    assert.equal(res.ok, true);
+    assert.equal(res.specVerification?.ok, false);
+    const warningText = (res.warnings ?? []).join(" ");
+    assert.ok(warningText.includes("반영되지"), "user must be told the draft may not reflect their words");
+    // The warning names the missing words (capped at 8) — never a silent gate.
+    const firstMissing = res.specVerification.missingWords[0];
+    assert.ok(firstMissing, "missingWords must be populated");
+    assert.ok(warningText.includes(firstMissing), "the missing words must be named (no silent rejection)");
+  });
+});

--- a/apps/dashboard/src/app/projects/[id]/spec/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/spec/page.tsx
@@ -15,6 +15,7 @@ import {
   markProjectSyncFailed,
 } from "@/lib/workflow-store";
 import type { WorkspaceProductSpec } from "@/lib/workspace-types";
+import { applyResolvedDecision } from "@/lib/spec-decisions.mjs";
 import { saveProjectToDb } from "@/lib/workspace-check-api";
 import { SpecCompleteness } from "@/components/SpecCompleteness";
 import { OpenQuestionCard } from "@/components/OpenQuestionCard";
@@ -46,13 +47,54 @@ export default function SpecPage() {
   const [dExcluded, setDExcluded] = useState<string[]>([]);
 
   function resolveOpenDecision(question: string, answer: string) {
-    setResolved((prev) => {
-      const next = { ...prev };
-      if (answer) next[question] = answer;
-      else delete next[question];
-      saveExtendedProjectData(id, { resolvedOpenDecisions: next });
-      return next;
-    });
+    if (!project) return;
+    const next = { ...resolved };
+    if (answer) next[question] = answer;
+    else delete next[question];
+
+    // C2 → productSpec merge (P0-honesty, audit 2.3): the answer must reach the
+    // productSpec that checks/export/builder-pack actually read — the answered
+    // question moves out of openQuestions and into decisions as "질문 — 답".
+    // Un-answering reverses it. resolvedOpenDecisions stays as the UI's record
+    // of which card was answered.
+    const ext = loadExtendedProjectData(id);
+    const base: WorkspaceProductSpec = ext?.productSpec ?? {
+      productName: project.name,
+      oneLine: project.spec.goal,
+      targetUsers: [],
+      problem: "",
+      included: project.spec.included,
+      excluded: project.spec.excluded,
+      userFlow: [],
+      decisions: [],
+      openQuestions: project.spec.openDecisions ?? [],
+    };
+    const nextProductSpec = applyResolvedDecision(base, question, answer);
+    saveExtendedProjectData(id, { resolvedOpenDecisions: next, productSpec: nextProductSpec });
+
+    // Best-effort server sync (sticky upsert) so a DB-side export sees the
+    // merged spec too — same pattern as saveSpec below.
+    saveProjectToDb({
+      id,
+      userKey: getUserKey(),
+      title: project.name,
+      idea: project.description ?? "",
+      understood: {},
+      productSpec: nextProductSpec,
+      items: project.requirements.map((r) => ({
+        id: r.id,
+        title: r.title,
+        status: r.status,
+        criteria: ext?.itemCriteria?.[r.id] ?? [],
+        note: ext?.itemNotes?.[r.id] || undefined,
+      })),
+    })
+      .then((res) => {
+        if (!res || res.ok !== true) markProjectSyncFailed(id);
+      })
+      .catch(() => markProjectSyncFailed(id));
+
+    setResolved(next);
   }
 
   if (!project) return <ProjectNotFound />;

--- a/apps/dashboard/src/lib/spec-decisions.d.mts
+++ b/apps/dashboard/src/lib/spec-decisions.d.mts
@@ -1,0 +1,12 @@
+import type { WorkspaceProductSpec } from "./workspace-types";
+
+export function decisionLine(question: string, answer: string): string;
+export function applyResolvedDecision(
+  productSpec: WorkspaceProductSpec,
+  question: string,
+  answer: string,
+): WorkspaceProductSpec;
+export function applyAllResolvedDecisions(
+  productSpec: WorkspaceProductSpec,
+  resolved: Record<string, string> | undefined,
+): WorkspaceProductSpec;

--- a/apps/dashboard/src/lib/spec-decisions.mjs
+++ b/apps/dashboard/src/lib/spec-decisions.mjs
@@ -1,0 +1,60 @@
+/**
+ * spec-decisions.mjs — C2 answers → productSpec merge (audit v2 P0-honesty 2.3).
+ *
+ * When the user answers an open question (C2 card), the answer must reach the
+ * productSpec that checks/export/builder-pack actually read — not just the
+ * extended `resolvedOpenDecisions` side-channel. These pure functions produce
+ * the next productSpec: the answered question moves out of `openQuestions` and
+ * into `decisions` as "질문 — 답". Un-answering reverses it.
+ *
+ * Plain .mjs + .d.mts so node --test can import it without TS stripping.
+ */
+
+/** Marker format for a decision line derived from an answered open question. */
+export function decisionLine(question, answer) {
+  return `${question} — ${answer}`;
+}
+
+function isDecisionFor(entry, question) {
+  return typeof entry === "string" && entry.startsWith(`${question} — `);
+}
+
+/**
+ * Merge one resolved open question into a productSpec (immutably).
+ *
+ * - answer non-empty: remove the question from `openQuestions`, upsert the
+ *   "question — answer" line into `decisions` (replacing a previous answer
+ *   for the same question).
+ * - answer empty ("답 취소"): remove the decision line and put the question
+ *   back into `openQuestions` (if not already there).
+ */
+export function applyResolvedDecision(productSpec, question, answer) {
+  const decisions = Array.isArray(productSpec.decisions) ? productSpec.decisions : [];
+  const openQuestions = Array.isArray(productSpec.openQuestions) ? productSpec.openQuestions : [];
+  const q = (question ?? "").trim();
+  const a = (answer ?? "").trim();
+  if (!q) return productSpec;
+
+  if (a) {
+    const kept = decisions.filter((d) => !isDecisionFor(d, q));
+    return {
+      ...productSpec,
+      decisions: [...kept, decisionLine(q, a)],
+      openQuestions: openQuestions.filter((o) => o !== q),
+    };
+  }
+  return {
+    ...productSpec,
+    decisions: decisions.filter((d) => !isDecisionFor(d, q)),
+    openQuestions: openQuestions.includes(q) ? openQuestions : [...openQuestions, q],
+  };
+}
+
+/** Apply a whole {question: answer} map (e.g. re-sync after hydration). */
+export function applyAllResolvedDecisions(productSpec, resolved) {
+  let next = productSpec;
+  for (const [question, answer] of Object.entries(resolved ?? {})) {
+    next = applyResolvedDecision(next, question, answer);
+  }
+  return next;
+}

--- a/apps/dashboard/test/spec-decisions.test.mjs
+++ b/apps/dashboard/test/spec-decisions.test.mjs
@@ -1,0 +1,73 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  decisionLine,
+  applyResolvedDecision,
+  applyAllResolvedDecisions,
+} from "../src/lib/spec-decisions.mjs";
+
+// P0-honesty (audit v2 2.3): a C2 answer must reach the productSpec that
+// checks/export/builder-pack read — decisions gains "질문 — 답" and the
+// question leaves openQuestions. Previously the answer was stored only in
+// resolvedOpenDecisions and silently never reached the builder.
+
+const SPEC = {
+  productName: "동네 러닝 모임",
+  oneLine: "동네 러닝 모임 앱",
+  targetUsers: [],
+  problem: "",
+  included: [],
+  excluded: [],
+  userFlow: [],
+  decisions: ["로그인은 이메일만"],
+  openQuestions: ["모임 정원 제한?", "지도 표시 방식?"],
+};
+
+describe("applyResolvedDecision", () => {
+  it("answer moves the question into decisions and out of openQuestions", () => {
+    const next = applyResolvedDecision(SPEC, "모임 정원 제한?", "10명까지");
+    assert.deepEqual(next.openQuestions, ["지도 표시 방식?"]);
+    assert.deepEqual(next.decisions, ["로그인은 이메일만", decisionLine("모임 정원 제한?", "10명까지")]);
+    // immutable — the original is untouched
+    assert.deepEqual(SPEC.openQuestions, ["모임 정원 제한?", "지도 표시 방식?"]);
+  });
+
+  it("re-answering replaces the previous decision line (no duplicates)", () => {
+    const once = applyResolvedDecision(SPEC, "모임 정원 제한?", "10명까지");
+    const twice = applyResolvedDecision(once, "모임 정원 제한?", "20명까지");
+    assert.deepEqual(twice.decisions, ["로그인은 이메일만", "모임 정원 제한? — 20명까지"]);
+    assert.equal(twice.decisions.filter((d) => d.startsWith("모임 정원 제한?")).length, 1);
+  });
+
+  it("empty answer (취소) restores the question and removes the decision", () => {
+    const answered = applyResolvedDecision(SPEC, "모임 정원 제한?", "10명까지");
+    const restored = applyResolvedDecision(answered, "모임 정원 제한?", "");
+    assert.deepEqual(restored.decisions, ["로그인은 이메일만"]);
+    assert.ok(restored.openQuestions.includes("모임 정원 제한?"));
+    assert.equal(restored.openQuestions.filter((q) => q === "모임 정원 제한?").length, 1);
+  });
+
+  it("pre-existing unrelated decisions are never touched", () => {
+    const next = applyResolvedDecision(SPEC, "지도 표시 방식?", "목록만");
+    assert.ok(next.decisions.includes("로그인은 이메일만"));
+  });
+
+  it("blank question is a no-op", () => {
+    assert.equal(applyResolvedDecision(SPEC, "  ", "답"), SPEC);
+  });
+});
+
+describe("applyAllResolvedDecisions", () => {
+  it("applies a whole resolved map", () => {
+    const next = applyAllResolvedDecisions(SPEC, {
+      "모임 정원 제한?": "10명까지",
+      "지도 표시 방식?": "목록만",
+    });
+    assert.deepEqual(next.openQuestions, []);
+    assert.equal(next.decisions.length, 3);
+  });
+
+  it("handles undefined map", () => {
+    assert.deepEqual(applyAllResolvedDecisions(SPEC, undefined), SPEC);
+  });
+});


### PR DESCRIPTION
## P0 (Group B): verify-against-user-words 게이트 + C2 답 → productSpec 병합 — 감사 v2 P0-honesty · 2.3

### 바뀐 것
**verify 게이트 (central-plane):**
- 새 `workspace/verify-spec.ts` — 순수·결정론 함수. 사용자 원문(아이디어+답변)의 content 단어(한국어 조사/어미 어간화)가 생성 초안에 **60% 이상** 등장해야 통과. mock/LLM **무관하게** 적용 (#298의 트리거 좁히기보다 근본 — LLM도 날조하므로).
- mock 경로: 회의록 canned 초안은 게이트 통과 시에만 나감. "리뷰를 요약해줘" → 무관한 회의록 앱 대신 **사용자 아이디어를 그대로 인용하는 generic 초안**으로 강등.
- LLM 경로: 게이트 실패 시 **반영되지 않은 단어를 명시한 경고**를 붙여 전달 (침묵 rejection 금지, 침묵 날조도 금지). 모든 초안에 `specVerification` 첨부(추후 UI/관측 활용 가능).

**C2 병합 (dashboard):**
- 새 `lib/spec-decisions.mjs` — 답한 openQuestion이 `openQuestions`에서 빠지고 `decisions`에 "질문 — 답"으로 upsert (답 취소 시 원복). 순수 함수.
- `spec/page.tsx` `resolveOpenDecision`이 이제 checks/export/빌더팩이 읽는 **extended productSpec에 병합**하고 서버에도 best-effort 동기화. (기존: `resolvedOpenDecisions` 사이드채널에만 저장 → 빌더에 영영 도달 안 함.)

### 수동 검증 체크리스트 (실행 완료)
- [x] "리뷰를 요약해줘" 입력 → 회의록 앱 날조 **안 됨** (generic 초안, "리뷰" 반영) — 테스트로 pin
- [x] "회의 내용을 요약해서 할 일을 linear로 보내는 앱" → 회의록 맞춤 초안 정상 통과
- [x] "linear에 보내는 앱" → 사용자가 linear를 직접 명시했으므로 통과 (날조 아님)
- [x] 게이트 실패 시 경고에 **반영 안 된 단어가 명명됨** (침묵 rejection 없음) — 테스트로 pin
- [x] C2 답 → 실제 export 팩 `product.md`의 "결정된 사항"에 "질문 — 답" 등장 + "아직 결정이 필요한 사항"에서 제거 (dist 아티팩트 검증 실행)
- [x] 테스트: central-plane 1652 pass · dashboard 514 pass · pre-push `pnpm verify` 통과
- [ ] (배포 후) LLM 경로(키 있는 프로덕션)에서 스모크 — 배포 단계에서 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
