### PR TITLE
obs(llm): per-call usage log (4 fields + model/call_site/latency_ms) — caching deferred by ADR

### DIFF
--- a/apps/central-plane/src/workspace/anthropic-fetch.ts
+++ b/apps/central-plane/src/workspace/anthropic-fetch.ts
@@ -21,7 +21,44 @@ export type AnthropicMessagesBody = {
 export type AnthropicMessagesData = {
   content?: Array<{ type: string; text?: string }>;
   stop_reason?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
 };
+
+/**
+ * One structured JSON line per successful LLM call — the minimal cost/usage
+ * observability layer (2026-07-08 ADR: prompt caching deferred; these fields
+ * are the evidence base for re-evaluating it, and tomorrow's Langfuse wiring
+ * ingests this exact shape). Never throws: observability must not break the
+ * user-facing call.
+ */
+export function logAnthropicUsage(
+  callSite: string,
+  model: string,
+  usage: AnthropicMessagesData["usage"],
+  latencyMs: number,
+): void {
+  try {
+    console.log(
+      JSON.stringify({
+        event: "anthropic_usage",
+        call_site: callSite,
+        model,
+        input_tokens: usage?.input_tokens ?? 0,
+        output_tokens: usage?.output_tokens ?? 0,
+        cache_creation_input_tokens: usage?.cache_creation_input_tokens ?? 0,
+        cache_read_input_tokens: usage?.cache_read_input_tokens ?? 0,
+        latency_ms: latencyMs,
+      }),
+    );
+  } catch {
+    // never let logging break the call
+  }
+}
 
 /** POST /v1/messages with bounded retries. Throws on final failure. */
 export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
@@ -43,8 +80,11 @@ export async function anthropicMessages(
   timeoutMs: number,
   fetchImpl: FetchLike = fetch.bind(globalThis) as FetchLike,
   endpoint: string = anthropicEndpoint(),
+  /** Which workspace feature made this call (generate·check·fix·pr-review·recommend). */
+  callSite = "unknown",
 ): Promise<AnthropicMessagesData> {
   let lastErr: unknown = null;
+  const startedAt = Date.now();
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
@@ -68,7 +108,12 @@ export async function anthropicMessages(
       clearTimeout(timer);
     }
     if (resp) {
-      if (resp.ok) return (await resp.json()) as AnthropicMessagesData;
+      if (resp.ok) {
+        const data = (await resp.json()) as AnthropicMessagesData;
+        // latency_ms is wall time including retries — what the user waited.
+        logAnthropicUsage(callSite, body.model, data.usage, Date.now() - startedAt);
+        return data;
+      }
       const tail = await resp.text().catch(() => "");
       lastErr = new Error(`Anthropic ${resp.status}: ${tail.slice(0, 200)}`);
       if (!RETRYABLE.has(resp.status)) throw lastErr;

--- a/apps/central-plane/src/workspace/check.ts
+++ b/apps/central-plane/src/workspace/check.ts
@@ -164,6 +164,7 @@ async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | u
     timeoutMs,
     undefined,
     anthropicEndpoint(baseUrl),
+    "check",
   )) as { content?: Array<{ type: string; text?: string }> };
   return (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
 }

--- a/apps/central-plane/src/workspace/fix.ts
+++ b/apps/central-plane/src/workspace/fix.ts
@@ -108,6 +108,7 @@ async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | u
     timeoutMs,
     undefined,
     anthropicEndpoint(baseUrl),
+    "fix",
   )) as { content?: Array<{ type: string; text?: string }> };
   return (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
 }

--- a/apps/central-plane/src/workspace/generate.ts
+++ b/apps/central-plane/src/workspace/generate.ts
@@ -215,6 +215,7 @@ async function callAnthropic(
     timeoutMs,
     undefined,
     anthropicEndpoint(baseUrl),
+    "generate",
   )) as {
     content?: Array<{ type: string; text?: string }>;
     stop_reason?: string;

--- a/apps/central-plane/src/workspace/pr-review.ts
+++ b/apps/central-plane/src/workspace/pr-review.ts
@@ -113,6 +113,7 @@ async function callAnthropic(
     timeoutMs,
     fetchImpl,
     anthropicEndpoint(baseUrl),
+    "pr-review",
   )) as {
     content?: Array<{ type: string; text?: string }>;
     usage?: { input_tokens?: number; output_tokens?: number };

--- a/apps/central-plane/src/workspace/recommend.ts
+++ b/apps/central-plane/src/workspace/recommend.ts
@@ -99,6 +99,7 @@ async function callAnthropic(
     timeoutMs,
     undefined,
     anthropicEndpoint(baseUrl),
+    "recommend",
   )) as { content?: Array<{ type: string; text?: string }> };
   return (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
 }

