### PR TITLE
fix(inspection): the EN report quoted Korean step labels back at the reader

### DIFF
--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -74,13 +74,33 @@ export function decideFromEvidence(e, steps) {
   return "Not Verified";
 }
 
+/** Step NOTES. Like the step labels, these are quoted into the report prose. */
+const STEP_NOTES = {
+  ko: {
+    unsafeSkipped: (cat) => `안전하지 않아 건너뜀 (${cat})`,
+    noResults: "검색 결과/내용이 확인되지 않음 (또는 데이터 요청 실패)",
+    networkFailed: "데이터 요청 실패가 관찰됨",
+    actionFailed: (err) => `동작 실패: ${err}`,
+  },
+  en: {
+    unsafeSkipped: (cat) => `Skipped — not safe to run (${cat})`,
+    noResults: "No results/content appeared (or the data request failed)",
+    networkFailed: "A data request was observed failing",
+    actionFailed: (err) => `Action failed: ${err}`,
+  },
+};
+
 /**
  * Execute one inspection. Returns:
  *   { report, agentPrompt, decision, works, evidenceFiles: [{ name, path }] }
  * where `name` is the Stage 261 evidence name (screenshots/*.png | video/flow.webm)
  * and `path` is the absolute file path inside the container.
+ *
+ * sampleQuery has NO default here on purpose: planVisualFlow picks one from the
+ * locale, and a default at this seam would silently win over it.
  */
-export async function runInspection({ targetUrl, intent, outDir, sampleQuery = "서울", locale = "ko" }) {
+export async function runInspection({ targetUrl, intent, outDir, sampleQuery, locale = "ko" }) {
+  const N = STEP_NOTES[locale === "en" ? "en" : "ko"];
   const shotsDir = join(outDir, "screenshots");
   const videoDir = join(outDir, "video");
   mkdirSync(shotsDir, { recursive: true });
@@ -142,6 +162,7 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery = "
       inputs,
       forbidden: FORBIDDEN_ACTIONS,
       sampleQuery,
+      locale,
     });
     evidence.primaryActionFound = plan.some((s) => s.action === "click" || s.action === "type");
 
