### PR TITLE
obs(langfuse): accept LANGFUSE_BASE_URL alias + observable send-outcome log

### DIFF
--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -125,6 +125,9 @@ export interface Env {
    * secrets — set via Actions "set-worker-secrets" workflow (CF rule).
    */
   LANGFUSE_HOST?: string;
+  /** Alias for LANGFUSE_HOST. Either name works so a secret set as
+   *  LANGFUSE_BASE_URL (common Langfuse convention) doesn't silently no-op. */
+  LANGFUSE_BASE_URL?: string;
   LANGFUSE_PUBLIC_KEY?: string;
   LANGFUSE_SECRET_KEY?: string;
   /**

--- a/apps/central-plane/src/workspace/langfuse.ts
+++ b/apps/central-plane/src/workspace/langfuse.ts
@@ -17,9 +17,17 @@
 
 export type LangfuseEnv = {
   LANGFUSE_HOST?: string;
+  /** Alias for LANGFUSE_HOST — the region base URL (not a secret). Accepting
+   *  both names avoids a silent no-op when the value is set as LANGFUSE_BASE_URL. */
+  LANGFUSE_BASE_URL?: string;
   LANGFUSE_PUBLIC_KEY?: string;
   LANGFUSE_SECRET_KEY?: string;
 };
+
+/** The Langfuse base URL — LANGFUSE_HOST, or its LANGFUSE_BASE_URL alias. */
+export function resolveLangfuseHost(env: LangfuseEnv): string | undefined {
+  return (env.LANGFUSE_HOST ?? env.LANGFUSE_BASE_URL) || undefined;
+}
 
 /** The observability record for one LLM call — same fields as the
  *  `anthropic_usage` console line, plus a trace name and safe metadata. */
@@ -37,7 +45,7 @@ export type LlmUsageRecord = {
 };
 
 export function langfuseConfigured(env: LangfuseEnv): boolean {
-  return Boolean(env.LANGFUSE_HOST && env.LANGFUSE_PUBLIC_KEY && env.LANGFUSE_SECRET_KEY);
+  return Boolean(resolveLangfuseHost(env) && env.LANGFUSE_PUBLIC_KEY && env.LANGFUSE_SECRET_KEY);
 }
 
 /** Pure batch builder (Langfuse public ingestion envelope) — unit-testable. */
