### PR TITLE
fix(inspection): drive the app's real journey — accuracy eval + D5~D9

### DIFF
--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -72,12 +72,14 @@ const STEP_NOTES = {
     noResults: "검색 결과/내용이 확인되지 않음 (또는 데이터 요청 실패)",
     networkFailed: "데이터 요청 실패가 관찰됨",
     actionFailed: (err) => `동작 실패: ${err}`,
+    noChange: "동작 후 화면에 아무 변화가 없음",
   },
   en: {
     unsafeSkipped: (cat) => `Skipped — not safe to run (${cat})`,
     noResults: "No results/content appeared (or the data request failed)",
     networkFailed: "A data request was observed failing",
     actionFailed: (err) => `Action failed: ${err}`,
+    noChange: "Nothing on the screen changed after the action",
   },
 };
 
@@ -129,6 +131,10 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
     routeChanged: false,
     consoleErrors,
     networkFailures,
+    // D7/D9 (2026-07-17 accuracy eval): whether the driven action visibly
+    // changed anything. null until an action ran and an observe measured it.
+    visibleChangeAfterAction: null,
+    consoleErrorCount: 0,
   };
 
   async function snap(name) {
@@ -161,6 +167,16 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
     });
     evidence.primaryActionFound = plan.some((s) => s.action === "click" || s.action === "type");
 
+    // D7: success is measured as CHANGE from this baseline (body text or
+    // route), never as an absolute page size — the old `bodyLen > 200` check
+    // failed every small app card regardless of actual behavior.
+    const bodyTextAt = async () => (await page.locator("body").innerText().catch(() => "")).replace(/\s+/g, " ").trim();
+    const bodyBefore = await bodyTextAt();
+    // D6: when the plan submits via a CLICK step, Enter after typing would
+    // double-submit (or submit an incomplete form) — press Enter only when
+    // typing is the plan's only driver.
+    const planHasClick = plan.some((s) => s.action === "click");
+
     let stepIdx = 0;
     for (const step of plan) {
       stepIdx += 1;
@@ -183,17 +199,23 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
         } else if (step.action === "type") {
           const field = step.placeholder ? page.getByPlaceholder(step.placeholder).first() : page.locator("input").first();
           await field.fill(step.value, { timeout: 8000 });
-          await field.press("Enter").catch(() => {});
+          if (!planHasClick) await field.press("Enter").catch(() => {});
           evidence.interacted = true;
           await page.waitForTimeout(1800);
           await snap(shotName);
-          // Did results/content appear? Heuristic: page text grew and no fresh network failure.
-          const bodyLen = (await page.locator("body").innerText().catch(() => "")).length;
-          const ok = bodyLen > 200 && networkFailures.length === 0;
-          stepOutcomes.push({ label: step.label, ok, note: ok ? undefined : N.noResults });
+          // The type step itself only claims "the value went in" — whether
+          // anything HAPPENED is the observe step's job (D7 change check).
+          stepOutcomes.push({ label: step.label, ok: true });
         } else {
           await snap(shotName);
-          stepOutcomes.push({ label: step.label, ok: networkFailures.length === 0, note: networkFailures.length ? N.networkFailed : undefined });
+          // D7: judge by change, not size. An action that changed neither the
+          // body text nor the route did nothing observable.
+          const bodyNow = await bodyTextAt();
+          const visibleChange = bodyNow !== bodyBefore || evidence.routeChanged;
+          if (evidence.interacted) evidence.visibleChangeAfterAction = visibleChange;
+          const ok = networkFailures.length === 0 && (!evidence.interacted || visibleChange);
+          const note = networkFailures.length ? N.networkFailed : ok ? undefined : N.noChange;
+          stepOutcomes.push({ label: step.label, ok, note });
         }
       } catch (err) {
         await snap(shotName);
@@ -217,6 +239,7 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
     /* video optional */
   }
 
