### PR TITLE
feat(dashboard): fix-first pack routing — 확인 결과 마친 뒤 빌더팩

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -27,6 +27,7 @@ import {
   type RemoteOutcome,
 } from "@/lib/workspace-export-api";
 import { downloadBuildPackZip } from "@/lib/zip-utils";
+import { packReadiness } from "@/lib/project-steps.mjs";
 import { filesForTextBundle, hasSecretFiles } from "@/lib/pack-bundle.mjs";
 import { StatusBadge } from "@/components/StatusBadge";
 import type { ItemStatus } from "@/lib/labels";
@@ -181,6 +182,8 @@ export default function ExportPage() {
   const checkResultMap = new Map(
     (ext?.checkResults?.results ?? []).map((r) => [r.itemId, r.status as ItemStatus]),
   );
+  // Fix-first routing: does this pack still miss fix plans for failed items?
+  const readiness = packReadiness(ext?.checkResults, ext?.fixSuggestions);
 
   const allItems: SelectableItem[] = (project?.requirements ?? []).map((r) => ({
     id: r.id,
@@ -396,6 +399,30 @@ export default function ExportPage() {
         className="block bg-brand-50 border border-brand-100 rounded-xl px-4 py-3 text-sm text-brand-800 hover:bg-brand-100 transition-colors">
         {t.exportPage.prepMoved} →
       </Link>
+
+      {/* Fix-first routing (Bae 2026-07-17): when a review found failures that
+          still lack fix plans, the default path is checks → fixes → THEN the
+          pack, so it ships fix briefs instead of an empty fixes.md. Soft gate:
+          informing + primary CTA, exporting stays possible (no dead end). */}
+      {readiness.state === "fixes_missing" && (
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-5">
+          <p className="text-sm font-semibold text-amber-900 mb-1">{t.exportPage.fixFirst.title}</p>
+          <p className="text-sm text-amber-800 mb-3">
+            {t.exportPage.fixFirst.descBefore}{readiness.failedCount}{t.exportPage.fixFirst.descFailed}{readiness.missingCount}{t.exportPage.fixFirst.descMissing}
+          </p>
+          <div className="flex items-center gap-3 flex-wrap">
+            <Link href={`/projects/${id}/checks`} className="btn btn-sm btn-primary">
+              {t.exportPage.fixFirst.cta} →
+            </Link>
+            <span className="text-xs text-amber-700">{t.exportPage.fixFirst.anyway}</span>
+          </div>
+        </div>
+      )}
+      {readiness.state === "fixes_ready" && (
+        <div className="bg-green-50 border border-green-200 rounded-xl px-4 py-3 text-sm text-green-800">
+          {t.exportPage.fixFirst.readyBadge}
+        </div>
+      )}
 
       {/* ── Step 0: which agent is this pack for? ── */}
       {!agentChosen && (() => {

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -616,6 +616,15 @@ export type Dictionary = {
       siteDesc: string;
       siteCta: string;
     };
+    fixFirst: {
+      title: string;
+      descBefore: string;
+      descFailed: string;
+      descMissing: string;
+      cta: string;
+      anyway: string;
+      readyBadge: string;
+    };
     deployTools: {
       title: string;
       intro: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -691,6 +691,15 @@ const EN = {
       siteDesc: "Add your live app URL to run a visual check of the finished screens.",
       siteCta: "Connect app URL",
     },
+    fixFirst: {
+      title: "Finish the check results first",
+      descBefore: "Your review found ",
+      descFailed: " item(s) that don't pass, and ",
+      descMissing: " still have no fix plan. Create fix plans on the check-results screen first — then this package will include exact fix instructions for your dev AI.",
+      cta: "Go to check results",
+      anyway: "You can still export now, but the package will go out without fix instructions.",
+      readyBadge: "Fix instructions for every failed item are included in this package.",
+    },
     deployTools: {
       title: "Let your AI deploy it in one shot",
       intro: "Connect these tools once in your editor. Then your dev AI can push the code and put the app online by itself — no copy-pasting keys, and Simsa never sees your tokens.",
@@ -3053,6 +3062,15 @@ const KO = {
       siteTitle: "배포된 웹사이트 연결",
       siteDesc: "배포된 앱 주소를 넣어 완성된 화면을 시각 검수합니다.",
       siteCta: "앱 주소 연결하기",
+    },
+    fixFirst: {
+      title: "확인 결과부터 마치면 더 좋은 패키지가 나와요",
+      descBefore: "검수에서 안 맞음이 ",
+      descFailed: "건 나왔고, 그중 ",
+      descMissing: "건은 아직 고칠 방법이 준비되지 않았어요. 확인 결과 화면에서 고쳐보기를 먼저 만들면, 이 패키지에 개발 AI에게 줄 정확한 수정 지시가 함께 담깁니다.",
+      cta: "확인 결과로 가기",
+      anyway: "지금 그대로 내보낼 수도 있지만, 수정 지시 없이 나갑니다.",
+      readyBadge: "안 맞았던 항목 전부의 수정 지시가 이 패키지에 담깁니다.",
     },
     deployTools: {
       title: "AI가 한 번에 배포까지 하도록",

--- a/apps/dashboard/src/lib/project-steps.d.mts
+++ b/apps/dashboard/src/lib/project-steps.d.mts
@@ -28,3 +28,13 @@ export type NextProjectAction =
 export function nextProjectAction(
   facts: ProjectStepFacts,
 ): { action: NextProjectAction; slug: string } | null;
+
+export type PackReadiness = {
+  state: "no_review" | "fixes_missing" | "fixes_ready";
+  failedCount: number;
+  missingCount: number;
+};
+export function packReadiness(
+  checkResults: { results?: Array<{ itemId: string; status: string }> } | null | undefined,
+  fixSuggestions: Record<string, unknown> | null | undefined,
+): PackReadiness;

--- a/apps/dashboard/src/lib/project-steps.mjs
+++ b/apps/dashboard/src/lib/project-steps.mjs
@@ -166,6 +166,43 @@ export function nextScreenSlug(slug, entryPath) {
       ? ["settings", "github", "items", "checks", "fixes"]
       : ["idea", "spec", "items", "export"];
   const i = order.indexOf(slug);
-  if (i === -1 || i === order.length - 1) return null;
-  return order[i + 1];
+  if (i !== -1) return i === order.length - 1 ? null : order[i + 1];
+
+  // Post-review loop on the builder branches (Bae 2026-07-17): once a review
+  // exists the right order is 확인 결과 → 고쳐보기 → 빌더팩 — the pack is handed
+  // AFTER fixes are prepared, so it carries the fix briefs instead of an empty
+  // fixes.md. checks/fixes aren't in the base walk for these branches, so this
+  // chain only ever engages after the user reached the review screens.
+  if (entryPath !== "code") {
+    const loop = ["checks", "fixes", "export"];
+    const j = loop.indexOf(slug);
+    if (j !== -1 && j < loop.length - 1) return loop[j + 1];
+  }
+  return null;
+}
+
+/**
+ * packReadiness — should the export screen route the user through 확인 결과
+ * first? (Bae 2026-07-17: "수정을 다 마치고 빌더팩을 전달해줘야지".)
+ *
+ * A pack exported while failed check items still lack a fix suggestion ships an
+ * empty fixes.md — legal but weak. This computes that state so the export
+ * screen can lead with "확인 결과부터" (soft gate: informing + default CTA,
+ * never a hard lock — dead ends are worse than a weaker pack).
+ *
+ * @param {{ results?: Array<{ itemId: string, status: string }> } | null | undefined} checkResults
+ * @param {Record<string, unknown> | null | undefined} fixSuggestions
+ * @returns {{ state: "no_review" | "fixes_missing" | "fixes_ready", failedCount: number, missingCount: number }}
+ *   no_review: no review ran, or nothing failed — no notice needed.
+ */
+export function packReadiness(checkResults, fixSuggestions) {
+  const results = Array.isArray(checkResults?.results) ? checkResults.results : [];
+  const failed = results.filter((r) => r && r.status === "failed");
+  if (failed.length === 0) return { state: "no_review", failedCount: 0, missingCount: 0 };
+  const fs = fixSuggestions ?? {};
+  const missing = failed.filter((r) => !Object.prototype.hasOwnProperty.call(fs, r.itemId));
+  if (missing.length > 0) {
+    return { state: "fixes_missing", failedCount: failed.length, missingCount: missing.length };
+  }
+  return { state: "fixes_ready", failedCount: failed.length, missingCount: 0 };
 }

--- a/apps/dashboard/test/project-steps.test.mjs
+++ b/apps/dashboard/test/project-steps.test.mjs
@@ -192,3 +192,54 @@ test("nextScreenSlug: the CODE branch walks repo-connect FIRST (이미 만든 �
   assert.equal(nextScreenSlug("items", "idea"), "export");
   assert.equal(nextScreenSlug("items", null), "export");
 });
+
+// ── Fix-first routing (Bae 2026-07-17): 확인 결과 → 고쳐보기 → 빌더팩 ─────────
+
+test("post-review walk (builder branches): checks → fixes → export", () => {
+  assert.equal(nextScreenSlug("checks", "idea"), "fixes");
+  assert.equal(nextScreenSlug("fixes", "idea"), "export");
+  assert.equal(nextScreenSlug("checks", "spec"), "fixes");
+  assert.equal(nextScreenSlug("fixes", "spec"), "export");
+  // pre-review walk unchanged: items → export is still the idea-branch end
+  assert.equal(nextScreenSlug("items", "idea"), "export");
+  assert.equal(nextScreenSlug("export", "idea"), null);
+  // code branch unchanged: its own order still ends at fixes (PR flow, not pack)
+  assert.equal(nextScreenSlug("fixes", "code"), null);
+  assert.equal(nextScreenSlug("checks", "code"), "fixes");
+});
+
+test("packReadiness: no review / nothing failed → no_review (no notice)", async () => {
+  const { packReadiness } = await import("../src/lib/project-steps.mjs");
+  assert.equal(packReadiness(undefined, undefined).state, "no_review");
+  assert.equal(packReadiness({ results: [] }, {}).state, "no_review");
+  assert.equal(
+    packReadiness({ results: [{ itemId: "a", status: "passed" }] }, {}).state,
+    "no_review",
+  );
+});
+
+test("packReadiness: failed items without fix plans → fixes_missing with counts", async () => {
+  const { packReadiness } = await import("../src/lib/project-steps.mjs");
+  const r = packReadiness(
+    { results: [
+      { itemId: "a", status: "failed" },
+      { itemId: "b", status: "failed" },
+      { itemId: "c", status: "inconclusive" },
+    ] },
+    { a: { itemId: "a" } }, // only one of two failures has a plan
+  );
+  assert.equal(r.state, "fixes_missing");
+  assert.equal(r.failedCount, 2);
+  assert.equal(r.missingCount, 1);
+});
+
+test("packReadiness: every failed item has a fix plan → fixes_ready", async () => {
+  const { packReadiness } = await import("../src/lib/project-steps.mjs");
+  const r = packReadiness(
+    { results: [{ itemId: "a", status: "failed" }] },
+    { a: { itemId: "a" } },
+  );
+  assert.equal(r.state, "fixes_ready");
+  assert.equal(r.failedCount, 1);
+  assert.equal(r.missingCount, 0);
+});


### PR DESCRIPTION
배 님 피드백(2026-07-17): "확인 결과를 먼저 가서 수정을 다 마치고 빌더팩을 전달해줘야지."

## 확인된 문제

- 검수에서 안 맞음이 나온 상태에서 고쳐보기 없이 빌더팩을 받으면 **fixes.md가 '아직 수정 제안이 없습니다'로 비어 나가는데, 화면은 아무 경고도 하지 않았음**
- 검수 후 걷기 순서가 없어서 빌더팩을 받은 뒤 어디로 갈지 안내 부재

## 변경

- `packReadiness`(순수 함수): 안 맞음 항목 vs 고쳐보기 보유 → `no_review` / `fixes_missing` / `fixes_ready`
- 빌더팩 화면: 고쳐보기 미완 → 앰버 안내 + **[확인 결과로 가기]** 기본 CTA (소프트 게이트 — 그대로 내보내기는 가능하되 '수정 지시 없이 나갑니다' 명시, 데드엔드 없음) / 전부 준비됨 → "수정 지시 담김" 그린 배너
- `nextScreenSlug`: 빌더 갈래에 검수 후 걷기 **확인 결과 → 고쳐보기 → 빌더팩** 추가. 검수 전 걷기(아이디어→설명서→항목→빌더팩)와 코드 갈래(PR 흐름)는 불변

## Verification

- project-steps +4 테스트(25/25), dashboard 524/524 + tsc green

🤖 Generated with [Claude Code](https://claude.com/claude-code)