### PR TITLE
feat(projects): per-project delete (localStorage + D1/R2 cascade, ownership-gated)

### DIFF
--- a/apps/central-plane/src/routes/cors.ts
+++ b/apps/central-plane/src/routes/cors.ts
@@ -34,7 +34,7 @@ export function corsHeaders(origin: string | null): Record<string, string> {
       : (ALLOWED_ORIGINS[0] as string);
   return {
     "Access-Control-Allow-Origin": allowed,
-    "Access-Control-Allow-Methods": "GET, POST, PATCH, OPTIONS",
+    "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type, Idempotency-Key, X-Simsa-User-Key",
     "Access-Control-Max-Age": "86400",
     Vary: "Origin",

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -33,6 +33,7 @@ import {
   upsertProject,
   getProject,
   getOwnedProject,
+  deleteProject,
   listProjectsByUser,
   saveCheckRun,
   saveFixSuggestion as saveFixSuggestionToDb,
@@ -413,6 +414,31 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
     } catch (err) {
       console.error("[workspace/projects] fetch failed:", err);
       return new Response(JSON.stringify({ ok: false, error: "fetch_failed" }), { status: 500, headers: { "content-type": "application/json", ...headers } });
+    }
+  });
+
+  // ── DELETE /workspace/projects/:id ───────────────────────────────────────────
+  // Hard-delete a project and every project-scoped row + R2 object it owns.
+  // Ownership is enforced via getOwnedProject → 404 for both missing and
+  // not-owned (so ids can't be probed). User-scoped data (GitHub auth, credit
+  // wallet/ledger, notification settings) is deliberately preserved — see
+  // deleteProject() in workspace/db.ts.
+  app.delete("/workspace/projects/:id", async (c) => {
+    const origin = c.req.header("origin") ?? null;
+    const headers = { ...corsHeaders(origin), "Access-Control-Allow-Methods": "GET, DELETE, OPTIONS" };
+    const id = c.req.param("id");
+    const userKey = c.req.query("userKey") ?? "";
+    if (!userKey) {
+      return new Response(JSON.stringify({ ok: false, error: "userKey_required" }), { status: 400, headers: { "content-type": "application/json", ...headers } });
+    }
+    try {
+      const project = await getOwnedProject(c.env, id, userKey);
+      if (!project) return new Response(JSON.stringify({ ok: false, error: "not_found" }), { status: 404, headers: { "content-type": "application/json", ...headers } });
+      await deleteProject(c.env, id);
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json", ...headers } });
+    } catch (err) {
+      console.error("[workspace/projects DELETE] failed:", err);
+      return new Response(JSON.stringify({ ok: false, error: "delete_failed" }), { status: 500, headers: { "content-type": "application/json", ...headers } });
     }
   });
 

--- a/apps/central-plane/src/workspace/db.ts
+++ b/apps/central-plane/src/workspace/db.ts
@@ -198,6 +198,96 @@ export async function listProjectsByUser(
   }));
 }
 
