### PR TITLE
test(delete): lock the trailing slash that keeps a project delete from wiping its neighbours

### DIFF
--- a/apps/central-plane/test/workspace-project-delete.test.mjs
+++ b/apps/central-plane/test/workspace-project-delete.test.mjs
@@ -199,6 +199,45 @@ describe("deleteProject — cascade boundary", () => {
     assert.ok(bucket[`checks/uk_stranger/${PROJECT}/vc_9/screenshots/step-01.png`], "other user must survive");
   });
 
+  // The whole safety of a prefix sweep rests on the trailing "/". Without it,
+  // deleting proj_x would also wipe proj_x2 and proj_x_backup — an irreversible
+  // cross-project data loss, and the objects are gone before anyone notices.
+  // Nothing else in the suite would fail if the slash were dropped.
+  it("a project id that is a PREFIX of another id must not drag the other one's evidence with it", async () => {
+    const bucket = {
+      [`checks/${USER}/proj_x/vc_1/screenshots/a.png`]: 1,
+      [`checks/${USER}/proj_x2/vc_1/screenshots/a.png`]: 1,
+      [`checks/${USER}/proj_x_backup/vc_1/screenshots/a.png`]: 1,
+      [`docs/${USER}/proj_x2/src_1/spec.pdf`]: 1,
+    };
+    const { env } = makeEnv({ bucket });
+    await deleteProject(env, "proj_x", USER);
+    assert.deepEqual(
+      Object.keys(bucket).sort(),
+      [
+        `checks/${USER}/proj_x2/vc_1/screenshots/a.png`,
+        `checks/${USER}/proj_x_backup/vc_1/screenshots/a.png`,
+        `docs/${USER}/proj_x2/src_1/spec.pdf`,
+      ].sort(),
+      "only proj_x's own object may be deleted — ids that merely share its prefix must survive",
+    );
+  });
+
+  // Same hazard on the userKey segment.
+  it("a userKey that is a prefix of another userKey must not reach the other user's evidence", async () => {
+    const bucket = {
+      [`checks/uk_a/${PROJECT}/vc_1/screenshots/a.png`]: 1,
+      [`checks/uk_ab/${PROJECT}/vc_1/screenshots/a.png`]: 1,
+    };
+    const { env } = makeEnv({ bucket });
+    await deleteProject(env, PROJECT, "uk_a");
+    assert.deepEqual(
+      Object.keys(bucket),
+      [`checks/uk_ab/${PROJECT}/vc_1/screenshots/a.png`],
+      "uk_ab's evidence must survive uk_a's delete",
+    );
+  });
+
   it("follows the R2 list cursor — evidence past the first page is not left behind", async () => {
     // R2 caps a real page at 1000 objects; squeeze it to 2 to force pagination.
     const { env, deletedR2 } = makeEnv({ listLimit: 2 });


### PR DESCRIPTION
## 왜

#336의 R2 프리픽스 스윕이 안전한 이유는 **오직 프리픽스 끝의 `/` 하나** 때문입니다.

그 한 글자를 지우면 `checks/{userKey}/proj_x/` → `checks/{userKey}/proj_x` 가 되고, **`proj_x2`·`proj_x_backup`까지 매칭**됩니다. userKey 세그먼트도 같은 위험이 있습니다(`uk_a` → `uk_ab` 매칭).

이건 **되돌릴 수 없는 교차 프로젝트 데이터 손실**이고, 아무도 눈치채기 전에 객체가 사라집니다.

## 이 테스트가 필요한 이유 (실증)

슬래시를 지우고 전체 스위트를 돌려봤습니다:

| | 결과 |
|---|---|
| 슬래시 제거 + 기존 12개 테스트 | **전부 통과** ← 아무도 못 잡음 |
| 슬래시 제거 + 이 PR의 새 테스트 | **정확히 이것만 실패** |

즉 **기존 스위트의 어떤 테스트도 이 사고를 막지 못합니다.** 그게 이 PR이 닫는 격차입니다.

## 성격

**동작 변경 없음** — 현재 코드는 이미 정확합니다. 이건 **되돌릴 수 없는 경로에 대한 미래 수정 방어**입니다.

- [x] 13/13 pass
- [x] 슬래시 제거 시 새 테스트만 실패 — 가드가 실제로 작동함을 실증
- [x] 소스 변경 없음 (test-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
