### PR TITLE
fix(inspection): stop calling a working site broken — noise-filter the verdict (P0-B)

### DIFF
--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -23,7 +23,7 @@ import { chromium } from "playwright";
 import { mkdirSync, copyFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { planVisualFlow } from "./dist/visual-flow-plan.js";
-import { buildNonDevReport, buildAgentFixPrompt } from "./dist/nondev-report.js";
+import { buildNonDevReport, buildAgentFixPrompt, isNoiseResource, decideFromEvidence } from "./dist/nondev-report.js";
 import { classifyActionSafety } from "./safety.mjs";
 
 /** Forbidden action words handed to the planner (mirrors visual-run.mjs). */
@@ -63,16 +63,7 @@ async function collectInputs(page) {
   );
 }
 
-/** Deterministic decision ladder from the deep-flow evidence (mirrors visual-run.mjs). */
-export function decideFromEvidence(e, steps) {
-  if (e.loadStatus && e.loadStatus >= 400) return "Not Verified";
-  if (e.networkFailures.length || e.consoleErrors.length) return "Needs Fix";
-  if (e.interacted && e.routeAfterClick && /\/undefined|\/null|\/404|not-found|error/i.test(e.routeAfterClick)) return "Needs Fix";
-  if (steps.some((s) => !s.ok)) return "Needs Fix";
-  if (!e.primaryActionFound) return "Needs Clarification";
-  if (e.interacted) return "User Acceptance Required"; // journey ran clean, but no visual oracle for "usable"
-  return "Not Verified";
-}
+// decideFromEvidence now lives in nondev-report.ts (shared + unit-tested).
 
 /** Step NOTES. Like the step labels, these are quoted into the report prose. */
 const STEP_NOTES = {
@@ -117,10 +108,14 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
   const page = await context.newPage();
 
   const consoleErrors = [];
-  const networkFailures = [];
+  const networkFailures = []; // real: app domain + its backend (drives verdict)
+  const noiseFailures = []; // analytics/ads/fonts/telemetry (info only)
+  const recordNet = (url, line) => (isNoiseResource(url) ? noiseFailures : networkFailures).push(line);
   page.on("console", (m) => m.type() === "error" && consoleErrors.push(m.text().slice(0, 300)));
-  page.on("requestfailed", (r) => networkFailures.push(`${r.method()} ${r.url().slice(0, 200)} (${r.failure()?.errorText ?? "failed"})`));
-  page.on("response", (r) => r.status() >= 500 && networkFailures.push(`HTTP ${r.status()} ${r.url().slice(0, 200)}`));
+  page.on("requestfailed", (r) =>
+    recordNet(r.url(), `${r.method()} ${r.url().slice(0, 200)} (${r.failure()?.errorText ?? "failed"})`),
+  );
+  page.on("response", (r) => r.status() >= 500 && recordNet(r.url(), `HTTP ${r.status()} ${r.url().slice(0, 200)}`));
 
   const evidenceFiles = [];
   const stepOutcomes = [];
@@ -233,6 +228,7 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
     routeChanged: evidence.routeChanged,
     consoleErrors,
     networkFailures,
+    noiseFailures,
     decision,
     steps: stepOutcomes,
   };