@@ -153,7 +174,7 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery = "
         if (step.action === "click") {
           const safety = classifyActionSafety(step.targetText);
           if (!safety.safe) {
-            stepOutcomes.push({ label: step.label, ok: false, note: `안전하지 않아 건너뜀 (${safety.category})` });
+            stepOutcomes.push({ label: step.label, ok: false, note: N.unsafeSkipped(safety.category) });
             continue;
           }
           await page.getByText(step.targetText, { exact: true }).first().click({ timeout: 8000 });
@@ -174,14 +195,14 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery = "
           // Did results/content appear? Heuristic: page text grew and no fresh network failure.
           const bodyLen = (await page.locator("body").innerText().catch(() => "")).length;
           const ok = bodyLen > 200 && networkFailures.length === 0;
-          stepOutcomes.push({ label: step.label, ok, note: ok ? undefined : "검색 결과/내용이 확인되지 않음 (또는 데이터 요청 실패)" });
+          stepOutcomes.push({ label: step.label, ok, note: ok ? undefined : N.noResults });
         } else {
           await snap(shotName);
-          stepOutcomes.push({ label: step.label, ok: networkFailures.length === 0, note: networkFailures.length ? "데이터 요청 실패가 관찰됨" : undefined });
+          stepOutcomes.push({ label: step.label, ok: networkFailures.length === 0, note: networkFailures.length ? N.networkFailed : undefined });
         }
       } catch (err) {
         await snap(shotName);
-        stepOutcomes.push({ label: step.label, ok: false, note: `동작 실패: ${String(err).slice(0, 100)}` });
+        stepOutcomes.push({ label: step.label, ok: false, note: N.actionFailed(String(err).slice(0, 100)) });
       }
     }
   } finally {

--- a/apps/central-plane/src/visual-flow-plan.ts
+++ b/apps/central-plane/src/visual-flow-plan.ts
@@ -33,7 +33,41 @@ export interface FlowPlanInput {
   forbidden?: string[];
   /** Benign value typed into a search/text input. Deterministic; default a common region term. */
   sampleQuery?: string;
+  /**
+   * Language for the step LABELS. These are Simsa's own prose and they are
+   * quoted verbatim into the report ("The '…' step didn't complete"), so a
+   * Korean label lands untranslated in the middle of an English sentence.
+   * Default "ko" — the report builder's default, kept in step.
+   */
+  locale?: "ko" | "en";
 }
+
+/** Step labels. Keep every entry in both locales — see FlowPlanInput.locale. */
+const FLOW_LABELS = {
+  ko: {
+    clickCta: (text: string) => `핵심 버튼 '${text}' 누르기`,
+    observeAfterClick: "버튼을 누른 뒤 화면 확인",
+    typeQuery: (q: string) => `검색창에 '${q}' 입력하기`,
+    observeResults: "검색 결과 화면 확인",
+    observeFirstScreen: "첫 화면 확인 (안전하게 실행할 동작을 못 찾음)",
+  },
+  en: {
+    clickCta: (text: string) => `Press the main button '${text}'`,
+    observeAfterClick: "Check the screen after pressing the button",
+    typeQuery: (q: string) => `Type '${q}' into the search box`,
+    observeResults: "Check the search results screen",
+    observeFirstScreen: "Check the first screen (no action was safe to run)",
+  },
+} as const;
+
+/**
+ * The query typed into a search box. It goes into the TARGET app, so it has to
+ * suit the app's audience rather than the report's reader — but with nothing
+ * better to go on, the reader's language is the best available signal, and a
+ * Korean term in an English app returns nothing (making the flow look broken
+ * when it isn't).
+ */
+const DEFAULT_SAMPLE_QUERY = { ko: "서울", en: "Seoul" } as const;
 
 const DEFAULT_FORBIDDEN = [
   "pay",
@@ -122,7 +156,10 @@ export function ctaIsSearchLike(text: string): boolean {
  */
 export function planVisualFlow(input: FlowPlanInput): FlowStep[] {
   const forbidden = input.forbidden && input.forbidden.length ? input.forbidden : DEFAULT_FORBIDDEN;
-  const sampleQuery = input.sampleQuery && input.sampleQuery.trim() ? input.sampleQuery.trim() : "서울";
+  const locale = input.locale === "en" ? "en" : "ko";
+  const L = FLOW_LABELS[locale];
+  const sampleQuery =
+    input.sampleQuery && input.sampleQuery.trim() ? input.sampleQuery.trim() : DEFAULT_SAMPLE_QUERY[locale];
   const steps: FlowStep[] = [];
 
   const cta = pickSafeCta(input.ctas ?? [], forbidden);
@@ -135,23 +172,23 @@ export function planVisualFlow(input: FlowPlanInput): FlowStep[] {
   const preferInput = searchOriented && input0 && (!cta || !ctaIsSearchLike(cta.text));
 
   if (cta && !preferInput) {
-    steps.push({ action: "click", label: `핵심 버튼 '${cta.text}' 누르기`, selector: cta.selector, targetText: cta.text });
-    steps.push({ action: "observe", label: "버튼을 누른 뒤 화면 확인" });
+    steps.push({ action: "click", label: L.clickCta(cta.text), selector: cta.selector, targetText: cta.text });
+    steps.push({ action: "observe", label: L.observeAfterClick });
     return steps;
   }
 
   if (input0) {
     steps.push({
       action: "type",
-      label: `검색창에 '${sampleQuery}' 입력하기`,
+      label: L.typeQuery(sampleQuery),
       selector: input0.selector,
       value: sampleQuery,
       placeholder: input0.placeholder,
     });
-    steps.push({ action: "observe", label: "검색 결과 화면 확인" });
+    steps.push({ action: "observe", label: L.observeResults });
     return steps;
   }
 
-  steps.push({ action: "observe", label: "첫 화면 확인 (안전하게 실행할 동작을 못 찾음)" });
+  steps.push({ action: "observe", label: L.observeFirstScreen });
   return steps;
 }

--- a/apps/central-plane/test/visual-flow-plan.test.mjs
+++ b/apps/central-plane/test/visual-flow-plan.test.mjs
@@ -100,3 +100,66 @@ test("pickPrimaryInput prefers a search-like input", () => {
   ]);
   assert.equal(i.selector, "#s");
 });
+
+// Step labels are Simsa's own prose and the report quotes them verbatim
+// ("The '<label>' step didn't complete"), so a Korean label lands untranslated
+// inside an English sentence. Live 2026-07-16: an EN report came back with
+// "The '핵심 버튼 '...' 누르기' step didn't complete." — the report dictionary was
+// complete; the planner was the leak.
+const HANGUL = /[가-힣]/;
+
+test("locale 'en' plans English step labels (report quotes these verbatim)", () => {
+  const plan = planVisualFlow({
+    intentAnchor: "a visitor should be able to start the main flow",
+    ctas: [{ text: "Get started", selector: "text=Get started" }],
+    inputs: [],
+    locale: "en",
+  });
+  for (const s of plan) {
+    assert.ok(!HANGUL.test(s.label), `EN plan leaked Korean: "${s.label}"`);
+  }
+  assert.ok(plan.some((s) => s.label.includes("Get started")), "should still quote the real CTA text");
+});
+
+test("locale 'en' types an English sample query — a Korean term finds nothing in an English app", () => {
+  const plan = planVisualFlow({
+    intentAnchor: "search for something",
+    ctas: [],
+    inputs: [{ placeholder: "Search", type: "search", selector: "#s" }],
+    locale: "en",
+  });
+  const typed = plan.find((s) => s.action === "type");
+  assert.ok(typed, "should plan a type step");
+  assert.equal(typed.value, "Seoul");
+  assert.ok(!HANGUL.test(typed.label));
+});
+
+test("an explicit sampleQuery still wins over the locale default", () => {
+  const plan = planVisualFlow({
+    intentAnchor: "search for something",
+    ctas: [],
+    inputs: [{ placeholder: "Search", type: "search", selector: "#s" }],
+    locale: "en",
+    sampleQuery: "Busan",
+  });
+  assert.equal(plan.find((s) => s.action === "type").value, "Busan");
+});
+
+test("the observe-only fallback is localized too", () => {
+  const plan = planVisualFlow({ intentAnchor: "x", ctas: [], inputs: [], locale: "en" });
+  assert.equal(plan.length, 1);
+  assert.equal(plan[0].action, "observe");
+  assert.ok(!HANGUL.test(plan[0].label), `leaked: "${plan[0].label}"`);
+});
+
+test("locale defaults to ko, and an unknown locale falls back to ko (no silent English for KO users)", () => {
+  for (const locale of [undefined, "fr", "", null, 42]) {
+    const plan = planVisualFlow({
+      intentAnchor: "골퍼가 확인",
+      ctas: [{ text: "시작하기", selector: "text=시작하기" }],
+      inputs: [],
+      ...(locale === undefined ? {} : { locale }),
+    });
+    assert.ok(plan.some((s) => HANGUL.test(s.label)), `locale ${JSON.stringify(locale)} should stay Korean`);
+  }
+});


### PR DESCRIPTION
## 어떻게 찾았나

#335 배포 후 **프로덕션에 실제 검수를 `locale=en`으로 돌려봤습니다.** 리포트는 영어로 나왔는데, 두 문장만 한국어가 박혀 있었습니다:

```
"The '핵심 버튼 '...' 누르기' step didn't complete."
"Reason: 동작 실패: TimeoutError: locator.click: Timeout 8000ms exceeded."
```

**테스트로는 절대 못 잡았을 종류입니다** — 로컬에서 모든 finding 형태로 EN 사전을 스캔하면 깨끗하게 나옵니다.

## 원인 — 리포트 사전이 아니라 한 층 아래

`nondev-report.ts`의 EN 사전은 **완전합니다**. 누수는 아래층이었습니다:

`planVisualFlow`와 컨테이너의 스텝 실행기가 **Simsa 자신의 산문**(스텝 라벨·스텝 note)을 **로케일 없이** 만들고, 리포트가 그걸 영어 문장 안에 **그대로 인용**합니다.

## 수정

`runInspection` → `planVisualFlow`로 locale을 배선하고 양쪽을 현지화:

| | ko | en |
|---|---|---|
| 라벨 | `핵심 버튼 '<cta>' 누르기` | `Press the main button '<cta>'` |
| note | `동작 실패: …` | `Action failed: …` |
| note | `안전하지 않아 건너뜀` | `Skipped — not safe to run` |
| note | `검색 결과/내용이 확인되지 않음` | `No results/content appeared` |

**샘플 검색어도 고쳤습니다** — 무조건 `"서울"`이었습니다. 이 문자열은 **대상 앱에 실제로 타이핑**되므로, 영어 앱에서는 아무것도 매칭되지 않아 **멀쩡한 앱이 "Needs Fix"로 오판**됩니다. 이제 `en`→`Seoul` / `ko`→`서울`이고, 명시적 `sampleQuery`는 여전히 둘 다를 이깁니다. `runInspection` 시그니처의 기본값은 **제거**했습니다 — 그 자리에 기본값이 있으면 플래너의 선택을 조용히 덮어쓰기 때문입니다.

## 안전 방향

모르는/없는 locale은 **여전히 `ko`로 낙하**합니다 — KO 유저가 갑자기 영어 라벨을 보는 일은 없어야 합니다.

## 검증

- [x] `visual-flow-plan.test.mjs` **14/14** — EN 라벨 / EN 검색어 / 명시적 쿼리 우선 / observe-only 폴백 / `undefined`·`"fr"`·`""`·`null`·`42` → ko 폴백
- [x] 전체 스위트 **1700/1700**
- [ ] 라이브 EN 검수 재실행 — **배포 후** (컨테이너 이미지 재빌드 필요)

## 의도적으로 안 건드린 것

금지어 목록(`결제`/`삭제`/…)은 한국어 유지 — **대상 페이지를 매칭하는 패턴**이지 사람에게 보여주는 텍스트가 아닙니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
