### PR TITLE
fix(delete): project delete never removed a single screenshot — R2 evidence orphaned 100% of the time

### DIFF
--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -442,7 +442,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
     try {
       const project = await getOwnedProject(c.env, id, userKey);
       if (!project) return new Response(JSON.stringify({ ok: false, error: "not_found" }), { status: 404, headers: { "content-type": "application/json", ...headers } });
-      await deleteProject(c.env, id);
+      await deleteProject(c.env, id, userKey);
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json", ...headers } });
     } catch (err) {
       console.error("[workspace/projects DELETE] failed:", err);

--- a/apps/central-plane/src/workspace/db.ts
+++ b/apps/central-plane/src/workspace/db.ts
@@ -250,32 +250,58 @@ const PROJECT_SCOPED_TABLES = [
  * R2 deletes are best-effort (an orphaned object is storage cost, not a
  * correctness or privacy leak once its DB row is gone).
  */
-export async function deleteProject(env: Env, id: string): Promise<void> {
+/**
+ * Every R2 key under `prefix`, following the truncation cursor. R2 caps a list
+ * page at 1000 objects, so a project with more evidence than that would leak
+ * the tail if we only read the first page.
+ */
+async function listKeysByPrefix(bucket: R2Bucket, prefix: string): Promise<string[]> {
+  const keys: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await bucket.list({ prefix, limit: 1000, ...(cursor ? { cursor } : {}) });
+    for (const obj of page.objects) keys.push(obj.key);
+    cursor = page.truncated ? page.cursor : undefined;
+  } while (cursor);
+  return keys;
+}
+
+export async function deleteProject(env: Env, id: string, userKey: string): Promise<void> {
   // 1. Collect R2 evidence keys before the rows referencing them are deleted:
   //    uploaded documents (user content — must be removed) + visual-check shots.
-  const r2Keys: string[] = [];
+  const r2Keys = new Set<string>();
   try {
     const docs = await env.DB.prepare(
       `SELECT reference FROM project_sources WHERE project_id = ? AND type = 'document' AND reference != 'pending'`,
     )
       .bind(id)
       .all<{ reference: string }>();
-    for (const row of docs.results ?? []) if (row.reference) r2Keys.push(row.reference);
+    for (const row of docs.results ?? []) if (row.reference) r2Keys.add(row.reference);
   } catch (err) {
     console.error("[workspace/db deleteProject] source R2 scan failed:", err);
   }
-  try {
-    const vis = await env.DB.prepare(
-      `SELECT evidence_keys_json FROM workspace_visual_checks WHERE project_id = ?`,
-    )
-      .bind(id)
-      .all<{ evidence_keys_json: string }>();
-    for (const row of vis.results ?? []) {
-      const keys = safeJson(row.evidence_keys_json ?? "[]");
-      if (Array.isArray(keys)) for (const k of keys) if (typeof k === "string") r2Keys.push(k);
+
+  // Visual-check evidence is NOT enumerable from D1: the upload writes the full
+  // key `checks/{userKey}/{projectId}/{runId}/{name}` but records only the
+  // relative `name` (the read path in workspace-visual-checks.ts reconstructs
+  // the rest). Feeding those names straight to R2.delete() deleted keys that
+  // never existed — and R2 resolves a delete of a missing key successfully, so
+  // it failed silently and every screenshot/video survived every project
+  // delete.
+  //
+  // Enumerate by prefix instead of rebuilding keys from the manifest. Both
+  // project-scoped prefixes embed `{userKey}/{projectId}/`, so this is exactly
+  // scoped — it cannot reach another user's or another project's objects — and
+  // it also sweeps objects the manifest never knew about (a `put` that landed
+  // while its D1 append failed, or a document stuck at reference='pending').
+  if (env.EVIDENCE && userKey) {
+    for (const prefix of [`checks/${userKey}/${id}/`, `docs/${userKey}/${id}/`]) {
+      try {
+        for (const k of await listKeysByPrefix(env.EVIDENCE, prefix)) r2Keys.add(k);
+      } catch (err) {
+        console.error(`[workspace/db deleteProject] R2 prefix scan failed (${prefix}):`, err);
+      }
     }
-  } catch (err) {
-    console.error("[workspace/db deleteProject] visual R2 scan failed:", err);
   }
 
   // 2. Cascade-delete all D1 rows in one transaction FIRST. Experiment
@@ -297,8 +323,16 @@ export async function deleteProject(env: Env, id: string): Promise<void> {
 
   // 3. Delete R2 objects (best-effort, in parallel) — now that no DB row refers
   //    to them, an orphan here is pure storage cost, not a dangling reference.
-  if (env.EVIDENCE && r2Keys.length) {
-    await Promise.all(r2Keys.map((k) => env.EVIDENCE!.delete(k).catch(() => {})));
+  if (env.EVIDENCE && r2Keys.size) {
+    await Promise.all(
+      [...r2Keys].map((k) =>
+        env.EVIDENCE!.delete(k).catch((err) => {
+          // Still best-effort, but no longer silent: an orphan is pure storage
+          // cost, and the only way we learn it happened is this line.
+          console.error(`[workspace/db deleteProject] R2 delete failed (${k}):`, err);
+        }),
+      ),
+    );
   }
 }
 

--- a/apps/central-plane/test/workspace-project-delete.test.mjs
+++ b/apps/central-plane/test/workspace-project-delete.test.mjs
@@ -8,7 +8,30 @@ import { deleteProject } from "../dist/workspace/db.js";
 // This test pins that boundary at the SQL level so a future table addition
 // can't silently widen or narrow the blast radius.
 
-function makeEnv() {
+const USER = "uk_owner";
+const PROJECT = "proj_x";
+
+// The R2 bucket as it ACTUALLY looks after uploads: evidence lives under the
+// full `checks/{userKey}/{projectId}/{runId}/{name}` key, while D1 records only
+// the relative `name`. An earlier version of this test mocked evidence_keys_json
+// as ["vis-1","vis-2"] — values shaped like full keys, which no upload path ever
+// writes — and then asserted those were the keys deleted. That mock encoded the
+// bug as the spec: real deletes were calling R2.delete("screenshots/step-01.png"),
+// which silently no-ops, so every screenshot survived every project delete.
+const BUCKET = {
+  [`docs/${USER}/${PROJECT}/src_1/spec.pdf`]: 1,
+  [`checks/${USER}/${PROJECT}/vc_1/screenshots/step-00-initial.png`]: 1,
+  [`checks/${USER}/${PROJECT}/vc_1/screenshots/step-01.png`]: 1,
+  [`checks/${USER}/${PROJECT}/vc_1/video/flow.webm`]: 1,
+  [`checks/${USER}/${PROJECT}/vc_2/screenshots/step-00-initial.png`]: 1,
+  // An object whose D1 append failed after put — no manifest knows about it.
+  [`checks/${USER}/${PROJECT}/vc_3/screenshots/orphan.png`]: 1,
+  // Must survive: another project of the same user, and another user entirely.
+  [`checks/${USER}/proj_other/vc_9/screenshots/step-01.png`]: 1,
+  [`checks/uk_stranger/${PROJECT}/vc_9/screenshots/step-01.png`]: 1,
+};
+
+function makeEnv({ bucket = { ...BUCKET }, listLimit = 1000 } = {}) {
   const deletedR2 = [];
   const batched = [];
   const sequence = [];
@@ -24,11 +47,8 @@ function makeEnv() {
         async all() {
           if (/FROM project_sources/.test(sql)) {
             // reference != 'pending' is enforced in SQL; the mock returns the
-            // already-filtered row set.
-            return { results: [{ reference: "doc-key-1" }] };
-          }
-          if (/FROM workspace_visual_checks/.test(sql)) {
-            return { results: [{ evidence_keys_json: JSON.stringify(["vis-1", "vis-2"]) }] };
+            // already-filtered row set. Documents store the FULL R2 key.
+            return { results: [{ reference: `docs/${USER}/${PROJECT}/src_1/spec.pdf` }] };
           }
           return { results: [] };
         },
@@ -47,12 +67,30 @@ function makeEnv() {
     },
   };
   const EVIDENCE = {
+    // Paginates like the real thing: R2 caps a page at 1000 and hands back a
+    // cursor. listLimit is squeezed in one test to prove the cursor is followed.
+    async list({ prefix, cursor }) {
+      sequence.push("r2list");
+      const all = Object.keys(bucket)
+        .filter((k) => k.startsWith(prefix))
+        .sort();
+      const start = cursor ? Number(cursor) : 0;
+      const page = all.slice(start, start + listLimit);
+      const end = start + page.length;
+      const truncated = end < all.length;
+      return {
+        objects: page.map((key) => ({ key })),
+        truncated,
+        ...(truncated ? { cursor: String(end) } : {}),
+      };
+    },
     async delete(key) {
       sequence.push("r2");
       deletedR2.push(key);
+      delete bucket[key];
     },
   };
-  return { env: { DB: db, EVIDENCE }, deletedR2, batched, sequence };
+  return { env: { DB: db, EVIDENCE }, deletedR2, batched, sequence, bucket };
 }
 
 const PROJECT_SCOPED = [
@@ -87,7 +125,7 @@ const USER_SCOPED_NEVER = [
 describe("deleteProject — cascade boundary", () => {
   it("deletes every project-scoped table + the project row", async () => {
     const { env, batched } = makeEnv();
-    await deleteProject(env, "proj_x");
+    await deleteProject(env, PROJECT, USER);
     const joined = batched.join("\n");
     for (const table of PROJECT_SCOPED) {
       assert.match(joined, new RegExp(`DELETE FROM ${table}\\b`), `should delete ${table}`);
@@ -97,7 +135,7 @@ describe("deleteProject — cascade boundary", () => {
 
   it("deletes experiment candidates via the experiment_id subquery", async () => {
     const { env, batched } = makeEnv();
-    await deleteProject(env, "proj_x");
+    await deleteProject(env, PROJECT, USER);
     const joined = batched.join("\n");
     assert.match(
       joined,
@@ -108,7 +146,7 @@ describe("deleteProject — cascade boundary", () => {
 
   it("NEVER touches user-scoped tables (would break other projects)", async () => {
     const { env, batched } = makeEnv();
-    await deleteProject(env, "proj_x");
+    await deleteProject(env, PROJECT, USER);
     const joined = batched.join("\n");
     for (const table of USER_SCOPED_NEVER) {
       assert.doesNotMatch(joined, new RegExp(`DELETE FROM ${table}\\b`), `must NOT delete ${table}`);
@@ -117,13 +155,74 @@ describe("deleteProject — cascade boundary", () => {
 
   it("removes R2 evidence — uploaded documents and visual-check shots", async () => {
     const { env, deletedR2 } = makeEnv();
-    await deleteProject(env, "proj_x");
-    assert.deepEqual([...deletedR2].sort(), ["doc-key-1", "vis-1", "vis-2"].sort());
+    await deleteProject(env, PROJECT, USER);
+    assert.deepEqual(
+      [...deletedR2].sort(),
+      [
+        `checks/${USER}/${PROJECT}/vc_1/screenshots/step-00-initial.png`,
+        `checks/${USER}/${PROJECT}/vc_1/screenshots/step-01.png`,
+        `checks/${USER}/${PROJECT}/vc_1/video/flow.webm`,
+        `checks/${USER}/${PROJECT}/vc_2/screenshots/step-00-initial.png`,
+        `checks/${USER}/${PROJECT}/vc_3/screenshots/orphan.png`,
+        `docs/${USER}/${PROJECT}/src_1/spec.pdf`,
+      ].sort(),
+    );
+  });
+
+  // The regression this file previously certified as correct.
+  it("deletes visual-check evidence by its REAL key, not the relative name D1 stores", async () => {
+    const { env, deletedR2, bucket } = makeEnv();
+    await deleteProject(env, PROJECT, USER);
+    for (const k of deletedR2) {
+      assert.ok(
+        k.startsWith("checks/") || k.startsWith("docs/"),
+        `deleted key must be a full R2 key, got "${k}" (a relative name deletes nothing)`,
+      );
+    }
+    const leftovers = Object.keys(bucket).filter((k) => k.includes(`/${PROJECT}/`) && k.startsWith(`checks/${USER}/`));
+    assert.deepEqual(leftovers, [], "no evidence for this project may survive the delete");
+  });
+
+  it("sweeps an object whose D1 append failed after the upload landed", async () => {
+    const { env, deletedR2 } = makeEnv();
+    await deleteProject(env, PROJECT, USER);
+    assert.ok(
+      deletedR2.includes(`checks/${USER}/${PROJECT}/vc_3/screenshots/orphan.png`),
+      "prefix sweep must reach objects no manifest records",
+    );
+  });
+
+  it("never reaches another project of the same user, or another user's bucket space", async () => {
+    const { env, bucket } = makeEnv();
+    await deleteProject(env, PROJECT, USER);
+    assert.ok(bucket[`checks/${USER}/proj_other/vc_9/screenshots/step-01.png`], "other project must survive");
+    assert.ok(bucket[`checks/uk_stranger/${PROJECT}/vc_9/screenshots/step-01.png`], "other user must survive");
+  });
+
+  it("follows the R2 list cursor — evidence past the first page is not left behind", async () => {
+    // R2 caps a real page at 1000 objects; squeeze it to 2 to force pagination.
+    const { env, deletedR2 } = makeEnv({ listLimit: 2 });
+    await deleteProject(env, PROJECT, USER);
+    assert.equal(
+      deletedR2.filter((k) => k.startsWith(`checks/${USER}/${PROJECT}/`)).length,
+      5,
+      "all 5 check objects must be deleted across paginated list calls",
+    );
+  });
+
+  it("without a userKey the prefix sweep is skipped rather than guessing a prefix", async () => {
+    const { env, deletedR2 } = makeEnv();
+    await deleteProject(env, PROJECT, "");
+    assert.deepEqual(
+      deletedR2,
+      [`docs/${USER}/${PROJECT}/src_1/spec.pdf`],
+      "only the D1-recorded full key is removable without a userKey",
+    );
   });
 
   it("commits the D1 transaction BEFORE deleting R2 (no dangling references on partial failure)", async () => {
     const { env, sequence } = makeEnv();
-    await deleteProject(env, "proj_x");
+    await deleteProject(env, PROJECT, USER);
     const firstBatch = sequence.indexOf("batch");
     const firstR2 = sequence.indexOf("r2");
     assert.ok(firstBatch >= 0, "D1 batch must run");
@@ -134,6 +233,6 @@ describe("deleteProject — cascade boundary", () => {
   it("tolerates a missing EVIDENCE binding (R2 cleanup is best-effort)", async () => {
     const { env } = makeEnv();
     delete env.EVIDENCE;
-    await assert.doesNotReject(deleteProject(env, "proj_x"));
+    await assert.doesNotReject(deleteProject(env, PROJECT, USER));
   });
 });


### PR DESCRIPTION
## 이월 항목이 틀렸습니다

핸드오프에 **"R2 orphan 청소 잡 — 미착수"**로, 삭제 순서상 **드물게** 생기는 비용 누수로 적혀 있었습니다. 둘 다 사실이 아닙니다.

R2 삭제는 **#322/#323에서 이미 구현됐고**, 키 포맷이 어긋나 **처음부터 완전한 no-op**이었습니다. 부분 실패 시의 누수가 아니라 **모든 삭제에서 100% 결정론적으로** 새고 있었습니다.

## 원인

업로드는 **전체 키**로 쓰고, D1에는 **상대 이름만** 기록합니다:

```ts
put(`checks/${userKey}/${projectId}/${runId}/${name}`)   // workspace-visual-checks.ts:179
appendVisualCheckEvidenceKey(env, runId, name)           // workspace-visual-checks.ts:181  ← name만
```

읽기 경로가 이름으로부터 전체 키를 **재구성**한다는 사실이 저장값이 상대경로라는 증거입니다(`workspace-visual-checks.ts:226`).

그런데 `deleteProject`는 그 상대 이름을 **전체 키인 양** R2에 그대로 넣었습니다(`db.ts:275` → `db.ts:301`) — 즉 `screenshots/step-01.png`를 삭제하려 한 겁니다. **R2는 없는 키의 삭제도 성공으로 처리**하므로 `.catch(() => {})`가 발화하지 않았고, 아무 신호도 없었습니다.

**결과: 모든 스크린샷·동영상이 모든 프로젝트 삭제에서 살아남았습니다.** 문서는 무사합니다(`project_sources.reference`가 전체 키를 저장).

## 수정

매니페스트에서 키를 재구성하는 대신 **R2에서 프리픽스로 열거**합니다.

두 프리픽스 모두 `{userKey}/{projectId}/`를 포함하므로 스코프가 정확합니다 — **다른 유저·다른 프로젝트에 도달할 수 없습니다**(테스트로 고정). 덤으로 매니페스트가 모르는 객체까지 쓸어냅니다: `put`은 됐는데 D1 append가 실패한 객체, `reference='pending'`에 멈춘 문서. list 커서로 페이지네이션합니다(R2 페이지 상한 1000).

**D1 → R2 순서는 그대로 두었습니다.** dangling reference가 orphan보다 나쁘다는 판단은 옳았고, 버그는 순서가 아니었습니다.

추가로 best-effort R2 삭제가 더 이상 에러를 **조용히 삼키지 않습니다** — orphan은 순수 비용이고, 그 로그 줄이 우리가 알 수 있는 유일한 통로입니다.

## 테스트가 버그를 스펙으로 굳혀놨습니다

기존 테스트는 `evidence_keys_json`을 `["vis-1", "vis-2"]`로 모킹했습니다 — **전체 키처럼 생겼지만 어떤 업로드 경로도 쓰지 않는 값**입니다. 그리고 그 값들이 삭제됐다고 단언했습니다. 이 모크가 버그를 정답으로 만들었고, 그래서 통과한 채 배포됐습니다.

프로덕션과 같은 모양의 버킷으로 다시 썼고, **회귀를 실제로 잡는지 증명**했습니다:

| | 결과 |
|---|---|
| **옛 코드 + 새 테스트** | **7 pass / 4 fail** ← 버그가 실제로 잡힘 |
| 새 코드 + 새 테스트 | **11 / 11** |

옛 코드에서 실패한 4개에는 가짜 모크 시절 통과하던 `"removes R2 evidence"`가 포함됩니다.

## 검증

- [x] `node --test test/workspace-project-delete.test.mjs` — **11/11**
- [x] 옛 코드 대조 — 4개 실패 (회귀 포착 실증)
- [x] **central-plane 전체 스위트 1692/1692**
- [x] 타 유저·타 프로젝트 미침범 (테스트로 고정)
- [x] list 커서 추종 (page limit 2로 강제 페이지네이션)
- [x] `EVIDENCE` 바인딩 없음 / `userKey` 없음 — 안전 열화

## 이 PR에 **의도적으로 넣지 않은 것**

1. **백필** — #322 배포 이후 삭제된 프로젝트의 증거물은 이미 버킷에 남아 있습니다. 이 PR은 출혈을 멈출 뿐 과거를 청소하지 않습니다.
2. **`workspace_pr_review_runs.training_r2_key`** (`events/…`) — 행은 삭제되는데 R2 키는 수집되지 않아 **객체는 살고 포인터만 죽습니다**. 이건 비용이 아니라 **동의·보존 정책** 판단이 필요합니다(배님 결정 필요).
3. **툼스톤** — D1 batch는 커밋됐는데 R2 스윕이 죽는 잔여 부분실패 창. 비용이 유한하므로 결정론적 출혈을 먼저 막았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
