### PR TITLE
obs(langfuse): minimal wiring — generate usage → Langfuse (env-gated, fail-open, content-free)

### DIFF
--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -118,6 +118,16 @@ export interface Env {
   OPENAI_API_KEY?: string;
   GEMINI_API_KEY?: string;
   /**
+   * 2026-07-09 — Langfuse minimal wiring (Simsa flow observability).
+   * All three must be set for traces to be sent; otherwise the workspace
+   * routes silently skip Langfuse (fail-open — never blocks a user call).
+   * HOST is not a secret (wrangler.toml [vars] is fine); the keys are
+   * secrets — set via Actions "set-worker-secrets" workflow (CF rule).
+   */
+  LANGFUSE_HOST?: string;
+  LANGFUSE_PUBLIC_KEY?: string;
+  LANGFUSE_SECRET_KEY?: string;
+  /**
    * Tasks #51 — per-deploy salt mixed into the IP hash for the
    * /saas/demo/review rate-limit table. Rotate to invalidate all
    * demo rate-limit rows. Optional — defaults to a fixed string when

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -14,6 +14,7 @@ import { Hono } from "hono";
 import type { Env } from "../env.js";
 import { ALLOWED_ORIGINS } from "./cors.js";
 import { generateIdeaToSpecDraft, type IdeaToSpecDraftRequest } from "../workspace/generate.js";
+import { sendLangfuseGeneration } from "../workspace/langfuse.js";
 import { normalizeBuiltWith } from "../workspace/built-with.js";
 import { classifyTopics } from "../workspace/topic-tags.js";
 import {
@@ -260,6 +261,30 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
       eventType: "workspace_idea_to_spec_generated",
       metadata: { source: result.source },
     });
+
+    // Langfuse (2026-07-09 minimal wiring): forward the LLM call's usage off
+    // the response path. No-op when LANGFUSE_* env is absent; metadata only,
+    // never user content. waitUntil keeps it out of the user's latency.
+    if (result.llmUsage) {
+      c.executionCtx.waitUntil(
+        sendLangfuseGeneration(c.env, {
+          traceName: "workspace/idea-to-spec-draft",
+          callSite: "generate",
+          model: result.llmUsage.model,
+          inputTokens: result.llmUsage.inputTokens,
+          outputTokens: result.llmUsage.outputTokens,
+          cacheCreationInputTokens: result.llmUsage.cacheCreationInputTokens,
+          cacheReadInputTokens: result.llmUsage.cacheReadInputTokens,
+          latencyMs: result.llmUsage.latencyMs,
+          metadata: {
+            source: result.source,
+            locale: input.locale,
+            verification_ok: result.specVerification?.ok,
+            verification_coverage: result.specVerification?.coverage,
+          },
+        }),
+      );
+    }
 
     return new Response(JSON.stringify(result), {
       status: 200,

--- a/apps/central-plane/src/workspace/generate.ts
+++ b/apps/central-plane/src/workspace/generate.ts
@@ -60,6 +60,19 @@ export type IdeaToSpecDraftResponse = {
    *  Present on every successful draft; ok:false means the draft did not
    *  reflect enough of the user's own words and a loud warning was attached. */
   specVerification?: SpecVerification;
+  /** 2026-07-09 Langfuse wiring — token/latency record of the LLM call that
+   *  produced this draft (absent on the mock path). Additive and safe to
+   *  expose; the route forwards it to Langfuse via waitUntil. */
+  llmUsage?: LlmCallUsage;
+};
+
+export type LlmCallUsage = {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  latencyMs: number;
 };
 
 // ─── Prompt ───────────────────────────────────────────────────────────────────
