### PR TITLE
fix(flow): idea-branch walk ends at builder pack + sidebar shows new projects

### DIFF
--- a/apps/dashboard/src/components/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar.tsx
@@ -76,6 +76,15 @@ export function AppSidebar() {
     return () => window.removeEventListener("simsa:auth-changed", onAuthChanged);
   }, [syncSession]);
 
+  // A project created on /projects/new must appear in this list without a full
+  // page reload — client-side navigation never remounts the layout sidebar, so
+  // re-read the local bucket on every route change (localStorage is sync/cheap).
+  // Live finding 2026-07-10: idea-branch users landed on their new project with
+  // the sidebar still not showing it.
+  useEffect(() => {
+    setProjects([...loadLocalProjects(), ...MOCK_PROJECTS]);
+  }, [pathname]);
+
   // Close the account menu on outside click / Escape.
   useEffect(() => {
     if (!accountMenuOpen) return;

--- a/apps/dashboard/src/components/StepNextButton.tsx
+++ b/apps/dashboard/src/components/StepNextButton.tsx
@@ -29,6 +29,7 @@ export function StepNextButton() {
     items: t.nav.items,
     settings: t.nav.settings,
     github: t.nav.github,
+    export: t.nav.export,
     checks: t.nav.checks,
     fixes: t.nav.fixes,
   };

--- a/apps/dashboard/src/lib/project-steps.mjs
+++ b/apps/dashboard/src/lib/project-steps.mjs
@@ -155,10 +155,16 @@ export function nextProjectAction(facts) {
  * @returns {string | null} next slug, or null when there is no obvious next
  */
 export function nextScreenSlug(slug, entryPath) {
+  // Idea/spec entries have NO CODE YET: their walk ends at the builder pack
+  // (go build it), never marching into repo-connect/PR screens — that funnel
+  // only makes sense AFTER the app exists (2026-07-10 live walkthrough: an
+  // idea-branch user was walked settings→github→history in a loop with
+  // nothing to connect). The post-build return path (/p/:id/connect, checks)
+  // is reachable from the export screen and the sidebar, not a forced walk.
   const order =
     entryPath === "code"
       ? ["settings", "github", "items", "checks", "fixes"]
-      : ["idea", "spec", "items", "settings", "github", "checks", "fixes"];
+      : ["idea", "spec", "items", "export"];
   const i = order.indexOf(slug);
   if (i === -1 || i === order.length - 1) return null;
   return order[i + 1];

--- a/apps/dashboard/test/project-steps.test.mjs
+++ b/apps/dashboard/test/project-steps.test.mjs
@@ -166,14 +166,15 @@ test("idea branch with confirmed-no items → create_items first", async () => {
   );
 });
 
-test("nextScreenSlug walks the canonical order and ends cleanly", () => {
+test("nextScreenSlug: idea/spec entries walk to the builder pack and STOP (no code yet)", () => {
+  // Pre-build users must never be marched into repo-connect/PR screens —
+  // that funnel only exists after the app does (2026-07-10 live walkthrough).
   assert.equal(nextScreenSlug("idea"), "spec");
   assert.equal(nextScreenSlug("spec"), "items");
-  assert.equal(nextScreenSlug("items"), "settings");
-  assert.equal(nextScreenSlug("settings"), "github");
-  assert.equal(nextScreenSlug("github"), "checks");
-  assert.equal(nextScreenSlug("checks"), "fixes");
-  assert.equal(nextScreenSlug("fixes"), null); // last — no forced next
+  assert.equal(nextScreenSlug("items"), "export");
+  assert.equal(nextScreenSlug("export"), null); // go build — return path is explicit, not a forced walk
+  assert.equal(nextScreenSlug("settings"), null); // repo screens are outside the pre-build walk
+  assert.equal(nextScreenSlug("github"), null);
   assert.equal(nextScreenSlug("benchmark"), null); // advanced screens stay out of the walk
 });
 
@@ -187,7 +188,7 @@ test("nextScreenSlug: the CODE branch walks repo-connect FIRST (이미 만든 �
   assert.equal(nextScreenSlug("fixes", "code"), null);
   // idea/spec are not on the code walk at all
   assert.equal(nextScreenSlug("idea", "code"), null);
-  // other entries keep the canonical order
-  assert.equal(nextScreenSlug("items", "idea"), "settings");
-  assert.equal(nextScreenSlug("items", null), "settings");
+  // other entries walk to the builder pack (pre-build — no repo screens)
+  assert.equal(nextScreenSlug("items", "idea"), "export");
+  assert.equal(nextScreenSlug("items", null), "export");
 });


### PR DESCRIPTION
2026-07-10 아이디어 갈래 라이브 워크스루(배님) 대응 1차:

- **사이드바에 새 프로젝트 즉시 표시** — 마운트 시에만 localStorage를 읽어 클라 내비게이션으로는 안 나타나던 것 → 라우트 변경마다 재읽기.
- **아이디어/스펙 갈래 스텝 워크를 idea→spec→items→export(빌더팩)에서 종료** — 코드가 아직 없는 유저를 settings→github→PR로 강제 행진시키던 무한 루프 제거. 복귀 경로(/p/:id/connect·export 링크·사이드바)는 명시적으로 유지, 코드 갈래 워크는 불변.

검증: typecheck ✅ · 520 tests ✅(새 워크 고정). 미검증: 브라우저 실동작.
잔여(후속): 확인 직후 뜨는 "완성도 요약" 노이즈 · export 페이지 출구 보강 · #295 처분.

🤖 Generated with [Claude Code](https://claude.com/claude-code)