### PR TITLE
feat(generate): feasibility honesty — stop speccing a native app/game as a finished web app (P0-A)

### DIFF
--- a/apps/central-plane/src/workspace/generate.ts
+++ b/apps/central-plane/src/workspace/generate.ts
@@ -207,12 +207,82 @@ export function detectSoloUse(req: IdeaToSpecDraftRequest): boolean {
   return SOLO_MARKERS.test(text);
 }
 
+/**
+ * Deterministic feasibility detector (D1, P0-A). A non-developer's coding agent
+ * builds a WEB app; when the idea is a native mobile app, a 3D/engine game, a
+ * desktop binary, hardware, or a browser extension, generating a confident web
+ * spec is dishonest — it's exactly the PISTA failure (Kotlin app → "Next.js on
+ * Vercel" shell). A matcher, not an LLM judgement, so it's predictable/testable.
+ *
+ * A plain "웹앱/website" marker VETOES — "모바일에서도 잘 보이는 웹앱" is web, not
+ * a native app. Returns the kind so the honesty message can be specific.
+ */
+const WEB_MARKERS =
+  /웹앱|웹\s*사이트|웹사이트|홈페이지|웹\s*서비스|반응형|웹\s*게임|브라우저\s*게임|브라우저에서|web\s*app|website|web\s*site|web\s*service|responsive|browser[-\s]?based|browser\s*game|in\s*the\s*browser/i;
+// "게임" alone is NOT native — browser/puzzle games are web-buildable. Only a
+// genuine native-game signal (3D / a game engine) counts; "아이폰 게임" is caught
+// by the mobile marker instead.
+const NATIVE_KIND: Array<{ kind: "mobile" | "desktop" | "game" | "hardware" | "extension"; re: RegExp }> = [
+  { kind: "game", re: /\b3d\b|3\s*d\s*게임|언리얼|유니티|unreal|unity|godot|게임\s*엔진|game\s*engine|3d\s*game/i },
+  { kind: "mobile", re: /아이폰|아이패드|안드로이드|네이티브\s*앱|모바일\s*앱|앱스토어|플레이\s*스토어|iphone|ipad|android\s*app|ios\s*app|native\s*app|mobile\s*app|app\s*store|play\s*store|swift|kotlin|react\s*native|flutter/i },
+  { kind: "desktop", re: /데스크톱\s*(?:앱|프로그램|프로그램)|윈도우\s*(?:앱|프로그램)|맥\s*앱|\.exe|설치\s*(?:형|파일)|native\s*desktop|electron\s*app|windows\s*app|mac\s*app|desktop\s*(?:app|program|application)/i },
+  { kind: "hardware", re: /아두이노|라즈베리\s*파이|펌웨어|하드웨어|IoT|사물인터넷|임베디드|arduino|raspberry\s*pi|firmware|embedded|robot|드론|drone/i },
+  { kind: "extension", re: /크롬\s*확장|브라우저\s*확장|익스텐션|chrome\s*extension|browser\s*extension|플러그인|plugin/i },
+];
+
+export function detectNonWebBuildable(
+  req: IdeaToSpecDraftRequest,
+): { hit: false } | { hit: true; kind: "mobile" | "desktop" | "game" | "hardware" | "extension" } {
+  const text = [req.idea, req.context ?? ""].join(" ");
+  // An explicit "web app / website" statement wins — the user wants web.
+  if (WEB_MARKERS.test(text)) return { hit: false };
+  for (const { kind, re } of NATIVE_KIND) {
+    if (re.test(text)) return { hit: true, kind };
+  }
+  return { hit: false };
+}
+
 /** The solo-use rule injected into the prompt (D1). Empty when not solo. */
 function soloGuard(locale: "ko" | "en" | undefined, solo: boolean): string {
   if (!solo) return "";
   return locale === "ko"
     ? `\n- 이 앱은 **혼자(개인용)** 쓰는 앱이다. 권한·역할·멀티유저·사용자 구분/격리·"누구에게 접근을 허용하나" 류의 질문이나 항목은 만들지 마라 — 이 사용자에겐 무의미하다.`
     : `\n- This app is for **solo/personal use**. Do NOT create any question or item about permissions, roles, multi-user, user separation/isolation, or "who to grant access to" — it is meaningless for this user.`;
+}
+
+/** Human-readable name of a non-web-buildable kind, per locale. */
+const FEASIBILITY_KIND_LABEL = {
+  ko: { mobile: "휴대폰 네이티브 앱", desktop: "데스크톱 설치형 프로그램", game: "3D·게임엔진 게임", hardware: "하드웨어·기기", extension: "브라우저 확장 프로그램" },
+  en: { mobile: "a native mobile app", desktop: "an installed desktop program", game: "a 3D / game-engine game", hardware: "hardware / a device", extension: "a browser extension" },
+} as const;
+
+/**
+ * Feasibility honesty rule (D1, P0-A). When the idea needs a non-web build, the
+ * coding agent (which produces a WEB app) cannot ship the real thing — say so,
+ * and scope the spec to the honest web slice + a handoff, never a confident
+ * native spec. Empty when the idea is web-buildable.
+ */
+function feasibilityGuard(
+  locale: "ko" | "en" | undefined,
+  feas: ReturnType<typeof detectNonWebBuildable>,
+): string {
+  if (!feas.hit) return "";
+  const label = FEASIBILITY_KIND_LABEL[locale === "en" ? "en" : "ko"][feas.kind];
+  return locale === "ko"
+    ? `\n- **실현가능성 정직성 (매우 중요):** 이 아이디어는 ${label}이 필요하다. 사용자가 쓰는 개발 AI(v0·Lovable·Cursor 등)는 **웹앱만** 만든다. 따라서: (1) 웹으로 되는 부분(예: 웹 프로토타입, 관리/설정 화면, 랜딩)만 included에 넣고, (2) ${label} 자체(네이티브 빌드·앱스토어 출시·3D 엔진 등)는 excluded에 넣되 "웹으로는 만들 수 없고 전문 개발이 필요"함을 openQuestions에 정직히 적어라. **네이티브 기능을 웹앱처럼 included에 넣어 '다 된다'고 하지 마라.**`
+    : `\n- **Feasibility honesty (very important):** this idea needs ${label}. The user's coding AI (v0, Lovable, Cursor…) builds **web apps only**. So: (1) put only the web-buildable slice (a web prototype, admin/config screens, a landing page) in "included", and (2) put ${label} itself (native build, app-store release, 3D engine…) in "excluded", and state honestly in openQuestions that it **cannot be built on the web and needs specialist development**. Do NOT list native features as if a web app delivers them.`;
+}
+
+/** Deterministic honesty warning surfaced to the user (D1). Empty when web-buildable. */
+export function feasibilityWarning(
+  req: IdeaToSpecDraftRequest,
+): string | null {
+  const feas = detectNonWebBuildable(req);
+  if (!feas.hit) return null;
+  const label = FEASIBILITY_KIND_LABEL[req.locale === "en" ? "en" : "ko"][feas.kind];
+  return req.locale === "en"
+    ? `Heads up: this looks like ${label}. The coding tools Simsa hands off to build web apps, so the web-buildable parts can be made now, but ${label} itself needs specialist development — the spec marks that honestly rather than pretending a web app covers it.`
+    : `참고: 이건 ${label}이 필요해 보여요. 심사가 연결하는 개발 도구는 웹앱을 만들기 때문에, 웹으로 되는 부분은 지금 만들 수 있지만 ${label} 자체는 전문 개발이 필요해요 — 설명서에는 그 점을 '다 된다'고 하지 않고 정직하게 표시했어요.`;
 }
 
 /** Extra-context block (D2). Empty when the user gave none. */
