### PR TITLE
canary: deploy-stale alerts only when undeployed commits touch Worker paths

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -78,11 +78,20 @@ jobs:
                    "https://api.github.com/repos/${GITHUB_REPOSITORY}/compare/${deployed}...${head}")
               ahead=$(printf '%s' "$cmp" | jq -r '.ahead_by // 0')
               oldest=$(printf '%s' "$cmp" | jq -r '.commits[0].commit.committer.date // empty')
-              if [ "${ahead:-0}" -gt 0 ] && [ -n "$oldest" ]; then
+              # Only Worker-relevant paths count. Dashboard ships via Vercel and
+              # docs ship nowhere — a docs-only merge must not page anyone about
+              # the Worker (2026-07-15: dashboard-only #327/#328 kept this red).
+              # Fail-safe: compare API truncates files at 300, so a huge range
+              # with zero listed worker files still alerts (files may be hidden).
+              worker_touched=$(printf '%s' "$cmp" | jq -r '
+                if ((.files // []) | length) >= 300 then "assume"
+                else [(.files // [])[].filename | select(test("^(apps/central-plane/|packages/|pnpm-lock\\.yaml$|pnpm-workspace\\.yaml$)"))] | length
+                end')
+              if [ "${ahead:-0}" -gt 0 ] && [ -n "$oldest" ] && [ "$worker_touched" != "0" ]; then
                 age=$(( $(date -u +%s) - $(date -u -d "$oldest" +%s) ))
                 if [ "$age" -gt 43200 ]; then
                   hrs=$(( age / 3600 ))
-                  fails="$fails\n- deploy stale: main is ${ahead} commit(s) ahead of the deployed Worker (oldest undeployed ~${hrs}h old). Run deploy-central-plane."
+                  fails="$fails\n- deploy stale: main is ${ahead} commit(s) ahead of the deployed Worker with Worker-path changes (oldest undeployed ~${hrs}h old). Run deploy-central-plane."
                 fi
               fi
             fi


### PR DESCRIPTION
Symptom: any merge to main (docs, dashboard-only) made the deploy-stale
probe compare main head vs the Worker's deployedSha and go red after
12h — dashboard-only #327/#328 kept the canary red for 5 days over a
Worker that had nothing to deploy, and today's #331/#332 (dashboard/docs)
would have re-reddened it within 12h.

Fix: filter the compare-API file list to Worker-relevant paths
(apps/central-plane/, packages/, pnpm-lock.yaml, pnpm-workspace.yaml)
and alert only when those changed. >=300 files (API truncation) assumes
worker-touched; missing files field suppresses, matching the probe's
existing 'ambiguity -> no alert' posture. jq logic table-tested on
4 cases (docs-only=0, packages=1, empty=0, lockfile=1); YAML parse OK.

Swept repo (rule 1): deployedSha freshness comparison exists only in
canary.yml — single site.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
