### PR TITLE
fix(privacy): strip llmUsage from idea-to-spec response (operator-only observability)

### DIFF
--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -13,7 +13,7 @@
 import { Hono } from "hono";
 import type { Env } from "../env.js";
 import { ALLOWED_ORIGINS } from "./cors.js";
-import { generateIdeaToSpecDraft, type IdeaToSpecDraftRequest } from "../workspace/generate.js";
+import { generateIdeaToSpecDraft, toClientDraft, type IdeaToSpecDraftRequest } from "../workspace/generate.js";
 import { sendLangfuseGeneration } from "../workspace/langfuse.js";
 import { normalizeBuiltWith } from "../workspace/built-with.js";
 import { classifyTopics } from "../workspace/topic-tags.js";
@@ -286,7 +286,10 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
       );
     }
 
-    return new Response(JSON.stringify(result), {
+    // llmUsage (token counts + latency) is operator observability: it was sent
+    // to Langfuse + logged above, and toClientDraft() strips it here so it never
+    // reaches the non-dev client or leaks the cost structure in the response.
+    return new Response(JSON.stringify(toClientDraft(result)), {
       status: 200,
       headers: { "content-type": "application/json", ...headers },
     });

--- a/apps/central-plane/src/workspace/generate.ts
+++ b/apps/central-plane/src/workspace/generate.ts
@@ -75,6 +75,22 @@ export type LlmCallUsage = {
   latencyMs: number;
 };
 
+/** The draft as it goes to the (non-developer) client — without operator-only fields. */
+export type ClientIdeaToSpecDraft = Omit<IdeaToSpecDraftResponse, "llmUsage">;
+
+/**
+ * Strip operator-only observability from a draft before it reaches the client.
+ * `llmUsage` (token counts + latency) belongs in Langfuse and logs only — a
+ * non-developer user must never see it, and the per-token cost structure must
+ * not leak in the API response body. This is the single boundary where the
+ * field is removed; the route must serialize the result of this function, not
+ * the raw draft. (2026-07-09, per Bae — audit "결과부터 평이하게".)
+ */
+export function toClientDraft(result: IdeaToSpecDraftResponse): ClientIdeaToSpecDraft {
+  const { llmUsage: _internal, ...clientResult } = result;
+  return clientResult;
+}
+
 // ─── Prompt ───────────────────────────────────────────────────────────────────
 
 const SCHEMA_DESCRIPTION = `{

--- a/apps/central-plane/test/workspace-langfuse.test.mjs
+++ b/apps/central-plane/test/workspace-langfuse.test.mjs
@@ -7,7 +7,8 @@ import assert from "node:assert/strict";
 
 const { langfuseConfigured, buildIngestionBatch, sendLangfuseGeneration } =
   await import("../dist/workspace/langfuse.js");
-const { generateIdeaToSpecDraft } = await import("../dist/workspace/generate.js");
+const { generateIdeaToSpecDraft, toClientDraft } = await import("../dist/workspace/generate.js");
+const { createApp } = await import("../dist/router.js");
 
 const ENV = {
   LANGFUSE_HOST: "https://langfuse.example.test/",
@@ -113,5 +114,100 @@ describe("generate llmUsage exposure", () => {
     assert.equal(res.ok, true);
     assert.equal(res.source, "mock-fallback");
     assert.equal(res.llmUsage, undefined);
+  });
+});
+
+describe("toClientDraft — operator fields never reach the client", () => {
+  it("strips llmUsage, keeps the user-facing draft, does not mutate the input", () => {
+    const full = {
+      ok: true,
+      source: "llm",
+      understood: { summary: "s", targetUsers: [], mainFlow: [] },
+      questions: [],
+      productSpec: { productName: "P" },
+      items: [],
+      specVerification: { ok: true, coverage: 1 },
+      warnings: ["w"],
+      llmUsage: {
+        model: "m",
+        inputTokens: 1,
+        outputTokens: 2,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        latencyMs: 3,
+      },
+    };
+    const client = toClientDraft(full);
+    assert.equal("llmUsage" in client, false, "token/latency must not reach the client");
+    assert.equal(client.source, "llm");
+    assert.equal(client.productSpec.productName, "P");
+    assert.ok(client.specVerification, "user-facing fields survive");
+    assert.deepEqual(client.warnings, ["w"]);
+    assert.equal("llmUsage" in full, true, "original object is not mutated");
+  });
+
+  it("is a no-op shape when there is no llmUsage (mock path)", () => {
+    const client = toClientDraft({ ok: true, source: "mock-fallback", productSpec: {}, items: [] });
+    assert.equal("llmUsage" in client, false);
+    assert.equal(client.source, "mock-fallback");
+  });
+});
+
+describe("route strips llmUsage from the LLM-path response", () => {
+  it("the HTTP response carries the draft but never llmUsage (operator-only observability)", async () => {
+    // Build a valid draft the stubbed model will "continue" from the "{" prefill.
+    const draft = {
+      understood: { summary: "s", targetUsers: [], mainFlow: [] },
+      questions: [],
+      productSpec: {
+        productName: "테스트",
+        oneLine: "o",
+        targetUsers: [],
+        problem: "",
+        included: [],
+        excluded: [],
+        userFlow: [],
+        decisions: [],
+        openQuestions: [],
+      },
+      items: [
+        { id: "req_001", title: "a", status: "not_started", criteria: ["c"] },
+        { id: "req_002", title: "b", status: "not_started", criteria: ["c"] },
+        { id: "req_003", title: "c", status: "not_started", criteria: ["c"] },
+      ],
+    };
+    const afterBrace = JSON.stringify(draft).slice(1); // model continues after the "{" prefill
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: afterBrace }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 111, output_tokens: 222 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    try {
+      const app = createApp();
+      // DB:{} → rate-limit/usage helpers are fail-open; ANTHROPIC_API_KEY set → LLM path;
+      // ctx.waitUntil provided so the Langfuse forward (a no-op without LANGFUSE_*) doesn't throw.
+      const res = await app.fetch(
+        new Request("http://localhost/workspace/idea-to-spec-draft", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ idea: "테스트 앱", locale: "ko", userKey: "uk_t" }),
+        }),
+        { DB: {}, ENVIRONMENT: "test", ANTHROPIC_API_KEY: "sk-test" },
+        { waitUntil() {}, passThroughOnException() {} },
+      );
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.source, "llm", "LLM path was taken (usage exists to strip)");
+      assert.equal("llmUsage" in body, false, "token counts + latency must NOT reach the client");
+      assert.ok(body.productSpec, "the draft itself still ships");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
   });
 });


### PR DESCRIPTION
## `llmUsage`를 idea-to-spec 응답에서 제거 — 관측 데이터는 operator 전용

배님 지적(주의 ①) 반영. #309가 `llmUsage`(토큰 수+latency)를 유저 대면 JSON에 남겼는데, 이는 generate.ts→라우트로 usage를 Langfuse에 넘기기 위한 **배관용 필드**였고 클라이언트 필드가 아니었습니다. 의도된 설계 아님.

### 왜 제거
- 비개발자 유저에게 노이즈 — 감사의 "결과부터 평이하게" 원칙과 역행
- 원가 구조(토큰 단가 역산) 외부 노출
- 관측 데이터의 자리는 응답 본문이 아니라 Langfuse + 로그

### 바뀐 것
- `generate.ts`: `toClientDraft()` export 신설 — 직렬화 전 `llmUsage`를 걷어내는 **단일 경계**. named+주석이라 미래 편집이 조용히 되살릴 수 없음. Langfuse forward + console 로그는 operator 쪽에 그대로 유지.
- `routes/workspace.ts`: raw draft가 아니라 `toClientDraft(result)`를 직렬화.
- 인라인 destructure가 아니라 named 계약으로 만든 이유: 어제 등재한 "PR 오픈≠완료"와 같은 종류의 회귀(조용한 되돌림)를 테스트로 pin.

### 검증
- [x] `toClientDraft` unit: llmUsage 제거·유저 필드 보존·원본 무변형
- [x] **라우트 레벨 LLM-path 테스트**(`createApp` + 전역 fetch 스텁 + ctx): HTTP 응답이 `source:"llm"`이면서 `llmUsage` 없음 — 라우트가 실제로 strip함을 증명
- [x] central-plane **1666 pass** · pre-push verify 통과
- [x] dashboard가 `llmUsage` 소비 안 함(grep 0건) — 클라이언트 무영향

스모크는 `wrangler tail`/Langfuse trace로(usage의 올바른 자리), 응답 본문 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
