### PR TITLE
fix(inspection): capture pageerror so the D9 crash conjunction can fire

### DIFF
--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -114,6 +114,11 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
   const noiseFailures = []; // analytics/ads/fonts/telemetry (info only)
   const recordNet = (url, line) => (isNoiseResource(url) ? noiseFailures : networkFailures).push(line);
   page.on("console", (m) => m.type() === "error" && consoleErrors.push(m.text().slice(0, 300)));
+  // An UNCAUGHT exception fires "pageerror", not "console" — without this, a
+  // load-time crash that kills every handler (dead-button app) left
+  // consoleErrors empty and the D9 crash conjunction could never fire
+  // (2026-07-17 eval F4: js-crash fixture read as "확인 필요" instead of broken).
+  page.on("pageerror", (err) => consoleErrors.push(`Uncaught ${String(err).slice(0, 300)}`));
   page.on("requestfailed", (r) =>
     recordNet(r.url(), `${r.method()} ${r.url().slice(0, 200)} (${r.failure()?.errorText ?? "failed"})`),
   );

--- a/apps/central-plane/test/inspector-invariants.test.mjs
+++ b/apps/central-plane/test/inspector-invariants.test.mjs
@@ -125,3 +125,11 @@ test("inspector runner keeps the forbidden-action + headless/viewport/timeout ra
   assert.match(runMjs, /width:\s*1280,\s*height:\s*800/, "viewport must be 1280x800");
   assert.match(serverMjs, /INSPECTION_TIMEOUT_MS\s*=\s*4\s*\*\s*60\s*\*\s*1000/, "wall-clock rail must be ~4 minutes");
 });
+
+test("inspector runner captures UNCAUGHT exceptions (pageerror), not just console.error", () => {
+  // 2026-07-17 eval F4: a load-time crash fires "pageerror" — without this
+  // listener consoleErrors stays empty and the D9 dead-button conjunction
+  // can never fire, so a crashed app reads as "확인 필요" instead of broken.
+  const runMjs = readFileSync(path.join(ROOT, "inspector-container/inspector-run.mjs"), "utf8");
+  assert.match(runMjs, /page\.on\("pageerror"/, "runner must listen for pageerror");
+});

--- a/tools/simsa-completion-loop-spike/visual-run.mjs
+++ b/tools/simsa-completion-loop-spike/visual-run.mjs
@@ -70,6 +70,8 @@ export async function visualRun(config, outDir) {
   const consoleErrors = [];
   const networkFailures = [];
   page.on("console", (m) => m.type() === "error" && consoleErrors.push(m.text().slice(0, 300)));
+  // Parity with inspector-run.mjs: uncaught exceptions arrive via "pageerror".
+  page.on("pageerror", (err) => consoleErrors.push(`Uncaught ${String(err).slice(0, 300)}`));
   page.on("requestfailed", (r) => networkFailures.push(`${r.method()} ${r.url().slice(0, 200)} (${r.failure()?.errorText ?? "failed"})`));
   page.on("response", (r) => r.status() >= 500 && networkFailures.push(`HTTP ${r.status()} ${r.url().slice(0, 200)}`));
 


### PR DESCRIPTION
2차 실측 F4(js-crash 픽스처)에서 발견: 로드시 uncaught 예외는 Playwright의 'pageerror' 이벤트로 오는데 실행기는 'console'만 수집 → consoleErrorCount=0 → #352의 D9 죽은버튼 conjunction이 발화 불가 → 크래시 앱이 '확인 필요'로 남음. 리스너 1줄 + dev 러너 패리티 + 소스 인베리언트 테스트. 1758/1758 green. 머지 후 배포+컨테이너 재빌드 필요. 근거: docs/simsa-inspection-accuracy-eval-2026-07-17.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)