+/**
+ * Project-scoped tables that a project delete must cascade. Every entry has a
+ * genuine `project_id` column (verified against the migrations). USER-scoped
+ * tables are deliberately EXCLUDED — deleting one project must never touch data
+ * shared across a user's other projects:
+ *   - workspace_github_connections / workspace_oauth_states  (user's GitHub auth)
+ *   - workspace_credit_balances                              (user's credit wallet)
+ *   - workspace_credit_ledger                                (financial audit trail)
+ *   - workspace_notification_settings                        (user's chat wiring)
+ * These are constant identifiers we control (never user input), so interpolating
+ * them into the DELETE is injection-safe; the project id is always bound.
+ */
+const PROJECT_SCOPED_TABLES = [
+  "workspace_items",
+  "workspace_check_runs",
+  "workspace_fix_suggestions",
+  "builder_pack_outcomes",
+  "workspace_project_repos",
+  "workspace_project_pull_requests",
+  "workspace_pr_review_runs",
+  "workspace_pr_comments",
+  "workspace_usage_events",
+  "workspace_notifications",
+  "workspace_agent_benchmarks",
+  "workspace_agent_experiments",
+  "workspace_evolution_action_packs",
+  "workspace_agent_workflow_records",
+  "project_sources",
+  "workspace_visual_checks",
+  "workspace_repair_jobs",
+  "workspace_feedback",
+] as const;
+
+/**
+ * Hard-delete a project and every project-scoped row + R2 object it owns.
+ * The CALLER must confirm ownership first (getOwnedProject) — this helper does
+ * not re-check, it just executes the cascade for the given id.
+ *
+ * Order matters: R2 keys are read BEFORE their rows are deleted; the whole D1
+ * cascade runs as one batched transaction so a failure leaves nothing partial.
+ * R2 deletes are best-effort (an orphaned object is storage cost, not a
+ * correctness or privacy leak once its DB row is gone).
+ */
+export async function deleteProject(env: Env, id: string): Promise<void> {
+  // 1. Collect R2 evidence keys before the rows referencing them are deleted:
+  //    uploaded documents (user content — must be removed) + visual-check shots.
+  const r2Keys: string[] = [];
+  try {
+    const docs = await env.DB.prepare(
+      `SELECT reference FROM project_sources WHERE project_id = ? AND type = 'document' AND reference != 'pending'`,
+    )
+      .bind(id)
+      .all<{ reference: string }>();
+    for (const row of docs.results ?? []) if (row.reference) r2Keys.push(row.reference);
+  } catch (err) {
+    console.error("[workspace/db deleteProject] source R2 scan failed:", err);
+  }
+  try {
+    const vis = await env.DB.prepare(
+      `SELECT evidence_keys_json FROM workspace_visual_checks WHERE project_id = ?`,
+    )
+      .bind(id)
+      .all<{ evidence_keys_json: string }>();
+    for (const row of vis.results ?? []) {
+      const keys = safeJson(row.evidence_keys_json ?? "[]");
+      if (Array.isArray(keys)) for (const k of keys) if (typeof k === "string") r2Keys.push(k);
+    }
+  } catch (err) {
+    console.error("[workspace/db deleteProject] visual R2 scan failed:", err);
+  }
+
+  // 2. Delete R2 objects (best-effort, in parallel).
+  if (env.EVIDENCE && r2Keys.length) {
+    await Promise.all(r2Keys.map((k) => env.EVIDENCE!.delete(k).catch(() => {})));
+  }
+
+  // 3. Cascade-delete all D1 rows in one transaction. Experiment candidates key
+  //    by experiment_id, so they go first via a subquery (before the experiment
+  //    rows they reference are deleted). The project row itself goes last.
+  const stmts = [
+    env.DB.prepare(
+      `DELETE FROM workspace_agent_experiment_candidates
+       WHERE experiment_id IN (SELECT id FROM workspace_agent_experiments WHERE project_id = ?)`,
+    ).bind(id),
+    ...PROJECT_SCOPED_TABLES.map((t) => env.DB.prepare(`DELETE FROM ${t} WHERE project_id = ?`).bind(id)),
+    env.DB.prepare(`DELETE FROM workspace_projects WHERE id = ?`).bind(id),
+  ];
+  await env.DB.batch(stmts);
+}
+
 // ─── Check runs ───────────────────────────────────────────────────────────────
 
 export async function saveCheckRun(

--- a/apps/central-plane/test/workspace-project-delete.test.mjs
+++ b/apps/central-plane/test/workspace-project-delete.test.mjs
@@ -1,0 +1,126 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { deleteProject } from "../dist/workspace/db.js";
+
+// A project delete must cascade every PROJECT-scoped row + its R2 evidence, and
+// must NEVER touch USER-scoped data shared across the user's other projects
+// (GitHub auth, credit wallet/ledger, oauth states, notification settings).
+// This test pins that boundary at the SQL level so a future table addition
+// can't silently widen or narrow the blast radius.
+
+function makeEnv() {
+  const deletedR2 = [];
+  const batched = [];
+  const db = {
+    prepare(sql) {
+      return {
+        _sql: sql,
+        _args: [],
+        bind(...args) {
+          this._args = args;
+          return this;
+        },
+        async all() {
+          if (/FROM project_sources/.test(sql)) {
+            // reference != 'pending' is enforced in SQL; the mock returns the
+            // already-filtered row set.
+            return { results: [{ reference: "doc-key-1" }] };
+          }
+          if (/FROM workspace_visual_checks/.test(sql)) {
+            return { results: [{ evidence_keys_json: JSON.stringify(["vis-1", "vis-2"]) }] };
+          }
+          return { results: [] };
+        },
+        async run() {
+          return { success: true };
+        },
+        async first() {
+          return null;
+        },
+      };
+    },
+    async batch(stmts) {
+      for (const s of stmts) batched.push(s._sql);
+      return stmts.map(() => ({ success: true }));
+    },
+  };
+  const EVIDENCE = {
+    async delete(key) {
+      deletedR2.push(key);
+    },
+  };
+  return { env: { DB: db, EVIDENCE }, deletedR2, batched };
+}
+
+const PROJECT_SCOPED = [
+  "workspace_items",
+  "workspace_check_runs",
+  "workspace_fix_suggestions",
+  "builder_pack_outcomes",
+  "workspace_project_repos",
+  "workspace_project_pull_requests",
+  "workspace_pr_review_runs",
+  "workspace_pr_comments",
+  "workspace_usage_events",
+  "workspace_notifications",
+  "workspace_agent_benchmarks",
+  "workspace_agent_experiments",
+  "workspace_evolution_action_packs",
+  "workspace_agent_workflow_records",
+  "project_sources",
+  "workspace_visual_checks",
+  "workspace_repair_jobs",
+  "workspace_feedback",
+];
+
+const USER_SCOPED_NEVER = [
+  "workspace_github_connections",
+  "workspace_oauth_states",
+  "workspace_credit_balances",
+  "workspace_credit_ledger",
+  "workspace_notification_settings",
+];
+
+describe("deleteProject — cascade boundary", () => {
+  it("deletes every project-scoped table + the project row", async () => {
+    const { env, batched } = makeEnv();
+    await deleteProject(env, "proj_x");
+    const joined = batched.join("\n");
+    for (const table of PROJECT_SCOPED) {
+      assert.match(joined, new RegExp(`DELETE FROM ${table}\\b`), `should delete ${table}`);
+    }
+    assert.match(joined, /DELETE FROM workspace_projects WHERE id = \?/, "should delete the project row");
+  });
+
+  it("deletes experiment candidates via the experiment_id subquery", async () => {
+    const { env, batched } = makeEnv();
+    await deleteProject(env, "proj_x");
+    const joined = batched.join("\n");
+    assert.match(
+      joined,
+      /DELETE FROM workspace_agent_experiment_candidates[\s\S]*SELECT id FROM workspace_agent_experiments WHERE project_id = \?/,
+      "candidates must be deleted through their parent experiments",
+    );
+  });
+
+  it("NEVER touches user-scoped tables (would break other projects)", async () => {
+    const { env, batched } = makeEnv();
+    await deleteProject(env, "proj_x");
+    const joined = batched.join("\n");
+    for (const table of USER_SCOPED_NEVER) {
+      assert.doesNotMatch(joined, new RegExp(`DELETE FROM ${table}\\b`), `must NOT delete ${table}`);
+    }
+  });
+
+  it("removes R2 evidence — uploaded documents and visual-check shots", async () => {
+    const { env, deletedR2 } = makeEnv();
+    await deleteProject(env, "proj_x");
+    assert.deepEqual([...deletedR2].sort(), ["doc-key-1", "vis-1", "vis-2"].sort());
+  });
+
+  it("tolerates a missing EVIDENCE binding (R2 cleanup is best-effort)", async () => {
+    const { env } = makeEnv();
+    delete env.EVIDENCE;
+    await assert.doesNotReject(deleteProject(env, "proj_x"));
+  });
+});

--- a/apps/dashboard/src/app/projects/page.tsx
+++ b/apps/dashboard/src/app/projects/page.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { MOCK_PROJECTS, getProjectStats, type Project } from "@/lib/mock-data";
-import { loadLocalProjects } from "@/lib/workflow-store";
+import { loadLocalProjects, deleteProject, getUserKey } from "@/lib/workflow-store";
+import { deleteProjectFromDb } from "@/lib/workspace-check-api";
 import { SpecCompleteness } from "@/components/SpecCompleteness";
 import { useI18n } from "@/i18n/I18nProvider";
 import { statusLabel } from "@/i18n/dictionary.mjs";
@@ -48,7 +49,12 @@ export default function ProjectsPage() {
       ) : (
         <div className="grid gap-4">
           {localProjects.map((project) => (
-            <ProjectCard key={project.id} project={project} t={t} />
+            <ProjectCard
+              key={project.id}
+              project={project}
+              t={t}
+              onDeleted={(id) => setLocalProjects((prev) => prev.filter((p) => p.id !== id))}
+            />
           ))}
         </div>
       )}
