### PR TITLE
feat(workspace): #296 Phase 3+4 — interview profile drives pack guidance and handoff brief

### DIFF
--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -729,6 +729,17 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
     // `/p/{projectId}/connect` re-entry link. Env is resolved here (route) to
     // keep generateBuilderPack pure. Omitted cleanly when projectId is absent.
     const appBaseUrl = c.env.DASHBOARD_BASE_URL ?? BRAND.appUrl;
+    // #296 Phase 3: interview profile — enum-whitelisted, anything else dropped.
+    const rawProfile = (body as Record<string, unknown>)["userProfile"];
+    const userProfile = (() => {
+      if (typeof rawProfile !== "object" || rawProfile === null) return undefined;
+      const p = rawProfile as Record<string, unknown>;
+      const out: { platform?: "web" | "mobile" | "unknown"; githubLevel?: "fluent" | "heard" | "new"; aiToolLevel?: "yes" | "some" | "no" } = {};
+      if (p.platform === "web" || p.platform === "mobile" || p.platform === "unknown") out.platform = p.platform;
+      if (p.githubLevel === "fluent" || p.githubLevel === "heard" || p.githubLevel === "new") out.githubLevel = p.githubLevel;
+      if (p.aiToolLevel === "yes" || p.aiToolLevel === "some" || p.aiToolLevel === "no") out.aiToolLevel = p.aiToolLevel;
+      return Object.keys(out).length > 0 ? out : undefined;
+    })();
     const result = generateBuilderPack({
       project,
       projectId: req.projectId,
@@ -739,6 +750,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
       // Prep layer: the in-Simsa setup UI sends the collected services/env values
       // per-export. Passed straight into the pack (.env), never stored server-side.
       ...(req.services ? { services: req.services } : {}),
+      ...(userProfile ? { userProfile } : {}),
     });
 
     // Record usage event (non-fatal)

--- a/apps/central-plane/src/workspace/export.ts
+++ b/apps/central-plane/src/workspace/export.ts
@@ -128,9 +128,19 @@ export type WorkspaceExportBuilderPackRequest = {
    *  the setup UI supplied real values). No-store: values arrive here per-export
    *  and are only written into the pack, never persisted server-side (Rule 3). */
   services?: BuilderPackService[];
+  /** #296 Phase 3: onboarding interview profile. githubLevel picks the deploy
+   *  path the prompts lead with; aiToolLevel "no" adds first-timer pacing.
+   *  Absent → neutral guidance (unchanged pre-Phase-3 behavior). */
+  userProfile?: ExportUserProfile;
   target: ExportTarget;
   format: ExportFormat;
   locale?: "ko" | "en";