@@ -241,6 +311,7 @@ function rejectedBlock(
 
 export function buildPrompt(req: IdeaToSpecDraftRequest): string {
   const solo = detectSoloUse(req);
+  const feas = detectNonWebBuildable(req);
   // English-first product: generate in English unless the caller asks for Korean.
   if (req.locale === "ko") {
     const answersText =
@@ -258,7 +329,7 @@ export function buildPrompt(req: IdeaToSpecDraftRequest): string {
 - 좋은 질문 = 답에 따라 제품이 실제로 달라지는 구체적 질문. 아래 축을 폭넓게 살펴 이 아이디어에 맞는 것을 고른다:
   구현 범위 · 사용자 흐름 · 데이터 보관 · 로그인/권한 · 외부 연동 · 대상 사용자 숙련도 · 성공 기준 ·
   **화면·디자인(UIUX)**: 참고하는 앱이나 느낌(예: Linear처럼 미니멀 / Notion처럼 정돈 / 밝고 친근하게), 핵심 화면이 몇 개이고 무엇이 먼저 보여야 하는지, 주로 모바일인지 데스크톱인지
-- 나쁜 질문 = 답이 제품을 바꾸지 않는 추상적 질문("장기 비전은?", "전반적으로 어떤 느낌?"). 단, 위처럼 **구체적인 UIUX 질문은 좋은 질문**이다.${soloGuard("ko", solo)}
+- 나쁜 질문 = 답이 제품을 바꾸지 않는 추상적 질문("장기 비전은?", "전반적으로 어떤 느낌?"). 단, 위처럼 **구체적인 UIUX 질문은 좋은 질문**이다.${soloGuard("ko", solo)}${feasibilityGuard("ko", feas)}
 - 꼭 들어가야 할 항목은 8~10개, 각 항목마다 완성 기준 2~4개
 - 완성 기준은 확인 가능한 구체적 동작으로 작성
 
@@ -282,7 +353,7 @@ Follow these rules strictly:
 - Good questions = concrete questions whose answers actually change the product. Draw broadly from these axes, picking what fits this idea:
   scope · user flow · data retention · login/permissions · integrations · target-user skill level · success criteria ·
   **screens/design (UI/UX)**: a reference app or feel (e.g. minimal like Linear / tidy like Notion / bright & friendly), how many key screens there are and what should appear first, mainly mobile or desktop
-- Bad questions = abstract ones whose answers don't change the product ("what's the long-term vision?", "overall feel?"). But concrete UI/UX questions like the above ARE good.${soloGuard("en", solo)}
+- Bad questions = abstract ones whose answers don't change the product ("what's the long-term vision?", "overall feel?"). But concrete UI/UX questions like the above ARE good.${soloGuard("en", solo)}${feasibilityGuard("en", feas)}
 - Include 8-10 must-have items, each with 2-4 acceptance criteria
 - Acceptance criteria must be concrete, verifiable behaviors
 
@@ -698,15 +769,21 @@ function withVerification(
   req: IdeaToSpecDraftRequest,
   res: IdeaToSpecDraftResponse,
 ): IdeaToSpecDraftResponse {
+  // P0-A: the deterministic feasibility warning rides on EVERY draft (LLM or
+  // mock) — it's the honest "this needs a native build" heads-up, independent of
+  // the coverage gate. Prepended so it's the first thing the user sees.
+  const feas = feasibilityWarning(req);
+  const base = feas ? [feas] : [];
+
   const v = res.specVerification ?? verifySpecAgainstUserWords(userWordsOf(req), gateDraftOf(res));
-  if (v.ok) return { ...res, specVerification: v };
+  if (v.ok) return { ...res, specVerification: v, warnings: [...base, ...(res.warnings ?? [])] };
   console.warn(
     `[workspace/generate] user-words gate failed: source=${res.source} coverage=${v.coverage.toFixed(2)} missing=${v.missingWords.slice(0, 8).join("|")}`,
   );
   return {
     ...res,
     specVerification: v,
-    warnings: [...(res.warnings ?? []), coverageWarning(v, req.locale)],
+    warnings: [...base, ...(res.warnings ?? []), coverageWarning(v, req.locale)],
   };
 }
 

--- a/apps/central-plane/test/generate-feasibility.test.mjs
+++ b/apps/central-plane/test/generate-feasibility.test.mjs
@@ -1,0 +1,88 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// P0-A feasibility honesty (2026-07-17). A non-dev's coding agent builds WEB
+// apps; when the idea needs a native mobile app / 3D game / desktop binary /
+// hardware / extension, generating a confident web spec is the PISTA failure.
+// Design: docs/simsa-accuracy-p0-2026-07-17.md.
+
+const { detectNonWebBuildable, buildPrompt, feasibilityWarning, generateIdeaToSpecDraft } =
+  await import("../dist/workspace/generate.js");
+
+describe("detectNonWebBuildable — deterministic, kinded", () => {
+  it("flags native mobile apps and 3D/engine games", () => {
+    const cases = [
+      ["아이폰용 3D 액션 게임, 실시간 멀티플레이", "game"],   // 3d wins (also mobile)
+      ["안드로이드 네이티브 앱으로 만들고 싶어", "mobile"],
+      ["앱스토어에 출시할 iOS 앱", "mobile"],
+      ["유니티로 만드는 게임", "game"],
+      ["윈도우 데스크톱 설치형 프로그램", "desktop"],
+      ["아두이노로 센서를 읽는 펌웨어", "hardware"],
+      ["크롬 확장 프로그램", "extension"],
+    ];
+    for (const [idea, kind] of cases) {
+      const r = detectNonWebBuildable({ idea });
+      assert.equal(r.hit, true, `should flag: ${idea}`);
+      assert.equal(r.kind, kind, `${idea} → kind`);
+    }
+  });
+
+  it("does NOT flag web-buildable ideas — an explicit web marker vetoes", () => {
+    for (const idea of [
+      "개인 가계부 웹앱",
+      "미용실 예약 웹사이트",
+      "브라우저에서 하는 간단한 퍼즐 게임",   // browser game = web
+      "모바일에서도 잘 보이는 반응형 웹앱",     // 'mobile' word but it's a web app
+      "고객 리뷰를 요약하는 웹 서비스",
+    ]) {
+      assert.equal(detectNonWebBuildable({ idea }).hit, false, `should NOT flag: ${idea}`);
+    }
+  });
+
+  it("bare '게임' is not native — only 3D / engine signals count", () => {
+    assert.equal(detectNonWebBuildable({ idea: "웹으로 하는 단어 맞추기 게임" }).hit, false);
+    assert.equal(detectNonWebBuildable({ idea: "3D 게임" }).hit, true);
+  });
+});
+
+describe("feasibility guard is injected into the prompt only when non-web", () => {
+  it("native idea → prompt forbids listing native features as done (ko + en)", () => {
+    const ko = buildPrompt({ idea: "아이폰 3D 게임", locale: "ko" });
+    assert.match(ko, /실현가능성 정직성/);
+    assert.match(ko, /웹앱만|다 된다.*하지 마라|excluded에 넣/);
+    const en = buildPrompt({ idea: "a native iPhone 3D game", locale: "en" });
+    assert.match(en, /Feasibility honesty/i);
+    assert.match(en, /web apps only|Do NOT list native features/i);
+  });
+
+  it("web idea → no feasibility guard", () => {
+    assert.doesNotMatch(buildPrompt({ idea: "가계부 웹앱", locale: "ko" }), /실현가능성 정직성/);
+    assert.doesNotMatch(buildPrompt({ idea: "a budget web app", locale: "en" }), /Feasibility honesty/i);
+  });
+});
+
+describe("feasibilityWarning — the honest heads-up shown to the user", () => {
+  it("names the kind and says the web part can be built but native needs specialists", () => {
+    const ko = feasibilityWarning({ idea: "아이폰 네이티브 앱", locale: "ko" });
+    assert.ok(ko && /전문 개발|웹으로 되는|정직/.test(ko), ko);
+    const en = feasibilityWarning({ idea: "a native android app", locale: "en" });
+    assert.ok(en && /specialist development/i.test(en), en);
+  });
+  it("is null for a web idea", () => {
+    assert.equal(feasibilityWarning({ idea: "예약 웹앱", locale: "ko" }), null);
+  });
+});
+
+describe("the warning actually rides on the generated draft (mock path)", () => {
+  it("a mobile-game idea draft carries the feasibility warning first", async () => {
+    const res = await generateIdeaToSpecDraft({ idea: "아이폰 3D 멀티플레이 게임", locale: "ko" }, undefined);
+    assert.equal(res.source, "mock-fallback");
+    assert.ok((res.warnings ?? []).some((w) => /전문 개발|실현|웹으로 되는/.test(w)), JSON.stringify(res.warnings));
+    // and it's first
+    assert.match(res.warnings[0], /참고:|전문 개발|웹으로 되는/);
+  });
+  it("a plain web idea draft has NO feasibility warning", async () => {
+    const res = await generateIdeaToSpecDraft({ idea: "동네 미용실 예약 웹앱", locale: "ko" }, undefined);
+    assert.ok(!(res.warnings ?? []).some((w) => /전문 개발이 필요/.test(w)), JSON.stringify(res.warnings));
+  });
+});

--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -694,6 +694,15 @@ function NewProjectInner() {
 
               {isFallback && <div className="callout mb-5 border-amber-100 bg-amber-50 text-xs text-amber-700">{t.np.draftNote}</div>}
 
+              {/* Honest heads-ups from the server (P0-A feasibility, coverage) —
+                  the feasibility warning tells a non-dev up front when their idea
+                  needs a native build the web tools can't fully deliver. */}
+              {(result.warnings ?? []).map((w, i) => (
+                <div key={i} className="callout mb-3 border-amber-200 bg-amber-50 text-sm leading-relaxed text-amber-800">
+                  {w}
+                </div>
+              ))}
+
               <UnderstoodCard t={t} understood={result.understood} />
 
               <button onClick={() => setStep(3)} className="btn btn-primary w-full py-3">

--- a/docs/simsa-accuracy-p0-2026-07-17.md
+++ b/docs/simsa-accuracy-p0-2026-07-17.md
@@ -1,0 +1,67 @@
+# Simsa 정확도 P0 2건 (설계 노트)
+
+> 상태: 설계 확정, 구현 착수. Bae 지시(2026-07-17, 실측 평가 리포트 후 "착수해").
+> 근거: `simsa-assessment.html` 실측 — 아이디어→스펙 앞단은 견고하나 두 곳에 확인된 갭.
+> 진실의 소스: `docs/simsa-prd.md`.
+
+## 근본 문제 (2026-07-16 실측으로 확인)
+
+**P0-A 실현가능성 경고 부재** — "아이폰 3D 실시간 멀티플레이 게임"을 웹 빌더로 불가능한데도
+경고 없이 웹앱 스펙("Google/Apple 로그인·클라우드 서버·인앱결제")으로 생성. 비개발자가
+v0/Lovable로 못 만든다는 신호 전무. PRD §6.1이 P1 미결로 인정한 갭이 프로덕션에 살아있음.
+
+**P0-B 시각 검수 false-negative** — 완벽히 작동하는 vercel.com을 "작동 안 해요 — 고쳐야
+해요"로 오판. 원인은 실제 결함이 아니라 검수 도구 한계: (1) 봇차단/서드파티 403·네트워크
+실패를 결함으로 셈, (2) 복잡한 SPA의 CTA 클릭 8초 타임아웃을 "기능 고장"으로. 판정 사다리
+`decideFromEvidence`의 `networkFailures.length || consoleErrors.length → Needs Fix`가
+first-party(대상 앱)와 third-party(애널리틱스·봇차단·광고·CDN)를 구분하지 않음.
+
+## 결정
+
+- **D1 [LOCKED]** 실현가능성은 **결정론적으로 감지**(LLM 판단 아님). `detectNonWebBuildable()`가
+  아이디어+컨텍스트에서 네이티브 신호(아이폰/안드로이드 앱·게임엔진·3D 게임·앱스토어 출시·
+  데스크톱 exe·하드웨어/IoT·브라우저 확장)를 매칭. 감지 시 (a) 프롬프트에 "웹으로 완전 구현
+  불가임을 정직히 알리고, included에 무리한 네이티브 기능을 넣지 말고, 웹으로 되는 프로토타입
+  범위 + 네이티브는 전문 개발 필요를 excluded/openQuestions에 명시" 규칙 주입, (b) 응답
+  `warnings`에 결정론적 정직 경고 1줄 추가(서버에서, LLM 무관). **원칙 잠금, 마커·문구는
+  파라미터.** 완전한 플랫폼 매트릭스 UI(web_buildable/mobile_handoff/other_handoff)는 P1(#296).
+
+- **D2 [LOCKED]** 검수 증거를 **first-party vs third-party로 분류**. 대상 앱 URL의
+  등록가능도메인(eTLD+1 근사: 마지막 2개 라벨)과 같으면 first-party(서브도메인 API 포함 →
+  Potemkin 감지 유지). 네트워크 실패·콘솔 에러·HTTP 4xx/5xx 각각에 URL을 붙여 판정.
+
+- **D3 [LOCKED]** 판정 사다리 재작성:
+  - **first-party** 네트워크 실패/4xx-5xx/콘솔 에러 → `Needs Fix` (백엔드 미연결 = Potemkin
+    핵심 신호, 유지·강화).
+  - **third-party만** 실패 → 그것만으로는 `Needs Fix` 아님. 다음 신호로 진행.
+  - 유일한 문제가 **CTA 클릭 실패(step fail)**뿐이고 first-party 결함이 없으면 →
+    `User Acceptance Required`(사람이 눈으로 확인). "버튼을 못 찾음"을 "앱이 고장"으로 단정 않음.
+  - 로드 자체 실패(5xx/DNS)는 **빈 리포트 금지** — 명확한 verdict + finding.
+
+- **D4 [LOCKED]** finding 생성도 동일 분리: third-party 실패는 finding에서 제외하거나 info로
+  격하, first-party만 high. **정확도 방향은 관대함이 아니라 "결함 신호와 도구 잡음의 분리"** —
+  진짜 Potemkin(first-party API 404/500)은 여전히 강하게 잡아야 한다.
+
+## 스테이지
+
+- **S1 (central-plane, P0-A)** — `detectNonWebBuildable()` + 프롬프트 정직성 규칙(KO/EN) +
+  warnings 주입 + 테스트. 가벼움(generate.ts). 대시보드는 기존 warnings 표시 재사용.
+- **S2 (central-plane + 컨테이너, P0-B)** — 에러 URL 구조화 수집(`m.location()`, response
+  4xx 포함) + first-party 분류 헬퍼(src 공유) + `decideFromEvidence` 재작성 + `classifyFindings`
+  분리 + 테스트. **컨테이너 이미지 재빌드 필요.**
+
+배포: S1 → central 1회. S2 → central 1회(컨테이너 포함). 라이브 재검증: 모바일 게임 → 정직
+경고 확인 / vercel.com → 더 이상 오탐 아님 확인.
+
+## 게이트 레지스트리
+
+| 게이트 | 문구 | 발효 |
+|---|---|---|
+| 설계 잠금 | (Bae "착수해"로 착수 승인) | D1~D4 LOCKED, 구현 착수 |
+| 배포 | `deploy <target> approved.` 건별 | 미발효 — S1/S2 완료 후 |
+
+## 비목표
+
+- 완전한 온보딩 플랫폼 매트릭스 UI (P1, #296 설계 문서)
+- 검수 정확도의 실제-타겟(신생 vibe 앱) 수치 실증 — 별도 데이터셋 필요, 이번 범위는 오탐 원인 제거
+- LLM 기반 실현가능성 판정 — 결정론 우선(예측·테스트 가능)


### PR DESCRIPTION
## 배경 — 실측 평가에서 확인된 P0-A

2026-07-16 실측: **"아이폰 3D 실시간 멀티플레이 게임"**을 넣으니 웹으로 불가능한데도 "Google/Apple 로그인·클라우드 서버·인앱결제" 웹앱 스펙을 **경고 없이** 생성. 비개발자의 개발 AI(v0/Lovable/Cursor)는 **웹앱만** 만드는데 네이티브 게임을 "다 된다"고 함. 배님이 PISTA(Kotlin 앱 → "Next.js/Vercel" 껍데기)에서 겪은 바로 그 실패. 설계: `docs/simsa-accuracy-p0-2026-07-17.md`.

## 수정

`detectNonWebBuildable()` — **결정론적**(매처, LLM 아님), 종류 구분(mobile/desktop/game/hardware/extension):
- **웹 마커 veto** — "웹앱·website·브라우저 게임"이면 통과
- **"게임" 단독은 네이티브 아님** — 3D·게임엔진 신호만 잡음(브라우저 게임은 웹으로 가능)

감지 시:
1. **프롬프트 정직성 규칙**(KO/EN) — 웹으로 되는 부분만 included, 네이티브는 excluded, openQuestions에 "전문 개발 필요" 명시. 네이티브 기능을 웹앱처럼 넣지 말 것.
2. **결정론적 사용자 경고**(LLM 무관, 맨 앞) — "이건 [종류]가 필요해요. 웹으로 되는 부분은 지금 만들 수 있지만 [종류] 자체는 전문 개발이 필요해요 — 설명서에는 '다 된다'고 하지 않고 정직하게 표시했어요."

**대시보드**가 이제 `result.warnings`를 이해 단계에서 렌더 — 경고가 실제로 비개발자에게 도달(전엔 draft 태그만).

## 검증

- [x] `generate-feasibility.test.mjs` **9/9** — 종류별 감지·웹 veto·게임 단독 제외·프롬프트 가드(네이티브일 때만)·경고가 draft 맨 앞
- [x] 전체 스위트 **1724/1724** · dashboard typecheck clean
- [ ] 배포 후 라이브: 모바일 게임 → 정직 경고 확인

## 범위

완전한 온보딩 플랫폼 매트릭스 UI(web_buildable/mobile_handoff/other_handoff)는 P1(#296 설계)로 유지. 이 PR은 실측이 지적한 P0 갭(경고 부재)만 닫음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