+  evidence.consoleErrorCount = consoleErrors.length;
   const decision = decideFromEvidence(evidence, stepOutcomes);
   const reportInput = {
     targetUrl,

--- a/apps/central-plane/src/nondev-report.ts
+++ b/apps/central-plane/src/nondev-report.ts
@@ -251,6 +251,12 @@ export interface DecisionEvidence {
   interacted: boolean;
   routeAfterClick: string | null;
   primaryActionFound: boolean;
+  /** D9 (2026-07-17): did the driven action visibly change anything (body text
+   *  or route)? null/undefined = not measured (older callers stay valid). */
+  visibleChangeAfterAction?: boolean | null;
+  /** D9: console error count — NEVER a verdict driver alone (noise lesson);
+   *  only its CONJUNCTION with a dead action is a crash signal. */
+  consoleErrorCount?: number;
 }
 
 /**
@@ -275,6 +281,12 @@ export function decideFromEvidence(
   if (e.loadStatus && e.loadStatus >= 400) return "Not Verified";
   if (e.networkFailures.length) return "Needs Fix";
   if (e.interacted && e.routeAfterClick && /\/undefined|\/null|\/404|not-found|error/i.test(e.routeAfterClick)) return "Needs Fix";
+  // D9 (2026-07-17 accuracy eval): an action that visibly changed NOTHING plus a
+  // console error is a crashed app (the handler never bound — dead button), not
+  // an inspector limitation. The CONJUNCTION is the signal: a console error
+  // alone stays non-fatal (healthy sites are noisy — the vercel.com lesson), and
+  // a no-change action alone stays "couldn't confirm" (subtle UIs exist).
+  if (e.interacted && e.visibleChangeAfterAction === false && (e.consoleErrorCount ?? 0) > 0) return "Needs Fix";
   if (steps.some((s) => !s.ok)) return e.interacted ? "User Acceptance Required" : "Needs Clarification";
   if (!e.primaryActionFound) return "Needs Clarification";
   if (e.interacted) return "User Acceptance Required";

--- a/apps/central-plane/src/visual-flow-plan.ts
+++ b/apps/central-plane/src/visual-flow-plan.ts
@@ -48,6 +48,7 @@ const FLOW_LABELS = {
     clickCta: (text: string) => `핵심 버튼 '${text}' 누르기`,
     observeAfterClick: "버튼을 누른 뒤 화면 확인",
     typeQuery: (q: string) => `검색창에 '${q}' 입력하기`,
+    typeField: (q: string) => `입력창에 '${q}' 입력하기`,
     observeResults: "검색 결과 화면 확인",
     observeFirstScreen: "첫 화면 확인 (안전하게 실행할 동작을 못 찾음)",
   },
@@ -55,6 +56,7 @@ const FLOW_LABELS = {
     clickCta: (text: string) => `Press the main button '${text}'`,
     observeAfterClick: "Check the screen after pressing the button",
     typeQuery: (q: string) => `Type '${q}' into the search box`,
+    typeField: (q: string) => `Type '${q}' into the input field`,
     observeResults: "Check the search results screen",
     observeFirstScreen: "Check the first screen (no action was safe to run)",
   },
@@ -100,7 +102,16 @@ const INTENT_CTA_PRIORITY = [
   /start|시작/i,
   /sign ?up|signup|register|가입|등록/i,
   /begin|try|continue|join|다음|계속/i,
+  // D5② (2026-07-17 accuracy eval): the common single-purpose vibe-app verbs.
+  // Before this tier, "추가/저장/계산하기…" scored 0 and the app's ONE button was
+  // never clicked — every input+button app collapsed into "확인 필요".
+  /추가|저장|기록|계산|변환|만들|생성|올리기|업로드|입력|조회|add|save|create|submit|calculate|convert|upload|record/i,
 ];
+
+/** D5③: with at most this many safe CTAs, the page is single-purpose-shaped
+ *  and the first safe CTA is the flow even when no vocabulary tier matches.
+ *  A parameter, not a principle. */
+const FEW_CTA_MAX = 4;
 
 function isForbidden(text: string, forbidden: string[]): boolean {
   const t = (text || "").toLowerCase();
@@ -115,20 +126,48 @@ function ctaScore(text: string): number {
   return 0;
 }
 
-/** Pick the best safe CTA that matches the intent, or null. Pure & deterministic. */
-export function pickSafeCta(ctas: DetectedCta[], forbidden: string[]): DetectedCta | null {
+/**
+ * Pick the best safe CTA, or null. Pure & deterministic. Three tiers (D5,
+ * 2026-07-17 accuracy eval — docs/simsa-inspection-accuracy-eval-2026-07-17.md):
+ *   ① a CTA the intent NAMES verbatim ("추가 버튼을 누르면…" → the '추가' button)
+ *   ② the action-vocabulary priority match (existing behavior, vocab broadened)
+ *   ③ few-CTA fallback: on a single-purpose-shaped page (≤ FEW_CTA_MAX safe
+ *      CTAs) the first safe CTA is the flow.
+ * The forbidden filter applies to every tier.
+ */
+export function pickSafeCta(
+  ctas: DetectedCta[],
+  forbidden: string[],
+  intentAnchor = "",
+): DetectedCta | null {
+  const safe = ctas.filter((c) => (c.text || "").trim().length > 0 && !isForbidden(c.text, forbidden));
+
+  // ① intent-named CTA — the user's own words pick the button (longest match wins).
+  let named: DetectedCta | null = null;
+  for (const c of safe) {
+    const t = c.text.trim();
+    if (t.length >= 2 && intentAnchor.includes(t) && (!named || t.length > named.text.trim().length)) {
+      named = c;
+    }
+  }
+  if (named) return named;
+
+  // ② vocabulary tiers.
   let best: DetectedCta | null = null;
   let bestScore = 0;
-  for (const c of ctas) {
+  for (const c of safe) {
     const score = ctaScore(c.text);
     if (score <= 0) continue;
-    if (isForbidden(c.text, forbidden)) continue;
     if (score > bestScore) {
       best = c;
       bestScore = score;
     }
   }
-  return best;
+  if (best) return best;
+
+  // ③ single-purpose-shaped page.
+  if (safe.length > 0 && safe.length <= FEW_CTA_MAX) return safe[0]!;
+  return null;
 }
 
 /** Pick the primary search/text input (prefers a search-like placeholder). */
@@ -148,10 +187,15 @@ export function ctaIsSearchLike(text: string): boolean {
 }
 
 /**
- * Build the deep flow plan:
- *   - If a safe intent CTA exists → click it, then observe.
- *   - Else if a search/text input exists → type a benign query into it, then observe.
- *   - Always ends by observing the result screen.
+ * Build the deep flow plan (D6, 2026-07-17 accuracy eval):
+ *   - Input AND a safe CTA → type, then CLICK the CTA (the form journey — this
+ *     is what actually fires a button-submitted app's action, e.g. a Potemkin
+ *     app's backend call), then observe.
+ *     Exception: a search-oriented intent with a non-search, un-named CTA keeps
+ *     the type→Enter path (golf-now case: don't click "보험 가입하기" after
+ *     typing a search).
+ *   - Only a CTA → click it, then observe.
+ *   - Only an input → type (Enter submits), then observe.
  * If neither exists, the plan is just a single observe (nothing safe to drive).
  */
 export function planVisualFlow(input: FlowPlanInput): FlowStep[] {
@@ -162,29 +206,44 @@ export function planVisualFlow(input: FlowPlanInput): FlowStep[] {
     input.sampleQuery && input.sampleQuery.trim() ? input.sampleQuery.trim() : DEFAULT_SAMPLE_QUERY[locale];
   const steps: FlowStep[] = [];
 
-  const cta = pickSafeCta(input.ctas ?? [], forbidden);
+  const cta = pickSafeCta(input.ctas ?? [], forbidden, input.intentAnchor ?? "");
   const input0 = pickPrimaryInput(input.inputs ?? []);
   const searchOriented = intentIsSearchOriented(input.intentAnchor);
 
   // Intent alignment: when the goal is to CHECK/SEARCH something and a search box exists, prefer
   // typing into it over clicking a non-search CTA (e.g. don't click "보험 가입하기" for a
   // "check course conditions" intent). A CTA that is itself a search/check action still wins.
-  const preferInput = searchOriented && input0 && (!cta || !ctaIsSearchLike(cta.text));
+  const ctaNamedByIntent = !!cta && (input.intentAnchor ?? "").includes(cta.text.trim());
+  const preferInput = searchOriented && input0 && (!cta || !(ctaIsSearchLike(cta.text) || ctaNamedByIntent));
+
+  // D8: a benign value the input actually accepts — "서울" in a number field
+  // throws at fill time and poisoned the whole run as "couldn't interact".
+  const typeValue = input0 && input0.type === "number" ? "5" : sampleQuery;
+  const typeLabel =
+    input0 && (input0.type === "search" || /search|검색|찾기/i.test(input0.placeholder))
+      ? L.typeQuery(typeValue)
+      : L.typeField(typeValue);
+
+  const pushType = (i: DetectedInput) =>
+    steps.push({ action: "type", label: typeLabel, selector: i.selector, value: typeValue, placeholder: i.placeholder });
+  const pushClick = (c: DetectedCta) =>
+    steps.push({ action: "click", label: L.clickCta(c.text), selector: c.selector, targetText: c.text });
+
+  if (input0 && cta && !preferInput) {
+    pushType(input0);
+    pushClick(cta);
+    steps.push({ action: "observe", label: L.observeAfterClick });
+    return steps;
+  }
 
   if (cta && !preferInput) {
-    steps.push({ action: "click", label: L.clickCta(cta.text), selector: cta.selector, targetText: cta.text });
+    pushClick(cta);
     steps.push({ action: "observe", label: L.observeAfterClick });
     return steps;
   }
 
   if (input0) {
-    steps.push({
-      action: "type",
-      label: L.typeQuery(sampleQuery),
-      selector: input0.selector,
-      value: sampleQuery,
-      placeholder: input0.placeholder,
-    });
+    pushType(input0);
     steps.push({ action: "observe", label: L.observeResults });
     return steps;
   }

--- a/apps/central-plane/test/inspection-accuracy.test.mjs
+++ b/apps/central-plane/test/inspection-accuracy.test.mjs
@@ -85,6 +85,37 @@ describe("decideFromEvidence — Potemkin is STILL caught (no over-softening)", 
   });
 });
 
+describe("decideFromEvidence — D9: dead-button crash is the CONJUNCTION, never either signal alone", () => {
+  // 2026-07-17 accuracy eval F4: a load-time JS crash leaves the button dead —
+  // clickable, zero network failures, but nothing ever changes. Console error
+  // ALONE stays non-fatal (vercel lesson); no-change ALONE stays non-fatal
+  // (subtle UIs); together they are a crashed app.
+  it("action + NO visible change + console error → Needs Fix", () => {
+    const d = decideFromEvidence(
+      { ...base, interacted: true, visibleChangeAfterAction: false, consoleErrorCount: 1 },
+      [{ ok: true }, { ok: false }],
+    );
+    assert.equal(d, "Needs Fix");
+  });
+  it("console error alone (screen DID change) stays a clean acceptance ask", () => {
+    const d = decideFromEvidence(
+      { ...base, interacted: true, visibleChangeAfterAction: true, consoleErrorCount: 3 },
+      [{ ok: true }],
+    );
+    assert.equal(d, "User Acceptance Required");
+  });
+  it("no visible change alone (no console error) is 'couldn't confirm', not broken", () => {
+    const d = decideFromEvidence(
+      { ...base, interacted: true, visibleChangeAfterAction: false, consoleErrorCount: 0 },
+      [{ ok: true }, { ok: false }],
+    );
+    assert.notEqual(d, "Needs Fix");
+  });
+  it("older callers without the D9 fields keep their existing verdicts (fields optional)", () => {
+    assert.equal(decideFromEvidence({ ...base, interacted: true }, [{ ok: true }]), "User Acceptance Required");
+  });
+});
+
 describe("classifyFindings — noise is info, real failures are high, console is low", () => {
   const input = (over) => ({
     targetUrl: "https://myapp.vercel.app/", intentAnchor: "x", loadStatus: 200,

--- a/apps/central-plane/test/visual-flow-plan.test.mjs
+++ b/apps/central-plane/test/visual-flow-plan.test.mjs
@@ -77,14 +77,18 @@ test("intent alignment: a 'check' intent prefers the search box over a non-searc
   assert.equal(plan[0].selector, "#q");
 });
 
-test("intent alignment: a search-like CTA still wins even for a check intent", () => {
+test("intent alignment: a search-like CTA still wins even for a check intent (now as type→click, D6)", () => {
   const plan = planVisualFlow({
     intentAnchor: "코스 조건을 확인하는 흐름",
     ctas: [{ text: "코스 검색", selector: "text=코스 검색" }],
     inputs: [{ placeholder: "골프장 검색", type: "text", selector: "#q" }],
   });
-  assert.equal(plan[0].action, "click"); // "코스 검색" is itself the intent action
-  assert.equal(plan[0].targetText, "코스 검색");
+  // 2026-07-17 (D6): with both an input and the search CTA, the journey is
+  // type THEN click — deeper than the old click-only plan, same CTA.
+  assert.equal(plan[0].action, "type");
+  assert.equal(plan[1].action, "click");
+  assert.equal(plan[1].targetText, "코스 검색");
+  assert.equal(plan[2].action, "observe");
 });
 
 test("no CTA and no input → single safe observe (nothing to drive)", () => {
@@ -150,6 +154,85 @@ test("the observe-only fallback is localized too", () => {
   assert.equal(plan.length, 1);
   assert.equal(plan[0].action, "observe");
   assert.ok(!HANGUL.test(plan[0].label), `leaked: "${plan[0].label}"`);
+});
+
+// ─── D5/D6/D8 (2026-07-17 accuracy eval) ─────────────────────────────────────
+// Baseline measurement: every input+button vibe app (todo/저장/계산기) collapsed
+// into "확인 필요" because their verbs scored 0 and typing never submitted.
+// docs/simsa-inspection-accuracy-eval-2026-07-17.md
+
+test("D5①: a CTA named in the intent wins ('추가 버튼을 누르면' → the 추가 button)", () => {
+  const cta = pickSafeCta(
+    [
+      { text: "둘러보기", selector: "#b" },
+      { text: "추가", selector: "#add" },
+    ],
+    [],
+    "할 일을 입력하고 추가 버튼을 누르면 목록에 나타나야 한다",
+  );
+  assert.equal(cta.selector, "#add");
+});
+
+test("D5②: common single-purpose verbs (추가/저장/계산/변환) now score — the app's one button gets clicked", () => {
+  for (const text of ["추가", "저장", "계산하기", "변환하기", "Save", "Add item"]) {
+    const cta = pickSafeCta([{ text, selector: "#x" }], []);
+    assert.ok(cta, `should pick: ${text}`);
+  }
+});
+
+test("D5③: few-CTA fallback — a single-purpose page's only safe CTA is the flow even with no vocab match", () => {
+  assert.ok(pickSafeCta([{ text: "환전 실행", selector: "#go" }], []));
+  // …but never a forbidden one
+  assert.equal(pickSafeCta([{ text: "계정 삭제", selector: "#del" }], ["삭제"]), null);
+});
+
+test("D5③ stays off on link-heavy pages (many CTAs, none matching) — no random nav click", () => {
+  const many = ["홈", "소개", "블로그", "채용", "문의", "이용약관"].map((t, i) => ({ text: t, selector: `#l${i}` }));
+  assert.equal(pickSafeCta(many, []), null);
+});
+
+test("D6: input + button app plans the form journey — type, then CLICK submits (fires the app's real action)", () => {
+  const plan = planVisualFlow({
+    intentAnchor: "고객 메모를 입력하고 저장을 누르면 목록에 나타나야 한다",
+    ctas: [{ text: "저장", selector: "text=저장" }],
+    inputs: [{ placeholder: "고객 이름과 메모", type: "text", selector: "#n" }],
+  });
+  assert.deepEqual(plan.map((s) => s.action), ["type", "click", "observe"]);
+  assert.equal(plan[1].targetText, "저장");
+});
+
+test("D6 exception preserved: search intent + unrelated non-search CTA still types WITHOUT clicking it", () => {
+  const plan = planVisualFlow({
+    intentAnchor: "코스가 지금 플레이 가능한지 확인",
+    ctas: [{ text: "보험 가입하기", selector: "#ins" }],
+    inputs: [{ placeholder: "골프장 검색", type: "text", selector: "#q" }],
+  });
+  assert.deepEqual(plan.map((s) => s.action), ["type", "observe"]);
+});
+
+test("D8: a number input gets a numeric sample value, not '서울' (fill would throw)", () => {
+  const plan = planVisualFlow({
+    intentAnchor: "숫자를 입력하고 변환하기를 누르면 결과가 보여야 한다",
+    ctas: [{ text: "변환하기", selector: "#go" }],
+    inputs: [{ placeholder: "예: 5", type: "number", selector: "#km" }],
+  });
+  const typed = plan.find((s) => s.action === "type");
+  assert.equal(typed.value, "5");
+});
+
+test("D8: non-search inputs get the '입력창' label, search inputs keep '검색창'", () => {
+  const form = planVisualFlow({
+    intentAnchor: "메모를 저장",
+    ctas: [{ text: "저장", selector: "#s" }],
+    inputs: [{ placeholder: "메모", type: "text", selector: "#m" }],
+  });
+  assert.match(form.find((s) => s.action === "type").label, /입력창/);
+  const search = planVisualFlow({
+    intentAnchor: "검색해서 확인",
+    ctas: [],
+    inputs: [{ placeholder: "골프장 검색", type: "text", selector: "#q" }],
+  });
+  assert.match(search.find((s) => s.action === "type").label, /검색창/);
 });
 
 test("locale defaults to ko, and an unknown locale falls back to ko (no silent English for KO users)", () => {

--- a/docs/simsa-inspection-accuracy-eval-2026-07-17.md
+++ b/docs/simsa-inspection-accuracy-eval-2026-07-17.md
@@ -1,0 +1,90 @@
+# Simsa 검수 verdict 정확도 실측 설계 (2026-07-17)
+
+> HANDOFF-2026-07-17 § 남은 것의 P1 — "실제-타겟 검수 정확도 실증". P0-B(#347)가 오탐
+> **원인**을 제거했지만, 타겟다운 앱에서의 verdict 정확도 **수치**는 아직 없다 = 이번의 증명 대상.
+
+## 원칙 (잠금)
+
+- **E1** ground truth가 알려진 데이터셋만 정확도를 주장할 수 있다. 실제 신생 vibe 앱은
+  작동 여부의 정답을 모르므로, **vibe 앱 실패 아키타입을 재현한 합성 픽스처**(작동/고장을
+  우리가 설계)로 측정하고, 문서에 "합성 아키타입"임을 명시한다. 실유저 앱 수치가 아니다.
+- **E2** 측정은 **프로덕션 경로 전체**(worker → DO → 컨테이너 → verdict)를 통과해야 한다.
+  로컬 하네스 재현은 참고일 뿐 수치의 근거가 될 수 없다 (라이브 실측 > 사전 스캔).
+- **E3** 채점은 방향 구분: 작동 앱을 "고장"이라 하면 **false-negative**(P0-B가 잡은 축),
+  고장 앱을 "작동"이라 하면 **false-positive**(Potemkin 놓침 축). `works=null`("확인 필요")은
+  오답이 아닌 **부분점**으로 별도 집계 — 정직한 불확실 표명은 오판과 다르다.
+- **E4** 측정 기록은 지우지 않는다. 결과는 이 문서에 날짜와 함께 덧붙인다.
+
+## 데이터셋 (파라미터 — 아키타입 추가는 자유)
+
+픽스처 워커: `tools/simsa-inspection-fixtures/` → `simsa-inspection-fixtures.seunghunbae.workers.dev`.
+v0/Lovable 산출물풍(그라디언트 히어로·이모지·단일 페이지)으로 스타일링해 타겟 유사성 확보.
+
+| # | 경로 | 아키타입 | ground truth | 기대 verdict |
+|---|---|---|---|---|
+| F1 | `/working-todo` | 완전 작동 할 일 앱 (localStorage, 추가·표시 실동작) | 작동 | `works=true` |
+| F2 | `/noisy-working` | **작동하는데 시끄러운** 앱 — 애널리틱스/광고 로드 실패 + 콘솔 에러, 핵심 기능(단위 변환)은 실동작 | 작동 | `works=true` (#347 allowlist의 라이브 증명) |
+| F3 | `/potemkin-crm` | **Potemkin** — 예쁜 UI, 저장 버튼이 존재하지 않는 Supabase 도메인으로 fetch → 조용히 무동작 | 고장 | `works=false` (#347이 유지해야 한다고 주장한 축) |
+| F4 | `/js-crash` | 로드 시 JS 크래시로 버튼이 죽은 계산기 — 클릭돼도 아무 일 없음 | 고장 | `works=false` |
+| F5 | `/blank` | 200이지만 본문이 사실상 빈 페이지 | 고장 | `works=false` |
+| R1 | `app.trysimsa.com` | 실제 프로덕션 앱 (참조군) | 작동 | `works=false`만 아니면 통과 (복잡 SPA라 null 허용) |
+
+## 방법
+
+`tools/simsa-inspection-fixtures/eval-run.mjs` — 타겟마다 익명 userKey로
+프로젝트 생성 → website 소스 등록 → `visual-checks/run` → 폴링(≤6분) → verdict 기록 →
+프로젝트 삭제. 순차 실행(프로젝트당 1 active run 가드 + 컨테이너 부하 배려).
+
+## 채점
+
+- **정답**: 기대 verdict와 일치. **부분**: `works=null`. **오답**: 방향이 반대.
+- 보고 수치: 정답률, false-negative 수(작동→고장 오판), false-positive 수(고장→작동 오판),
+  null 수. 축별로 따로 — 단일 정확도 %로 뭉개지 않는다 (신호/잡음 분리 교훈의 채점판 버전).
+
+## 채점 정정 (측정 1차 후)
+
+`decideFromEvidence`에는 "Ready" 반환 경로가 없다 — **자동 검수의 상한은 "User Acceptance
+Required"**(사람 수용 대기)이고 `works=true`는 사용자의 수용으로만 발생한다(제품 설계상 맞음:
+Simsa는 acceptance 레이어). 따라서 채점은 works가 아니라 decision 레벨로:
+- 작동 앱 정답 = **실패 스텝 0개인 User Acceptance Required** (깨끗한 수용 대기)
+- 고장 앱 정답 = **Needs Fix** (works=false)
+
+## 결과 — 1차 측정 (2026-07-17, main=02f00ca, 수정 전 베이스라인)
+
+| # | 기대 | decision | works | 실패 스텝 | 채점 |
+|---|---|---|---|---|---|
+| F1 작동 todo | 깨끗한 UAR | User Acceptance Required | null | "'서울' 입력 단계 미완" | ❌ 더러운 UAR |
+| F2 작동+노이즈 | 깨끗한 UAR | Needs Clarification | null | fill 예외(number 입력창) | ❌ |
+| F3 Potemkin | Needs Fix | User Acceptance Required | null | "'서울' 입력 단계 미완" | ❌ **F1과 구별 불가** |
+| F4 JS 크래시 | Needs Fix | Needs Clarification | null | fill 예외(number 입력창) | ❌ |
+| F5 빈 페이지 | Needs Fix(또는 noPrimary null) | (2차 측정) | | | |
+| R1 실제 앱 | false 아님 | (2차 측정) | | | |
+
+**집계(1차)**: false-negative 0 ✅ (P0-B 유지 — 작동 앱을 "고장"이라 하진 않음) ·
+false-positive 0 · **그러나 변별력 0** — 작동 앱과 Potemkin이 동일한 리포트를 받음.
+Potemkin의 백엔드 호출은 저장 버튼이 클릭되지 않아 발화조차 안 됨.
+
+## 근본 원인 4건 (전부 결정론 코드)
+
+1. `pickSafeCta`가 우선순위 어휘(시작/검색/가입…) 매치를 요구 — 단일 목적 vibe 앱의 흔한
+   동사 버튼(추가/저장/계산/변환…)은 score 0 → 영원히 클릭 안 됨.
+2. type 경로에 **submit 클릭 스텝이 없음**(Enter만 가정) — 버튼 제출형 앱에서 액션 미발화.
+3. type 성공 판정이 `bodyLen > 200` **절대 크기** — 콘텐츠 사이트 기준이라 작은 앱 카드는
+   실제 동작과 무관하게 항상 "단계 미완".
+4. `pickPrimaryInput`이 input type 무시 — number 입력창에 "서울" fill → Playwright 예외 →
+   interacted=false로 오염.
+
+## 수정 설계 (2차 측정 전)
+
+- **D5 [LOCKED 원칙/파라미터 어휘]** CTA 선택 3단: ① intent 문장에 텍스트가 그대로 등장하는
+  CTA 최우선(사용자 의도의 결정론 반영) ② 액션 동사 어휘 확장(추가·저장·기록·계산·변환·
+  만들기·생성·조회 등 — 파라미터) ③ 감지 CTA가 소수(≤4)면 첫 안전 CTA 폴백(단일 목적 앱 형상).
+  forbidden 필터는 모든 단계에 그대로.
+- **D6 [LOCKED]** type 경로는 **type → (안전 CTA 있으면) submit 클릭 → observe** 합성으로.
+  이것이 Potemkin의 백엔드 fetch를 실제로 발화시키는 단계다.
+- **D7 [LOCKED]** type/관찰 성공 판정은 절대 크기가 아니라 **변화**(액션 전후 body 텍스트
+  변화 또는 라우트 변화) + 신규 네트워크 실패 없음.
+- **D8 [LOCKED]** 입력값은 input type을 존중 — number형엔 숫자 샘플("5"), 그 외 sampleQuery.
+
+측정 2차(수정 배포 후 동일 데이터셋 재실행) 결과를 아래에 덧붙인다.
+

--- a/tools/simsa-completion-loop-spike/visual-run.mjs
+++ b/tools/simsa-completion-loop-spike/visual-run.mjs
@@ -16,7 +16,10 @@ import { mkdirSync, writeFileSync, copyFileSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { planVisualFlow } from "../../apps/central-plane/dist/visual-flow-plan.js";
-import { buildNonDevReport, buildAgentFixPrompt, renderNonDevReportHtml } from "../../apps/central-plane/dist/nondev-report.js";
+// decideFromEvidence: this file used to carry its OWN pre-#347 copy (console
+// errors → Needs Fix, the exact false-negative the noise filter removed) —
+// drifted duplicates get the canonical, unit-tested ladder instead.
+import { buildNonDevReport, buildAgentFixPrompt, renderNonDevReportHtml, decideFromEvidence } from "../../apps/central-plane/dist/nondev-report.js";
 import { classifyActionSafety } from "./lib/safety.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -119,6 +122,12 @@ export async function visualRun(config, outDir) {
     evidence.plan = plan;
     evidence.primaryActionFound = plan.some((s) => s.action === "click" || s.action === "type");
 
+    // D6/D7 parity with inspector-run.mjs (2026-07-17 accuracy eval): success is
+    // change-from-baseline, and Enter is pressed only when no click step submits.
+    const bodyTextAt = async () => (await page.locator("body").innerText().catch(() => "")).replace(/\s+/g, " ").trim();
+    const bodyBefore = await bodyTextAt();
+    const planHasClick = plan.some((s) => s.action === "click");
+
     let stepIdx = 0;
     for (const step of plan) {
       stepIdx += 1;
@@ -141,17 +150,19 @@ export async function visualRun(config, outDir) {
         } else if (step.action === "type") {
           const field = step.placeholder ? page.getByPlaceholder(step.placeholder).first() : page.locator("input").first();
           await field.fill(step.value, { timeout: 8000 });
-          await field.press("Enter").catch(() => {});
+          if (!planHasClick) await field.press("Enter").catch(() => {});
           evidence.interacted = true;
           await page.waitForTimeout(1800);
           await snap(shotName, `${step.label} 후 화면`);
-          // Did results/content appear? Heuristic: page text grew and no fresh network failure.
-          const bodyLen = (await page.locator("body").innerText().catch(() => "")).length;
-          const ok = bodyLen > 200 && networkFailures.length === 0;
-          stepOutcomes.push({ label: step.label, ok, note: ok ? undefined : "검색 결과/내용이 확인되지 않음 (또는 데이터 요청 실패)" });
+          stepOutcomes.push({ label: step.label, ok: true });
         } else {
           await snap(shotName, step.label);
-          stepOutcomes.push({ label: step.label, ok: networkFailures.length === 0, note: networkFailures.length ? "데이터 요청 실패가 관찰됨" : undefined });
+          const bodyNow = await bodyTextAt();
+          const visibleChange = bodyNow !== bodyBefore || evidence.routeChanged;
+          if (evidence.interacted) evidence.visibleChangeAfterAction = visibleChange;
+          const ok = networkFailures.length === 0 && (!evidence.interacted || visibleChange);
+          const note = networkFailures.length ? "데이터 요청 실패가 관찰됨" : ok ? undefined : "동작 후 화면에 아무 변화가 없음";
+          stepOutcomes.push({ label: step.label, ok, note });
         }
       } catch (err) {
         await snap(shotName, `${step.label} (실패)`);
@@ -175,6 +186,7 @@ export async function visualRun(config, outDir) {
     /* video optional */
   }
 
+  evidence.consoleErrorCount = consoleErrors.length;
   const decision = decideFromEvidence(evidence, stepOutcomes);
   const reportInput = {
     targetUrl: config.targetUrl,
@@ -199,17 +211,6 @@ export async function visualRun(config, outDir) {
   writeFileSync(join(outDir, "report.md"), toMarkdown(report));
   writeFileSync(join(outDir, "agent-prompt.md"), agentPrompt);
   return { report, reportInput, agentPrompt, decision, shots, videoRel };
-}
-
-/** Deterministic decision from the deep-flow evidence (mirrors the spike's ladder, journey-aware). */
-function decideFromEvidence(e, steps) {
-  if (e.loadStatus && e.loadStatus >= 400) return "Not Verified";
-  if (e.networkFailures.length || e.consoleErrors.length) return "Needs Fix";
-  if (e.interacted && e.routeAfterClick && /\/undefined|\/null|\/404|not-found|error/i.test(e.routeAfterClick)) return "Needs Fix";
-  if (steps.some((s) => !s.ok)) return "Needs Fix";
-  if (!e.primaryActionFound) return "Needs Clarification";
-  if (e.interacted) return "User Acceptance Required"; // journey ran clean, but no visual oracle for "usable"
-  return "Not Verified";
 }
 
 function toMarkdown(r) {

--- a/tools/simsa-inspection-fixtures/eval-results-2026-07-17-F3-F4.json
+++ b/tools/simsa-inspection-fixtures/eval-results-2026-07-17-F3-F4.json
@@ -1,0 +1,31 @@
+{
+  "base": "https://conclave-ai.seunghunbae.workers.dev",
+  "fixtures": "https://simsa-inspection-fixtures.seunghunbae.workers.dev",
+  "date": "2026-07-17",
+  "results": [
+    {
+      "id": "F3",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/potemkin-crm",
+      "expected": "broken",
+      "intent": "고객 메모를 입력하고 저장을 누르면 저장된 메모가 목록에 나타나야 한다",
+      "works": null,
+      "decision": "User Acceptance Required",
+      "verdict": "직접 눈으로 확인이 필요해요",
+      "oneLine": "아직 '작동한다'고 확정하기엔 확인이 더 필요해요. '검색창에 '서울' 입력하기' 단계가 끝까지 되지 않았어요.",
+      "runStatus": "done",
+      "score": "partial(null)"
+    },
+    {
+      "id": "F4",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/js-crash",
+      "expected": "broken",
+      "intent": "원화 금액을 입력하고 계산하기를 누르면 달러 금액이 보여야 한다",
+      "works": null,
+      "decision": "Needs Clarification",
+      "verdict": "무엇을 확인해야 할지 애매해요",
+      "oneLine": "아직 '작동한다'고 확정하기엔 확인이 더 필요해요. '검색창에 '서울' 입력하기' 단계가 끝까지 되지 않았어요.",
+      "runStatus": "done",
+      "score": "partial(null)"
+    }
+  ]
+}

--- a/tools/simsa-inspection-fixtures/eval-results-2026-07-17-F5-R1.json
+++ b/tools/simsa-inspection-fixtures/eval-results-2026-07-17-F5-R1.json
@@ -1,0 +1,24 @@
+{
+  "base": "https://conclave-ai.seunghunbae.workers.dev",
+  "fixtures": "https://simsa-inspection-fixtures.seunghunbae.workers.dev",
+  "date": "2026-07-17",
+  "results": [
+    {
+      "id": "F5",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/blank",
+      "expected": "broken",
+      "intent": "방문자가 이 서비스가 무엇인지 화면에서 알 수 있어야 한다",
+      "runStatus": "dispatch_failed(202 container returned 500: Failed to start container: Maximum number of running container instances exceeded. Try again later, or try configuring a higher value for max_instances)",
+      "score": "no-result"
+    },
+    {
+      "id": "R1",
+      "url": "https://app.trysimsa.com",
+      "expected": "working",
+      "nullOk": true,
+      "intent": "방문자가 이 제품이 무엇인지 이해하고 시작할 수 있어야 한다",
+      "runStatus": "dispatch_failed(202 container returned 500: Failed to start container: Maximum number of running container instances exceeded. Try again later, or try configuring a higher value for max_instances)",
+      "score": "no-result"
+    }
+  ]
+}

--- a/tools/simsa-inspection-fixtures/eval-results-2026-07-17.json
+++ b/tools/simsa-inspection-fixtures/eval-results-2026-07-17.json
@@ -1,0 +1,31 @@
+{
+  "base": "https://conclave-ai.seunghunbae.workers.dev",
+  "fixtures": "https://simsa-inspection-fixtures.seunghunbae.workers.dev",
+  "date": "2026-07-17",
+  "results": [
+    {
+      "id": "F1",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/working-todo",
+      "expected": "working",
+      "intent": "할 일을 입력하고 추가 버튼을 누르면 목록에 나타나야 한다",
+      "works": null,
+      "decision": "User Acceptance Required",
+      "verdict": "직접 눈으로 확인이 필요해요",
+      "oneLine": "아직 '작동한다'고 확정하기엔 확인이 더 필요해요. '검색창에 '서울' 입력하기' 단계가 끝까지 되지 않았어요.",
+      "runStatus": "done",
+      "score": "partial(null)"
+    },
+    {
+      "id": "F2",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/noisy-working",
+      "expected": "working",
+      "intent": "숫자를 입력하고 변환하기를 누르면 마일 결과가 보여야 한다",
+      "works": null,
+      "decision": "Needs Clarification",
+      "verdict": "무엇을 확인해야 할지 애매해요",
+      "oneLine": "아직 '작동한다'고 확정하기엔 확인이 더 필요해요. 화면에서 코드 오류가 났어요.",
+      "runStatus": "done",
+      "score": "partial(null)"
+    }
+  ]
+}

--- a/tools/simsa-inspection-fixtures/eval-run.mjs
+++ b/tools/simsa-inspection-fixtures/eval-run.mjs
@@ -1,0 +1,138 @@
+/**
+ * eval-run.mjs — measure the PRODUCTION inspection verdict against fixtures
+ * with known ground truth. Design + scoring rules (E1~E4):
+ * docs/simsa-inspection-accuracy-eval-2026-07-17.md
+ *
+ * Per target: anonymous userKey → create project → register website source →
+ * visual-checks/run → poll (≤6 min) → record verdict → delete project.
+ * Sequential on purpose (one-active-run guard + container courtesy).
+ *
+ * Usage: node eval-run.mjs            (all targets)
+ *        node eval-run.mjs F3 F4     (subset by id)
+ * Writes eval-results-<date>.json next to this file.
+ */
+
+const BASE = process.env.SIMSA_BASE ?? "https://conclave-ai.seunghunbae.workers.dev";
+const FIXTURES = process.env.FIXTURES_BASE ?? "https://simsa-inspection-fixtures.seunghunbae.workers.dev";
+const POLL_MS = 10_000;
+const MAX_WAIT_MS = 6 * 60_000;
+
+// expected: "working" → works=true is correct; "broken" → works=false is correct.
+// null is a PARTIAL either way (honest uncertainty, not a wrong call).
+// nullOk: complex real-world reference where null is a full pass.
+const TARGETS = [
+  { id: "F1", url: `${FIXTURES}/working-todo`, expected: "working",
+    intent: "할 일을 입력하고 추가 버튼을 누르면 목록에 나타나야 한다" },
+  { id: "F2", url: `${FIXTURES}/noisy-working`, expected: "working",
+    intent: "숫자를 입력하고 변환하기를 누르면 마일 결과가 보여야 한다" },
+  { id: "F3", url: `${FIXTURES}/potemkin-crm`, expected: "broken",
+    intent: "고객 메모를 입력하고 저장을 누르면 저장된 메모가 목록에 나타나야 한다" },
+  { id: "F4", url: `${FIXTURES}/js-crash`, expected: "broken",
+    intent: "원화 금액을 입력하고 계산하기를 누르면 달러 금액이 보여야 한다" },
+  { id: "F5", url: `${FIXTURES}/blank`, expected: "broken",
+    intent: "방문자가 이 서비스가 무엇인지 화면에서 알 수 있어야 한다" },
+  { id: "R1", url: "https://app.trysimsa.com", expected: "working", nullOk: true,
+    intent: "방문자가 이 제품이 무엇인지 이해하고 시작할 수 있어야 한다" },
+];
+
+async function api(method, path, body) {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    ...(body ? { headers: { "content-type": "application/json" }, body: JSON.stringify(body) } : {}),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const text = await res.text();
+  let json;
+  try { json = JSON.parse(text); } catch { json = { _raw: text.slice(0, 300) }; }
+  return { status: res.status, json };
+}
+
+async function evalTarget(t) {
+  const userKey = `uk_eval_${t.id.toLowerCase()}_${Date.now().toString(36)}`;
+  const row = { ...t, works: undefined, decision: undefined, verdict: undefined, oneLine: undefined, runStatus: undefined };
+
+  const created = await api("POST", "/workspace/projects", {
+    userKey, title: `inspection eval ${t.id}`,
+    idea: "검수 정확도 측정용 프로젝트", understood: null, productSpec: null, items: [], entryPath: "code",
+  });
+  const projectId = created.json?.project?.id ?? created.json?.id;
+  if (!projectId) { row.runStatus = `project_create_failed(${created.status})`; return row; }
+
+  try {
+    const src = await api("POST", `/workspace/projects/${projectId}/sources`, {
+      userKey, type: "website", reference: t.url, label: `eval ${t.id}`,
+    });
+    if (src.status >= 300) { row.runStatus = `source_failed(${src.status})`; return row; }
+
+    const run = await api("POST", `/workspace/projects/${projectId}/visual-checks/run`, {
+      userKey, locale: "ko", targetUrl: t.url, intent: t.intent,
+    });
+    const runId = run.json?.check?.id;
+    if (!runId || run.json?.dispatched !== true) {
+      row.runStatus = `dispatch_failed(${run.status} ${run.json?.note ?? ""})`; return row;
+    }
+
+    const started = Date.now();
+    while (Date.now() - started < MAX_WAIT_MS) {
+      await new Promise((r) => setTimeout(r, POLL_MS));
+      const got = await api("GET", `/workspace/projects/${projectId}/visual-checks/${runId}?userKey=${encodeURIComponent(userKey)}`);
+      const st = got.json?.check?.status;
+      process.stdout.write(`    …${st} (${Math.round((Date.now() - started) / 1000)}s)\r`);
+      if (st === "done" || st === "failed") {
+        const chk = got.json.check;
+        row.runStatus = st;
+        row.works = chk.works ?? chk.report?.works ?? null;
+        row.decision = chk.decision ?? null;
+        row.verdict = chk.report?.verdict ?? null;
+        row.oneLine = chk.report?.oneLine ?? null;
+        break;
+      }
+    }
+    if (row.runStatus === undefined) row.runStatus = "timeout";
+    return row;
+  } finally {
+    await api("DELETE", `/workspace/projects/${projectId}?userKey=${encodeURIComponent(userKey)}`).catch(() => {});
+  }
+}
+
+function score(row) {
+  if (row.runStatus !== "done") return "no-result";
+  const w = row.works;
+  if (row.expected === "working") {
+    if (w === true) return "correct";
+    if (w === null || w === undefined) return row.nullOk ? "correct" : "partial(null)";
+    return "FALSE-NEGATIVE"; // working app called broken — the P0-B axis
+  }
+  if (w === false) return "correct";
+  if (w === null || w === undefined) return "partial(null)";
+  return "FALSE-POSITIVE"; // broken app called working — Potemkin missed
+}
+
+const only = process.argv.slice(2);
+const list = only.length ? TARGETS.filter((t) => only.includes(t.id)) : TARGETS;
+console.log(`inspection accuracy eval — base=${BASE}\nfixtures=${FIXTURES}\ntargets=${list.map((t) => t.id).join(", ")}\n`);
+
+const results = [];
+for (const t of list) {
+  console.log(`▶ ${t.id} ${t.url} (expected: ${t.expected})`);
+  const row = await evalTarget(t);
+  row.score = score(row);
+  results.push(row);
+  console.log(`    ${row.runStatus} works=${row.works} decision=${row.decision} → ${row.score}`);
+  if (row.oneLine) console.log(`    "${String(row.oneLine).slice(0, 110)}"`);
+}
+
+const tally = results.reduce((m, r) => ((m[r.score] = (m[r.score] ?? 0) + 1), m), {});
+console.log(`\n── 결과 ──`);
+for (const r of results) console.log(`${r.id.padEnd(3)} expected=${r.expected.padEnd(7)} works=${String(r.works).padEnd(9)} ${r.score}`);
+console.log(`\n집계: ${JSON.stringify(tally)}`);
+
+const stamp = new Date().toISOString().slice(0, 10);
+const suffix = only.length ? `-${only.join("-")}` : "";
+const outPath = new URL(`./eval-results-${stamp}${suffix}.json`, import.meta.url);
+const { writeFileSync } = await import("node:fs");
+writeFileSync(outPath, JSON.stringify({ base: BASE, fixtures: FIXTURES, date: stamp, results }, null, 2));
+console.log(`saved: ${outPath.pathname}`);
+
+const bad = results.filter((r) => r.score.startsWith("FALSE") || r.score === "no-result").length;
+process.exit(bad === 0 ? 0 : 1);

--- a/tools/simsa-inspection-fixtures/src/index.mjs
+++ b/tools/simsa-inspection-fixtures/src/index.mjs
@@ -1,0 +1,148 @@
+/**
+ * simsa-inspection-fixtures — vibe-app archetypes with KNOWN ground truth,
+ * used to measure the production inspection verdict accuracy.
+ * Design: docs/simsa-inspection-accuracy-eval-2026-07-17.md (F1~F5).
+ *
+ * Styled like typical v0/Lovable output (gradient hero, emoji, single page)
+ * so the targets resemble what Simsa's real users actually inspect.
+ */
+
+const SHELL = (title, body, extraHead = "") => `<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+${extraHead}
+<style>
+  * { box-sizing: border-box; margin: 0; }
+  body { font-family: -apple-system, 'Segoe UI', sans-serif; min-height: 100vh;
+         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+         display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .card { background: #fff; border-radius: 16px; padding: 40px; max-width: 460px; width: 100%;
+          box-shadow: 0 20px 60px rgba(0,0,0,.25); }
+  h1 { font-size: 26px; margin-bottom: 8px; }
+  p.sub { color: #666; margin-bottom: 24px; font-size: 14px; }
+  .row { display: flex; gap: 8px; margin-bottom: 16px; }
+  input { flex: 1; padding: 12px 14px; border: 2px solid #e2e2f0; border-radius: 10px; font-size: 15px; }
+  button { padding: 12px 20px; border: 0; border-radius: 10px; font-size: 15px; font-weight: 600;
+           color: #fff; background: linear-gradient(135deg, #667eea, #764ba2); cursor: pointer; }
+  ul { list-style: none; } li { padding: 10px 12px; background: #f5f5fb; border-radius: 8px; margin-bottom: 8px; }
+  .result { padding: 14px; background: #f0fdf4; border-radius: 10px; font-size: 16px; min-height: 20px; }
+</style>
+</head>
+<body><div class="card">${body}</div></body>
+</html>`;
+
+// F1 — fully working todo. Clicking the CTA always produces a visible change
+// (empty input falls back to a default item), and items persist in localStorage.
+const WORKING_TODO = SHELL(
+  "오늘 할 일 ✅",
+  `<h1>✅ 오늘 할 일</h1>
+<p class="sub">할 일을 적고 추가 버튼을 누르세요</p>
+<div class="row"><input id="t" placeholder="예: 우유 사기"><button id="add">추가</button></div>
+<ul id="list"></ul>
+<script>
+  const list = document.getElementById("list");
+  const saved = JSON.parse(localStorage.getItem("todos") || "[]");
+  const render = () => { list.innerHTML = saved.map(t => "<li>📝 " + t + "</li>").join(""); };
+  document.getElementById("add").addEventListener("click", () => {
+    const v = document.getElementById("t").value.trim() || "새 할 일";
+    saved.push(v); localStorage.setItem("todos", JSON.stringify(saved));
+    document.getElementById("t").value = ""; render();
+  });
+  render();
+</script>`,
+);
+
+// F2 — WORKING but noisy: analytics + ad scripts from allowlisted-noise domains
+// fail to load, and a legacy console.error fires — yet the core feature works.
+// A correct verdict ignores the noise (#347) and says it works.
+const NOISY_WORKING = SHELL(
+  "단위 변환기 📏",
+  `<h1>📏 단위 변환기</h1>
+<p class="sub">킬로미터를 마일로 바꿔드려요</p>
+<div class="row"><input id="km" type="number" placeholder="예: 5"><button id="go">변환하기</button></div>
+<div class="result" id="out">결과가 여기에 표시됩니다</div>
+<script>
+  console.error("[legacy] deprecated config format — please migrate"); // harmless noise
+  document.getElementById("go").addEventListener("click", () => {
+    const km = parseFloat(document.getElementById("km").value) || 5;
+    document.getElementById("out").textContent = km + " km = " + (km * 0.621371).toFixed(2) + " miles 🎉";
+  });
+</script>`,
+  `<script async src="https://www.google-analytics.com/analytics.js"></script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>`,
+);
+
+// F3 — POTEMKIN: pretty UI, the save button POSTs to a nonexistent Supabase
+// backend and silently does nothing. Looks finished, is not wired.
+const POTEMKIN_CRM = SHELL(
+  "고객 메모장 💼",
+  `<h1>💼 고객 메모장</h1>
+<p class="sub">고객 이름과 메모를 저장하고 관리하세요</p>
+<div class="row"><input id="n" placeholder="고객 이름과 메모"><button id="save">저장</button></div>
+<ul id="notes"><li>💬 (아직 저장된 메모가 없습니다)</li></ul>
+<script>
+  document.getElementById("save").addEventListener("click", async () => {
+    try {
+      await fetch("https://xyzzy-nonexistent-simsa-eval.supabase.co/rest/v1/notes", {
+        method: "POST",
+        headers: { "content-type": "application/json", apikey: "anon-key" },
+        body: JSON.stringify({ note: document.getElementById("n").value }),
+      });
+      // (unreachable — and even on success nothing would re-render)
+    } catch (e) { /* swallowed: the classic silent Potemkin */ }
+  });
+</script>`,
+);
+
+// F4 — JS crash at load: the handler is never attached, the button is dead.
+const JS_CRASH = SHELL(
+  "환율 계산기 💱",
+  `<h1>💱 환율 계산기</h1>
+<p class="sub">원화를 달러로 계산해드려요</p>
+<div class="row"><input id="won" type="number" placeholder="예: 10000"><button id="calc">계산하기</button></div>
+<div class="result" id="usd">결과가 여기에 표시됩니다</div>
+<script>
+  const rates = undefined;
+  const base = rates.USD; // TypeError: crashes before the handler binds
+  document.getElementById("calc").addEventListener("click", () => {
+    document.getElementById("usd").textContent = (document.getElementById("won").value / base).toFixed(2) + " USD";
+  });
+</script>`,
+);
+
+// F5 — 200 OK, effectively empty body.
+const BLANK = `<!doctype html><html><head><meta charset="utf-8"><title></title></head><body></body></html>`;
+
+const INDEX = SHELL(
+  "Simsa inspection fixtures",
+  `<h1>Simsa inspection fixtures</h1>
+<p class="sub">docs/simsa-inspection-accuracy-eval-2026-07-17.md</p>
+<ul>
+  <li><a href="/working-todo">F1 /working-todo — 작동</a></li>
+  <li><a href="/noisy-working">F2 /noisy-working — 작동+노이즈</a></li>
+  <li><a href="/potemkin-crm">F3 /potemkin-crm — Potemkin</a></li>
+  <li><a href="/js-crash">F4 /js-crash — JS 크래시</a></li>
+  <li><a href="/blank">F5 /blank — 빈 페이지</a></li>
+</ul>`,
+);
+
+const ROUTES = {
+  "/": INDEX,
+  "/working-todo": WORKING_TODO,
+  "/noisy-working": NOISY_WORKING,
+  "/potemkin-crm": POTEMKIN_CRM,
+  "/js-crash": JS_CRASH,
+  "/blank": BLANK,
+};
+
+export default {
+  async fetch(request) {
+    const { pathname } = new URL(request.url);
+    const html = ROUTES[pathname];
+    if (!html) return new Response("not found", { status: 404 });
+    return new Response(html, { headers: { "content-type": "text/html; charset=utf-8" } });
+  },
+};

--- a/tools/simsa-inspection-fixtures/wrangler.toml
+++ b/tools/simsa-inspection-fixtures/wrangler.toml
@@ -1,0 +1,6 @@
+# simsa-inspection-fixtures — ground-truth fixture apps for the inspection
+# accuracy eval (docs/simsa-inspection-accuracy-eval-2026-07-17.md).
+# Plain static worker, no bindings, no secrets. Deploy: npx wrangler deploy
+name = "simsa-inspection-fixtures"
+main = "src/index.mjs"
+compatibility_date = "2026-01-01"


### PR DESCRIPTION
## 무엇 (P1 — 실제-타겟 검수 정확도 실증 + 측정이 드러낸 결함 수정)

ground truth를 아는 **vibe 앱 아키타입 픽스처 5종**(작동 todo / 작동+노이즈 / Potemkin /
JS크래시 / 빈 페이지)을 배포하고 **프로덕션 검수 경로 전체**를 실측했습니다.
설계·베이스라인·수정 설계(D5~D9): `docs/simsa-inspection-accuracy-eval-2026-07-17.md`

**베이스라인(main=02f00ca) 팩트:** false-negative 0 · false-positive 0 — 그러나 **변별력 0**.
작동하는 todo 앱과 Potemkin 앱이 **동일한 "확인 필요" 리포트**를 받음. 플로우 드라이버가
어느 앱의 액션도 발화시키지 못했기 때문(4개 결정론 결함).

## 수정 (전부 결정론, LLM 무관)

| D | 결함 | 수정 |
|---|---|---|
| **D5** | `pickSafeCta`가 우선순위 어휘 매치 요구 → "추가/저장/계산하기" 등 단일 목적 앱 버튼은 score 0, 영원히 클릭 안 됨 | 3단: ① intent가 그대로 명명한 CTA ② 액션 동사 어휘 확장 ③ ≤4 CTA면 첫 안전 CTA(단일 목적 형상). forbidden 필터는 전 단계 적용 |
| **D6** | type 후 submit 클릭 없음(Enter만 가정) → Potemkin의 백엔드 호출이 발화조차 안 됨 | 입력+안전 CTA → **type → click → observe** 폼 여정. golf-now 예외(검색 의도+무관 CTA는 type→Enter) 보존, 테스트로 고정 |
| **D7** | type 성공 판정 `bodyLen > 200` 절대 크기 → 작은 앱 카드는 무조건 "단계 미완" | **변화 기준**(액션 전후 body 텍스트/라우트 변화). Enter는 클릭 스텝 없을 때만(중복 제출 방지) |
| **D8** | number 입력창에 "서울" fill → Playwright 예외 → interacted=false 오염 | number형엔 숫자 샘플 "5". 비검색 입력창 라벨 "입력창"(리포트 인용 정직성) |
| **D9** | 죽은 버튼(로드시 JS 크래시)이 "확인 필요"로 뭉개짐 | **conjunction 신호**: 액션 실행 + 화면 무변화 + 콘솔에러 → Needs Fix. 콘솔에러 단독/무변화 단독은 계속 비치명(vercel 교훈, 양방향 테스트 고정) |

- 보너스: dev 레퍼런스 러너 `visual-run.mjs`가 갖고 있던 **#347 이전의 낡은
  `decideFromEvidence` 사본**(콘솔에러→Needs Fix) 제거, 정본 import로 교체.

## 평가 인프라 (재실행 가능하게 커밋)

- `tools/simsa-inspection-fixtures/` — 픽스처 워커(배포됨: `simsa-inspection-fixtures.seunghunbae.workers.dev`) + `eval-run.mjs`(익명 생성→소스등록→검수→폴링→채점) + 베이스라인 결과 JSON

## 검증

- visual-flow-plan 테스트 8건 신규 + 기존 1건 의도적 심화(검색 CTA: click-only→type+click, 사유 주석)
- inspection-accuracy 테스트 4건 신규(D9 양방향 + 옵셔널 필드 호환)
- 전체 central-plane **1757/1757** green, pre-push verify 통과
- 신규 테스트는 옛 코드에서 실패 확인됨(D5~D9 모두 동작 변화)

## 머지 후

1. deploy-central-plane (**컨테이너 이미지 재빌드** 필요 — planner/executor가 컨테이너에서 실행)
2. 동일 데이터셋 **2차 실측** → 결과를 설계 문서에 덧붙임(E4)

## 체크리스트

- [x] 테스트 신규 + 전체 green
- [x] base = main
- [x] 시크릿/과금/인증 변경 없음
- [ ] 원격 CI green 확인 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
