### PR TITLE
feat(generate): non-developer language in openQuestions (P1)

### DIFF
--- a/apps/central-plane/src/workspace/generate.ts
+++ b/apps/central-plane/src/workspace/generate.ts
@@ -131,7 +131,7 @@ const SCHEMA_DESCRIPTION = `{
     "excluded": ["이번 버전에서 제외할 것"],
     "userFlow": ["1. 사용자 흐름 단계"],
     "decisions": ["질문 답변에 따라 결정된 사항"],
-    "openQuestions": ["아직 결정이 필요한 것"]
+    "openQuestions": ["아직 결정이 필요한 것 (도구 이름 없이 일반인 언어로)"]
   },
   "items": [
     {
@@ -169,7 +169,7 @@ const SCHEMA_DESCRIPTION_EN = `{
     "excluded": ["out of scope for this version"],
     "userFlow": ["1. user flow step"],
     "decisions": ["decisions made from the answers"],
-    "openQuestions": ["things still to decide"]
+    "openQuestions": ["things still to decide (plain language, no tool names)"]
   },
   "items": [
     {
@@ -285,6 +285,78 @@ export function feasibilityWarning(
     : `참고: 이건 ${label}이 필요해 보여요. 심사가 연결하는 개발 도구는 웹앱을 만들기 때문에, 웹으로 되는 부분은 지금 만들 수 있지만 ${label} 자체는 전문 개발이 필요해요 — 설명서에는 그 점을 '다 된다'고 하지 않고 정직하게 표시했어요.`;
 }
 
+// ─── Non-developer language (P1, 2026-07-17) ─────────────────────────────────
+
+/**
+ * openQuestions is where developer tool names leaked in live measurement
+ * (2026-07-17 assessment: 3/6 drafts named Firebase/AWS/Chart.js/API). The
+ * target user cannot decide "Firebase vs AWS" — the decision they CAN make is
+ * "where should my data live". Each category maps a jargon marker to the plain
+ * decision it stands for. A matcher, not a judgement: markers are parameters,
+ * the principle (no tool names in a non-developer's open decisions) is not.
+ */
+const JARGON_CATEGORIES: Array<{ re: RegExp; ko: string; en: string }> = [
+  {
+    re: /firebase|supabase|amazon\s*s3|\bs3\b|\baws\b|dynamodb|mongodb|postgres(?:ql)?|mysql|redis|데이터베이스|\bdb\b/i,
+    ko: "자료를 어디에 어떻게 보관할지 정하기",
+    en: "Decide where and how your data is kept",
+  },
+  {
+    re: /chart\.js|\bd3(?:\.js)?\b|recharts|highcharts/i,
+    ko: "차트·그래프를 어떤 모습으로 보여줄지 정하기",
+    en: "Decide how charts and graphs should look",
+  },
+  {
+    re: /\bstt\b|speech[-\s]?to[-\s]?text|\btts\b/i,
+    ko: "음성 인식을 어느 수준까지 지원할지 정하기",
+    en: "Decide how far speech recognition should go",
+  },
+  {
+    re: /oauth|\bjwt\b|\bsso\b/i,
+    ko: "로그인 방식을 어떻게 할지 정하기",
+    en: "Decide how sign-in works",
+  },
+  {
+    re: /\bapi\b|\bsdk\b|webhook|웹훅|graphql|엔드포인트|endpoint/i,
+    ko: "외부 서비스와 무엇을 주고받을지 정하기",
+    en: "Decide what to exchange with external services",
+  },
+  {
+    re: /vercel|netlify|cloudflare|heroku|호스팅|hosting|docker|kubernetes/i,
+    ko: "서비스를 인터넷에 올리는 방식 정하기",
+    en: "Decide how the service goes live",
+  },
+];
+
+/**
+ * Deterministic rewrite of open questions into non-developer language. A
+ * question naming a developer tool/service is replaced by the plain decision
+ * for its category; duplicates collapsing onto the same canonical question are
+ * deduped. A term the user typed THEMSELVES is exempt — their own words are
+ * their language, not a leak (and removing them would also hurt the
+ * user-words coverage gate).
+ */
+export function sanitizeOpenQuestions(
+  questions: string[],
+  locale: "ko" | "en" | undefined,
+  userWords: string,
+): string[] {
+  const lang = locale === "en" ? "en" : "ko";
+  const lowerUserWords = userWords.toLowerCase();
+  const out: string[] = [];
+  for (const q of questions) {
+    let rewritten = q;
+    for (const cat of JARGON_CATEGORIES) {
+      const m = cat.re.exec(q);
+      if (!m) continue;
+      if (!lowerUserWords.includes(m[0].toLowerCase())) rewritten = cat[lang];
+      break;
+    }
+    if (!out.includes(rewritten)) out.push(rewritten);
+  }
+  return out;
+}
+
 /** Extra-context block (D2). Empty when the user gave none. */
 function contextBlock(locale: "ko" | "en" | undefined, context: string | undefined): string {
   const c = (context ?? "").trim();
@@ -325,6 +397,7 @@ export function buildPrompt(req: IdeaToSpecDraftRequest): string {
 다음 규칙을 반드시 따르세요:
 - 모든 사용자 대상 텍스트는 자연스러운 한국어로 작성
 - PRD, Requirement, Acceptance Criteria, FAIL, INCONCLUSIVE 같은 개발자 용어 사용 금지
+- openQuestions·decisions에도 개발 도구·서비스 이름(Firebase, AWS, Chart.js, API 등)을 쓰지 마라. "STT 서비스 선택"이 아니라 "음성 인식을 어느 수준까지 지원할지 정하기"처럼, 사용자가 실제로 내릴 수 있는 결정을 일반인 언어로 적어라. 단, 사용자가 직접 언급한 도구 이름은 그대로 써도 된다.
 - 질문은 이 아이디어에 맞춤형으로 4~6개 생성 (단순 템플릿 반복 금지). 그중 **최소 1개는 화면·디자인(UIUX)** 에 관한 것.
 - 좋은 질문 = 답에 따라 제품이 실제로 달라지는 구체적 질문. 아래 축을 폭넓게 살펴 이 아이디어에 맞는 것을 고른다:
   구현 범위 · 사용자 흐름 · 데이터 보관 · 로그인/권한 · 외부 연동 · 대상 사용자 숙련도 · 성공 기준 ·
@@ -349,6 +422,7 @@ Idea: ${req.idea}${contextBlock("en", req.context)}${answersText}${rejectedBlock
 Follow these rules strictly:
 - Write all user-facing text in natural, plain English
 - Do NOT use developer jargon like PRD, Requirement, Acceptance Criteria, FAIL, INCONCLUSIVE
+- Do NOT name developer tools or services (Firebase, AWS, Chart.js, API, …) in openQuestions/decisions either. Write the decision the user can actually make in plain words — "Decide where and how your data is kept", not "Choose Firebase vs AWS". Tools the user themselves mentioned are fine to keep.
 - Generate 4-6 questions tailored to this idea (no repetitive templates). At least ONE must be about screens/design (UI/UX).
 - Good questions = concrete questions whose answers actually change the product. Draw broadly from these axes, picking what fits this idea:
   scope · user flow · data retention · login/permissions · integrations · target-user skill level · success criteria ·
@@ -565,7 +639,7 @@ function buildMockFallback(req: IdeaToSpecDraftRequest): IdeaToSpecDraftResponse
         problem: "회의 후 내용 정리와 할 일 분배에 시간이 많이 걸립니다.",
         included: [
           "녹음 파일 업로드",
-          "STT 변환",
+          "음성을 텍스트로 변환",
           "요약 생성 (결정사항·할 일 구분)",
           "할 일 추출",
           confirmSend ? "사용자 확인 후 Linear 전송" : "처리 완료 후 Linear 자동 전송",
@@ -769,6 +843,20 @@ function withVerification(
   req: IdeaToSpecDraftRequest,
   res: IdeaToSpecDraftResponse,
 ): IdeaToSpecDraftResponse {
+  // P1 non-developer language: openQuestions is the field that leaked tool
+  // names in live measurement. Sanitized here — the single choke point every
+  // successful draft (LLM and mock alike) passes through.
+  res = {
+    ...res,
+    productSpec: {
+      ...res.productSpec,
+      openQuestions: sanitizeOpenQuestions(
+        res.productSpec.openQuestions,
+        req.locale,
+        userWordsOf(req),
+      ),
+    },
+  };
   // P0-A: the deterministic feasibility warning rides on EVERY draft (LLM or
   // mock) — it's the honest "this needs a native build" heads-up, independent of
   // the coverage gate. Prepended so it's the first thing the user sees.

--- a/apps/central-plane/test/generate-nondev-language.test.mjs
+++ b/apps/central-plane/test/generate-nondev-language.test.mjs
@@ -1,0 +1,108 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// P1 non-developer language (2026-07-17). Live measurement found openQuestions
+// naming developer tools in 3/6 drafts (Firebase/AWS/Chart.js/API) — decisions
+// the target user cannot make. Fix = prompt rule + deterministic category
+// rewrite at the single draft choke point. HANDOFF-2026-07-17 § 남은 것.
+
+const { sanitizeOpenQuestions, buildPrompt, generateIdeaToSpecDraft } =
+  await import("../dist/workspace/generate.js");
+
+describe("sanitizeOpenQuestions — deterministic category rewrite", () => {
+  it("rewrites the live-measured leaks into plain decisions (ko)", () => {
+    const out = sanitizeOpenQuestions(
+      [
+        "Firebase와 AWS 중 어떤 것을 쓸지 결정",
+        "Chart.js로 차트를 그릴지 결정",
+        "외부 API 연동 범위 확정",
+        "STT 서비스 선택",
+      ],
+      "ko",
+      "동네 미용실 예약 웹앱",
+    );
+    for (const q of out) {
+      assert.doesNotMatch(q, /firebase|aws|chart\.js|\bapi\b|\bstt\b/i, q);
+    }
+    assert.ok(out.includes("자료를 어디에 어떻게 보관할지 정하기"), JSON.stringify(out));
+    assert.ok(out.includes("차트·그래프를 어떤 모습으로 보여줄지 정하기"), JSON.stringify(out));
+    assert.ok(out.includes("외부 서비스와 무엇을 주고받을지 정하기"), JSON.stringify(out));
+    assert.ok(out.includes("음성 인식을 어느 수준까지 지원할지 정하기"), JSON.stringify(out));
+  });
+
+  it("rewrites in English for locale=en", () => {
+    const out = sanitizeOpenQuestions(
+      ["Choose between Firebase and AWS", "Pick an OAuth provider"],
+      "en",
+      "a budget web app",
+    );
+    assert.deepEqual(out, [
+      "Decide where and how your data is kept",
+      "Decide how sign-in works",
+    ]);
+  });
+
+  it("dedupes questions that collapse onto the same plain decision", () => {
+    const out = sanitizeOpenQuestions(
+      ["Firebase 요금제 확인", "PostgreSQL 스키마 설계", "결과 화면 구성 정하기"],
+      "ko",
+      "가계부 웹앱",
+    );
+    assert.deepEqual(out, ["자료를 어디에 어떻게 보관할지 정하기", "결과 화면 구성 정하기"]);
+  });
+
+  it("keeps jargon-free questions untouched", () => {
+    const qs = ["파일 크기 상한선 (예: 500MB)", "구체적인 기능 범위 정하기"];
+    assert.deepEqual(sanitizeOpenQuestions(qs, "ko", "메모 웹앱"), qs);
+  });
+
+  it("a term the user typed themselves is exempt — their words, not a leak", () => {
+    const out = sanitizeOpenQuestions(
+      ["Firebase 무료 요금제로 충분한지 확인", "AWS 요금 확인"],
+      "ko",
+      "Firebase에 데이터를 저장하는 재고 관리 웹앱",
+    );
+    // Firebase kept (user said it); AWS still rewritten.
+    assert.equal(out[0], "Firebase 무료 요금제로 충분한지 확인");
+    assert.equal(out[1], "자료를 어디에 어떻게 보관할지 정하기");
+  });
+
+  it("does not false-positive on ordinary words (rest, library app in user words)", () => {
+    const out = sanitizeOpenQuestions(
+      ["도서관 좌석 예약 규칙 정하기", "Decide the rest of the features later"],
+      "ko",
+      "도서관 좌석 예약 웹앱",
+    );
+    assert.deepEqual(out, ["도서관 좌석 예약 규칙 정하기", "Decide the rest of the features later"]);
+  });
+});
+
+describe("the prompt forbids tool names in openQuestions (ko + en)", () => {
+  it("ko prompt carries the rule and the schema hint", () => {
+    const ko = buildPrompt({ idea: "가계부 웹앱", locale: "ko" });
+    assert.match(ko, /openQuestions·decisions에도 개발 도구·서비스 이름/);
+    assert.match(ko, /도구 이름 없이 일반인 언어로/);
+  });
+  it("en prompt carries the rule and the schema hint", () => {
+    const en = buildPrompt({ idea: "a budget web app", locale: "en" });
+    assert.match(en, /Do NOT name developer tools or services/);
+    assert.match(en, /plain language, no tool names/);
+  });
+});
+
+describe("the choke point sanitizes real drafts (mock path)", () => {
+  it("meeting mock's 'STT 서비스 선택' never reaches the user", async () => {
+    const res = await generateIdeaToSpecDraft(
+      { idea: "회의 녹음을 요약해서 할 일을 뽑아주는 앱", locale: "ko" },
+      undefined,
+    );
+    assert.equal(res.source, "mock-fallback");
+    for (const q of res.productSpec.openQuestions) {
+      assert.doesNotMatch(q, /\bstt\b|firebase|aws|\bapi\b/i, q);
+    }
+    assert.ok(
+      res.productSpec.openQuestions.includes("음성 인식을 어느 수준까지 지원할지 정하기"),
+      JSON.stringify(res.productSpec.openQuestions),
+    );
+  });
+});

--- a/tools/simsa-completion-loop-spike/nondev-language-probe.mjs
+++ b/tools/simsa-completion-loop-spike/nondev-language-probe.mjs
@@ -1,0 +1,47 @@
+// Live probe: openQuestions must carry no developer tool names (P1, 2026-07-17).
+// Direct POST to the production worker (no login — the endpoint is free-beta).
+// Run from this directory: `node nondev-language-probe.mjs`
+//
+// The sanitize layer is deterministic server-side, so ANY draft that comes
+// back is proof of the wiring — we pick ideas that leaked in the 2026-07-17
+// assessment (charts / data storage / integrations) to stress the LLM side too.
+
+const BASE = process.env.SIMSA_BASE ?? "https://conclave-ai.seunghunbae.workers.dev";
+
+const JARGON =
+  /firebase|supabase|amazon\s*s3|\baws\b|dynamodb|mongodb|postgres(?:ql)?|mysql|redis|데이터베이스|\bdb\b|chart\.js|\bd3(?:\.js)?\b|recharts|highcharts|\bstt\b|speech[-\s]?to[-\s]?text|\btts\b|oauth|\bjwt\b|\bsso\b|\bapi\b|\bsdk\b|webhook|웹훅|graphql|엔드포인트|endpoint|vercel|netlify|cloudflare|heroku|호스팅|hosting|docker|kubernetes/i;
+
+const CASES = [
+  { locale: "ko", idea: "주식 포트폴리오를 차트로 보여주는 대시보드 웹앱" },
+  { locale: "ko", idea: "출장 경비 영수증을 올리면 자동 분류하고 월별 리포트를 만들어주는 웹앱" },
+  { locale: "ko", idea: "회의 녹음을 올리면 요약하고 할 일을 정리해주는 웹앱" },
+  { locale: "en", idea: "a web dashboard that tracks my running stats and shows progress charts" },
+];
+
+let failed = 0;
+for (const c of CASES) {
+  const res = await fetch(`${BASE}/workspace/idea-to-spec-draft`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(c),
+  });
+  const body = await res.json().catch(() => null);
+  if (!res.ok || !body?.ok) {
+    console.log(`❌ [${c.locale}] HTTP ${res.status} ${JSON.stringify(body)?.slice(0, 200)} — ${c.idea}`);
+    failed++;
+    continue;
+  }
+  const qs = body.productSpec?.openQuestions ?? [];
+  const leaks = qs.filter((q) => JARGON.test(q));
+  const tag = `[${c.locale}] source=${body.source} openQuestions=${qs.length}`;
+  if (leaks.length === 0) {
+    console.log(`✅ ${tag} — 누수 0 — ${c.idea}`);
+    for (const q of qs) console.log(`     · ${q}`);
+  } else {
+    console.log(`❌ ${tag} — 누수 ${leaks.length}: ${JSON.stringify(leaks)} — ${c.idea}`);
+    failed++;
+  }
+}
+
+console.log(failed === 0 ? "\n프로브 통과 (전 케이스 누수 0)" : `\n프로브 실패 ${failed}건`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## 무엇

2026-07-17 실측 평가에서 남은 P1 — **openQuestions 비개발자 언어 누수** 제거.
실측 3/6 초안이 Firebase/AWS/Chart.js/API 등 개발자 도구 이름을 "아직 결정할 것"으로
제시했는데, 비개발자 타겟 유저는 그 결정을 내릴 수 없습니다. (HANDOFF-2026-07-17 § 남은 것)

## 어떻게 (2겹)

1. **프롬프트 규칙 (ko+en) + 스키마 힌트** — openQuestions/decisions에 도구·서비스 이름 금지,
   "사용자가 실제로 내릴 수 있는 결정"을 일반인 언어로. 사용자가 직접 언급한 도구는 허용.
2. **결정론 후처리 `sanitizeOpenQuestions`** — 단일 초크포인트(`withVerification`, LLM·mock
   공통 통과점)에서 카테고리 재작성:
   - storage(Firebase/AWS/DB…) → "자료를 어디에 어떻게 보관할지 정하기"
   - charts(Chart.js/D3…) → "차트·그래프를 어떤 모습으로 보여줄지 정하기"
   - speech(STT/TTS) → "음성 인식을 어느 수준까지 지원할지 정하기"
   - auth(OAuth/JWT/SSO) → "로그인 방식을 어떻게 할지 정하기"
   - integration(API/SDK/webhook…) → "외부 서비스와 무엇을 주고받을지 정하기"
   - infra(Vercel/호스팅/Docker…) → "서비스를 인터넷에 올리는 방식 정하기"
   - 같은 카테고리로 접히는 중복은 dedupe. **사용자가 직접 쓴 용어는 면제**(그들의 언어이지
     누수가 아님 — user-words coverage gate 보호 겸).
   - 매처는 파라미터, 원칙(비개발자의 열린 결정에 도구 이름 금지)은 원칙 — P0-A/D1과 동일 스타일.

미팅 mock의 `"STT 서비스 선택"` openQuestion은 **의도적으로 남김** — 초크포인트가 실제로
잡아내는지의 영구 라이브 프로브(테스트가 배출 초안의 청정성을 단언).

## 검증

- 신규 `generate-nondev-language.test.mjs` 8건: ko/en 재작성, dedupe, 무해 통과,
  사용자 용어 면제, 오탐 가드(rest/도서관), 프롬프트 규칙 존재, mock 초크포인트.
- **옛 코드에서 실패 확인**: `sanitizeOpenQuestions` 미존재 + 프롬프트 규칙 부재로 신규
  테스트는 이전 코드에서 import/assert 실패 (회귀 테스트 규율).
- 전체 central-plane 스위트 **1745/1745** green. pre-push verify 통과.

## 체크리스트

- [x] 테스트 신규 + 전체 green
- [x] base = main
- [x] 시크릿/과금/인증/데이터저장 변경 없음 (프롬프트+순수함수)
- [ ] 원격 CI green 확인 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
