### PR TITLE
fix(honesty): hide beta credit banner at the code-check point (audit 5.3)

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/github/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/github/page.tsx
@@ -730,15 +730,13 @@ function CreditDryRunBanner({ t, dryRun, projectId }: { t: Dictionary; dryRun: C
   const enforcement = dryRun as CreditEnforcementResult;
   const blocked = enforcement.actualDebitsEnabled === true && enforcement.blocked === true;
 
-  // Beta: actual debits are OFF. The "이번 달 0/5 · 5회 무료 남음" counter is a
-  // post-beta pricing SIMULATION and read like a real limit ("5번 무료?" — Bae).
-  // While debits are off, say the one true thing and nothing else.
+  // Beta: actual debits are OFF, so there is no credit fact to state at the point
+  // of action. The old "이번 달 0/5 · 5회 무료 남음" counter — even softened to a
+  // "무료예요" line — introduced billing/pricing to a non-developer who never opted
+  // into it, and read like a real limit ("5번 무료?" — Bae). While debits are off,
+  // show nothing here; the dedicated credits page still carries the honest detail.
   if (enforcement.actualDebitsEnabled !== true) {
-    return (
-      <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-        <p className="text-xs text-slate-600">{t.credit.disabledBeta}</p>
-      </div>
-    );
+    return null;
   }
 
   // Product-friendly: hide internal billing flags (dry-run, rollout, debit ledger).


### PR DESCRIPTION
## 무엇을
베타에서 코드체크(github) 화면의 크레딧 배너(`CreditDryRunBanner`)를 완전히 숨깁니다.

## 왜
- 베타 기간엔 실제 크레딧 차감이 OFF(`actualDebitsEnabled=false`)입니다. 차감이 없으면 행동 시점(코드체크)에 알릴 크레딧 사실 자체가 없습니다.
- 기존엔 "이번 달 0/5 · 5회 무료 남음" 카운터를 "무료예요" 회색 박스로 완화만 했는데, 이 박스가 여전히 비개발자에게 과금/가격 개념을 소개하고 실제 한도처럼 읽혔습니다("5번 무료?" — 배님 지적, 코드 주석에 기록돼 있던 사안).

## 어떻게
- `enforcement.actualDebitsEnabled !== true` 브랜치를 `return null`로 변경.
- "N/5 무료" 카운터는 이미 debits-on 브랜치에만 있어 별도 조치 불필요.
- 전용 credits 페이지 + admin 콘솔은 정직한 allowance 상세를 그대로 유지(의도적으로 들어가는 화면).

## 검증
- `pnpm turbo run typecheck --filter @simsa/dashboard` ✅
- `pnpm turbo run test --filter @simsa/dashboard` ✅ 519/519 (i18n parity 포함)
- G2-A 전수: `usedThisPeriod|includedRuns|coveredByAllowance` — 메인 플로우엔 이 배너가 유일, 나머지는 credits/admin 전용.

PRD §9.3 (베타엔 크레딧 UI 숨김) / §12 (크레딧 차감 프로덕션 OFF) / audit 5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)