### PR TITLE
docs: decision #13 divergence — Langfuse Cloud for Simsa flow

### DIFF
--- a/docs/decision-status.md
+++ b/docs/decision-status.md
@@ -29,7 +29,7 @@ Legend:
 | 10 | Gemini SDK → `@google/genai` | ✅ | `packages/agent-gemini` |
 | 11 | MCP tool protocol | ✅ | `packages/cli/src/commands/mcp-server.ts` |
 | 12 | Zod → JSON Schema | ✅ | `packages/core/src/schema.ts` + per-agent `review-schema.ts` |
-| 13 | Observability → self-hosted Langfuse | ✅ | `packages/observability-langfuse` |
+| 13 | Observability → self-hosted Langfuse | 🔄 | `packages/observability-langfuse` (Node/Conclave). **Divergence 2026-07-09 (Bae 승인):** Simsa flow(central-plane Worker)는 **Langfuse Cloud**로 시작 — `workspace/langfuse.ts`가 공개 ingestion API 직결(#309). 근거: 측정 시작 가치 > self-hosted 원칙, 이관 비용 ≈ env 3종 교체. 데이터 리전: (가입 시 기록). self-hosted 이관은 트래픽/규정 필요 시점에 재평가 |
 | 14 | Workflow engine → GitHub Actions | ✅ | `.github/workflows/` |
 | 15 | Native pixel diff → odiff | ✅ | `packages/visual-review/src/odiff-diff.ts` (opt-in) |
 | 16 | Config loader → cosmiconfig | ✅ | `packages/cli/src/lib/config.ts` |


### PR DESCRIPTION
CLAUDE.md 규약대로 결정 #13 divergence 기록: Simsa flow는 Cloud로 시작(#309 배선), self-hosted 이관은 env 3종 교체로 가능. 데이터 리전은 배님 가입 시 이 줄에 기입.

🤖 Generated with [Claude Code](https://claude.com/claude-code)