### PR TITLE
feat(inspection): E-corpus-1 #415 — 러너 재작성(무조건 부분 리포트)

### DIFF
--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -157,6 +157,19 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
     timedOutPartial: false,
   };
 
+  // E-corpus-1 재작성 (2026-07-19, #415): 예산에 도달하면 컨텍스트를 강제 종료해
+  // 진행 중이던 Playwright 작업을 "Target closed"로 터뜨린다 → 아래 catch가 지금까지
+  // 모은 evidence로 무조건 판정을 만들어 반환한다. 개별 작업(innerText/$$eval/
+  // screenshot/waitForTimeout)이 예산 가드를 우회해도(무거운 사이트) server.mjs의
+  // hard 4분 레일에 닿기 전에 부분 리포트가 반드시 나온다 — 빈손 타임아웃 제거의 핵심.
+  let killTimer = null;
+  if (deadline !== Infinity) {
+    killTimer = setTimeout(() => {
+      evidence.timedOutPartial = true;
+      context.close().catch(() => {});
+    }, budgetMs);
+  }
+
   async function snap(name) {
     const p = join(shotsDir, name);
     try {
@@ -302,9 +315,22 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
     if (evidence.timedOutPartial) {
       stepOutcomes.push({ label: N.partial, ok: false, note: N.partial });
     }
+  } catch (err) {
+    // #415: 여기서 절대 다시 던지지 않는다 — 지금까지의 evidence로 판정한다.
+    if (evidence.timedOutPartial) {
+      // killTimer가 컨텍스트를 강제 종료한 경우 = 예산 초과 → 정직한 부분 리포트.
+      if (!stepOutcomes.some((s) => s.label === N.partial)) {
+        stepOutcomes.push({ label: N.partial, ok: false, note: N.partial });
+      }
+    } else {
+      // 예산과 무관한 조기 실패(로드 자체 실패 등) — evidence(networkFailures/
+      // loadStatus)가 이미 사실을 담고 있으니 판정 사다리에 맡긴다.
+      stepOutcomes.push({ label: N.actionFailed(String(err?.message ?? err).slice(0, 100)), ok: false });
+    }
   } finally {
-    await context.close(); // finalizes the video
-    await browser.close();
+    if (killTimer) clearTimeout(killTimer);
+    try { await context.close(); } catch { /* killTimer가 이미 닫았을 수 있음 */ }
+    try { await browser.close(); } catch { /* ignore */ }
   }
 
   // Save the recorded video next to the screenshots.

--- a/apps/central-plane/test/inspector-invariants.test.mjs
+++ b/apps/central-plane/test/inspector-invariants.test.mjs
@@ -134,6 +134,18 @@ test("inspector runner captures UNCAUGHT exceptions (pageerror), not just consol
   assert.match(runMjs, /page\.on\("pageerror"/, "runner must listen for pageerror");
 });
 
+test("E-corpus-1 #415: runner force-closes at budget and never re-throws (always partial report)", () => {
+  // 2026-07-19: gard-only 접근(#412/#414)이 무거운 사이트에서 실패 → 러너를
+  // "예산 도달 시 context 강제 종료 + catch에서 지금까지 evidence로 판정" 구조로
+  // 재작성. killTimer가 context.close()로 진행 중 작업을 터뜨리고, catch가 그
+  // throw를 삼켜 부분 리포트를 반환한다. 이 세 요소가 모두 있어야 빈손 타임아웃이
+  // 구조적으로 불가능해진다.
+  const runMjs = readFileSync(path.join(ROOT, "inspector-container/inspector-run.mjs"), "utf8");
+  assert.match(runMjs, /killTimer\s*=\s*setTimeout/, "runner must arm a budget kill-timer");
+  assert.match(runMjs, /context\.close\(\)\.catch/, "kill-timer must force-close the context");
+  assert.match(runMjs, /\}\s*catch\s*\(err\)\s*\{[\s\S]*timedOutPartial[\s\S]*\}\s*finally/, "the main try must catch (not re-throw) and finalize");
+});
+
 test("E-corpus-1: soft budget is passed to the runner and sits BELOW the hard rail", () => {
   // 2026-07-19 corpus eval: heavy marketing sites hit the 4-min rail and
   // returned an EMPTY timeout failure. The soft budget must be strictly less


### PR DESCRIPTION
가드-only 실패 후 근본 재작성. 컨테이너 재빌드. 배포+롤아웃 후 F7 실증. 상세는 커밋 메시지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)