### PR TITLE
fix(funnel): 계측 구멍 2건 — 생성/팩 userKey 미전송 + 프로브 오염

### DIFF
--- a/apps/central-plane/src/routes/workspace-admin-stats.ts
+++ b/apps/central-plane/src/routes/workspace-admin-stats.ts
@@ -286,8 +286,10 @@ async function funnelStageCounts(db: D1Database, cutoff: string): Promise<Array<
     FUNNEL_STAGES.map(async (s) => {
       const r = await db
         .prepare(
+          // probe_% = 운영 프로브 키(라이브 실증 도구) — 실유저 퍼널에서 제외.
           `SELECT COUNT(DISTINCT user_key) AS n FROM workspace_usage_events
-            WHERE event_type = ? AND created_at >= ? AND user_key != 'anonymous'`,
+            WHERE event_type = ? AND created_at >= ?
+              AND user_key != 'anonymous' AND user_key NOT LIKE 'probe_%'`,
         )
         .bind(s.key, cutoff)
         .first<{ n: number }>();
@@ -305,6 +307,7 @@ async function returnedAfterPackCount(db: D1Database, cutoff: string): Promise<n
          FROM workspace_usage_events e
         WHERE e.event_type = 'workspace_builder_pack_exported'
           AND e.created_at >= ? AND e.user_key != 'anonymous'
+          AND e.user_key NOT LIKE 'probe_%'
           AND EXISTS (
             SELECT 1 FROM workspace_usage_events l
              WHERE l.user_key = e.user_key
@@ -424,7 +427,11 @@ export function createWorkspaceAdminStatsRoutes(): Hono<{ Bindings: Env }> {
         range,
         cutoff,
         ...computeFunnelSummary(stages, returned),
-        notes: ["distinct userKey 기준(anonymous 제외)", "시각 검수 실행은 v1 미포함(자체 테이블)"],
+        notes: [
+          "distinct userKey 기준(anonymous·probe_* 제외)",
+          "시각 검수 실행은 v1 미포함(자체 테이블)",
+          "2026-07-19 이전 생성/팩 이벤트는 userKey 미전송으로 anonymous에 묻혀 있음 — 이후부터 정확",
+        ],
       });
     } catch (err) {
       console.error("[admin/funnel] query failed:", err);

--- a/apps/dashboard/src/app/projects/[id]/export/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/export/page.tsx
@@ -275,6 +275,8 @@ export default function ExportPage() {
       }
 
       const res = await callExportBuilderPackApi({
+        // G7 계측: userKey 없인 export 이벤트가 anonymous로 묶여 퍼널에 안 잡힘.
+        userKey: getUserKey(),
         project: {
           title: project.name,
           productSpec,

--- a/apps/dashboard/src/lib/workspace-api.ts
+++ b/apps/dashboard/src/lib/workspace-api.ts
@@ -10,6 +10,7 @@
  */
 
 import type { IdeaToSpecDraftResponse } from "./workspace-types";
+import { getUserKey } from "./workflow-store";
 import {
   generateUnderstanding,
   generateQuestions,
@@ -71,6 +72,9 @@ export async function callWorkspaceApi(
         answers: input.answers ?? [],
         locale: "ko",
         mode: "standard",
+        // G7 계측: userKey 없이는 생성 이벤트가 전부 anonymous로 묶여 퍼널에서
+        // 사라진다 (2026-07-19 첫 실측이 드러낸 구멍).
+        userKey: getUserKey(),
         ...(input.context?.trim() ? { context: input.context.trim() } : {}),
         ...(input.rejectedQuestions?.length ? { rejectedQuestions: input.rejectedQuestions } : {}),
       }),


### PR DESCRIPTION
G7 첫 실측의 직접 발견. 상세는 커밋 메시지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)