### PR TITLE
fix(ux): failed loads no longer misdirect or dead-end (UX Basics ④)

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/checks/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/checks/page.tsx
@@ -55,7 +55,8 @@ export default function ChecksPage() {
   // ── PR code check state ───────────────────────────────────────────────────
   const [linkedPulls, setLinkedPulls] = useState<LinkedPull[]>([]);
   const [prReviews, setPrReviews] = useState<Record<number, ReviewRun>>({});
-  const [prLoadPhase, setPrLoadPhase] = useState<"idle" | "loading" | "done">("idle");
+  const [prLoadPhase, setPrLoadPhase] = useState<"idle" | "loading" | "done" | "error">("idle");
+  const [prReloadNonce, setPrReloadNonce] = useState(0);
 
   useEffect(() => {
     const ext = loadExtendedProjectData(id);
@@ -87,7 +88,10 @@ export default function ChecksPage() {
       setPrLoadPhase("loading");
       const linkedRes = await fetchLinkedPulls(id, getUserKey());
       if (cancelled) return;
-      if (!linkedRes.ok) { setPrLoadPhase("done"); return; }
+      // A failed load must NOT collapse into the "no PR review yet → connect a PR"
+      // empty state — that misdirects a user who already connected a PR into
+      // re-connecting it. Surface a distinct error state with retry instead.
+      if (!linkedRes.ok) { setPrLoadPhase("error"); return; }
       setLinkedPulls(linkedRes.pulls);
       const reviews: Record<number, ReviewRun> = {};
       await Promise.all(
@@ -103,7 +107,7 @@ export default function ChecksPage() {
     }
     load();
     return () => { cancelled = true; };
-  }, [id]);
+  }, [id, prReloadNonce]);
 
   const runCheck = useCallback(async () => {
     if (!project) return;
@@ -309,6 +313,15 @@ export default function ChecksPage() {
           <div className="flex items-center gap-2 text-sm text-gray-500">
             <div className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-gray-200 border-t-gray-500" />
             {t.checks.prLoading}
+          </div>
+        )}
+
+        {prLoadPhase === "error" && (
+          <div className="card p-8 text-center">
+            <p className="mb-4 text-sm text-gray-600">{t.checks.prLoadError}</p>
+            <button type="button" onClick={() => setPrReloadNonce((n) => n + 1)} className="btn btn-md btn-secondary">
+              {t.common.retry}
+            </button>
           </div>
         )}
 

--- a/apps/dashboard/src/app/projects/[id]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/page.tsx
@@ -445,6 +445,7 @@ function EvolutionLearningCard({ projectId, t }: { projectId: string; t: Diction
   const [learning, setLearning] = useState<ProjectEvolutionLearningSignals | null>(null);
   const [phase, setPhase] = useState<"idle" | "loading" | "ready" | "error">("idle");
   const [userKey, setUserKey] = useState<string>("");
+  const [reloadNonce, setReloadNonce] = useState(0);
 
   useEffect(() => {
     setUserKey(getUserKey());
@@ -467,13 +468,20 @@ function EvolutionLearningCard({ projectId, t }: { projectId: string; t: Diction
     return () => {
       cancelled = true;
     };
-  }, [projectId, userKey]);
+  }, [projectId, userKey, reloadNonce]);
 
   if (phase === "loading") {
     return <p className="card p-5 text-xs text-gray-500">{t.outcome.loading}</p>;
   }
   if (phase === "error") {
-    return <p className="card p-5 text-xs text-red-600">{t.errors.loadFailed}</p>;
+    return (
+      <div className="card flex items-center justify-between gap-3 p-5">
+        <p className="text-xs text-red-600">{t.errors.loadFailed}</p>
+        <button type="button" onClick={() => setReloadNonce((n) => n + 1)} className="btn btn-sm btn-secondary flex-shrink-0">
+          {t.common.retry}
+        </button>
+      </div>
+    );
   }
   if (!learning) {
     return <p className="card p-5 text-xs text-gray-500">{t.evolution.learningEmpty}</p>;
@@ -633,6 +641,7 @@ function EvolutionTimelineCard({ projectId, t }: { projectId: string; t: Diction
   const [timeline, setTimeline] = useState<ProjectEvolutionTimeline | null>(null);
   const [phase, setPhase] = useState<"idle" | "loading" | "ready" | "error">("idle");
   const [userKey, setUserKey] = useState<string>("");
+  const [reloadNonce, setReloadNonce] = useState(0);
 
   useEffect(() => {
     setUserKey(getUserKey());
@@ -655,13 +664,20 @@ function EvolutionTimelineCard({ projectId, t }: { projectId: string; t: Diction
     return () => {
       cancelled = true;
     };
-  }, [projectId, userKey]);
+  }, [projectId, userKey, reloadNonce]);
 
   if (phase === "loading") {
     return <p className="card p-5 text-xs text-gray-500">{t.outcome.loading}</p>;
   }
   if (phase === "error") {
-    return <p className="card p-5 text-xs text-red-600">{t.errors.loadFailed}</p>;
+    return (
+      <div className="card flex items-center justify-between gap-3 p-5">
+        <p className="text-xs text-red-600">{t.errors.loadFailed}</p>
+        <button type="button" onClick={() => setReloadNonce((n) => n + 1)} className="btn btn-sm btn-secondary flex-shrink-0">
+          {t.common.retry}
+        </button>
+      </div>
+    );
   }
   if (!timeline) {
     return <p className="card p-5 text-xs text-gray-500">{t.evolution.timelineEmpty}</p>;

--- a/apps/dashboard/src/app/projects/[id]/sources/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/sources/page.tsx
@@ -56,6 +56,7 @@ export default function SourcesPage() {
 
   const [phase, setPhase] = useState<"loading" | "done" | "error">("loading");
   const [sources, setSources] = useState<ProjectSource[]>([]);
+  const [disconnectError, setDisconnectError] = useState<string | null>(null);
 
   const [websiteUrl, setWebsiteUrl] = useState("");
   const [websiteBusy, setWebsiteBusy] = useState(false);
@@ -137,8 +138,12 @@ export default function SourcesPage() {
 
   async function handleDisconnect(sourceId: string) {
     if (!window.confirm(t.sources.confirmDisconnect)) return;
+    setDisconnectError(null);
     const res = await deleteProjectSource(id, sourceId, userKey);
     if (res.ok) await load();
+    // A swallowed failure leaves the source in the list with no signal that the
+    // disconnect didn't take — tell the user and keep the row so they can retry.
+    else setDisconnectError(t.sources.errors.disconnectFailed);
   }
 
   return (
@@ -237,7 +242,20 @@ export default function SourcesPage() {
         )}
 
         {phase === "error" && (
-          <div className="callout callout-error">{t.sources.errors.loadFailed}</div>
+          <div className="callout callout-error flex items-center justify-between gap-3">
+            <span>{t.sources.errors.loadFailed}</span>
+            <button
+              type="button"
+              onClick={() => { setPhase("loading"); void load(); }}
+              className="btn btn-sm btn-secondary flex-shrink-0"
+            >
+              {t.common.retry}
+            </button>
+          </div>
+        )}
+
+        {disconnectError && (
+          <div className="callout callout-error">{disconnectError}</div>
         )}
 
         {phase === "done" && sources.length === 0 && (

--- a/apps/dashboard/src/app/projects/new/intake/page.tsx
+++ b/apps/dashboard/src/app/projects/new/intake/page.tsx
@@ -120,6 +120,8 @@ export default function IntakePage() {
   const [listLoading, setListLoading] = useState(false);
   const [openRecord, setOpenRecord] = useState<WorkflowRecord | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
+  const [listError, setListError] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
   // Stage 118 — saved workflow management (archive / restore / delete).
   const [showArchived, setShowArchived] = useState(false);
   const [manageBusyId, setManageBusyId] = useState<string | null>(null);
@@ -310,8 +312,13 @@ export default function IntakePage() {
 
   async function refreshSavedList(includeArchived = showArchived) {
     setListLoading(true);
+    setListError(false);
     const res = await listWorkflowRecords(getUserKey(), { includeArchived });
-    setSavedList(res.ok ? res.records : []);
+    // A failed fetch must not be coerced to [] — that renders the "no saved
+    // records" empty state and falsely tells a user with saved plans they have
+    // none. Keep the prior list and surface a distinct error + retry.
+    if (res.ok) setSavedList(res.records);
+    else setListError(true);
     setListLoading(false);
   }
 
@@ -323,9 +330,11 @@ export default function IntakePage() {
 
   async function openSavedRecord(id: string) {
     setDetailLoading(true);
+    setDetailError(null);
     setOpenRecord(null);
     const res = await getWorkflowRecord(id, getUserKey());
     if (res.ok) setOpenRecord(res.record);
+    else setDetailError(id);
     setDetailLoading(false);
   }
 
@@ -1139,12 +1148,24 @@ export default function IntakePage() {
             <p className="mt-2 text-xs text-gray-500">{manageMsg}</p>
           )}
 
-          {savedList === null && (
+          {listError && (
+            <div className="mt-3 flex items-center gap-3">
+              <p className="text-sm text-red-600">{ic.listLoadError}</p>
+              <button
+                type="button"
+                onClick={() => void refreshSavedList()}
+                className="text-xs font-medium text-brand-700 hover:underline"
+              >
+                {ic.retryButton}
+              </button>
+            </div>
+          )}
+          {!listError && savedList === null && (
             <p className="mt-3 text-sm text-gray-500">
               {ic.refreshHint}
             </p>
           )}
-          {savedList !== null && savedList.length === 0 && (
+          {!listError && savedList !== null && savedList.length === 0 && (
             <p className="mt-3 text-sm text-gray-500">{ob.emptyStates.noSavedRecords}</p>
           )}
           {savedList !== null && savedList.length > 0 && !openRecord && !detailLoading && (
@@ -1221,6 +1242,19 @@ export default function IntakePage() {
               label={tr.loading.reviewingEvidence}
               className="mt-3"
             />
+          )}
+
+          {detailError && !detailLoading && (
+            <div className="mt-3 flex items-center gap-3">
+              <p className="text-sm text-red-600">{ic.detailLoadError}</p>
+              <button
+                type="button"
+                onClick={() => void openSavedRecord(detailError)}
+                className="text-xs font-medium text-brand-700 hover:underline"
+              >
+                {ic.retryButton}
+              </button>
+            </div>
           )}
 
           {openRecord && (

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -433,6 +433,7 @@ export type Dictionary = {
     noPrReview: string;
     noPrReviewDesc: string;
     connectPr: string;
+    prLoadError: string;
     reviewedPr: string;
     viewComparison: string;
     toGithub: string;
@@ -1765,6 +1766,9 @@ export type Dictionary = {
       showArchived: string;
       refreshButton: string;
       refreshHint: string;
+      listLoadError: string;
+      detailLoadError: string;
+      retryButton: string;
       openButton: string;
       restoreButton: string;
       archiveButton: string;
@@ -2107,6 +2111,7 @@ export type Dictionary = {
       forbidden: string;
       generic: string;
       loadFailed: string;
+      disconnectFailed: string;
     };
     draft: {
       cta: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -506,6 +506,7 @@ const EN = {
     noPrReview: "No GitHub code review yet.",
     noPrReviewDesc: "Connect your project's code on GitHub, choose the change to check, then run a review.",
     connectPr: "Connect and review code changes",
+    prLoadError: "Couldn't load your connected code changes. This is a loading problem, not a sign that nothing is connected.",
     reviewedPr: "Reviewed PR",
     viewComparison: "View comparison in GitHub",
     toGithub: "Go to code review",
@@ -1877,6 +1878,9 @@ const EN = {
       showArchived: "Show archived",
       refreshButton: "Refresh",
       refreshHint: "Press Refresh to load your saved workflow plans.",
+      listLoadError: "Couldn't load your saved plans. This is a loading problem, not a sign you have none.",
+      detailLoadError: "Couldn't open this plan. Please try again.",
+      retryButton: "Try again",
       openButton: "Open",
       restoreButton: "Restore",
       archiveButton: "Archive",
@@ -2257,6 +2261,7 @@ const EN = {
       forbidden: "You do not have access to this project.",
       generic: "Something went wrong. Please try again.",
       loadFailed: "Could not load sources. Please try again.",
+      disconnectFailed: "Could not disconnect this source. Please try again.",
     },
     // Stage 267 — document → spec draft flow.
     draft: {
@@ -2812,6 +2817,7 @@ const KO = {
     noPrReview: "아직 GitHub 코드 확인 결과가 없어요.",
     noPrReviewDesc: "GitHub의 코드 저장소와 확인할 코드 변경(PR)을 연결한 뒤 확인을 실행할 수 있습니다.",
     connectPr: "코드 변경(PR) 연결하고 확인하기",
+    prLoadError: "연결된 코드 변경을 불러오지 못했어요. 연결된 게 없다는 뜻이 아니라 불러오기 문제예요.",
     reviewedPr: "확인된 PR",
     viewComparison: "GitHub에서 비교 결과 보기",
     toGithub: "코드 확인 화면으로",
@@ -4176,6 +4182,9 @@ const KO = {
       showArchived: "보관된 플랜 표시",
       refreshButton: "새로고침",
       refreshHint: "새로고침을 누르면 저장된 워크플로우 플랜을 불러옵니다.",
+      listLoadError: "저장된 플랜을 불러오지 못했어요. 플랜이 없다는 뜻이 아니라 불러오기 문제예요.",
+      detailLoadError: "이 플랜을 열지 못했어요. 다시 시도해주세요.",
+      retryButton: "다시 시도",
       openButton: "열기",
       restoreButton: "복원",
       archiveButton: "보관",
@@ -4550,6 +4559,7 @@ const KO = {
       forbidden: "이 프로젝트에 접근할 권한이 없어요.",
       generic: "문제가 발생했어요. 다시 시도해주세요.",
       loadFailed: "연결된 소스를 불러오지 못했어요. 다시 시도해주세요.",
+      disconnectFailed: "이 소스의 연결을 해제하지 못했어요. 다시 시도해주세요.",
     },
     // Stage 267 — 문서 → 제품 설명서 초안 흐름.
     draft: {


### PR DESCRIPTION
## 무엇을
UX Basics 5 전수 점검(PRD §9.2)에서 발견한 **실패한 비동기 로드가 오도/데드엔드로 붕괴하는 6곳**을 수정합니다. 전부 code-check 링크상태 유실 버그(#317)와 같은 계열 — 일시적 실패를 "여기엔 아무것도 없음"으로 오독하는 패턴.

## 고친 곳 (Rule ④/⑤)
| 화면 | 증상 | 수정 |
|---|---|---|
| checks | `fetchLinkedPulls` 실패 → "PR 리뷰 없음 → PR 연결"로 붕괴(이미 연결한 PR 재연결 유도) | `prLoadPhase="error"` + reload nonce, 별도 에러+재시도 |
| intake (목록) | 목록 실패 → `[]` → "저장된 워크플로 없음" 거짓 빈 상태 | 별도 에러+재시도, 기존 목록 유지 |
| intake (재열기) | 재열기 실패 시 스피너만 사라지고 무반응 | 실패 id 보관 → 에러+재시도 |
| sources (로드) | 로드 에러 콜아웃에 재시도 없음 | 콜아웃에 재시도 버튼 |
| sources (해제) | `handleDisconnect` 실패 완전 무시 | disconnect-failed 안내(행 유지, 재시도 가능) |
| overview | Evolution 학습/타임라인 카드 에러에 재시도 없음(형제 중복) | 둘 다 nonce로 재시도 |

## i18n
신규 키 EN/KO parity + `.d.mts`: `checks.prLoadError`, `intake.page.{listLoadError,detailLoadError,retryButton}`, `sources.errors.disconnectFailed`. 재시도 라벨은 기존 `common.retry` 재사용.

## 검증
- `pnpm turbo run typecheck --filter @simsa/dashboard` ✅
- `pnpm turbo run test --filter @simsa/dashboard` ✅ **519/519** (i18n EN/KO parity 포함)
- **확인 못 한 것:** 로컬 dev 서버가 없어 브라우저에서 실제 에러 경로를 직접 트리거하진 못했습니다. 각 변경은 조건부 렌더 추가로, 코드 경로 추적 + typecheck + 테스트로 검증했습니다. 배포 후 라이브 QA 권장.

## 의도적 보류 (감사에서 lower-severity로 분류)
- `CommandCenterCard`의 best-effort 배경 fetch(`.catch(()=>{})`)는 그레이스풀 degrade — 침습적 재시도 UI 대신 유지.
- ③ 비활성 버튼 이유 힌트(new/·items) — 필드가 버튼 바로 위라 이유 자명, 별도 폴리시 PR로.

PRD §9.2 UX Basics ④/⑤.

🤖 Generated with [Claude Code](https://claude.com/claude-code)