### PR TITLE
docs: HANDOFF — delete feature (#322/#323) + R2 orphan cleanup carryover

### DIFF
--- a/docs/HANDOFF-2026-07-09.md
+++ b/docs/HANDOFF-2026-07-09.md
@@ -46,12 +46,24 @@
 - **테마 중복**: #295의 "forward exits from dead-ends"가 T6의 데드엔드 6곳과 부분 겹칠 수 있음.
 - **처리**: main에 rebase → 충돌 해소 → T6 대비 **net-new 가치 남는지** 확인 → 남으면 머지, 아니면 non-overlap 부분만 cherry-pick. 배님 판단.
 
+## 5-B. [2026-07-10 추가] 프로젝트 삭제 기능 (#322 + 하드닝 #323) — 머지됨, **배포 대기**
+
+배님 요청으로 전체 프로젝트 삭제를 로컬+서버 end-to-end 신규 구현(기존엔 삭제 경로가 어디에도 없었음).
+
+- **dashboard**: `workflow-store.deleteProject(id)`(리스트 엔트리 + `conclave_wf_ext_*`/`conclave_outcomes_*` 블롭 + sync-failed 정리) + 카드 휴지통 버튼(예제 카드 제외) + `deleteProjectFromDb` 미러.
+- **central-plane**: `DELETE /workspace/projects/:id`(getOwnedProject 게이트, missing/not-owned 둘 다 404) + `db.deleteProject` — **18개 프로젝트 스코프 테이블 + experiment candidates(서브쿼리) + 프로젝트 행**을 단일 배치 트랜잭션 캐스케이드, R2 증거(업로드 문서·visual-check 스크린샷)도 삭제. **user 스코프(github_connections·oauth_states·credit_balances·credit_ledger·notification_settings)는 절대 미접촉** — 마이그레이션 테이블별 대조 검증. CORS `Allow-Methods`에 DELETE 추가(기존 sources 삭제 잠재 갭도 해소).
+- **하드닝 #323** (배포 전 3종 가드 스크루티니 → 2개 보강): ① `window.confirm` 단일 → **acknowledge 체크박스 모달**("되돌릴 수 없음" red 강조, 체크 전 "영구 삭제" disabled) ② 캐스케이드 순서 **D1 트랜잭션 먼저 → R2 나중**(부분실패 시 dangling 참조 방지, 순서 테스트로 고정) ③ silent `.catch(()=>{})` 제거 → 미러 실패 토스트, 404=idempotent 성공. → 메모리 `feedback-destructive-action-guardrails`.
+- **검증**: 캐스케이드/순서 테스트 6/6 · central 1681 · dashboard 519(EN/KO parity) · typecheck 양쪽 ✅. **미검증 = 브라우저 실동작**.
+- **배포**: 배님 승인 대기. central-plane 변경 포함 → **central 먼저** → 스모크 → dashboard. 배포 후 라이브 QA 2종: ⓐ 체크박스 안 누르면 "영구 삭제" disabled ⓑ 정상 삭제 1건 → 목록에서 사라짐 + **새로고침 후에도 안 돌아옴**(D1 실삭제).
+- **★R2 orphan 비용 누수 (후속 청소 잡 필요 — 방치 아님)**: D1→R2 순서상 D1 커밋 후 R2 삭제가 실패하면 무해한 orphan 객체가 남음(dangling 참조는 없으나 **누적 시 스토리지 비용**). 지금은 로그만 남고 재시도 없음. 후속: 주기적 청소 잡(예: cron이 `project_sources`/`workspace_visual_checks`에 참조 없는 EVIDENCE 키 목록화 → 삭제) 또는 R2 lifecycle rule. **"orphan = 무해"는 정확성 관점이지 비용 관점이 아님.**
+
 ## 6. 이월 항목 (묻히지 않게 — 이 배치에 안 담김)
 
 - **Langfuse 키 등록**: usage 로그(`anthropic_usage`)는 쌓이는 중. UI trace는 2026-07-09 **실증됨**(#312/#313 후 배님 UI trace 2건, EU 리전). 남은 것: `docs/decision-status.md` #310 **리전 줄 기입**(배님 가입 리전).
 - **latency = 출력길이 첫 쿼리**: #303 decisions 병합 배포 전후 **output_tokens 평균**이 실제 뛰었는지 Langfuse로 확인. 뛰었으면 대응 = 성능이 아니라 **spec 출력 길이 상한/요약**(비개발자에 5k 토큰 spec = 과부하, "한 화면 한 질문" 원칙과 충돌).
 - **#298** (날조 mock 제거, p0-generate-no-fabrication): #303과 상보적. **rebase-merge 권고** 기록됨 — 열린 상태.
 - **로그인 벽 P1 재등재**: #299 CLOSED(정직화 미반영). 백로그 정식 등재 대기.
+- **R2 orphan 청소 잡**: 프로젝트 삭제(§5-B)의 D1→R2 순서상 R2 삭제 실패 시 orphan 객체 누적 → 스토리지 비용. 주기 청소 잡(cron이 미참조 EVIDENCE 키 삭제) 또는 R2 lifecycle rule. 상세 §5-B.
 
 ## 7. 정직 보류 (감사 lower-severity, 재작업 방지)
 


### PR DESCRIPTION
HANDOFF가 삭제 기능 이전에 작성돼 두 가지가 빠져 있었음 (배님 지적):

- **§5-B 신설** — 프로젝트 삭제(#322) + 하드닝(#323): 머지됨·**배포 대기**(central 먼저), 배포 후 라이브 QA 2종(체크박스 게이트 / 새로고침 후 실삭제 확인).
- **★R2 orphan 비용 누수 명시** — D1→R2 순서상 R2 삭제 실패 시 orphan 객체 누적 = 스토리지 비용. 후속 청소 잡(미참조 EVIDENCE 키 cron 스윕 or R2 lifecycle rule) 기록. "orphan = 무해"는 정확성 관점이지 비용 관점이 아님 — 미래 세션이 "방치해도 됨"으로 오인하지 않게.
- §6 이월 목록에도 한 줄 포인터.

docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)