### PR TITLE
fix(inspection): report language never reached the inspector — EN readers always got Korean

### DIFF
--- a/apps/central-plane/inspector-container/server.mjs
+++ b/apps/central-plane/inspector-container/server.mjs
@@ -123,6 +123,9 @@ for (const sig of ["SIGTERM", "SIGINT"]) {
 
 async function runJob(payload) {
   const { runId, projectId, userKey, targetUrl, intent, baseUrl, callbackUrl, callbackToken, runningUrl } = payload;
+  // Report language, dispatched with the job. Older Workers won't send it —
+  // fall back to "ko" rather than trusting an arbitrary value off the wire.
+  const locale = payload.locale === "en" ? "en" : "ko";
   const start = Date.now();
   console.log(`[run ${runId}] start (target host: ${safeHost(targetUrl)})`);
 
@@ -143,7 +146,7 @@ async function runJob(payload) {
     // not exceed ~4 minutes. On timeout the run is reported failed; the
     // leaked browser (if any) dies with the container's sleepAfter.
     const result = await withTimeout(
-      runInspection({ targetUrl, intent, outDir }),
+      runInspection({ targetUrl, intent, outDir, locale }),
       INSPECTION_TIMEOUT_MS,
       `inspection timed out after ${Math.round(INSPECTION_TIMEOUT_MS / 1000)}s`,
     );

--- a/apps/central-plane/src/routes/workspace-visual-check-runs.ts
+++ b/apps/central-plane/src/routes/workspace-visual-check-runs.ts
@@ -96,6 +96,7 @@ export async function dispatchInspection(
     userKey: string;
     targetUrl: string;
     intent: string;
+    locale: "ko" | "en";
     publicBaseUrl: string;
   },
 ): Promise<{ dispatched: boolean; note?: string }> {
@@ -112,6 +113,10 @@ export async function dispatchInspection(
     userKey: args.userKey,
     targetUrl: args.targetUrl,
     intent: args.intent,
+    // The container builds the non-dev report prose at inspection time, so the
+    // reader's locale has to travel WITH the job — the dashboard only renders
+    // the stored report_json and cannot retranslate it afterwards.
+    locale: args.locale,
     baseUrl: base,
     callbackUrl: `${base}/internal/visual-check-done`,
     runningUrl: `${base}/internal/visual-check-running`,
@@ -143,7 +148,13 @@ export function createWorkspaceVisualCheckRunRoutes(): Hono<{ Bindings: Env }> {
   app.post("/workspace/projects/:id/visual-checks/run", async (c) => {
     const projectId = c.req.param("id");
 
-    let body: { userKey?: unknown; sourceId?: unknown; targetUrl?: unknown; intent?: unknown };
+    let body: {
+      userKey?: unknown;
+      sourceId?: unknown;
+      targetUrl?: unknown;
+      intent?: unknown;
+      locale?: unknown;
+    };
     try {
       body = await c.req.json();
     } catch {
@@ -157,6 +168,10 @@ export function createWorkspaceVisualCheckRunRoutes(): Hono<{ Bindings: Env }> {
     const project = await getProject(c.env, projectId);
     if (!project) return c.json({ ok: false, error: "project_not_found" }, 404);
     if (project.userKey !== userKey) return c.json({ ok: false, error: "forbidden" }, 403);
+
+    // Report language. Same shape as every other workspace route
+    // (workspace-document-intake, workspace-github): unknown → "ko".
+    const locale: "ko" | "en" = body.locale === "en" ? "en" : "ko";
 
     // Intent: optional, ≤1000 chars, sensible Korean generic default.
     let intent = DEFAULT_INSPECTION_INTENT;
@@ -223,6 +238,7 @@ export function createWorkspaceVisualCheckRunRoutes(): Hono<{ Bindings: Env }> {
       userKey,
       targetUrl,
       intent,
+      locale,
       publicBaseUrl,
     });
 

--- a/apps/central-plane/test/workspace-visual-check-runs.test.mjs
+++ b/apps/central-plane/test/workspace-visual-check-runs.test.mjs
@@ -320,6 +320,30 @@ test("run: INSPECTOR present → dispatched:true, DO named vc-<runId>, payload c
   assert.match(payload.callbackUrl, /\/internal\/visual-check-done$/);
   assert.match(payload.runningUrl, /\/internal\/visual-check-running$/);
   assert.ok(payload.baseUrl.startsWith("http"), "baseUrl for evidence uploads");
+  assert.equal(payload.locale, "ko", "no locale in the request → ko");
+});
+
+// The report prose is written by the inspector at run time and stored as-is,
+// so the reader's language must ride along with the dispatch. Before this was
+// plumbed, an EN reader's report always came back Korean: the container's
+// runInspection() defaulted locale to "ko" and the dashboard only ever renders
+// the stored report_json.
+test("run: locale rides the dispatch payload so the report is written in the reader's language", async () => {
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({ inspector: makeInspector(recorder) });
+  const r = await req(env, "POST", RUN_PATH, { userKey: USER, locale: "en" });
+  assert.equal(r.status, 202);
+  assert.equal(recorder.calls[0].body.locale, "en");
+});
+
+test("run: an unrecognized locale falls back to ko rather than reaching the container", async () => {
+  for (const locale of ["fr", "", 42, null, { evil: true }]) {
+    const recorder = { names: [], calls: [] };
+    const env = makeEnv({ inspector: makeInspector(recorder) });
+    const r = await req(env, "POST", RUN_PATH, { userKey: USER, locale });
+    assert.equal(r.status, 202, `locale ${JSON.stringify(locale)} must not break the run`);
+    assert.equal(recorder.calls[0].body.locale, "ko", `locale ${JSON.stringify(locale)} → ko`);
+  }
 });
 
 test("run: container dispatch failure → row failed immediately, dispatched:false with note", async () => {

--- a/apps/dashboard/src/app/projects/[id]/visual-checks/[runId]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/visual-checks/[runId]/page.tsx
@@ -295,11 +295,13 @@ function RepairSection({
   runId,
   userKey,
   t,
+  locale,
 }: {
   projectId: string;
   runId: string;
   userKey: string;
   t: Dictionary;
+  locale: Locale;
 }) {
   const s = t.visualChecks.repair;
   const router = useRouter();
@@ -370,7 +372,7 @@ function RepairSection({
     if (recheckSubmitting) return;
     setRecheckSubmitting(true);
     setRecheckNotice(null);
-    const res = await runVisualCheck(projectId, { userKey });
+    const res = await runVisualCheck(projectId, { userKey, locale });
     if (res.ok && res.dispatched) {
       // Keep the button disabled while the navigation happens.
       router.push(`/projects/${projectId}/visual-checks/${res.check.id}`);
@@ -766,7 +768,7 @@ export default function VisualCheckDetailPage() {
           {/* Stage 269 — "[고치기]": only a finished run that did NOT verify
               as working can dispatch a repair (draft fix-brief PR). */}
           {canRepair(check) && (
-            <RepairSection projectId={id} runId={runId} userKey={userKey} t={t} />
+            <RepairSection projectId={id} runId={runId} userKey={userKey} t={t} locale={locale} />
           )}
 
           {/* Copy-ready agent fix prompt */}

--- a/apps/dashboard/src/app/projects/[id]/visual-checks/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/visual-checks/page.tsx
@@ -152,6 +152,7 @@ export default function VisualChecksPage() {
     const trimmedIntent = intent.trim();
     const res = await runVisualCheck(id, {
       userKey,
+      locale,
       ...(trimmedIntent ? { intent: trimmedIntent } : {}),
     });
     setSubmitting(false);

--- a/apps/dashboard/src/lib/workspace-visual-checks-api.ts
+++ b/apps/dashboard/src/lib/workspace-visual-checks-api.ts
@@ -78,6 +78,13 @@ export type VisualCheckRunInput = {
   sourceId?: string;
   targetUrl?: string;
   intent?: string;
+  /**
+   * Language for the report PROSE. The report is written by the inspector at
+   * run time and stored as-is, so this must be sent when the run is queued —
+   * toggling the UI language afterwards re-labels the chrome but cannot
+   * retranslate a finished report. Omitted → "ko".
+   */
+  locale?: "ko" | "en";
 };
 
 export type VisualCheckRunCheck = {


### PR DESCRIPTION
## 무엇이 문제였나

**T1 "리포트 EN 라이브 렌더"는 계정이 없어서 막힌 게 아니었습니다. 어떤 계정으로도 고칠 수 없는 코드 갭이었습니다.**

비개발자 리포트의 본문(verdict/oneLine/findings)은 인스펙터 컨테이너가 **검수 실행 시점에 작성해서 `report_json`에 그대로 저장**합니다. 대시보드는 저장된 걸 렌더만 합니다. 따라서 읽는 사람의 언어는 **디스패치되는 잡에 같이 실려가야** 하는데, 전 구간에서 빠져 있었습니다:

| 지점 | 상태 |
|---|---|
| `POST /workspace/projects/:id/visual-checks/run` | `body.locale`을 읽지 않음 |
| `dispatchInspection` 페이로드 | `locale` 필드 없음 |
| 컨테이너 `runJob` | 구조분해 안 함 |
| `runInspection({ ... })` | `locale` 기본값 `"ko"`로 낙하 |

결과: **#316에서 EN/KO를 배선했지만 클라우드 검수 경로로는 도달 불가**였습니다. `buildNonDevReport(input, "en")`은 처음부터 정상 동작했고, 단지 아무도 `"en"`으로 호출하지 않았습니다. UI를 영어로 바꾸면 리포트 **주변 라벨만** 영어가 되고 본문은 영구히 한국어였습니다.

## 무엇을 고쳤나

`locale`을 끝에서 끝까지 배선했습니다: 대시보드(run 호출부 2곳) → 라우트 → DO 페이로드 → 컨테이너 → `runInspection`.

- 라우트의 파싱은 다른 워크스페이스 라우트와 **동일한 컨벤션**을 따릅니다 (`workspace-document-intake`, `workspace-github`): `body.locale === "en" ? "en" : "ko"`.
- **라우트와 컨테이너 양쪽에서** 모르는 값은 `"ko"`로 낙하시킵니다 — 와이어를 신뢰하지 않고, 구버전 Worker가 신버전 컨테이너로 디스패치해도 동작합니다.
- `RepairSection`이 `t`만 받고 `locale`을 안 받고 있어 prop을 추가했습니다(재검수 버튼도 같은 run 디스패치를 씁니다).

## 검증

**실증 (`buildNonDevReport` / `buildAgentFixPrompt`, 실패한 검수 입력):**

| locale | verdict | 리포트 내 한글 문자 수 |
|---|---|---|
| `ko` | `확인 못 했어요` | **456** |
| `en` | `Couldn't verify` | **0** |

`locale="en"`에서 agent 프롬프트도 영어로 나옵니다 (`You are a development agent editing this project's code...`).

**자동 테스트** — `apps/central-plane/test/workspace-visual-check-runs.test.mjs`에 페이로드 계약을 잠갔습니다:
- locale 없음 → 페이로드 `ko` (기존 계약 테스트에 어서션 추가)
- `locale: "en"` → 페이로드 `en`
- `"fr"` / `""` / `42` / `null` / `{}` → 전부 `ko`, 202 유지 (쓰레기 값이 컨테이너에 도달하지 않음)

- [x] `node --test test/workspace-visual-check-runs.test.mjs` — **24/24 pass**
- [x] `pnpm build` (central-plane) — clean
- [x] `pnpm turbo run typecheck --filter @simsa/dashboard` — clean
- [ ] 라이브 EN 검수 1회 — **배포 후** 확인 (웹사이트 소스가 등록된 프로젝트 필요)

## 알려진 한계 (이 PR 범위 밖)

리포트 본문은 **검수 시점에 언어가 고정**됩니다. 검수를 끝낸 뒤 UI 언어를 바꿔도 기존 리포트는 재번역되지 않습니다 — 다시 검수해야 합니다. 저장된 산문을 사후 번역하려면 별도 설계가 필요하므로 여기서는 다루지 않았습니다. 대신 `VisualCheckRunInput.locale`에 이 제약을 주석으로 명시했습니다.

## 배포 주의

컨테이너 이미지(`inspector-container/server.mjs`)가 바뀌므로 **Worker 배포에 컨테이너 재빌드가 포함**되어야 EN이 실제로 적용됩니다. Worker만 갱신되면 `locale`은 전달되지만 구버전 컨테이너가 무시합니다(→ `ko` 유지, 안전한 열화).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
