### PR TITLE
feat(review): RC-2 검증 패널 (Train 1) — failed 판정 교차-벤더 2차 확인

### DIFF
--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -230,6 +230,8 @@ export interface Env {
    * Set via wrangler.toml [vars] (it is a URL, not a secret).
    */
   CF_AI_GATEWAY_ANTHROPIC_URL?: string;
+  /** RC-2 검증 패널의 교차-벤더(OpenAI) 호출용 게이트웨이 URL. Unset = direct. */
+  CF_AI_GATEWAY_OPENAI_URL?: string;
   BETA_PROJECT_CREATE_DAILY_LIMIT?: string;
   /**
    * In-app feedback (workspace-feedback.ts) admin notification targets.

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -19,8 +19,10 @@ import { normalizeBuiltWith } from "../workspace/built-with.js";
 import { classifyTopics } from "../workspace/topic-tags.js";
 import {
   generateCheckDraft,
+  normalizeProductSpec,
   type WorkspaceCheckDraftRequest,
 } from "../workspace/check.js";
+import { applyVerifyPanel } from "../workspace/verify-panel.js";
 import {
   generateFixSuggestion,
   type WorkspaceFixSuggestionRequest,
@@ -523,6 +525,14 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
 
     if (result.ok === false) {
       return new Response(JSON.stringify({ ok: false, error: "llm_unavailable" }), { status: 503, headers: { "content-type": "application/json", ...headers } });
+    }
+
+    // RC-2 검증 패널 (A, 전원): failed 판정만 교차-벤더 2차 확인. 어떤 실패에도
+    // 검수 자체를 깨지 않는다 — 패널 오류 시 원판정+single 표기로 진행.
+    try {
+      result = await applyVerifyPanel(result, normalizeProductSpec(req.productSpec), c.env);
+    } catch (err) {
+      console.error("[workspace/check-draft] verify-panel error (kept single):", err);
     }
 
     // Best-effort persist check run to D1 — only into projects the caller owns.

--- a/apps/central-plane/src/workspace/check.ts
+++ b/apps/central-plane/src/workspace/check.ts
@@ -80,6 +80,8 @@ export type CheckResultItem = {
   reason: string;
   evidence: string[];
   nextAction: string;
+  /** RC-2 검증 패널: failed 판정의 교차 확인 결과. 미실행 판정에는 없음. */
+  verification?: "dual_confirmed" | "downgraded" | "single";
 };
 
 export type WorkspaceCheckDraftRequest = {

--- a/apps/central-plane/src/workspace/verify-panel.ts
+++ b/apps/central-plane/src/workspace/verify-panel.ts
@@ -1,0 +1,216 @@
+/**
+ * workspace/verify-panel.ts — RC-2 검증 패널 (A 티어, 전원 적용).
+ *
+ * check-draft의 "안 맞음(failed)" 판정 — 사용자에게 유죄를 선고하는 판정 — 에만
+ * 두 번째 모델의 독립 교차 확인을 붙인다. 후하게 만드는 장치가 아니라 틀린
+ * 유죄판결을 막는 장치다 (정확도=신호/잡음 분리 원칙):
+ *
+ *   - 양쪽 동의       → 판정 유지 + verification: "dual_confirmed"
+ *   - 불일치          → "확인 부족(inconclusive)"으로 강등 + 두 관점 병기 ("downgraded")
+ *   - 2차 호출 실패   → 원판정 유지 + verification: "single" (조용히 2중인 척 금지)
+ *
+ * passed/inconclusive/needs_decision은 건드리지 않는다. 교차 확인은 교차-벤더
+ * 우선(OpenAI), 불가 시 Anthropic 상위 모델 폴백. 상한/모델은 파라미터(RC-2).
+ */
+import type { CheckResultItem, ProductSpecForCheck, WorkspaceCheckDraftResponse } from "./check.js";
+import { anthropicEndpoint } from "./anthropic-fetch.js";
+
+export type VerificationTag = "dual_confirmed" | "downgraded" | "single";
+
+export type VerifyPanelEnv = {
+  OPENAI_API_KEY?: string;
+  ANTHROPIC_API_KEY?: string;
+  /** CF AI Gateway 경유 (직행 Worker 이그레스는 403 — anthropic과 동일 함정). */
+  CF_AI_GATEWAY_OPENAI_URL?: string;
+  CF_AI_GATEWAY_ANTHROPIC_URL?: string;
+};
+
+function openaiEndpoint(baseUrl?: string): string {
+  const base = (baseUrl ?? "").trim().replace(/\/$/, "");
+  return base ? `${base}/chat/completions` : "https://api.openai.com/v1/chat/completions";
+}
+
+export type VerifyPanelOpts = {
+  /** 검수당 교차 확인 상한 (RC-5: 기본 5) */
+  maxChecks?: number;
+  timeoutMs?: number;
+  openaiModel?: string;
+  anthropicModel?: string;
+  fetchImpl?: typeof fetch;
+};
+
+type SecondOpinion = { supported: boolean; noteKo: string };
+
+function opinionPrompt(spec: ProductSpecForCheck, item: CheckResultItem): string {
+  return `You are an INDEPENDENT second reviewer. A first reviewer marked a product-spec item as "failed" (conflicts with the spec's excluded scope or decided directions). Decide independently whether the evidence supports that verdict.
+
+[Product spec]
+${JSON.stringify(spec)}
+
+[Item]
+title: ${item.title}
+first verdict: failed
+first reason: ${item.reason}
+first evidence: ${JSON.stringify(item.evidence)}
+
+Rule: supported=true ONLY if the item clearly conflicts with the spec's excluded scope or decided directions. If the conflict is unclear, arguable, or the evidence is weak, supported=false.
+
+Answer with JSON only (no markdown):
+{"supported": true, "note_ko": "<판단 근거 한 문장, 한국어>"}`;
+}
+
+function parseOpinion(text: string): SecondOpinion | null {
+  const m = text.match(/\{[\s\S]*\}/);
+  if (!m) return null;
+  try {
+    const o = JSON.parse(m[0]) as Record<string, unknown>;
+    if (typeof o["supported"] !== "boolean") return null;
+    return {
+      supported: o["supported"],
+      noteKo: typeof o["note_ko"] === "string" ? o["note_ko"].slice(0, 300) : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function askOpenAi(
+  key: string,
+  prompt: string,
+  model: string,
+  timeoutMs: number,
+  fetchImpl: typeof fetch,
+  baseUrl?: string,
+): Promise<SecondOpinion | null> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const r = await fetchImpl(openaiEndpoint(baseUrl), {
+      method: "POST",
+      headers: { authorization: `Bearer ${key}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: prompt }],
+        max_completion_tokens: 300,
+      }),
+      signal: ctrl.signal,
+    });
+    if (!r.ok) return null;
+    const j = (await r.json()) as { choices?: Array<{ message?: { content?: string } }> };
+    return parseOpinion(j.choices?.[0]?.message?.content ?? "");
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+async function askAnthropic(
+  key: string,
+  prompt: string,
+  model: string,
+  timeoutMs: number,
+  fetchImpl: typeof fetch,
+  baseUrl?: string,
+): Promise<SecondOpinion | null> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const r = await fetchImpl(anthropicEndpoint(baseUrl), {
+      method: "POST",
+      headers: {
+        "x-api-key": key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ model, max_tokens: 300, messages: [{ role: "user", content: prompt }] }),
+      signal: ctrl.signal,
+    });
+    if (!r.ok) return null;
+    const j = (await r.json()) as { content?: Array<{ type: string; text?: string }> };
+    return parseOpinion((j.content ?? []).find((b) => b.type === "text")?.text ?? "");
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+/** 교차-벤더 우선: OpenAI → (불가/실패 시) Anthropic 상위 모델. 둘 다 없으면 null. */
+async function secondOpinion(
+  env: VerifyPanelEnv,
+  prompt: string,
+  opts: Required<Pick<VerifyPanelOpts, "timeoutMs" | "openaiModel" | "anthropicModel">>,
+  fetchImpl: typeof fetch,
+): Promise<SecondOpinion | null> {
+  if (env.OPENAI_API_KEY) {
+    const o = await askOpenAi(env.OPENAI_API_KEY, prompt, opts.openaiModel, opts.timeoutMs, fetchImpl, env.CF_AI_GATEWAY_OPENAI_URL);
+    if (o) return o;
+  }
+  if (env.ANTHROPIC_API_KEY) {
+    return askAnthropic(env.ANTHROPIC_API_KEY, prompt, opts.anthropicModel, opts.timeoutMs, fetchImpl, env.CF_AI_GATEWAY_ANTHROPIC_URL);
+  }
+  return null;
+}
+
+/**
+ * failed 판정에 교차 확인을 적용하고 (필요시) 강등해 새 response를 만든다.
+ * 어떤 실패에도 검수 자체를 깨지 않는다 (fail-open + 정직 표기).
+ */
+export async function applyVerifyPanel(
+  response: WorkspaceCheckDraftResponse,
+  spec: ProductSpecForCheck,
+  env: VerifyPanelEnv,
+  opts: VerifyPanelOpts = {},
+): Promise<WorkspaceCheckDraftResponse> {
+  const maxChecks = opts.maxChecks ?? 5;
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  const openaiModel = opts.openaiModel ?? "gpt-5.4";
+  const anthropicModel = opts.anthropicModel ?? "claude-sonnet-5";
+  const fetchImpl = opts.fetchImpl ?? fetch;
+
+  const failedIdx = response.results
+    .map((r, i) => (r.status === "failed" ? i : -1))
+    .filter((i) => i >= 0)
+    .slice(0, maxChecks);
+  if (failedIdx.length === 0) return response;
+
+  const results = [...response.results];
+  await Promise.all(
+    failedIdx.map(async (i) => {
+      const item = results[i];
+      if (!item) return;
+      const opinion = await secondOpinion(
+        env,
+        opinionPrompt(spec, item),
+        { timeoutMs, openaiModel, anthropicModel },
+        fetchImpl,
+      );
+      if (opinion === null) {
+        results[i] = { ...item, verification: "single" };
+        return;
+      }
+      if (opinion.supported) {
+        results[i] = { ...item, verification: "dual_confirmed" };
+        return;
+      }
+      // 불일치 — 유죄판정을 단정하지 않는다. 강등 + 두 관점 병기.
+      results[i] = {
+        ...item,
+        status: "inconclusive",
+        userLabel: "확인 부족",
+        verification: "downgraded",
+        reason: `두 AI의 판단이 갈렸습니다. 1차 판단: ${item.reason} / 2차 판단: ${opinion.noteKo || "충돌 근거가 분명하지 않습니다."} 직접 한 번 확인해보세요.`,
+      };
+    }),
+  );
+
+  const summary = {
+    passed: results.filter((r) => r.status === "passed").length,
+    failed: results.filter((r) => r.status === "failed").length,
+    inconclusive: results.filter((r) => r.status === "inconclusive").length,
+    needsDecision: results.filter((r) => r.status === "needs_decision").length,
+  };
+
+  return { ...response, results, summary };
+}

--- a/apps/central-plane/test/verify-panel.test.mjs
+++ b/apps/central-plane/test/verify-panel.test.mjs
@@ -1,0 +1,120 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// RC-2 검증 패널 (2026-07-17, design: docs/simsa-review-consensus-design-2026-07-17.md):
+// failed 판정만 교차 확인, 동의→dual_confirmed, 불일치→inconclusive 강등+양관점,
+// 실패→single 정직 표기. passed 등은 절대 건드리지 않는다.
+
+const { applyVerifyPanel } = await import("../dist/workspace/verify-panel.js");
+
+const SPEC = {
+  productName: "테스트 앱", oneLine: "테스트", targetUsers: [], problem: "p",
+  included: ["기능 A"], excluded: ["결제"], userFlow: [], decisions: [], openQuestions: [],
+};
+
+const item = (id, status) => ({
+  itemId: id, status, title: `항목 ${id}`,
+  userLabel: status === "failed" ? "안 맞음" : "통과",
+  reason: "제외 범위 충돌", evidence: ["결제"], nextAction: "확인",
+});
+
+const resp = (results) => ({
+  ok: true, source: "llm",
+  summary: {
+    passed: results.filter((r) => r.status === "passed").length,
+    failed: results.filter((r) => r.status === "failed").length,
+    inconclusive: results.filter((r) => r.status === "inconclusive").length,
+    needsDecision: 0,
+  },
+  results,
+});
+
+/** OpenAI-shaped fetch stub returning the given opinion (or an HTTP error). */
+function stubFetch(opinion, log = []) {
+  return async (url, init) => {
+    log.push(String(url));
+    if (opinion === "http_error") return new Response("err", { status: 500 });
+    return new Response(JSON.stringify({
+      choices: [{ message: { content: JSON.stringify(opinion) } }],
+    }), { status: 200 });
+  };
+}
+
+const ENV = { OPENAI_API_KEY: "k" };
+
+describe("applyVerifyPanel — RC-2", () => {
+  it("agreement → status kept, verification dual_confirmed, summary unchanged", async () => {
+    const out = await applyVerifyPanel(
+      resp([item("a", "failed"), item("b", "passed")]), SPEC, ENV,
+      { fetchImpl: stubFetch({ supported: true, note_ko: "동의" }) },
+    );
+    assert.equal(out.results[0].status, "failed");
+    assert.equal(out.results[0].verification, "dual_confirmed");
+    assert.equal(out.results[1].verification, undefined, "passed items untouched");
+    assert.equal(out.summary.failed, 1);
+  });
+
+  it("disagreement → downgraded to inconclusive with BOTH perspectives, summary recomputed", async () => {
+    const out = await applyVerifyPanel(
+      resp([item("a", "failed")]), SPEC, ENV,
+      { fetchImpl: stubFetch({ supported: false, note_ko: "충돌 근거 약함" }) },
+    );
+    const r = out.results[0];
+    assert.equal(r.status, "inconclusive");
+    assert.equal(r.userLabel, "확인 부족");
+    assert.equal(r.verification, "downgraded");
+    assert.match(r.reason, /1차 판단/);
+    assert.match(r.reason, /충돌 근거 약함/);
+    assert.equal(out.summary.failed, 0);
+    assert.equal(out.summary.inconclusive, 1);
+  });
+
+  it("second-opinion failure → original verdict kept, honest 'single' tag (never silent dual)", async () => {
+    const out = await applyVerifyPanel(
+      resp([item("a", "failed")]), SPEC, { OPENAI_API_KEY: "k" },
+      { fetchImpl: stubFetch("http_error") },
+    );
+    assert.equal(out.results[0].status, "failed");
+    assert.equal(out.results[0].verification, "single");
+  });
+
+  it("no vendor keys at all → single tag, no fetch calls", async () => {
+    const log = [];
+    const out = await applyVerifyPanel(
+      resp([item("a", "failed")]), SPEC, {},
+      { fetchImpl: stubFetch({ supported: true }, log) },
+    );
+    assert.equal(out.results[0].verification, "single");
+    assert.equal(log.length, 0);
+  });
+
+  it("cap: only maxChecks failed items get cross-checked", async () => {
+    const log = [];
+    const many = resp(["a", "b", "c", "d", "e", "f", "g"].map((id) => item(id, "failed")));
+    const out = await applyVerifyPanel(many, SPEC, ENV, {
+      maxChecks: 5,
+      fetchImpl: stubFetch({ supported: true, note_ko: "" }, log),
+    });
+    assert.equal(log.length, 5);
+    assert.equal(out.results.filter((r) => r.verification === "dual_confirmed").length, 5);
+    assert.equal(out.results.filter((r) => r.verification === undefined).length, 2);
+  });
+
+  it("nothing failed → response returned untouched, zero calls", async () => {
+    const log = [];
+    const input = resp([item("a", "passed")]);
+    const out = await applyVerifyPanel(input, SPEC, ENV, { fetchImpl: stubFetch({ supported: true }, log) });
+    assert.equal(log.length, 0);
+    assert.deepEqual(out, input);
+  });
+
+  it("uses the CF AI Gateway URL when configured (Worker direct egress 403 trap)", async () => {
+    const log = [];
+    await applyVerifyPanel(
+      resp([item("a", "failed")]), SPEC,
+      { OPENAI_API_KEY: "k", CF_AI_GATEWAY_OPENAI_URL: "https://gw.example/openai" },
+      { fetchImpl: stubFetch({ supported: true, note_ko: "" }, log) },
+    );
+    assert.match(log[0], /^https:\/\/gw\.example\/openai\/chat\/completions$/);
+  });
+});

--- a/apps/central-plane/wrangler.toml
+++ b/apps/central-plane/wrangler.toml
@@ -23,6 +23,7 @@ AUTH_SIGNUP_MODE = "open"
 # (Settings → Authentication OFF) so the Worker's own x-api-key passes through;
 # the stored Anthropic key is not needed. Base only; code appends /v1/messages.
 CF_AI_GATEWAY_ANTHROPIC_URL = "https://gateway.ai.cloudflare.com/v1/8735d5a7b0af1d7f97dd46f705ace797/simsa/anthropic"
+CF_AI_GATEWAY_OPENAI_URL = "https://gateway.ai.cloudflare.com/v1/8735d5a7b0af1d7f97dd46f705ace797/simsa/openai"
 # Open-deploy batch (2026-07-05) — Better Auth canonical origin. Required for the
 # GitHub LOGIN OAuth app (#213): without it Better Auth derives the base URL from
 # the proxied request (workers.dev) and the GitHub callback becomes

--- a/apps/dashboard/src/app/projects/[id]/checks/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/checks/page.tsx
@@ -459,6 +459,17 @@ function CheckResultCard({
           <SeverityChip status={result.status} />
         )}
         <span className="min-w-0 flex-1 truncate text-sm font-medium text-gray-800">{result.title}</span>
+        {/* RC-2 검증 패널 표기: 2중 확인/단일 확인을 정직하게 구분 */}
+        {result.verification === "dual_confirmed" && (
+          <span className="inline-flex flex-shrink-0 items-center rounded-md border border-green-200 bg-green-50 px-1.5 py-0.5 text-[11px] font-medium text-green-700">
+            {t.checks.verifiedDual}
+          </span>
+        )}
+        {result.verification === "single" && (
+          <span className="inline-flex flex-shrink-0 items-center rounded-md border border-gray-200 bg-gray-50 px-1.5 py-0.5 text-[11px] font-medium text-gray-500">
+            {t.checks.verifiedSingle}
+          </span>
+        )}
         <StatusBadge status={result.status as ItemStatus} />
         <span className={`flex-shrink-0 text-xs text-gray-400 transition-transform ${open ? "rotate-180" : ""}`} aria-hidden>
           ▾

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -472,6 +472,8 @@ export type Dictionary = {
     viewComparison: string;
     toGithub: string;
     nextStep: string;
+    verifiedDual: string;
+    verifiedSingle: string;
   };
   runStatus: { error: string; running: string; queued: string };
   credit: {

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -547,6 +547,8 @@ const EN = {
     viewComparison: "View comparison in GitHub",
     toGithub: "Go to code review",
     nextStep: "Next step",
+    verifiedDual: "Double-checked by 2 AIs",
+    verifiedSingle: "Single check",
   },
   runStatus: { error: "Error", running: "Running", queued: "Queued" },
   credit: {
@@ -2919,6 +2921,8 @@ const KO = {
     viewComparison: "GitHub에서 비교 결과 보기",
     toGithub: "코드 확인 화면으로",
     nextStep: "다음 단계",
+    verifiedDual: "AI 2중 확인됨",
+    verifiedSingle: "단일 확인",
   },
   runStatus: { error: "확인 실패", running: "확인 중", queued: "대기 중" },
   credit: {

--- a/apps/dashboard/src/lib/workspace-check-api.ts
+++ b/apps/dashboard/src/lib/workspace-check-api.ts
@@ -24,6 +24,8 @@ export type CheckResultItem = {
   reason: string;
   evidence: string[];
   nextAction: string;
+  /** RC-2 검증 패널: failed 판정의 교차 확인 결과 (없으면 패널 미적용 판정). */
+  verification?: "dual_confirmed" | "downgraded" | "single";
 };
 
 export type CheckDraftResponse = {


### PR DESCRIPTION
RC-1~RC-6 설계 잠금(#370) 후 Train 1. failed 판정에만 2차 모델 독립 확인 — 동의=2중 확인 표기, 불일치=확인 부족 강등+양관점, 실패=단일 확인 정직 표기. 전원(무료 포함) 적용. 상세는 커밋 메시지·설계 문서 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)