@@ -105,7 +113,7 @@ export async function sendLangfuseGeneration(
 ): Promise<boolean> {
   if (!langfuseConfigured(env)) return false;
   try {
-    const host = (env.LANGFUSE_HOST ?? "").trim().replace(/\/+$/, "");
+    const host = (resolveLangfuseHost(env) ?? "").trim().replace(/\/+$/, "");
     const body = buildIngestionBatch(
       rec,
       {
@@ -124,7 +132,13 @@ export async function sendLangfuseGeneration(
       },
       body: JSON.stringify(body),
     });
-    if (!resp.ok && resp.status !== 207) {
+    // Observable outcome so `wrangler tail` can prove traces flow. Only fires
+    // on the configured path — absence of this line means Langfuse is off
+    // (intentional no-op), which is the diagnostic for "keys not set yet".
+    console.log(
+      JSON.stringify({ event: "langfuse_send", call_site: rec.callSite, status: resp.status, ok: resp.ok }),
+    );
+    if (!resp.ok) {
       console.warn(`[langfuse] ingestion ${resp.status} — trace dropped (fail-open)`);
       return false;
     }

--- a/apps/central-plane/test/workspace-langfuse.test.mjs
+++ b/apps/central-plane/test/workspace-langfuse.test.mjs
@@ -5,7 +5,7 @@ import assert from "node:assert/strict";
 // call via the public ingestion API. Env-gated, fail-open, metadata only —
 // user content must never appear in the payload.
 
-const { langfuseConfigured, buildIngestionBatch, sendLangfuseGeneration } =
+const { langfuseConfigured, buildIngestionBatch, sendLangfuseGeneration, resolveLangfuseHost } =
   await import("../dist/workspace/langfuse.js");
 const { generateIdeaToSpecDraft, toClientDraft } = await import("../dist/workspace/generate.js");
 const { createApp } = await import("../dist/router.js");
@@ -33,6 +33,25 @@ describe("langfuseConfigured", () => {
     assert.equal(langfuseConfigured(ENV), true);
     assert.equal(langfuseConfigured({}), false);
     assert.equal(langfuseConfigured({ ...ENV, LANGFUSE_SECRET_KEY: undefined }), false);
+  });
+
+  it("accepts LANGFUSE_BASE_URL as the host alias (no LANGFUSE_HOST needed)", () => {
+    const aliasEnv = {
+      LANGFUSE_BASE_URL: "https://us.cloud.langfuse.com",
+      LANGFUSE_PUBLIC_KEY: "pk",
+      LANGFUSE_SECRET_KEY: "sk",
+    };
+    assert.equal(langfuseConfigured(aliasEnv), true);
+    assert.equal(resolveLangfuseHost(aliasEnv), "https://us.cloud.langfuse.com");
+    // keys without any host → still not configured
+    assert.equal(langfuseConfigured({ LANGFUSE_PUBLIC_KEY: "pk", LANGFUSE_SECRET_KEY: "sk" }), false);
+  });
+
+  it("prefers LANGFUSE_HOST over the alias when both are set", () => {
+    assert.equal(
+      resolveLangfuseHost({ LANGFUSE_HOST: "https://cloud.langfuse.com", LANGFUSE_BASE_URL: "https://other" }),
+      "https://cloud.langfuse.com",
+    );
   });
 });
 
@@ -82,6 +101,21 @@ describe("sendLangfuseGeneration", () => {
     assert.ok(calls[0].init.headers.authorization.startsWith("Basic "));
     const body = JSON.parse(calls[0].init.body);
     assert.equal(body.batch.length, 2);
+  });
+
+  it("posts to the LANGFUSE_BASE_URL host when only the alias is set", async () => {
+    const aliasEnv = {
+      LANGFUSE_BASE_URL: "https://us.cloud.langfuse.com/",
+      LANGFUSE_PUBLIC_KEY: "pk",
+      LANGFUSE_SECRET_KEY: "sk",
+    };
+    let url = "";
+    const ok = await sendLangfuseGeneration(aliasEnv, REC, async (u) => {
+      url = u;
+      return new Response("{}", { status: 207 });
+    });
+    assert.equal(ok, true);
+    assert.equal(url, "https://us.cloud.langfuse.com/api/public/ingestion");
   });
 
   it("is a no-op when env is not configured", async () => {


### PR DESCRIPTION
Langfuse 실제 동작을 막던 이름 불일치 해소 + 실증 가능한 로그.

- **별칭:** `LANGFUSE_HOST`는 리전 base URL(비밀 아님)인데, 값을 `LANGFUSE_BASE_URL`로 등록하면(흔한 관례) 기존 코드는 `LANGFUSE_HOST`만 읽어 **조용히 no-op**였음. `resolveLangfuseHost()`가 둘 다 받음(HOST 우선). 배님이 등록한 repo secret이 `LANGFUSE_BASE_URL`이라 이게 필요.
- **전송 결과 로그:** `sendLangfuseGeneration`이 설정된 경로에서 `{event:"langfuse_send", call_site, status, ok}`를 남김 → `wrangler tail`로 trace 흐름 실증 가능. 로그 부재 = Langfuse off(미설정 진단).
- 테스트: BASE_URL 별칭만으로 configured, 별칭 host로 POST, HOST가 별칭보다 우선. 1669 pass.

배포 후 순서: 시크릿 3종 Worker 반영(set-worker-secrets) → 프로덕션 1회 → tail로 `langfuse_send ok:true` 확인 → Langfuse UI trace 확인(배님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)