--- a/apps/central-plane/test/anthropic-usage-logging.test.mjs
+++ b/apps/central-plane/test/anthropic-usage-logging.test.mjs
@@ -1,0 +1,97 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+// Minimal cost/usage observability (2026-07-08): every successful LLM call
+// emits ONE structured JSON line — 4 usage fields + model + call_site +
+// latency_ms — that tomorrow's Langfuse wiring ingests as-is. This pins that
+// the usage fields survive from the API response to the logger.
+
+const { anthropicMessages, logAnthropicUsage } = await import("../dist/workspace/anthropic-fetch.js");
+
+const USAGE = {
+  input_tokens: 2100,
+  output_tokens: 900,
+  cache_creation_input_tokens: 0,
+  cache_read_input_tokens: 0,
+};
+
+function okFetch() {
+  return async () =>
+    new Response(
+      JSON.stringify({ content: [{ type: "text", text: "hi" }], stop_reason: "end_turn", usage: USAGE }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+}
+
+function capturedUsageLines(logMock) {
+  return logMock.mock.calls
+    .map((c) => c.arguments[0])
+    .filter((a) => typeof a === "string" && a.includes('"anthropic_usage"'))
+    .map((a) => JSON.parse(a));
+}
+
+describe("anthropic usage logging", () => {
+  it("usage fields reach the logger as one structured JSON line", async (t) => {
+    const logMock = t.mock.method(console, "log");
+    const data = await anthropicMessages(
+      "key",
+      { model: "claude-haiku-4-5-20251001", max_tokens: 10, messages: [{ role: "user", content: "x" }] },
+      5000,
+      okFetch(),
+      "https://example.test/v1/messages",
+      "generate",
+    );
+    assert.equal(data.usage.input_tokens, 2100, "usage must not be dropped from the response");
+
+    const lines = capturedUsageLines(logMock);
+    assert.equal(lines.length, 1, "exactly one structured usage line per call");
+    const line = lines[0];
+    assert.equal(line.event, "anthropic_usage");
+    assert.equal(line.call_site, "generate");
+    assert.equal(line.model, "claude-haiku-4-5-20251001");
+    assert.equal(line.input_tokens, 2100);
+    assert.equal(line.output_tokens, 900);
+    assert.equal(line.cache_creation_input_tokens, 0);
+    assert.equal(line.cache_read_input_tokens, 0);
+    assert.equal(typeof line.latency_ms, "number");
+    assert.ok(line.latency_ms >= 0);
+  });
+
+  it("missing usage in the response logs zeros, never throws", async (t) => {
+    const logMock = t.mock.method(console, "log");
+    await anthropicMessages(
+      "key",
+      { model: "m", max_tokens: 10, messages: [{ role: "user", content: "x" }] },
+      5000,
+      async () => new Response(JSON.stringify({ content: [] }), { status: 200 }),
+      "https://example.test/v1/messages",
+      "check",
+    );
+    const [line] = capturedUsageLines(logMock);
+    assert.ok(line, "usage line still emitted");
+    assert.equal(line.call_site, "check");
+    assert.equal(line.input_tokens, 0);
+    assert.equal(line.cache_read_input_tokens, 0);
+  });
+
+  it("logAnthropicUsage never throws on weird input", () => {
+    const cyclic = {};
+    cyclic.self = cyclic;
+    assert.doesNotThrow(() => logAnthropicUsage("x", "m", cyclic, 1));
+  });
+
+  it("failed calls emit no usage line", async (t) => {
+    const logMock = t.mock.method(console, "log");
+    await assert.rejects(
+      anthropicMessages(
+        "key",
+        { model: "m", max_tokens: 10, messages: [{ role: "user", content: "x" }] },
+        5000,
+        async () => new Response("bad", { status: 400 }),
+        "https://example.test/v1/messages",
+        "fix",
+      ),
+    );
+    assert.equal(capturedUsageLines(logMock).length, 0);
+  });
+});


### PR DESCRIPTION
## P1 대체: LLM usage 구조화 로깅 (caching 스킵 결정 ①의 실행)

Phase 4 prompt caching은 실측 근거로 보류(ADR은 EoD 문서에 기록):
- Haiku 4.5 최소 캐시 prefix **4096 토큰** > 우리 정적 prefix 실측 1.5~3천 토큰 → `cache_control` 조용히 무시
- 베타 트래픽(생성 20/일)으로 5분 TTL 히트 불가 → 쓰기 프리미엄(1.25×)만 부담하는 순손실

### 바뀐 것
- `anthropic-fetch.ts`: 성공 호출마다 **한 줄 구조화 JSON** — `event:"anthropic_usage"` + 4필드(`input_tokens`/`output_tokens`/`cache_creation_input_tokens`/`cache_read_input_tokens`) + 3태그(`model`/`call_site`/`latency_ms`). latency는 재시도 포함 wall time. fail-open(로깅이 호출을 깨지 않음).
- 5개 호출부(`generate`/`check`/`fix`/`pr-review`/`recommend`)에 call_site 태그.
- 내일 Langfuse 배선이 이 포맷 그대로 ingest. 캐싱 재평가(특히 Sonnet 전환 시 min 1024로 즉시 자격)의 증거 베이스.

### 검증 체크리스트
- [x] 회귀 테스트 4개: usage 필드가 응답→로거까지 소실 없이 도달, usage 누락 시 0으로 fail-open, 순환 입력에도 무예외, 실패 호출은 로그 없음
- [x] central-plane 1656 pass · pre-push `pnpm verify` 통과
- [ ] (배포 후) 프로덕션 generate 1회 호출 → 로그에 4필드 등장 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
