### PR TITLE
fix(deploy-trend): LLM failure must not silently consume releases (D14 hardening)

### DIFF
--- a/apps/central-plane/src/deploy-trend-watcher.ts
+++ b/apps/central-plane/src/deploy-trend-watcher.ts
@@ -155,10 +155,12 @@ export interface DeployTrendRunSummary {
   sources: number;
   releases_processed: number;
   suggestions_saved: number;
+  /** LLM 호출 실패 수 — 0건 저장이 "조용한 주"인지 "장애"인지 구분하는 유일한 신호. */
+  llm_failures: number;
 }
 
 export async function runDeployTrendWatcher(env: Env): Promise<DeployTrendRunSummary> {
-  const summary: DeployTrendRunSummary = { sources: 0, releases_processed: 0, suggestions_saved: 0 };
+  const summary: DeployTrendRunSummary = { sources: 0, releases_processed: 0, suggestions_saved: 0, llm_failures: 0 };
   for (const src of DEPLOY_TREND_SOURCES) {
     summary.sources += 1;
     const mark = await getHighWaterMark(env, src.id);
@@ -168,9 +170,15 @@ export async function runDeployTrendWatcher(env: Env): Promise<DeployTrendRunSum
       .slice(-PER_SOURCE_RELEASE_LIMIT);
 
     for (const rel of releases) {
-      summary.releases_processed += 1;
       const text = await callHaiku(env, `Platform: ${src.label} (${src.repo})\nRelease ${rel.tag_name}:\n\n${(rel.body ?? "").slice(0, 6000)}`);
-      if (text) {
+      if (text === null) {
+        // 실패한 릴리스의 마크를 전진시키면 평가 없이 영영 소실된다. 이 소스는
+        // 여기서 멈추고(뒤 릴리스를 건너뛰면 마크 순서가 깨짐) 다음 사이클에 재시도.
+        summary.llm_failures += 1;
+        break;
+      }
+      summary.releases_processed += 1;
+      {
         for (const s of parseSuggestions(text)) {
           const id = `dts_${crypto.randomUUID().slice(0, 12)}`;
           await env.DB.prepare(

--- a/apps/central-plane/test/deploy-trend-watcher.test.mjs
+++ b/apps/central-plane/test/deploy-trend-watcher.test.mjs
@@ -6,7 +6,9 @@ import assert from "node:assert/strict";
 // human review queue (never auto-applied). Design:
 // docs/simsa-builder-pack-portability-2026-07-17.md §D14.
 
-const { parseSuggestions, DEPLOY_TREND_SOURCES } = await import("../dist/deploy-trend-watcher.js");
+const { parseSuggestions, DEPLOY_TREND_SOURCES, runDeployTrendWatcher } = await import(
+  "../dist/deploy-trend-watcher.js"
+);
 
 describe("parseSuggestions — strict JSONL, relevance-gated, capped", () => {
   it("keeps well-formed high/medium lines, drops the rest", () => {
@@ -27,6 +29,106 @@ describe("parseSuggestions — strict JSONL, relevance-gated, capped", () => {
     const line = `{"relevance":"high","title":"t","summary_ko":"s","guidance_key":"deploy"}`;
     assert.equal(parseSuggestions([line, line, line, line, line].join("\n")).length, 3);
     assert.equal(parseSuggestions(`{"relevance":"high","title":"t"}`).length, 0);
+  });
+});
+
+// ─── run loop: an LLM failure must not silently consume releases ─────────────
+// (2026-07-17 live-run finding: "suggestions_saved: 0" was indistinguishable
+// from a total LLM outage, and the high-water mark advanced either way — a
+// failed release would never be re-evaluated.)
+
+function fakeDb(log) {
+  return {
+    prepare(sql) {
+      return {
+        bind(...args) {
+          return {
+            first: async () => null,
+            run: async () => {
+              log.push({ sql, args });
+              return {};
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+const RELEASE = {
+  tag_name: "v1.0.0",
+  html_url: "https://github.com/vercel/vercel/releases/v1.0.0",
+  body: "New one-click deploy from the dashboard.",
+  published_at: "2026-07-16T00:00:00Z",
+  draft: false,
+  prerelease: false,
+};
+
+function mockFetch({ anthropicStatus, anthropicText }) {
+  return async (url) => {
+    const u = String(url);
+    if (u.startsWith("https://api.github.com/repos/vercel/vercel/")) {
+      return new Response(JSON.stringify([RELEASE]), { status: 200 });
+    }
+    if (u.startsWith("https://api.github.com/")) {
+      return new Response("[]", { status: 200 });
+    }
+    if (u.startsWith("https://api.anthropic.com/")) {
+      if (anthropicStatus !== 200) return new Response("err", { status: anthropicStatus });
+      return new Response(
+        JSON.stringify({ content: [{ type: "text", text: anthropicText }] }),
+        { status: 200 },
+      );
+    }
+    throw new Error(`unexpected fetch: ${u}`);
+  };
+}
+
+describe("runDeployTrendWatcher — LLM failure honesty", () => {
+  it("counts llm_failures and does NOT advance the high-water mark on API failure", async (t) => {
+    const realFetch = globalThis.fetch;
+    t.after(() => { globalThis.fetch = realFetch; });
+    globalThis.fetch = mockFetch({ anthropicStatus: 500 });
+
+    const log = [];
+    const summary = await runDeployTrendWatcher({ ANTHROPIC_API_KEY: "k", DB: fakeDb(log) });
+
+    assert.equal(summary.llm_failures, 1, "failure must be visible in the summary");
+    assert.equal(summary.releases_processed, 0, "an unevaluated release is not 'processed'");
+    const markWrites = log.filter((e) => e.sql.includes("spec_monitor_state"));
+    assert.equal(markWrites.length, 0, "mark must not advance — release retries next cycle");
+  });
+
+  it("on success: saves parsed suggestions and advances the mark", async (t) => {
+    const realFetch = globalThis.fetch;
+    t.after(() => { globalThis.fetch = realFetch; });
+    globalThis.fetch = mockFetch({
+      anthropicStatus: 200,
+      anthropicText: `{"relevance":"high","title":"One-click deploy","summary_ko":"대시보드에서 한 번에 배포됩니다","guidance_key":"deploy"}`,
+    });
+
+    const log = [];
+    const summary = await runDeployTrendWatcher({ ANTHROPIC_API_KEY: "k", DB: fakeDb(log) });
+
+    assert.equal(summary.llm_failures, 0);
+    assert.equal(summary.releases_processed, 1);
+    assert.equal(summary.suggestions_saved, 1);
+    assert.ok(log.some((e) => e.sql.includes("deploy_trend_suggestions")));
+    assert.ok(log.some((e) => e.sql.includes("spec_monitor_state")));
+  });
+
+  it("an empty LLM answer means 'irrelevant', not failure — mark still advances", async (t) => {
+    const realFetch = globalThis.fetch;
+    t.after(() => { globalThis.fetch = realFetch; });
+    globalThis.fetch = mockFetch({ anthropicStatus: 200, anthropicText: "" });
+
+    const log = [];
+    const summary = await runDeployTrendWatcher({ ANTHROPIC_API_KEY: "k", DB: fakeDb(log) });
+
+    assert.equal(summary.llm_failures, 0);
+    assert.equal(summary.releases_processed, 1);
+    assert.equal(summary.suggestions_saved, 0);
+    assert.ok(log.some((e) => e.sql.includes("spec_monitor_state")));
   });
 });
 


### PR DESCRIPTION
## What

D14 첫 라이브 실행(오늘 수동 트리거, 토큰 회전 후)에서 발견한 관측 갭 수정: LLM 호출이 실패해도 `suggestions_saved: 0`으로 조용한 주와 구분이 안 됐고, 하이워터마크가 무조건 전진해 실패한 릴리스는 영영 재평가되지 않았습니다.

## Changes

- `DeployTrendRunSummary`에 `llm_failures` 추가 — 0건 저장이 "조용한 주"인지 "장애"인지 구분하는 유일한 신호
- `callHaiku` null(실패) 시: `llm_failures` 카운트, `releases_processed` 미집계, 마크 비전진, 해당 소스 중단(순서 보존) → 다음 사이클 재시도
- 빈 응답("")은 기존대로 "무관 판정" — 마크 전진 유지

## Verification

- 신규 `runDeployTrendWatcher` 테스트 3건(fetch/DB seam 모킹) — **수정 전 코드에서 3/3 실패 확인** 후 수정 (회귀 테스트 규칙)
- central-plane 1793/1793 green
- 라이브: 오늘 첫 실행 `{"sources":5,"releases_processed":12,"suggestions_saved":0}` + 재실행 dedup `releases_processed:0` 확인 (머지·배포 후 응답에 `llm_failures` 필드 추가됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