@@ -193,16 +206,19 @@ ${SCHEMA_DESCRIPTION_EN}`;
 
 // ─── Anthropic fetch ──────────────────────────────────────────────────────────
 
+const GENERATE_MODEL = "claude-haiku-4-5-20251001";
+
 async function callAnthropic(
   apiKey: string,
   prompt: string,
   baseUrl: string | undefined,
   timeoutMs = 120000, // document-scale prompts (up to 80k chars) need generous time
-): Promise<string> {
+): Promise<{ text: string; usage: LlmCallUsage }> {
+  const startedAt = Date.now();
   const data = (await anthropicMessages(
     apiKey,
     {
-      model: "claude-haiku-4-5-20251001",
+      model: GENERATE_MODEL,
       max_tokens: 8000,
       // Assistant prefill: the reply MUST continue from "{" — a refusal or a
       // prose preamble becomes impossible. (Live 2026-07-05: the KO prompt
@@ -219,6 +235,12 @@ async function callAnthropic(
   )) as {
     content?: Array<{ type: string; text?: string }>;
     stop_reason?: string;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
   };
   const text = (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
   // Operational diagnostics (no user content): production fell back with
@@ -227,7 +249,17 @@ async function callAnthropic(
     `[workspace/generate] blocks=${(data.content ?? []).map((b) => b.type).join(",") || "none"}` +
       ` textLen=${text.length} stop=${data.stop_reason ?? "?"}`,
   );
-  return "{" + text;
+  return {
+    text: "{" + text,
+    usage: {
+      model: GENERATE_MODEL,
+      inputTokens: data.usage?.input_tokens ?? 0,
+      outputTokens: data.usage?.output_tokens ?? 0,
+      cacheCreationInputTokens: data.usage?.cache_creation_input_tokens ?? 0,
+      cacheReadInputTokens: data.usage?.cache_read_input_tokens ?? 0,
+      latencyMs: Date.now() - startedAt,
+    },
+  };
 }
 
 // ─── Validation ───────────────────────────────────────────────────────────────
@@ -582,8 +614,11 @@ export async function generateIdeaToSpecDraft(
 
   const prompt = buildPrompt(req);
   let rawText = "";
+  let llmUsage: LlmCallUsage | undefined;
   try {
-    rawText = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl);
+    const call = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl);
+    rawText = call.text;
+    llmUsage = call.usage;
   } catch (err) {
     console.error("[workspace/generate] LLM call failed:", err);
     return { ok: false as const, error: "llm_unavailable" as const };
@@ -618,5 +653,5 @@ export async function generateIdeaToSpecDraft(
   // The LLM can fabricate too — same deterministic gate as the mock path.
   // On failure the draft still ships, but with a loud "not reflected: …"
   // warning (never a silent rejection, never silent fabrication).
-  return withVerification(req, { ok: true, source: "llm", ...data });
+  return withVerification(req, { ok: true, source: "llm", ...data, llmUsage });
 }

--- a/apps/central-plane/src/workspace/langfuse.ts
+++ b/apps/central-plane/src/workspace/langfuse.ts
@@ -1,0 +1,136 @@
+/**
+ * workspace/langfuse.ts — minimal Langfuse wiring for the Simsa flow.
+ *
+ * Workers-safe: talks to the Langfuse public ingestion API with plain fetch
+ * (no SDK — the Node SDK's batching/timers don't fit the Worker lifecycle;
+ * packages/observability-langfuse is the Conclave/Node-side sink and stays
+ * untouched). One trace + one generation per LLM call, carrying exactly the
+ * `anthropic_usage` record (4 usage fields + model/call_site/latency_ms).
+ *
+ * Privacy: NO user content (idea/spec text) is sent — metadata only. That is
+ * deliberate; revisit only with an explicit decision.
+ *
+ * Fail-open: misconfiguration or Langfuse downtime must never break or slow
+ * a user call — callers fire this through ctx.waitUntil and every error is
+ * swallowed into a single console.warn.
+ */
+
+export type LangfuseEnv = {
+  LANGFUSE_HOST?: string;
+  LANGFUSE_PUBLIC_KEY?: string;
+  LANGFUSE_SECRET_KEY?: string;
+};
+
+/** The observability record for one LLM call — same fields as the
+ *  `anthropic_usage` console line, plus a trace name and safe metadata. */
+export type LlmUsageRecord = {
+  traceName: string;
+  callSite: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  latencyMs: number;
+  /** Safe, non-content metadata (locale, source, verification coverage …). */
+  metadata?: Record<string, unknown>;
+};
+
+export function langfuseConfigured(env: LangfuseEnv): boolean {
+  return Boolean(env.LANGFUSE_HOST && env.LANGFUSE_PUBLIC_KEY && env.LANGFUSE_SECRET_KEY);
+}
+
+/** Pure batch builder (Langfuse public ingestion envelope) — unit-testable. */
+export function buildIngestionBatch(
+  rec: LlmUsageRecord,
+  ids: { traceId: string; generationId: string; eventId1: string; eventId2: string },
+  endedAt: Date,
+): { batch: unknown[] } {
+  const end = endedAt.toISOString();
+  const start = new Date(endedAt.getTime() - rec.latencyMs).toISOString();
+  const metadata = {
+    call_site: rec.callSite,
+    cache_creation_input_tokens: rec.cacheCreationInputTokens,
+    cache_read_input_tokens: rec.cacheReadInputTokens,
+    latency_ms: rec.latencyMs,
+    ...(rec.metadata ?? {}),
+  };
+  return {
+    batch: [
+      {
+        id: ids.eventId1,
+        type: "trace-create",
+        timestamp: end,
+        body: {
+          id: ids.traceId,
+          name: rec.traceName,
+          timestamp: start,
+          metadata,
+        },
+      },
+      {
+        id: ids.eventId2,
+        type: "generation-create",
+        timestamp: end,
+        body: {
+          id: ids.generationId,
+          traceId: ids.traceId,
+          name: rec.callSite,
+          model: rec.model,
+          startTime: start,
+          endTime: end,
+          usage: {
+            input: rec.inputTokens,
+            output: rec.outputTokens,
+            total: rec.inputTokens + rec.outputTokens,
+            unit: "TOKENS",
+          },
+          metadata,
+        },
+      },
+    ],
+  };
+}
+
+export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Send one LLM call's usage to Langfuse. No-op when env is not configured.
+ * Never throws. Meant to run inside ctx.waitUntil (off the response path).
+ */
+export async function sendLangfuseGeneration(
+  env: LangfuseEnv,
+  rec: LlmUsageRecord,
+  fetchImpl: FetchLike = fetch.bind(globalThis) as FetchLike,
+): Promise<boolean> {
+  if (!langfuseConfigured(env)) return false;
+  try {
+    const host = (env.LANGFUSE_HOST ?? "").trim().replace(/\/+$/, "");
+    const body = buildIngestionBatch(
+      rec,
+      {
+        traceId: crypto.randomUUID(),
+        generationId: crypto.randomUUID(),
+        eventId1: crypto.randomUUID(),
+        eventId2: crypto.randomUUID(),
+      },
+      new Date(),
+    );
+    const resp = await fetchImpl(`${host}/api/public/ingestion`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Basic ${btoa(`${env.LANGFUSE_PUBLIC_KEY}:${env.LANGFUSE_SECRET_KEY}`)}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok && resp.status !== 207) {
+      console.warn(`[langfuse] ingestion ${resp.status} — trace dropped (fail-open)`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.warn("[langfuse] send failed — trace dropped (fail-open):", err);
+    return false;
+  }
+}

--- a/apps/central-plane/test/workspace-langfuse.test.mjs
+++ b/apps/central-plane/test/workspace-langfuse.test.mjs
@@ -1,0 +1,117 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// Langfuse minimal wiring (2026-07-09): one trace + one generation per LLM
+// call via the public ingestion API. Env-gated, fail-open, metadata only —
+// user content must never appear in the payload.
+
+const { langfuseConfigured, buildIngestionBatch, sendLangfuseGeneration } =
+  await import("../dist/workspace/langfuse.js");
+const { generateIdeaToSpecDraft } = await import("../dist/workspace/generate.js");
+
+const ENV = {
+  LANGFUSE_HOST: "https://langfuse.example.test/",
+  LANGFUSE_PUBLIC_KEY: "pk-lf-x",
+  LANGFUSE_SECRET_KEY: "sk-lf-y",
+};
+
+const REC = {
+  traceName: "workspace/idea-to-spec-draft",
+  callSite: "generate",
+  model: "claude-haiku-4-5-20251001",
+  inputTokens: 1226,
+  outputTokens: 5196,
+  cacheCreationInputTokens: 0,
+  cacheReadInputTokens: 0,
+  latencyMs: 39534,
+  metadata: { source: "llm", locale: "ko", verification_ok: true },
+};
+
+describe("langfuseConfigured", () => {
+  it("requires all three env values", () => {
+    assert.equal(langfuseConfigured(ENV), true);
+    assert.equal(langfuseConfigured({}), false);
+    assert.equal(langfuseConfigured({ ...ENV, LANGFUSE_SECRET_KEY: undefined }), false);
+  });
+});
+
+describe("buildIngestionBatch", () => {
+  const ids = { traceId: "t1", generationId: "g1", eventId1: "e1", eventId2: "e2" };
+  const end = new Date("2026-07-09T01:00:00.000Z");
+
+  it("emits trace-create + generation-create with the usage fields", () => {
+    const { batch } = buildIngestionBatch(REC, ids, end);
+    assert.equal(batch.length, 2);
+    const [trace, gen] = batch;
+    assert.equal(trace.type, "trace-create");
+    assert.equal(trace.body.id, "t1");
+    assert.equal(trace.body.name, "workspace/idea-to-spec-draft");
+    assert.equal(gen.type, "generation-create");
+    assert.equal(gen.body.traceId, "t1");
+    assert.equal(gen.body.model, "claude-haiku-4-5-20251001");
+    assert.deepEqual(gen.body.usage, { input: 1226, output: 5196, total: 6422, unit: "TOKENS" });
+    assert.equal(gen.body.metadata.cache_read_input_tokens, 0);
+    assert.equal(gen.body.metadata.latency_ms, 39534);
+    assert.equal(gen.body.metadata.locale, "ko");
+    // startTime = endTime - latency
+    assert.equal(new Date(gen.body.endTime) - new Date(gen.body.startTime), 39534);
+  });
+
+  it("never contains user content fields (key whitelist)", () => {
+    const { batch } = buildIngestionBatch(REC, ids, end);
+    const [trace, gen] = batch;
+    // No `input`/`output` bodies (where Langfuse would carry content) — metadata only.
+    assert.deepEqual(Object.keys(trace.body).sort(), ["id", "metadata", "name", "timestamp"]);
+    assert.deepEqual(
+      Object.keys(gen.body).sort(),
+      ["endTime", "id", "metadata", "model", "name", "startTime", "traceId", "usage"],
+    );
+  });
+});
+
+describe("sendLangfuseGeneration", () => {
+  it("posts to /api/public/ingestion with basic auth (trailing slash trimmed)", async () => {
+    const calls = [];
+    const ok = await sendLangfuseGeneration(ENV, REC, async (url, init) => {
+      calls.push({ url, init });
+      return new Response("{}", { status: 207 });
+    });
+    assert.equal(ok, true);
+    assert.equal(calls[0].url, "https://langfuse.example.test/api/public/ingestion");
+    assert.ok(calls[0].init.headers.authorization.startsWith("Basic "));
+    const body = JSON.parse(calls[0].init.body);
+    assert.equal(body.batch.length, 2);
+  });
+
+  it("is a no-op when env is not configured", async () => {
+    let called = false;
+    const ok = await sendLangfuseGeneration({}, REC, async () => {
+      called = true;
+      return new Response("{}", { status: 200 });
+    });
+    assert.equal(ok, false);
+    assert.equal(called, false);
+  });
+
+  it("fail-open: fetch throw and non-2xx both return false, never throw", async () => {
+    assert.equal(
+      await sendLangfuseGeneration(ENV, REC, async () => {
+        throw new Error("boom");
+      }),
+      false,
+    );
+    assert.equal(
+      await sendLangfuseGeneration(ENV, REC, async () => new Response("no", { status: 401 })),
+      false,
+    );
+  });
+});
+
+describe("generate llmUsage exposure", () => {
+  it("mock path (no API key) carries no llmUsage — nothing to send to Langfuse", async () => {
+    const res = await generateIdeaToSpecDraft({ idea: "동네 러닝 모임 앱", locale: "ko" }, undefined);
+    assert.equal(res.ok, true);
+    assert.equal(res.source, "mock-fallback");
+    assert.equal(res.llmUsage, undefined);
+  });
+});


### PR DESCRIPTION
## Langfuse 최소 배선 — generate 경로 trace+generation 1건씩

어제 심은 `anthropic_usage` 레코드(4필드+model/call_site/latency_ms)를 그대로 Langfuse 공개 ingestion API로 전송합니다.

### 설계
- **Workers-safe fetch 클라이언트** (`workspace/langfuse.ts`) — SDK 미사용(Node SDK의 배칭/타이머가 Worker 수명주기와 안 맞음). 기존 `packages/observability-langfuse`는 Conclave/Node용이라 미변경.
- **env-gated + fail-open**: `LANGFUSE_HOST/PUBLIC_KEY/SECRET_KEY` 셋 다 있어야 전송, 없으면 조용히 no-op → **키 없이 머지·배포 안전**. 전송 실패는 warn 한 줄로 삼킴.
- **`waitUntil`로 응답 경로 밖에서 전송** — 유저 latency에 0 영향.
- **유저 콘텐츠 무전송**: 아이디어/스펙 텍스트는 절대 안 보냄. usage+메타데이터(locale·source·verification coverage)만. 키 화이트리스트 테스트로 pin.
- generate 응답에 additive `llmUsage` 노출(mock 경로엔 없음) — latency 가설(output 길이 vs #303) 분석용 데이터가 Langfuse에 쌓임.
- 나머지 4개 call site(check/fix/pr-review/recommend)는 동일 클라이언트로 후속 1줄 배선 가능 — 오늘은 감사·latency 대상인 generate만(최소 스코프).

### 검증
- [x] 테스트 7개 신규: 배치 형태(trace+generation·usage 수치·start=end−latency), Basic auth·엔드포인트, env 미설정 no-op, fail-open(throw·non-2xx), 콘텐츠 부재(키 화이트리스트), mock 경로 llmUsage 없음 — central-plane **1663 pass**
- [ ] (활성화 후) 프로덕션 generate 1회 → Langfuse UI에 trace 등장 (model·토큰·latency 표시)

### 활성화 (배님 1스텝, 코드 머지와 독립)
1. Langfuse 인스턴스 결정(cloud.langfuse.com 프로젝트 또는 self-hosted) → repo secrets에 `LANGFUSE_HOST`·`LANGFUSE_PUBLIC_KEY`·`LANGFUSE_SECRET_KEY` 등록
2. Actions → **set-worker-secrets** 실행: confirm=`set`, names=`LANGFUSE_HOST,LANGFUSE_PUBLIC_KEY,LANGFUSE_SECRET_KEY` (CF Containers 시크릿 룰: 로컬 wrangler 금지)
3. deploy-central-plane 재실행 → 제가 프로덕션 1회 호출로 trace 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
