### PR TITLE
fix(flow): code-check 도돌이표 — repo-connected 도출 3곳 retry 통일 (root cause)

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -23,6 +23,7 @@ import {
   type CreditEnforcementDryRun,
   type CreditEnforcementResult,
 } from "@/lib/workspace-github-api";
+import { fetchProjectRepoSettled } from "@/lib/repo-settle.mjs";
 import { StatusBadge } from "@/components/StatusBadge";
 import { StatusText } from "@/components/StatusText";
 import { useI18n } from "@/i18n/I18nProvider";
@@ -150,11 +151,7 @@ export default function GitHubPage() {
     // D1 propagates. Retry a few times before concluding "no repo" — otherwise a
     // user who just connected gets funneled back to /settings to reconnect what
     // is already connected, which reads as an infinite loop (무한 도돌이표).
-    let repoRes = await fetchProjectRepo(id, getUserKey());
-    for (let attempt = 0; attempt < 3 && repoRes.ok && !repoRes.repo; attempt++) {
-      await new Promise((r) => setTimeout(r, 700));
-      repoRes = await fetchProjectRepo(id, getUserKey());
-    }
+    const repoRes = await fetchProjectRepoSettled(fetchProjectRepo, id, getUserKey());
     const linkedRes = await fetchLinkedPulls(id, getUserKey());
     if (repoRes.ok && repoRes.repo) {
       setRepo(repoRes.repo);

--- a/apps/dashboard/src/app/projects/[id]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/page.tsx
@@ -42,6 +42,7 @@ import type { Dictionary, Locale } from "@/i18n/dictionary.mjs";
 import { nextProjectAction, computeProjectSteps } from "@/lib/project-steps.mjs";
 import { loadExtendedProjectData } from "@/lib/workflow-store";
 import { fetchProjectRepo, listProjectReviewHistory } from "@/lib/workspace-github-api";
+import { fetchProjectRepoSettled, repoConnectedFact } from "@/lib/repo-settle.mjs";
 import { listProjectSources } from "@/lib/workspace-sources-api";
 
 // Stage 272 — verdict/status chip tones on the overview inspection card
@@ -228,8 +229,8 @@ function CommandCenterCard({
   useEffect(() => {
     let cancelled = false;
     const uk = getUserKey();
-    fetchProjectRepo(projectId, uk)
-      .then((res) => { if (!cancelled) setHasRepo(res.ok ? Boolean(res.repo) : null); })
+    fetchProjectRepoSettled(fetchProjectRepo, projectId, uk)
+      .then((res) => { if (!cancelled) setHasRepo(repoConnectedFact(res)); })
       .catch(() => {});
     listProjectReviewHistory(projectId, uk, { limit: 1 })
       .then((res) => { if (!cancelled) setHasReviewRun(res.ok ? res.runs.length > 0 : null); })

--- a/apps/dashboard/src/components/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar.tsx
@@ -12,6 +12,7 @@ import { Tooltip } from "@/components/Tooltip";
 import { getAuthSession, signOutAuth } from "@/lib/auth-client.mjs";
 import { computeProjectSteps } from "@/lib/project-steps.mjs";
 import { fetchProjectRepo, listProjectReviewHistory } from "@/lib/workspace-github-api";
+import { fetchProjectRepoSettled, repoConnectedFact } from "@/lib/repo-settle.mjs";
 import { SIMSA_REPO_URL } from "@/lib/simsa-share.mjs";
 
 const MOCK_IDS = new Set(MOCK_PROJECTS.map((p) => p.id));
@@ -110,8 +111,8 @@ export function AppSidebar() {
     setHasRepo(null);
     setHasReviewRun(null);
     const uk = getUserKey();
-    fetchProjectRepo(projectId, uk)
-      .then((res) => { if (!cancelled) setHasRepo(res.ok ? Boolean(res.repo) : null); })
+    fetchProjectRepoSettled(fetchProjectRepo, projectId, uk)
+      .then((res) => { if (!cancelled) setHasRepo(repoConnectedFact(res)); })
       .catch(() => {});
     listProjectReviewHistory(projectId, uk, { limit: 1 })
       .then((res) => { if (!cancelled) setHasReviewRun(res.ok ? res.runs.length > 0 : null); })

--- a/apps/dashboard/src/lib/repo-settle.d.mts
+++ b/apps/dashboard/src/lib/repo-settle.d.mts
@@ -1,0 +1,15 @@
+export type RepoFetchResult = { ok: boolean; repo?: unknown };
+
+/**
+ * Generic on the fetch's own result type so callers keep their concrete `repo`
+ * type (e.g. ProjectRepoResponse's `LinkedRepo | null`) instead of `unknown`.
+ */
+export function fetchProjectRepoSettled<T extends RepoFetchResult>(
+  fetchProjectRepo: (id: string, userKey: string) => Promise<T>,
+  id: string,
+  userKey: string,
+  opts?: { attempts?: number; delayMs?: number },
+): Promise<T>;
+
+/** true = linked · false = confirmed no repo · null = unknown (don't lock). */
+export function repoConnectedFact(res: RepoFetchResult): boolean | null;

--- a/apps/dashboard/src/lib/repo-settle.mjs
+++ b/apps/dashboard/src/lib/repo-settle.mjs
@@ -1,0 +1,44 @@
+/**
+ * repo-settle.mjs — resolve a project's linked repo, tolerant of D1
+ * read-after-write lag.
+ *
+ * Bug this fixes (3svs-os/error-patterns/transient-null-hard-false): the "repo
+ * connected" fact is re-derived from a live fetch that can transiently return
+ * `{ok:true, repo:null}` right after a link (D1 propagation). The github page's
+ * loadInitial already retried, but two sibling consumers — the sidebar and the
+ * project overview — collapsed that transient null straight to a hard `false`
+ * with NO retry, which reverted the progress map to "2 코드변경" and hid the
+ * already-linked PR (a re-connect도돌이표). This is the single source of the
+ * retry so the three sites can't diverge again.
+ *
+ * Pure except for the injected `fetchProjectRepo` — unit-testable with a fake.
+ */
+
+/**
+ * @param {(id: string, userKey: string) => Promise<{ok:boolean, repo?:unknown}>} fetchProjectRepo
+ * @param {string} id
+ * @param {string} userKey
+ * @param {{ attempts?: number, delayMs?: number }} [opts]
+ * @returns {Promise<{ok:boolean, repo?:unknown}>}
+ */
+export async function fetchProjectRepoSettled(fetchProjectRepo, id, userKey, opts = {}) {
+  const attempts = opts.attempts ?? 3;
+  const delayMs = opts.delayMs ?? 700;
+  let res = await fetchProjectRepo(id, userKey);
+  for (let i = 0; i < attempts && res.ok && !res.repo; i++) {
+    if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+    res = await fetchProjectRepo(id, userKey);
+  }
+  return res;
+}
+
+/**
+ * The repo-connected fact for the progress map, from a settled fetch result.
+ * true = linked · false = confirmed no repo (after retries) · null = unknown
+ * (fetch failed) → callers must treat null as "don't lock the flow".
+ * @param {{ok:boolean, repo?:unknown}} res
+ * @returns {boolean | null}
+ */
+export function repoConnectedFact(res) {
+  return res.ok ? Boolean(res.repo) : null;
+}

--- a/apps/dashboard/test/repo-settle.test.mjs
+++ b/apps/dashboard/test/repo-settle.test.mjs
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { fetchProjectRepoSettled, repoConnectedFact } from "../src/lib/repo-settle.mjs";
+
+// Root-cause pin for the code-check "reverts to 2 코드변경 + drops the linked PR"
+// bug: a just-linked repo transiently returns {ok:true, repo:null} (D1
+// read-after-write). The sidebar + overview collapsed that to a hard `false`
+// with no retry. The shared helper must retry transient nulls so a connected
+// repo resolves, and a confirmed-no-repo (persistently null) still returns
+// false — while unknown (fetch failed) stays null so the flow never falsely locks.
+
+const REPO = { fullName: "owner/repo" };
+
+function fakeFetch(sequence) {
+  let i = 0;
+  return async () => sequence[Math.min(i++, sequence.length - 1)];
+}
+
+describe("fetchProjectRepoSettled — retries transient read-after-write null", () => {
+  it("resolves a repo that appears on a later attempt (just-linked)", async () => {
+    const fetch = fakeFetch([
+      { ok: true, repo: null }, // transient right after link
+      { ok: true, repo: null },
+      { ok: true, repo: REPO }, // D1 settled
+    ]);
+    const res = await fetchProjectRepoSettled(fetch, "p1", "uk", { delayMs: 0 });
+    assert.deepEqual(res.repo, REPO);
+    assert.equal(repoConnectedFact(res), true, "connected → true (no false revert)");
+  });
+
+  it("confirmed no repo after retries → false", async () => {
+    const fetch = fakeFetch([{ ok: true, repo: null }]); // always null
+    const res = await fetchProjectRepoSettled(fetch, "p1", "uk", { attempts: 3, delayMs: 0 });
+    assert.equal(res.repo, null);
+    assert.equal(repoConnectedFact(res), false, "genuinely no repo → false (step legitimately shows connect)");
+  });
+
+  it("no retry needed when the first fetch already has the repo", async () => {
+    let calls = 0;
+    const fetch = async () => { calls++; return { ok: true, repo: REPO }; };
+    const res = await fetchProjectRepoSettled(fetch, "p1", "uk", { delayMs: 0 });
+    assert.equal(calls, 1, "connected repo resolves on the first call — no delay");
+    assert.equal(repoConnectedFact(res), true);
+  });
+
+  it("fetch failure stays unknown (null), never a hard false", async () => {
+    const fetch = fakeFetch([{ ok: false, error: "HTTP 503" }]);
+    const res = await fetchProjectRepoSettled(fetch, "p1", "uk", { delayMs: 0 });
+    assert.equal(repoConnectedFact(res), null, "transient fetch error must not lock the flow");
+  });
+
+  it("does not retry on a fetch error (ok:false) — only on ok+null", async () => {
+    let calls = 0;
+    const fetch = async () => { calls++; return { ok: false }; };
+    await fetchProjectRepoSettled(fetch, "p1", "uk", { attempts: 3, delayMs: 0 });
+    assert.equal(calls, 1, "an error is not a transient-null → no extra attempts");
+  });
+});


### PR DESCRIPTION
## 증상 (design-prep-layer §9)
코드변경 링크 후 "확인하기" 누르면 **"2 코드변경"으로 되돌아가고 링크된 PR이 사라짐**.

## 근본 원인 (computeProjectSteps 버그 아님 — 정상)
"repo 연결" 사실을 라이브 fetch로 재도출하는데, D1 read-after-write로 방금 링크한 repo가 일시적으로 `{ok:true, repo:null}`을 반환. github 페이지 loadInitial은 이미 3× 재시도했지만, **사이드바 + 개요 페이지는 재시도 없이 `Boolean(res.repo)`로 hard-false 붕괴** → 진행맵 되돌림 + linked-PR 하위트리 언마운트.

## G2-A 회귀 전수검색
같은 패턴이 **3곳**(github fixed, sidebar/overview 미적용) — "한 곳 고치고 형제 안 고침". **공유 retry 헬퍼로 3곳 통일**(다시 갈라지지 않게):
- `lib/repo-settle.mjs`(+`.d.mts` 제네릭, `LinkedRepo` 타입 보존, `as` 없음): `fetchProjectRepoSettled`가 일시적 ok+null 재시도, `repoConnectedFact`가 true/false/**null**(fetch 실패=unknown → 절대 flow 잠그지 않음).
- 사이드바·개요·github loadInitial 모두 이걸 호출.

## 검증
- 유닛 5개: 방금 링크한 repo 재시도로 해결·확정 no-repo→false·이미 있으면 재시도 안 함·fetch 실패는 null(hard false 아님)·에러는 재시도 안 함.
- dashboard **519 pass**, typecheck/lint clean(우회 없음). `3svs-os/error-patterns/transient-null-hard-false.md` 기록.

## 정직 (G1)
사이드바/개요 no-retry 붕괴 = "되돌림" 증상의 **확정 원인**. "확인하기 누른 즉시 같은 마운트에서 되돌림"의 정확한 인과는 라이브 repro 필요(조사가 플래그) — client-side 붕괴 원인은 확정이고 이 fix로 제거됨. **라이브 동작은 배포 후 미검증**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)