### PR TITLE
canary: a test-only commit is not a pending deploy — stop asking for a no-op deploy

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -78,14 +78,24 @@ jobs:
                    "https://api.github.com/repos/${GITHUB_REPOSITORY}/compare/${deployed}...${head}")
               ahead=$(printf '%s' "$cmp" | jq -r '.ahead_by // 0')
               oldest=$(printf '%s' "$cmp" | jq -r '.commits[0].commit.committer.date // empty')
-              # Only Worker-relevant paths count. Dashboard ships via Vercel and
-              # docs ship nowhere — a docs-only merge must not page anyone about
-              # the Worker (2026-07-15: dashboard-only #327/#328 kept this red).
+              # Only paths that actually ship in the Worker bundle count.
+              # Dashboard ships via Vercel and docs ship nowhere — a docs-only
+              # merge must not page anyone about the Worker (2026-07-15:
+              # dashboard-only #327/#328 kept this red).
+              # Second exclusion (2026-07-16): tests and markdown live UNDER
+              # apps/central-plane/ and packages/, so the path prefix alone still
+              # called a test-only commit a pending deploy. wrangler bundles src/
+              # — it never bundles test/, so that alert was asking for a deploy
+              # that would change nothing. This alarm is only worth having if
+              # every firing means something; the 5-day red was alarm fatigue.
               # Fail-safe: compare API truncates files at 300, so a huge range
               # with zero listed worker files still alerts (files may be hidden).
               worker_touched=$(printf '%s' "$cmp" | jq -r '
                 if ((.files // []) | length) >= 300 then "assume"
-                else [(.files // [])[].filename | select(test("^(apps/central-plane/|packages/|pnpm-lock\\.yaml$|pnpm-workspace\\.yaml$)"))] | length
+                else [(.files // [])[].filename
+                      | select(test("^(apps/central-plane/|packages/|pnpm-lock\\.yaml$|pnpm-workspace\\.yaml$)"))
+                      | select(test("(^|/)test/|\\.test\\.[a-z]+$|\\.md$") | not)]
+                     | length
                 end')
               if [ "${ahead:-0}" -gt 0 ] && [ -n "$oldest" ] && [ "$worker_touched" != "0" ]; then
                 age=$(( $(date -u +%s) - $(date -u -d "$oldest" +%s) ))


### PR DESCRIPTION
## 왜 #333으로 충분하지 않았나

#333이 deploy-stale 체크를 Worker 경로로 좁혀 대시보드/문서 헛알람을 없앴습니다. 그런데 **한 단계 덜 갔습니다** — 테스트와 마크다운은 `apps/central-plane/`와 `packages/` **아래**에 있어서, 경로 프리픽스만으로는 여전히 Worker 변경으로 셉니다.

`wrangler`는 `src/`를 번들합니다. **`test/`는 번들하지 않습니다.** 즉 test-only 머지에 대해 카나리가 "배포하세요"라고 요구하는데, 그 배포는 **출하되는 것을 아무것도 바꾸지 않습니다.**

바로 직전에 이걸 유발할 뻔했습니다 — #338(test-only)을 머지하면 헛알람이 났을 겁니다.

## 왜 이게 중요한가

5일 빨간불은 **신호 하나를 놓쳐서**가 아니라, **아무도 조치할 필요 없는 것에 알람이 계속 울리다가 결국 아무 알람에도 조치하지 않게 되어서** 생겼습니다. 알람은 **울릴 때마다 의미가 있을 때만** 가치가 있습니다.

## 변경

`worker_touched` 카운트에서 `test/` 디렉터리, `*.test.*` 파일, `*.md`를 제외합니다. `>=300` 파일 시 `"assume"` 페일세이프는 그대로 둡니다(compare API 잘림 대비).

## 검증 (jq 필터와 동치인 정규식으로 10개 케이스 전수 — 전부 통과)

| 기대 | 케이스 |
|---|---|
| **침묵** | test-only(#338) · docs-only · dashboard-only(#327/#328) · `packages/*/test` |
| **알람** | Worker src(#336) · src+test 동시(#335) · 컨테이너 이미지 · `pnpm-lock.yaml` · `packages/*/src` · `wrangler.toml` |

핵심: **src와 test가 같이 바뀌면 알람이 유지됩니다**(#335 같은 실제 배포 필요 건을 놓치지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
