### PR TITLE
canary: GitHub-issue alert on failure, auto-close on recovery (secret-free)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -20,6 +20,9 @@ jobs:
   probe:
     runs-on: ubuntu-latest
     timeout-minutes: 8
+    permissions:
+      contents: read
+      issues: write
     env:
       BASE: https://conclave-ai.seunghunbae.workers.dev
       APP: https://app.trysimsa.com
@@ -96,6 +99,42 @@ jobs:
             exit 1
           fi
           echo "All canary checks passed."
+
+      # Loud, secret-free alert channel. Email alone failed us: the canary
+      # ran red for 5 straight days (2026-07-10 → 07-15) and nobody noticed,
+      # because GitHub's failure email is easy to skim past. An OPEN issue is
+      # a standing red flag on the repo until someone acts; it auto-closes on
+      # the first green run so it can never go stale in the other direction.
+      - name: Open tracking issue (on failure, secret-free)
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MSG: ${{ steps.probe.outputs.summary }}
+        run: |
+          gh label create canary --repo "$GITHUB_REPOSITORY" \
+            --description "Production canary alerts" --color B60205 2>/dev/null || true
+          open_issue=$(gh issue list --repo "$GITHUB_REPOSITORY" --label canary \
+            --state open --json number --jq '.[0].number // empty')
+          body=$(printf '%s\n\nRun: %s/%s/actions/runs/%s\n(auto-filed by canary; closes itself on the first green run)' \
+            "${MSG:-🔴 Simsa canary failed.}" \
+            "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID")
+          if [ -z "$open_issue" ]; then
+            gh issue create --repo "$GITHUB_REPOSITORY" --label canary \
+              --title "🔴 Production canary failing" --body "$body"
+          else
+            echo "Canary issue #$open_issue already open — not spamming."
+          fi
+
+      - name: Close tracking issue (on recovery)
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for n in $(gh issue list --repo "$GITHUB_REPOSITORY" --label canary \
+                     --state open --json number --jq '.[].number'); do
+            gh issue close "$n" --repo "$GITHUB_REPOSITORY" \
+              --comment "✅ Canary green again: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          done
 
       - name: Telegram alert (optional)
         if: failure()


### PR DESCRIPTION
## 증상 → 근본 원인 → 수정

**증상**: 카나리가 2026-07-10 → 07-15 닷새간 40회+ 연속 빨간불인데 아무도 응답하지 않음.

**근본 원인**: 알림 채널이 GitHub 실패 이메일뿐 (Telegram secret 미설정). 이메일은 스킴하다 놓치기 쉬움 — 카나리가 잡으라던 바로 그 silent-failure 모드를 카나리 자신이 겪음.

**수정**: 실패 시 `canary` 라벨 이슈 1개 오픈(중복 오픈 없음 — 열려 있으면 스팸 안 함), 첫 green 런에서 자동 클로즈. 내장 `GITHUB_TOKEN`만 사용 — **신규 secret 불필요**. Telegram DM은 `TELEGRAM_BOT_TOKEN`/`CANARY_TELEGRAM_CHAT_ID` 주입 시 기존대로 동작 (Bae 액션, 별도).

**전수 검색 (규칙 1)**: `if: failure()` 알림 스텝은 canary.yml 유일. merge/review/rework 워크플로의 telegram 언급은 제품 노티파이어로 다른 클래스 — 단일 수정.

**검증**: js-yaml 파스 OK. 라이브 동작은 머지 후 다음 스케줄 런에서 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)