--- a/apps/central-plane/src/nondev-report.ts
+++ b/apps/central-plane/src/nondev-report.ts
@@ -31,7 +31,12 @@ export interface VisualCheckInput {
   routeAfterClick: string | null;
   routeChanged: boolean;
   consoleErrors: string[];
+  /** Network failures that matter — the app's own domain + its backend (Supabase,
+   *  Firebase, any API it calls). Drives the "data didn't load" finding. */
   networkFailures: string[];
+  /** Analytics/ads/fonts/telemetry failures — noise, shown only as an info note.
+   *  Optional: old callers that don't split still work (no noise finding). */
+  noiseFailures?: string[];
   /** One of the spike's decision states, e.g. "Needs Fix" / "Needs Clarification". */
   decision: string;
   /** Optional per-step flow outcomes (label + whether the step visibly succeeded). */
@@ -112,12 +117,43 @@ export function decisionToWorks(decision: string): boolean | null {
 
 type WWH = { what: string; why: string; how: string };
 
+/**
+ * Known analytics / ads / fonts / telemetry / social hosts — NOISE, not the
+ * app's own data plane. A failure here (e.g. vercel-scripts.com 403 when a
+ * headless browser is bot-blocked) says nothing about whether the app works, so
+ * it must NOT drive the verdict. Live 2026-07-16: vercel.com was falsely called
+ * "broken" because its analytics 403 + console noise were counted as defects.
+ *
+ * Crucially, the app's REAL backend (its own domain, or Supabase/Firebase/an
+ * unknown API it fetches from) is NOT on this list and still counts — that's the
+ * Potemkin signal we must keep catching.
+ */
+const NOISE_HOSTS =
+  /(?:^|\.)(?:google-analytics|googletagmanager|googlesyndication|doubleclick|adservice|adsystem|segment|sentry|hotjar|mixpanel|amplitude|fullstory|logrocket|smartlook|mouseflow|intercom|drift|zendesk|cloudflareinsights|vercel-scripts|vercel-insights|newrelic|nr-data|datadoghq|bugsnag|clarity|facebook|fbcdn|twitter|linkedin|tiktok|snapchat|pinterest|hs-scripts|hsubspot|recaptcha|gstatic|fontawesome)\b|fonts\.(?:googleapis|gstatic)|\.(?:analytics|vitals)\b/i;
+
+/** True when `url` is a known analytics/ads/fonts/telemetry host (i.e. noise). */
+export function isNoiseResource(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    return NOISE_HOSTS.test(new URL(url).hostname);
+  } catch {
+    return NOISE_HOSTS.test(url);
+  }
+}
+
+/** First http(s) URL in a raw network-failure log line, or null. */
+export function extractUrl(s: string | null | undefined): string | null {
+  const m = /(https?:\/\/[^\s)"']+)/i.exec(s ?? "");
+  return m ? m[1]! : null;
+}
+
 const FIND: Record<ReportLocale, {
   dns: WWH;
   server5xx: WWH;
   brokenRoute: WWH;
   genericNet: WWH;
   consoleErr: WWH;
+  noiseInfo: WWH;
   noPrimary: WWH;
   stepFailed: (label: string, note?: string) => WWH;
 }> = {
@@ -146,6 +182,11 @@ const FIND: Record<ReportLocale, {
       what: "화면에서 코드 오류가 났어요.",
       why: "자바스크립트 실행 중 문제가 생겼어요. 일부 기능이 안 될 수 있어요.",
       how: "브라우저 콘솔의 오류 메시지를 그대로 복사해 개발 도구(또는 이 리포트의 '개발자용' 칸)를 참고해 고치세요.",
+    },
+    noiseInfo: {
+      what: "외부 스크립트 일부가 불러와지지 않았어요 (앱 자체 문제는 아니에요).",
+      why: "광고·통계·폰트 같은 외부 서비스 요청이 실패했지만, 앱의 핵심 동작과는 무관해요. (자동 검수가 봇으로 차단됐을 때도 이렇게 보여요.)",
+      how: "특별히 고칠 필요는 없어요. 신경 쓰이면 안 쓰는 외부 스크립트를 정리하세요.",
     },
     noPrimary: {
       what: "처음 화면에서 무엇을 눌러 시작해야 할지 못 찾았어요.",
@@ -184,6 +225,11 @@ const FIND: Record<ReportLocale, {
       why: "Something went wrong while JavaScript was running. Some features may not work.",
       how: "Copy the error message from the browser console and fix it using your dev tool (or the 'for developers' section in this report).",
     },
+    noiseInfo: {
+      what: "Some external scripts didn't load (not a problem with your app).",
+      why: "Requests to third-party services like ads, analytics, or fonts failed, but they're unrelated to your app's core behavior. (This also shows up when the automated review is bot-blocked.)",
+      how: "No action needed. If it bothers you, remove third-party scripts you don't use.",
+    },
     noPrimary: {
       what: "On the first screen, it wasn't clear what to press to get started.",
       why: "No obvious button or input led to the intended core action (e.g. start, search).",
@@ -196,6 +242,44 @@ const FIND: Record<ReportLocale, {
     }),
   },
 };
+
+/** Evidence the decision ladder reads (a subset of what the inspector gathers). */
+export interface DecisionEvidence {
+  loadStatus: number | null;
+  /** NOISE-FILTERED network failures — app domain + backend only (never analytics). */
+  networkFailures: string[];
+  interacted: boolean;
+  routeAfterClick: string | null;
+  primaryActionFound: boolean;
+}
+
+/**
+ * Deterministic verdict from the deep-flow evidence. Lives here (not in the
+ * container's inspector-run.mjs) so it's unit-testable and can't drift from the
+ * finding logic it must agree with.
+ *
+ * P0-B (2026-07-16): driven by REAL failure signals only. `networkFailures` is
+ * already noise-filtered, so a remaining failure is the app's own domain or its
+ * backend (Supabase/Firebase/an API) — the Potemkin signal, which still fails.
+ * Console errors do NOT force a fail (they fire constantly on healthy sites from
+ * third-party scripts). A step that couldn't complete WITH no backend failure is
+ * "couldn't confirm", not "broken" — a complex SPA's click timeout is an
+ * inspector limitation, so we ask a human rather than false-fail (the vercel.com
+ * false-negative).
+ */
+export function decideFromEvidence(
+  e: DecisionEvidence,
+  steps: Array<{ ok: boolean }>,
+): string {
+  if (e.loadStatus && e.loadStatus >= 500) return "Needs Fix";
+  if (e.loadStatus && e.loadStatus >= 400) return "Not Verified";
+  if (e.networkFailures.length) return "Needs Fix";
+  if (e.interacted && e.routeAfterClick && /\/undefined|\/null|\/404|not-found|error/i.test(e.routeAfterClick)) return "Needs Fix";
+  if (steps.some((s) => !s.ok)) return e.interacted ? "User Acceptance Required" : "Needs Clarification";
+  if (!e.primaryActionFound) return "Needs Clarification";
+  if (e.interacted) return "User Acceptance Required";
+  return "Not Verified";
+}
 
 /**
  * 원시 증거(콘솔/네트워크 문자열, 상태코드, 라우트)를 비개발자용 finding 들로 번역.
@@ -227,8 +311,17 @@ export function classifyFindings(input: VisualCheckInput, locale: ReportLocale =
     findings.push({ severity: "high", ...t.genericNet, evidence: input.networkFailures[0] ?? null });
   }
 
+  // Console errors are noisy and hard to attribute (third-party scripts throw
+  // constantly on healthy sites), so they're INFORMATIONAL only — they never
+  // drive the verdict (see decideFromEvidence) and are low severity here.
   if (input.consoleErrors.length > 0 && !/ERR_NAME_NOT_RESOLVED/i.test(conText)) {
-    findings.push({ severity: "medium", ...t.consoleErr, evidence: input.consoleErrors[0] ?? null });
+    findings.push({ severity: "low", ...t.consoleErr, evidence: input.consoleErrors[0] ?? null });
+  }
+
+  // Noise (analytics/ads/fonts) failed — say so honestly, but as info, so the
+  // user isn't alarmed by a "broken" reading that's really a blocked tracker.
+  if ((input.noiseFailures?.length ?? 0) > 0) {
+    findings.push({ severity: "info", ...t.noiseInfo, evidence: input.noiseFailures![0] ?? null });
   }
 
   if (!input.primaryActionFound && !input.interacted) {

--- a/apps/central-plane/test/inspection-accuracy.test.mjs
+++ b/apps/central-plane/test/inspection-accuracy.test.mjs
@@ -1,0 +1,115 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// P0-B inspection accuracy (2026-07-16). Live: vercel.com (a working site) was
+// called "작동 안 해요 — 고쳐야 해요" because a third-party analytics 403 + console
+// noise + a CTA click timeout were all counted as defects. The fix: the verdict
+// keys off REAL failures only (app domain + backend), never analytics noise or
+// console errors; a click the inspector couldn't complete asks a human instead
+// of false-failing. Potemkin (a real backend failing) must STILL fail.
+// Design: docs/simsa-accuracy-p0-2026-07-17.md.
+
+const { isNoiseResource, extractUrl, decideFromEvidence, classifyFindings } =
+  await import("../dist/nondev-report.js");
+
+describe("isNoiseResource — allowlist the noise, count everything else", () => {
+  it("treats analytics/ads/fonts/telemetry as noise", () => {
+    for (const u of [
+      "https://va.vercel-scripts.com/v1/script.js",
+      "https://www.google-analytics.com/g/collect",
+      "https://www.googletagmanager.com/gtm.js",
+      "https://fonts.googleapis.com/css2",
+      "https://browser.sentry-cdn.com/x.js",
+      "https://static.hotjar.com/c/hotjar.js",
+      "https://connect.facebook.net/en_US/fbevents.js",
+      "https://cloudflareinsights.com/cdn-cgi/rum",
+    ]) {
+      assert.equal(isNoiseResource(u), true, `should be noise: ${u}`);
+    }
+  });
+
+  it("does NOT treat the app's own domain or a real backend as noise", () => {
+    for (const u of [
+      "https://myapp.vercel.app/api/todos",       // app's own API
+      "https://xyzcompany.supabase.co/rest/v1/x", // Supabase backend — the Potemkin case
+      "https://myproject.firebaseio.com/data.json",
+      "https://api.myapp.com/users",
+      "https://myapp.com/",
+      "https://some-unknown-backend.railway.app/q",
+    ]) {
+      assert.equal(isNoiseResource(u), false, `should NOT be noise (real backend): ${u}`);
+    }
+  });
+
+  it("extractUrl pulls the url from a failure log line", () => {
+    assert.equal(extractUrl("GET https://x.supabase.co/rest/v1/y (net::ERR_FAILED)"), "https://x.supabase.co/rest/v1/y");
+    assert.equal(extractUrl("no url here"), null);
+  });
+});
+
+const base = { loadStatus: 200, networkFailures: [], interacted: false, routeAfterClick: null, primaryActionFound: true };
+
+describe("decideFromEvidence — the vercel.com false-negative is fixed", () => {
+  it("a working site with only a CTA timeout (no backend failure) is NOT 'Needs Fix'", () => {
+    // vercel.com shape: loaded fine, noise already filtered out of networkFailures,
+    // one step failed because the inspector couldn't click a fancy CTA.
+    const d = decideFromEvidence(
+      { ...base, interacted: false, networkFailures: [] },
+      [{ ok: false }],
+    );
+    assert.notEqual(d, "Needs Fix", "a click the inspector couldn't complete must not read as broken");
+    assert.equal(d, "Needs Clarification"); // couldn't drive it → ask, don't fail
+  });
+
+  it("a clean interactive journey is User Acceptance Required, not a fail", () => {
+    assert.equal(decideFromEvidence({ ...base, interacted: true }, [{ ok: true }]), "User Acceptance Required");
+  });
+});
+
+describe("decideFromEvidence — Potemkin is STILL caught (no over-softening)", () => {
+  it("a real backend request failing → Needs Fix", () => {
+    const d = decideFromEvidence(
+      { ...base, networkFailures: ["GET https://xyz.supabase.co/rest/v1/todos (net::ERR_FAILED)"] },
+      [{ ok: true }],
+    );
+    assert.equal(d, "Needs Fix");
+  });
+  it("a 5xx on load → Needs Fix", () => {
+    assert.equal(decideFromEvidence({ ...base, loadStatus: 500 }, []), "Needs Fix");
+  });
+  it("a broken route after clicking (/undefined) → Needs Fix", () => {
+    assert.equal(decideFromEvidence({ ...base, interacted: true, routeAfterClick: "https://x/undefined" }, [{ ok: true }]), "Needs Fix");
+  });
+  it("4xx on load is ambiguous (auth/not-found) → Not Verified, not a hard fail", () => {
+    assert.equal(decideFromEvidence({ ...base, loadStatus: 403 }, []), "Not Verified");
+  });
+});
+
+describe("classifyFindings — noise is info, real failures are high, console is low", () => {
+  const input = (over) => ({
+    targetUrl: "https://myapp.vercel.app/", intentAnchor: "x", loadStatus: 200,
+    primaryActionFound: true, interacted: true, routeAfterClick: null, routeChanged: false,
+    consoleErrors: [], networkFailures: [], noiseFailures: [], decision: "User Acceptance Required", steps: [],
+    ...over,
+  });
+
+  it("a noise failure produces an INFO finding, not high", () => {
+    const f = classifyFindings(input({ noiseFailures: ["GET https://va.vercel-scripts.com/x 403"] }), "ko");
+    const noise = f.find((x) => x.severity === "info");
+    assert.ok(noise, "should surface an info note for blocked noise");
+    assert.ok(/외부 스크립트/.test(noise.what));
+    assert.ok(!f.some((x) => x.severity === "high"), "noise must not create a high finding");
+  });
+
+  it("a real backend failure produces a HIGH finding", () => {
+    const f = classifyFindings(input({ networkFailures: ["GET https://xyz.supabase.co/rest/v1/y (ERR_FAILED)"] }), "ko");
+    assert.ok(f.some((x) => x.severity === "high"), "a real data failure is high");
+  });
+
+  it("console errors are downgraded to LOW (no longer alarming medium)", () => {
+    const f = classifyFindings(input({ consoleErrors: ["TypeError: x is undefined"] }), "ko");
+    const con = f.find((x) => /코드 오류/.test(x.what));
+    assert.ok(con, "console finding still listed");
+    assert.equal(con.severity, "low", "console errors must be low, not medium");
+  });
+});


### PR DESCRIPTION
## 배경 — 실측 평가에서 확인된 P0-B (가장 냉정했던 부분)

2026-07-16 실측: **완벽히 작동하는 vercel.com을 "작동 안 해요 — 고쳐야 해요"로 오판**. 원인은 실제 결함이 아니라 검수 도구 잡음 — 서드파티 애널리틱스 403(`va.vercel-scripts.com`, 헤드리스 브라우저 봇차단) + 콘솔 에러 + 8초 안에 못 누른 CTA를 전부 결함으로 셈. 설계: `docs/simsa-accuracy-p0-2026-07-17.md`.

## 핵심 설계 판단 — same-site가 아니라 "노이즈 allowlist"

단순 same-site 비교로는 **실제 타겟(Supabase/Firebase 백엔드를 쓰는 vibe 앱)의 백엔드 실패를 third-party로 오분류해 Potemkin을 놓칩니다.** 그래서 반대로 했습니다: **애널리틱스/광고/폰트/텔레메트리만 노이즈로 무시하고, 나머지(앱 자체 도메인 + 백엔드)는 전부 결함으로 셉니다.**

## 수정

판정 사다리가 이제 **진짜 실패 신호만** 봅니다:
- **네트워크 실패를 수집 시점에 분리** — `isNoiseResource()`로 애널리틱스/광고/폰트/텔레메트리는 info 노트로만. 앱 자체 도메인·Supabase·Firebase·모든 API는 **노이즈 아님 → 계속 결함으로**(Potemkin 유지, 완화 아님).
- **콘솔 에러는 더 이상 판정을 좌우하지 않음** — 정상 사이트도 서드파티 스크립트가 늘 던짐. low·정보성 finding으로 격하.
- **못 누른 CTA + 백엔드 실패 없음 = "확인 못 함", "고장" 아님** — interacted면 `User Acceptance Required`(사람 확인), 아니면 `Needs Clarification`. false `Needs Fix` 제거.
- 로드 5xx → 명확한 `Needs Fix`, 4xx → 애매(인증/없음) `Not Verified`.

`decideFromEvidence`를 컨테이너의 `inspector-run.mjs`에서 **공유·컴파일되는 `nondev-report.ts`로 이동** — 단위 테스트 가능 + finding 로직과 드리프트 방지.

## 검증

- [x] `inspection-accuracy.test.mjs` **12/12** — 노이즈 allowlist(Supabase/Firebase/자체도메인은 노이즈 아님)·vercel 케이스 더 이상 실패 안 함·**Potemkin(백엔드 실패/5xx/깨진 라우트) 여전히 잡힘**·콘솔 low 격하
- [x] 전체 스위트 **1727/1727**
- [ ] 배포(컨테이너 재빌드) 후 라이브: vercel.com 재검수 → 더 이상 "작동 안 해요" 아님 확인

## ⚠ 배포 주의

`inspector-run.mjs`가 바뀌므로 **컨테이너 이미지 재빌드가 포함된 배포**여야 실제 적용됩니다(`wrangler deploy`가 자동 재빌드).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