@@ -72,46 +78,82 @@ function ProjectCard({
   project,
   t,
   exampleBadge,
+  onDeleted,
 }: {
   project: Project;
   t: Dictionary;
   exampleBadge?: string;
+  /** Present only for the user's own (deletable) projects — example projects are read-only. */
+  onDeleted?: (id: string) => void;
 }) {
   const stats = getProjectStats(project);
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete() {
+    if (deleting) return;
+    if (!window.confirm(t.projects.deleteConfirm.replace("{name}", project.name))) return;
+    setDeleting(true);
+    // localStorage is authoritative for the list — remove it there first so the
+    // card disappears immediately, then mirror the delete to D1/R2 best-effort.
+    deleteProject(project.id);
+    void deleteProjectFromDb(project.id, getUserKey()).catch(() => {});
+    onDeleted?.(project.id);
+  }
+
   return (
-    <Link
-      href={`/projects/${project.id}`}
-      className="card card-select block p-6"
-    >
-      <div className="mb-4 flex items-start justify-between gap-4">
-        <div>
-          <h2 className="flex items-center gap-2 text-base font-semibold text-gray-900">
-            {project.name}
-            {exampleBadge && (
-              <span className="rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500">
-                {exampleBadge}
-              </span>
-            )}
-          </h2>
-          <p className="mt-0.5 text-sm text-gray-500">{project.description}</p>
+    <div className="relative">
+      <Link
+        href={`/projects/${project.id}`}
+        className="card card-select block p-6"
+      >
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <h2 className="flex items-center gap-2 text-base font-semibold text-gray-900">
+              {project.name}
+              {exampleBadge && (
+                <span className="rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+                  {exampleBadge}
+                </span>
+              )}
+            </h2>
+            <p className="mt-0.5 text-sm text-gray-500">{project.description}</p>
+          </div>
+          <span className={`whitespace-nowrap text-xs text-gray-500 ${onDeleted ? "pr-7" : ""}`}>
+            {project.createdAt}
+          </span>
         </div>
-        <span className="whitespace-nowrap text-xs text-gray-500">{project.createdAt}</span>
-      </div>
 
-      <div className="mb-3">
-        <div className="mb-1 flex justify-between text-xs text-gray-500">
-          <span>{t.nav.spec}</span>
+        <div className="mb-3">
+          <div className="mb-1 flex justify-between text-xs text-gray-500">
+            <span>{t.nav.spec}</span>
+          </div>
+          <SpecCompleteness value={project.spec.completeness} />
         </div>
-        <SpecCompleteness value={project.spec.completeness} />
-      </div>
 
-      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
-        <span className="font-medium text-green-600">{statusLabel(t, "passed")} {stats.passed}</span>
-        <span className="font-medium text-red-600">{statusLabel(t, "failed")} {stats.failed}</span>
-        <span className="font-medium text-amber-600">{statusLabel(t, "inconclusive")} {stats.inconclusive}</span>
-        <span className="font-medium text-slate-600">{statusLabel(t, "needs_decision")} {stats.needsDecision}</span>
-        <span className="text-gray-500">{statusLabel(t, "not_started")} {stats.notStarted}</span>
-      </div>
-    </Link>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+          <span className="font-medium text-green-600">{statusLabel(t, "passed")} {stats.passed}</span>
+          <span className="font-medium text-red-600">{statusLabel(t, "failed")} {stats.failed}</span>
+          <span className="font-medium text-amber-600">{statusLabel(t, "inconclusive")} {stats.inconclusive}</span>
+          <span className="font-medium text-slate-600">{statusLabel(t, "needs_decision")} {stats.needsDecision}</span>
+          <span className="text-gray-500">{statusLabel(t, "not_started")} {stats.notStarted}</span>
+        </div>
+      </Link>
+
+      {onDeleted && (
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={deleting}
+          aria-label={t.projects.deleteAria.replace("{name}", project.name)}
+          title={t.projects.deleteLabel}
+          className="absolute right-3 top-3 rounded-md p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-red-500 disabled:opacity-50"
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+            <path d="M10 11v6M14 11v6" />
+          </svg>
+        </button>
+      )}
+    </div>
   );
 }

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -154,6 +154,10 @@ export type Dictionary = {
     examplesTitle: string;
     examplesNote: string;
     exampleBadge: string;
+    deleteLabel: string;
+    deleteAria: string;
+    deleteConfirm: string;
+    deleteFailed: string;
   };
   actions: {
     startProject: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -204,6 +204,10 @@ const EN = {
     examplesTitle: "Example projects",
     examplesNote: "Read-only samples that show what a reviewed project looks like — not your data.",
     exampleBadge: "Example",
+    deleteLabel: "Delete project",
+    deleteAria: "Delete {name}",
+    deleteConfirm: "Delete “{name}”? This removes the project and its review data, and can't be undone.",
+    deleteFailed: "Couldn't delete this project. Please try again.",
   },
   actions: {
     startProject: "Start a project",
@@ -2518,6 +2522,10 @@ const KO = {
     examplesTitle: "예시 프로젝트",
     examplesNote: "검수가 진행된 프로젝트가 어떻게 보이는지 보여주는 읽기 전용 샘플이에요 — 내 데이터가 아닙니다.",
     exampleBadge: "예시",
+    deleteLabel: "프로젝트 삭제",
+    deleteAria: "{name} 삭제",
+    deleteConfirm: "‘{name}’ 프로젝트를 삭제할까요? 프로젝트와 검수 데이터가 함께 삭제되며 되돌릴 수 없어요.",
+    deleteFailed: "프로젝트를 삭제하지 못했어요. 다시 시도해주세요.",
   },
   actions: {
     startProject: "프로젝트 시작",

--- a/apps/dashboard/src/lib/workflow-store.ts
+++ b/apps/dashboard/src/lib/workflow-store.ts
@@ -132,6 +132,35 @@ export function loadLocalProjects(): Project[] {
 }
 
 /**
+ * Delete a project and every local sibling blob it owns: its extended data
+ * (`conclave_wf_ext_*`), builder-pack outcomes (`conclave_outcomes_*`), and its
+ * entry in the sync-failed list. The projects list is authoritative for the UI,
+ * so removing it from the active namespace bucket makes the project vanish
+ * immediately. Server-side D1/R2 cleanup is a separate best-effort mirror call.
+ * Returns true if a project with that id was present and removed.
+ */
+export function deleteProject(id: string): boolean {
+  if (typeof window === "undefined") return false;
+  const key = projectsKeyFor(activeNamespace());
+  const projects = readProjectsAt(key);
+  const remaining = projects.filter((p) => p.id !== id);
+  const existed = remaining.length !== projects.length;
+  localStorage.setItem(key, JSON.stringify(remaining));
+  // Sibling blobs keyed by project id — leaving these would orphan storage.
+  try { localStorage.removeItem(EXT_KEY(id)); } catch { /* storage unavailable */ }
+  try { localStorage.removeItem(OUTCOMES_KEY(id)); } catch { /* storage unavailable */ }
+  // Drop from the sync-failed list so a deleted project never re-surfaces a banner.
+  try {
+    const raw = localStorage.getItem(SYNC_FAILED_KEY);
+    if (raw) {
+      const list = (JSON.parse(raw) as string[]).filter((x) => x !== id);
+      localStorage.setItem(SYNC_FAILED_KEY, JSON.stringify(list));
+    }
+  } catch { /* storage unavailable or corrupt — nothing else to do */ }
+  return existed;
+}
+
+/**
  * Reconcile the active namespace to a signed-in identity. Call on every
  * confirmed sign-in (with the account email/id) and on sign-out (with null).
  * Moving FROM anonymous TO an account "claims" the anonymous projects into the

--- a/apps/dashboard/src/lib/workspace-check-api.ts
+++ b/apps/dashboard/src/lib/workspace-check-api.ts
@@ -89,6 +89,29 @@ export async function saveProjectToDb(payload: {
   }
 }
 
+/**
+ * Best-effort server mirror of a project delete. The localStorage delete is
+ * authoritative for the UI (the list reads local only); this removes the D1 rows
+ * + R2 objects so an account never keeps an orphaned copy. Ownership is enforced
+ * server-side; a 404 (never mirrored, or not owned) is reported but not fatal —
+ * callers delete locally regardless.
+ */
+export async function deleteProjectFromDb(
+  id: string,
+  userKey: string,
+): Promise<{ ok: true } | ApiError> {
+  try {
+    const resp = await fetch(
+      `${CENTRAL_PLANE_URL}/workspace/projects/${encodeURIComponent(id)}?userKey=${encodeURIComponent(userKey)}`,
+      { method: "DELETE", signal: AbortSignal.timeout(10000) },
+    );
+    if (!resp.ok) return { ok: false, error: "server", message: `HTTP ${resp.status}` };
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: "network", message: String(err) };
+  }
+}
+
 // ─── check-draft ─────────────────────────────────────────────────────────────
 
 export type CheckDraftInput = {


### PR DESCRIPTION
## 무엇을
프로젝트 **삭제 기능**을 로컬·서버 end-to-end로 추가합니다. 지금은 리스트·설정·워커 어디에도 전체 프로젝트 삭제 경로가 없습니다.

## dashboard (local-first, 리스트의 진실)
- `workflow-store.deleteProject(id)` — 활성 네임스페이스 버킷에서 제거 + 형제 블롭(`conclave_wf_ext_*`, `conclave_outcomes_*`) + sync-failed 목록 정리.
- 프로젝트 카드마다 휴지통 버튼(확인 다이얼로그, EN/KO). **예제/mock 카드는 읽기전용이라 제외.** 로컬 먼저 삭제(즉시 사라짐) → 서버 미러 best-effort.
- `workspace-check-api.deleteProjectFromDb(id, userKey)`.

## central-plane
- `DELETE /workspace/projects/:id` — `getOwnedProject` 소유권 게이트(missing·not-owned 둘 다 404, id probing 차단), GET 라우트 미러.
- `db.deleteProject(env, id)` — **18개 프로젝트 스코프 테이블 + experiment candidates(experiment_id 서브쿼리) + 프로젝트 행**을 단일 배치 트랜잭션으로 캐스케이드, **R2 증거(업로드 문서 + visual-check 스크린샷)** 먼저 삭제.
- **★USER 스코프 테이블은 의도적으로 제외** — 한 프로젝트 삭제가 유저의 다른 프로젝트 공유 데이터를 지우면 안 됨: `github_connections`·`oauth_states`·`credit_balances`·`credit_ledger`(재무 감사)·`notification_settings`. **마이그레이션과 테이블별 대조로 검증**(추정 아님).
- **CORS**: `Access-Control-Allow-Methods`에 DELETE 추가(공유 `corsHeaders`가 GET/POST/PATCH만 나열 → cross-origin DELETE preflight가 브라우저에서 막혀 있었음, 기존 sources 삭제 잠재 갭 포함 해소).

## 테스트
- `workspace-project-delete.test.mjs` — 캐스케이드 경계를 SQL 레벨로 고정: 모든 프로젝트 테이블 삭제 · **user 스코프 테이블 절대 미접촉** · R2 정리 · EVIDENCE 미바인딩 허용. 5/5 ✅
- localStorage `deleteProject`는 node --test가 .ts를 못 실어 siblings(saveProject 등)와 동일하게 typecheck로 커버.

## 검증
- central-plane typecheck + **1681 tests** ✅ / dashboard typecheck + **519 tests** ✅ (EN/KO i18n parity 포함)
- **확인 못 한 것**: dev 서버 없어 브라우저 실동작 미검증. 조건부 렌더/새 라우트는 코드경로+테스트로 검증. **배포 후 라이브 QA 권장**(central-plane 변경 포함 → 배포 시 central 먼저).

🤖 Generated with [Claude Code](https://claude.com/claude-code)