+};
+
+export type ExportUserProfile = {
+  platform?: "web" | "mobile" | "unknown";
+  githubLevel?: "fluent" | "heard" | "new";
+  aiToolLevel?: "yes" | "some" | "no";
 };
 
 export type ExportFile = {
@@ -434,12 +444,23 @@ function genFixesMd(
  * signup URLs and exact click-paths, one step at a time. Korean, matching the
  * surrounding prompt and the KO-first audience.
  */
-function beginnerSetupGuidance(specText: string): string {
+function beginnerSetupGuidance(specText: string, profile?: ExportUserProfile): string {
   return [
     "## 사용자 안내 원칙 — 완전 초보자 가정",
     "",
     "이 프로젝트의 사용자는 개발 경험이 전혀 없는 비개발자일 수 있다. 외부 서비스(데이터베이스·호스팅·인증·결제 등)나 API 키, 환경변수, 터미널 명령이 필요한 순간에는 절대 \"알아서 준비하세요\"라고 넘기지 말고, 다음처럼 손을 잡고 안내하라:",
     "",
+    // #296 Phase 3: the interview said this user has never used an AI tool —
+    // pace the whole session for a first-timer, not just the service setup.
+    ...(profile?.aiToolLevel === "no"
+      ? [
+          "**이 사용자는 AI 도구로 무언가 만드는 것 자체가 처음이다 (온보딩에서 확인됨):**",
+          "- 첫 응답에서 앞으로의 진행 순서를 3줄 이내로 먼저 알려주고 시작하라. (예: \"①제가 앱을 만들고 → ②실행해서 보여드리고 → ③인터넷에 올리는 것까지 도와드려요.\")",
+          "- 한 번에 하나만 부탁하고, 사용자의 \"했어요\" 확인 없이는 다음 단계로 넘어가지 마라.",
+          "- 사용자가 이상한 답을 하거나 멈춰 있어도 재촉하지 말고, 지금 화면에 무엇이 보이는지부터 다시 물어라.",
+          "",
+        ]
+      : []),
     "- 왜 필요한지 한 문장으로 쉽게 설명한다. (예: \"데이터를 저장하려면 무료 데이터베이스가 필요해요.\")",
     "- 가입·설정 URL을 전체 주소 그대로 준다.",
     "- 화면에서 **어디를 눌러야 하는지 단계별로, 한 번에 하나씩** 안내한다. 전문용어(API 키, 환경변수, .env 등)는 그때그때 한 줄로 풀어 설명한다.",
@@ -449,8 +470,9 @@ function beginnerSetupGuidance(specText: string): string {
     "",
     "자주 쓰는 서비스 예시 — 이 제품에 필요한 것 기준 (UI가 바뀌었으면 현재 화면에 맞게 조정하되, 이 정도로 상세하게):",
     "",
-    // D12: base + need-matched walkthroughs + the D11 deploy-path chooser.
-    ...pickServiceExampleBlocks(specText),
+    // D12: base + need-matched walkthroughs + the D11 deploy-path chooser
+    // (#296 Phase 3: profile-aware — a known githubLevel skips the asking).
+    ...pickServiceExampleBlocks(specText, profile?.githubLevel),
     "",
     "**배포 대응(중요):** 앱이 스스로를 가리키는 주소 — 짧은 링크의 앞부분, 공유 URL, 리다이렉트 대상, API 주소 등 — 를 절대 `http://localhost:3000` 같은 개발용 주소로 하드코딩하지 마라. 런타임 origin에서 가져와라(브라우저는 `window.location.origin`, 서버는 요청 host 또는 `NEXT_PUBLIC_APP_URL` 같은 환경변수). 그래야 로컬에서도, 배포 후에도 주소가 자동으로 맞는다. 이걸 안 하면 배포했을 때 사용자에게 보이는 링크가 `localhost`로 깨진다.",
   ].join("\n");
@@ -597,6 +619,7 @@ function genClaudeCodePrompt(
   effectiveItems: ExportItem[],
   totalItems: number,
   services: BuilderPackService[] = [],
+  profile?: ExportUserProfile,
 ): string {
   const isFiltered = effectiveItems.length < totalItems;
   const itemList = effectiveItems.map((i) => `- [ ] ${i.title}`).join("\n");
@@ -637,7 +660,7 @@ function genClaudeCodePrompt(
     "- 애매한 점이 있으면 코드 작성 전에 질문한다.",
     ...(services.length > 0 ? ["", genServicesContext(services)] : []),
     "",
-    beginnerSetupGuidance(specTextOf(spec, effectiveItems)),
+    beginnerSetupGuidance(specTextOf(spec, effectiveItems), profile),
     "",
     NONDEV_WORKFLOW_GUIDANCE,
     "",
@@ -658,6 +681,7 @@ function genCodexPrompt(
   totalItems: number,
   fixSuggestions?: Record<string, ExportFixSuggestion>,
   services: BuilderPackService[] = [],
+  profile?: ExportUserProfile,
 ): string {
   const isFiltered = effectiveItems.length < totalItems;
 
@@ -754,7 +778,7 @@ function genCodexPrompt(
     "",
     "## Final response format",
     "",
-    beginnerSetupGuidance(specTextOf(spec, effectiveItems)),
+    beginnerSetupGuidance(specTextOf(spec, effectiveItems), profile),
     "",
     NONDEV_WORKFLOW_GUIDANCE,
     "",
@@ -900,8 +924,15 @@ function genHandoffBrief(
   idea: string,
   spec: ExportProductSpec,
   items: ExportItem[],
+  checkResults?: ExportCheckResults,
+  profile?: ExportUserProfile,
 ): string {
-  const feas = detectNonWebBuildable({ idea: `${idea} ${spec.oneLine} ${spec.included.join(" ")}` });
+  // #296 Phase 4: the interview's platform answer seeds the verdict here too —
+  // the brief must not contradict what generation already told the user (P2).
+  const feas = detectNonWebBuildable({
+    idea: `${idea} ${spec.oneLine} ${spec.included.join(" ")}`,
+    ...(profile?.platform ? { platform: profile.platform } : {}),
+  });
   const lines: string[] = [
     `# 전달용 브리프 — ${title}`,
     "",
@@ -943,6 +974,31 @@ function genHandoffBrief(
 
   lines.push("", "## 아직 결정 필요 (시작 전에 발주자와 확인)", "");
   lines.push(...(spec.openQuestions.length ? spec.openQuestions.map((q) => `- [ ] ${q}`) : ["- (없음)"]));
+
+  // #296 Phase 4: inspection report — what Simsa's review already found, in
+  // plain language, so the recipient starts from known problems instead of
+  // rediscovering them. Omitted cleanly when no check has run.
+  if (checkResults && checkResults.results.length > 0) {
+    const s = checkResults.summary;
+    lines.push(
+      "",
+      "## 최근 점검 결과 (Simsa 검수)",
+      "",
+      `통과 ${s.passed} · 안 맞음 ${s.failed} · 확인 부족 ${s.inconclusive} · 결정 필요 ${s.needsDecision}`,
+      "",
+    );
+    const notPassed = checkResults.results.filter((r) => r.status !== "passed");
+    if (notPassed.length > 0) {
+      lines.push("전달 시점에 남아 있던 문제:", "");
+      for (const r of notPassed) {
+        const next = r.nextAction ? ` (다음 할 일: ${r.nextAction})` : "";
+        lines.push(`- **${r.title}** — ${statusLabel(r.status)}: ${r.reason}${next}`);
+      }
+    } else {
+      lines.push("전달 시점 기준 모든 점검 항목이 통과했습니다.");
+    }
+    lines.push("", "이 결과는 전달 시점의 스냅샷입니다. 받은 분은 아래 수용 기준 체크리스트로 최종 확인해주세요.");
+  }
 
   lines.push("", "## 수용 기준 체크리스트 (이대로 되면 완성)", "");
   for (const item of items) {
@@ -1157,14 +1213,14 @@ export function generateBuilderPack(
   if (target === "claude_code" || target === "both") {
     baseFiles.push({
       path: "simsa-build-pack/CLAUDE_CODE_PROMPT.md",
-      content: genClaudeCodePrompt(title, productSpec, effectiveItems, allItems.length, services) + hookSuffix,
+      content: genClaudeCodePrompt(title, productSpec, effectiveItems, allItems.length, services, req.userProfile) + hookSuffix,
     });
   }
   if (target === "codex" || target === "both") {
     baseFiles.push({
       path: "simsa-build-pack/CODEX_PROMPT.md",
       content:
-        genCodexPrompt(title, productSpec, effectiveItems, allItems.length, effectiveFixSuggestions, services) +
+        genCodexPrompt(title, productSpec, effectiveItems, allItems.length, effectiveFixSuggestions, services, req.userProfile) +
         hookSuffix,
     });
   }
@@ -1178,7 +1234,7 @@ export function generateBuilderPack(
   if (target === "handoff") {
     baseFiles.push({
       path: "simsa-build-pack/HANDOFF_BRIEF.md",
-      content: genHandoffBrief(title, project.idea ?? "", productSpec, effectiveItems),
+      content: genHandoffBrief(title, project.idea ?? "", productSpec, effectiveItems, effectiveCheckResults, req.userProfile),
     });
   }
 

--- a/apps/central-plane/src/workspace/service-examples.ts
+++ b/apps/central-plane/src/workspace/service-examples.ts
@@ -43,6 +43,30 @@ export const DEPLOY_PATH_GUIDANCE: string = [
   "  3. 로그인·DB 쓰기 같은 **서버 기능이 있는 앱**은 (a)로는 안 된다 — (b) 또는 사용 중인 빌더의 내장 배포를 권하라.",
 ].join("\n");
 
+/**
+ * #296 Phase 3: when the onboarding interview captured the user's GitHub level,
+ * the deploy guidance stops asking and leads with the right path. No answer →
+ * the neutral D11 chooser above (unchanged behavior).
+ */
+export function deployPathGuidanceFor(githubLevel?: "fluent" | "heard" | "new"): string {
+  if (githubLevel === "fluent") {
+    return [
+      "- **배포 — 이 사용자는 GitHub에 익숙하다 (온보딩에서 확인됨). GitHub 경로를 기본으로 진행하라:**",
+      "  1. **기본 경로**: https://vercel.com 에 GitHub 계정으로 로그인 → `Add New → Project` → 저장소 선택 → `Environment Variables`에 키를 이름 그대로 추가 → `Deploy`. 끝나면 나오는 URL을 사용자에게 알려준다. (네게 GitHub·Vercel 도구가 연결돼 있으면 네가 직접 푸시·배포한다.)",
+      "  2. 로그인·데이터 저장이 없는 정적 앱을 빠르게만 올리고 싶어 하면, **Netlify Drop**(https://app.netlify.com/drop)에 빌드 폴더를 끌어다 놓는 지름길도 있다고만 알려준다.",
+    ].join("\n");
+  }
+  if (githubLevel === "new") {
+    return [
+      "- **배포 — 이 사용자는 GitHub이 처음이거나 계정이 없다 (온보딩에서 확인됨). 계정이 있냐고 되묻지 말고, GitHub 없이 되는 길부터 안내하라:**",
+      "  1. **지금 당장 가장 쉬운 길 (GitHub 없이)**: 로그인·데이터 저장이 없는 정적 앱이라면, 빌드 결과 폴더를 **Netlify Drop**(https://app.netlify.com/drop)에 드래그해서 놓으면 바로 인터넷 주소가 나온다. **Cloudflare Pages 직접 업로드**(dash.cloudflare.com → Workers & Pages → Create → Pages → Upload assets)도 같은 방식이다.",
+      "  2. **계속 키워갈 길 (GitHub부터, 원할 때만)**: ①https://github.com 가입 ②오른쪽 위 `+` → `New repository`로 저장소 만들기 ③코드 올리기(네게 GitHub 도구가 연결돼 있으면 네가 직접 푸시) ④https://vercel.com 에 GitHub 계정으로 로그인해 저장소를 연결하고 `Deploy`. 각 단계를 한 번에 하나씩, '했어요' 확인 후 다음으로.",
+      "  3. 로그인·DB 쓰기 같은 **서버 기능이 있는 앱**은 1번(드래그앤드롭)으로는 안 된다 — 2번 또는 사용 중인 빌더의 내장 배포를 권하라. 이때도 '어렵다'가 아니라 '한 단계씩 같이 하면 된다'는 톤을 유지한다.",
+    ].join("\n");
+  }
+  return DEPLOY_PATH_GUIDANCE;
+}
+
 /** Need-matched extra walkthroughs. Matchers are parameters — tune freely. */
 export const NEED_SERVICE_EXAMPLES: ServiceExampleNeed[] = [
   {
@@ -81,12 +105,15 @@ export const NEED_SERVICE_EXAMPLES: ServiceExampleNeed[] = [
  * Pick the walkthrough blocks for THIS product: base + whatever the spec text
  * actually needs. Deterministic, order-stable, no LLM.
  */
-export function pickServiceExampleBlocks(specText: string): string[] {
+export function pickServiceExampleBlocks(
+  specText: string,
+  githubLevel?: "fluent" | "heard" | "new",
+): string[] {
   const blocks = [...BASE_SERVICE_EXAMPLE_BLOCKS];
   for (const need of NEED_SERVICE_EXAMPLES) {
     if (need.re.test(specText)) blocks.push(need.block);
   }
-  blocks.push(DEPLOY_PATH_GUIDANCE);
+  blocks.push(deployPathGuidanceFor(githubLevel));
   blocks.push(
     "- 그 외 서비스도 같은 순서로: **가입 URL → 키를 찾는 정확한 위치 → 붙여넣을 곳** 순으로 상세히 안내한다.",
   );

--- a/apps/central-plane/test/builder-pack-portability.test.mjs
+++ b/apps/central-plane/test/builder-pack-portability.test.mjs
@@ -172,3 +172,101 @@ describe("D12 — need-based service examples", () => {
     assert.match(fileOf(res, "CODEX_PROMPT.md").content, /테스트 키로만 구현/);
   });
 });
+
+// #296 Phase 3 (2026-07-17): the onboarding interview profile branches the pack
+// prompts deterministically — githubLevel picks the deploy path the agent leads
+// with (instead of asking), aiToolLevel "no" adds first-timer pacing. No
+// profile → the neutral D11 chooser, byte-identical to pre-Phase-3 output.
+describe("#296 Phase 3 — profile-aware guidance", () => {
+  const claudePrompt = (extra) => fileOf(pack("claude_code", extra), "CLAUDE_CODE_PROMPT.md").content;
+
+  it("no profile → neutral deploy chooser (asks the user), no first-timer block", () => {
+    const p = claudePrompt({});
+    assert.match(p, /사용자 상황에 맞는 길을 먼저 물어라/);
+    assert.doesNotMatch(p, /온보딩에서 확인됨/);
+  });
+
+  it("githubLevel 'new' → leads with the no-GitHub path and never re-asks about an account", () => {
+    const p = claudePrompt({ userProfile: { githubLevel: "new" } });
+    assert.match(p, /GitHub이 처음이거나 계정이 없다/);
+    assert.match(p, /되묻지 말고/);
+    assert.match(p, /Netlify Drop/);
+    assert.doesNotMatch(p, /사용자 상황에 맞는 길을 먼저 물어라/);
+  });
+
+  it("githubLevel 'fluent' → GitHub+Vercel is the default path", () => {
+    const p = claudePrompt({ userProfile: { githubLevel: "fluent" } });
+    assert.match(p, /GitHub에 익숙하다/);
+    assert.match(p, /기본 경로/);
+    assert.doesNotMatch(p, /사용자 상황에 맞는 길을 먼저 물어라/);
+  });
+
+  it("githubLevel 'heard' → keeps the neutral chooser (asking is right when unsure)", () => {
+    const p = claudePrompt({ userProfile: { githubLevel: "heard" } });
+    assert.match(p, /사용자 상황에 맞는 길을 먼저 물어라/);
+  });
+
+  it("aiToolLevel 'no' → first-timer pacing block in BOTH CLI prompts", () => {
+    const res = pack("both", { userProfile: { aiToolLevel: "no" } });
+    for (const f of ["CLAUDE_CODE_PROMPT.md", "CODEX_PROMPT.md"]) {
+      assert.match(fileOf(res, f).content, /AI 도구로 무언가 만드는 것 자체가 처음/, f);
+    }
+  });
+
+  it("aiToolLevel 'yes' → no first-timer block", () => {
+    assert.doesNotMatch(
+      claudePrompt({ userProfile: { aiToolLevel: "yes" } }),
+      /AI 도구로 무언가 만드는 것 자체가 처음/,
+    );
+  });
+});
+
+// #296 Phase 4 (2026-07-17): the handoff brief becomes the full recipient
+// deliverable — the interview's platform answer seeds its verdict (it must not
+// contradict what generation told the user in P2), and Simsa's inspection
+// results ride along in plain language so the recipient starts from known
+// problems.
+describe("#296 Phase 4 — handoff brief: profile verdict + inspection report", () => {
+  const brief = (extra) => fileOf(pack("handoff", extra), "HANDOFF_BRIEF.md").content;
+
+  it("interview 'mobile' answer → native verdict even with marker-less text", () => {
+    // SPEC has no native markers; text detection alone says web.
+    const b = brief({ userProfile: { platform: "mobile" } });
+    assert.match(b, /휴대폰 네이티브 앱/);
+    assert.match(b, /웹앱만으로는 완전히 구현할 수 없습니다/);
+  });
+
+  it("interview 'web' answer vetoes text markers (mirrors P2)", () => {
+    const mobileSpec = { ...SPEC, oneLine: "안드로이드 앱으로 영수증을 정리합니다" };
+    const res = generateBuilderPack({
+      project: { title: SPEC.productName, productSpec: mobileSpec, items: ITEMS },
+      target: "handoff", format: "json", locale: "ko",
+      userProfile: { platform: "web" },
+    });
+    const b = fileOf(res, "HANDOFF_BRIEF.md").content;
+    assert.match(b, /\*\*웹앱\*\*으로 구현 가능/);
+  });
+
+  it("check results present → plain-language inspection report with remaining problems", () => {
+    const b = brief({
+      project: {
+        title: SPEC.productName, productSpec: SPEC, items: ITEMS,
+        checkResults: {
+          results: [
+            { itemId: "req_001", status: "passed", title: "영수증 사진을 올릴 수 있어야 함", reason: "정상 동작", evidence: [], nextAction: "" },
+            { itemId: "req_002", status: "failed", title: "월별 리포트가 이메일로 와야 함", reason: "이메일이 발송되지 않았습니다", evidence: [], nextAction: "이메일 서비스 연결 확인" },
+          ],
+          summary: { passed: 1, failed: 1, inconclusive: 0, needsDecision: 0 },
+        },
+      },
+    });
+    assert.match(b, /최근 점검 결과/);
+    assert.match(b, /통과 1 · 안 맞음 1/);
+    assert.match(b, /이메일이 발송되지 않았습니다/);
+    assert.match(b, /다음 할 일: 이메일 서비스 연결 확인/);
+  });
+
+  it("no check run → no inspection section (omitted cleanly)", () => {
+    assert.doesNotMatch(brief({}), /최근 점검 결과/);
+  });
+});

--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -262,6 +262,8 @@ export default function ExportPage() {
             ? (svcs as ExportBuilderPackInput["services"])
             : undefined;
         })(),
+        // #296 Phase 3: interview profile → server branches deploy path + pacing.
+        userProfile: ext?.userProfile ?? undefined,
         target: t,
       });
 
@@ -400,10 +402,13 @@ export default function ExportPage() {
         // #296 Phase 2: an explicit "mobile" interview answer outranks the
         // built-with mapping — a web-agent pack is only partial for a native
         // idea; the honest recommendation is the handoff brief.
+        // #296 Phase 3: precedence mobile > built-with tool > "AI 도구 처음".
+        // A first-timer with no tool named gets the no-install web-builder path.
         const recommended =
           ext?.userProfile?.platform === "mobile"
             ? ("handoff" as ExportTarget)
-            : recommendedTargetFor(ext?.builtWithTools);
+            : (recommendedTargetFor(ext?.builtWithTools) ??
+                (ext?.userProfile?.aiToolLevel === "no" ? ("web_builder" as ExportTarget) : null));
         const ordered = recommended
           ? [recommended, ...TARGET_VALUES.filter((v) => v !== recommended)]
           : TARGET_VALUES;

--- a/apps/dashboard/src/lib/workspace-export-api.ts
+++ b/apps/dashboard/src/lib/workspace-export-api.ts
@@ -58,6 +58,13 @@ export type ExportBuilderPackInput = {
       value?: string;
     }>;
   }>;
+  /** #296 Phase 3: onboarding interview profile — the server branches deploy
+   *  guidance (githubLevel) and pacing (aiToolLevel) in the pack prompts. */
+  userProfile?: {
+    platform?: "web" | "mobile" | "unknown";
+    githubLevel?: "fluent" | "heard" | "new";
+    aiToolLevel?: "yes" | "some" | "no";
+  };
   target: ExportTarget;
 };
 


### PR DESCRIPTION
## What

#296 Phase 3(경험 레벨 소비) + Phase 4(수령자별 핸드오프 풀버전). 온보딩 인터뷰(`userProfile`, Phase 1)가 이제 빌더팩 안내와 전달용 브리프를 실제로 분기시킵니다. 전부 결정론(LLM 없음).

## Phase 3 — 프로파일이 안내를 분기

- `githubLevel`이 배포 경로를 정합니다(되묻지 않음): `new` → GitHub 없이 되는 길(Netlify Drop·CF Pages 업로드) 우선 + "계정 있냐고 되묻지 마라" / `fluent` → GitHub+Vercel 기본 경로 / `heard`·미응답 → 기존 중립 선택지(변경 없음)
- `aiToolLevel: "no"` → 두 CLI 프롬프트에 첫-사용자 페이싱 블록(진행 순서 예고, 한 번에 하나, "했어요" 확인)
- 라우트에서 enum 화이트리스트 검증 — 그 외 값은 드롭(프롬프트 주입 불가)
- 대시보드: export마다 `userProfile` 전송, 추천 우선순위 = mobile > built-with 도구 > "AI 도구 처음"→web_builder

## Phase 4 — 핸드오프 브리프 = 완전한 수령자 산출물

- 인터뷰 플랫폼 답이 브리프의 플랫폼 판정을 시드(P2와 동일 의미론: "휴대폰 앱" 답 → 마커 없어도 정직 네이티브 판정 / "웹" 답 → 마커 거부) — 생성 단계가 말한 것과 브리프가 모순되지 않음
- Simsa 점검 결과를 쉬운 말로 동봉("최근 점검 결과": 통과/안 맞음 요약 + 남은 문제 + 다음 할 일) — 점검 이력 없으면 섹션 자체 생략

## Verification

- builder-pack-portability +10 테스트 (Phase 3 6건 · Phase 4 4건), 무프로파일 출력은 기존과 동일함을 고정
- central-plane 1803/1803 · dashboard 520/520 + tsc green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
