### PR TITLE
fix(landing): 루트 정본 리다이렉트 + HANDOFF (#363 실증)

### DIFF
--- a/apps/simsa-landing/vercel.json
+++ b/apps/simsa-landing/vercel.json
@@ -3,6 +3,24 @@
   "framework": "nextjs",
   "redirects": [
     {
+      "source": "/",
+      "has": [{ "type": "host", "value": "trysimsa.com" }],
+      "destination": "https://simsa.dev/",
+      "permanent": true
+    },
+    {
+      "source": "/",
+      "has": [{ "type": "host", "value": "www.trysimsa.com" }],
+      "destination": "https://simsa.dev/",
+      "permanent": true
+    },
+    {
+      "source": "/",
+      "has": [{ "type": "host", "value": "www.simsa.dev" }],
+      "destination": "https://simsa.dev/",
+      "permanent": true
+    },
+    {
       "source": "/:path*",
       "has": [{ "type": "host", "value": "trysimsa.com" }],
       "destination": "https://simsa.dev/:path*",

--- a/docs/HANDOFF-2026-07-17.md
+++ b/docs/HANDOFF-2026-07-17.md
@@ -128,6 +128,21 @@
   "확인 필요" 교정 확인**. R1·R2·R3 실앱 전부 false 아님. central+dashboard 배포(3ac3996).
   잔여: #296 Phase 1(온보딩 인터뷰)·Phase 2(LLM feasibility 분류)는 다음 트레인. 랜딩
   /demo→simsa.dev 구 도메인 리다이렉트 정리(별건).
+- **#363 (#296 Phase 1+2, 배 "T4만 홀드·나머지 다")** — Phase 1: 아이디어 화면 선택형
+  인터뷰 3줄(플랫폼/GitHub 경험/AI 도구 경험, 칩 재클릭으로 해제) → `userProfile` 저장.
+  Phase 2(결정론): **플랫폼 시드** — "휴대폰 앱" 답이 텍스트 마커 없어도 실현가능성 mobile
+  판정(PISTA 직접 방어), "웹" 답은 마커 거부, export 선택은 mobile 프로파일 시 handoff 추천.
+  central(a94d4da)+dashboard 배포, **라이브 실증**: 마커 없는 "가족 일정 공유 앱"+mobile 답
+  → 정직 경고 ✅ / web 답 → 경고 없음 ✅. 경험 레벨 소비(안내 강도)=Phase 3, 수령자별
+  핸드오프 확장=Phase 4 잔여.
+- **랜딩 정본 리다이렉트 집행** — trysimsa.com→simsa.dev가 vercel.json에 커밋돼 있었으나
+  루트 `/`는 미적용 상태(Vercel `/:path*`가 루트 미매치)였음 → 루트 전용 규칙 3종 추가 +
+  simsa-landing 재배포. **trysimsa.com/ → 308 → simsa.dev/ 확인.** (검수 R3 오탐의 뿌리였던
+  교차 도메인 RSC도 근원 해소. simsa-landing CLI 배포는 앱 폴더에서 — 루트 디렉토리 설정이
+  dashboard와 다름.)
+- **정정: T4=GitHub 계정 건.** Replit/Lovable 계정이 필요한 건 웹빌더 실완주 실측(별건).
+  방법론 질문에 대한 합의: 새 계획 문서 없이 **기존 #296 Phase 계획 소비 + 당일 완결 건은
+  D-번호+PR 게이트** — 오늘 운영 방식 그대로.
 - **전체 플로우 E2E 감사** (배 지시 "탭별 이동·프로세스 효율성·적합성 재검토") —
   `docs/simsa-flow-audit-2026-07-17.md`. 위저드 실완주(proj_hepck0xm) + 전 탭 순회.
   **효율**: 아이디어→프로젝트 ~11클릭(질문 6개 개별 수락이 최대 마찰 → "모두 추천대로" 제안),


### PR DESCRIPTION
Vercel /:path*가 루트 미매치 → 루트 전용 규칙. 배포·검증 완료(trysimsa.com/→308→simsa.dev/). HANDOFF 갱신 동반.

🤖 Generated with [Claude Code](https://claude.com/claude-code)