### PR TITLE
fix(sidebar): deleted project lingered in the sidebar until next navigation

### DIFF
--- a/apps/dashboard/src/components/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useI18n } from "@/i18n/I18nProvider";
-import { loadLocalProjects, loadExtendedProjectData, getUserKey, setActiveAccountNamespace, clearActiveAccount } from "@/lib/workflow-store";
+import { loadLocalProjects, loadExtendedProjectData, getUserKey, setActiveAccountNamespace, clearActiveAccount, PROJECTS_CHANGED_EVENT } from "@/lib/workflow-store";
 import { MOCK_PROJECTS, type Project } from "@/lib/mock-data";
 import { FeedbackModal } from "@/components/FeedbackModal";
 import { StampMark } from "@/components/brand/StampMark";
@@ -84,6 +84,16 @@ export function AppSidebar() {
   useEffect(() => {
     setProjects([...loadLocalProjects(), ...MOCK_PROJECTS]);
   }, [pathname]);
+
+  // Mutations on the SAME route (e.g. deleting a card on /projects) never
+  // change pathname — the store fires this event so the list updates in place.
+  // Live finding 2026-07-15: a deleted project's sidebar entry survived until
+  // the next navigation.
+  useEffect(() => {
+    const onProjectsChanged = () => setProjects([...loadLocalProjects(), ...MOCK_PROJECTS]);
+    window.addEventListener(PROJECTS_CHANGED_EVENT, onProjectsChanged);
+    return () => window.removeEventListener(PROJECTS_CHANGED_EVENT, onProjectsChanged);
+  }, []);
 
   // Close the account menu on outside click / Escape.
   useEffect(() => {

--- a/apps/dashboard/src/lib/workflow-store.ts
+++ b/apps/dashboard/src/lib/workflow-store.ts
@@ -113,6 +113,20 @@ export function clearDraft(): void {
   localStorage.removeItem(draftKeyFor(activeNamespace()));
 }
 
+/**
+ * Fired on window whenever the projects bucket changes (save/delete), so
+ * always-mounted listeners (AppSidebar) can re-read without a route change.
+ * Live finding 2026-07-15: deleting on /projects left the sidebar entry
+ * behind until the next navigation — same class as the 2026-07-10 create
+ * bug, fixed at the store level this time so every future mutator is covered.
+ */
+export const PROJECTS_CHANGED_EVENT = "simsa:projects-changed";
+
+function notifyProjectsChanged(): void {
+  if (typeof window === "undefined") return;
+  try { window.dispatchEvent(new Event(PROJECTS_CHANGED_EVENT)); } catch { /* non-DOM env */ }
+}
+
 export function saveProject(project: Project): void {
   if (typeof window === "undefined") return;
   const projects = loadLocalProjects();
@@ -123,6 +137,7 @@ export function saveProject(project: Project): void {
     projects.unshift(project);
   }
   localStorage.setItem(projectsKeyFor(activeNamespace()), JSON.stringify(projects));
+  notifyProjectsChanged();
 }
 
 export function loadLocalProjects(): Project[] {
@@ -157,6 +172,7 @@ export function deleteProject(id: string): boolean {
       localStorage.setItem(SYNC_FAILED_KEY, JSON.stringify(list));
     }
   } catch { /* storage unavailable or corrupt — nothing else to do */ }
+  notifyProjectsChanged();
   return existed;
 }
 


### PR DESCRIPTION
Symptom (live smoke 2026-07-15, anonymous delete QA): delete a project
card on /projects — the grid card vanishes but the sidebar entry
survives until a route change or reload (reload confirmed D1 delete
worked; this was UI-only staleness).

Root cause: AppSidebar re-reads the local bucket only on pathname
change (#327's fix) and on simsa:auth-changed. A same-route mutation
(card delete on /projects) changes neither, so the sidebar kept serving
its stale in-memory list.

Fix at the store choke point, not per call site: workflow-store now
fires simsa:projects-changed on every bucket mutation (saveProject +
deleteProject), and AppSidebar subscribes. Every current and future
mutator is covered without remembering to wire each caller.

Swept repo (rule 1): bucket mutators are saveProject/deleteProject
only — both now notify. saveProject call sites that previously relied
on navigation (create flow) are unaffected; same-route renames (e.g.
settings) are fixed by the same event as a side effect.

Verify: typecheck clean, dashboard tests 520/520.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
