### PR TITLE
fix(nav): hide GitHub tab from idea-branch projects until code exists

### DIFF
--- a/apps/dashboard/src/components/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar.tsx
@@ -186,9 +186,13 @@ export function AppSidebar() {
     },
     review: {
       label: t.stepsNav.review,
-      // 검수·준비 단계: 저장소 연결 + 빌더팩 다운로드(위로 올림). 서비스/키·알림은
-      // 준비 계층(P1)에서 이 단계에 추가된다.
-      items: [["github", t.nav.github], ["export", t.nav.export]],
+      // 검수·준비 단계: 빌더팩이 기본. "코드 변경"(GitHub) 탭은 코드 갈래이거나
+      // repo가 실제로 연결된 뒤에만 보인다 — 아이디어 갈래 유저에게 repo는 아직
+      // 존재하지도, 알 필요도 없는 개념이다 (배님 2026-07-10 라이브 워크스루).
+      items:
+        entryPath === "code" || hasRepo === true
+          ? [["github", t.nav.github], ["export", t.nav.export]]
+          : [["export", t.nav.export]],
     },
     results: {
       label: t.stepsNav.results,


### PR DESCRIPTION
아이디어 갈래엔 repo가 없고 유저는 repo가 뭔지도 모름(배님 2026-07-10). 사이드바 review 섹션이 모든 프로젝트에 '코드 변경' 탭을 노출하던 것을 → 코드 갈래이거나 repo 실연결 후에만 표시. 개요 커맨드센터는 이미 비코드→빌더팩으로 정상, #327이 강제 워크 제거 — 이 PR이 마지막 노출면을 닫음. 후속: settings 페이지 자체의 repo 섹션 강등(entryPath별). typecheck ✅ 520 ✅. 미검증: 브라우저.

🤖 Generated with [Claude Code](https://claude.com/claude-code)