### PR TITLE
fix(inspection): E-corpus-1 — browser.close() 강제종료

### DIFF
--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -166,7 +166,10 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
   if (deadline !== Infinity) {
     killTimer = setTimeout(() => {
       evidence.timedOutPartial = true;
-      context.close().catch(() => {});
+      // context.close()는 graceful이라 무한 hang(무거운 사이트의 innerText/
+      // $$eval 등)을 못 깬다 — browser.close()로 브라우저 프로세스를 강제
+      // 종료해 진행 중 모든 작업을 즉시 터뜨린다(아래 catch로 빠짐).
+      browser.close().catch(() => {});
     }, budgetMs);
   }
 

--- a/apps/central-plane/test/inspector-invariants.test.mjs
+++ b/apps/central-plane/test/inspector-invariants.test.mjs
@@ -142,7 +142,7 @@ test("E-corpus-1 #415: runner force-closes at budget and never re-throws (always
   // 구조적으로 불가능해진다.
   const runMjs = readFileSync(path.join(ROOT, "inspector-container/inspector-run.mjs"), "utf8");
   assert.match(runMjs, /killTimer\s*=\s*setTimeout/, "runner must arm a budget kill-timer");
-  assert.match(runMjs, /context\.close\(\)\.catch/, "kill-timer must force-close the context");
+  assert.match(runMjs, /browser\.close\(\)\.catch/, "kill-timer must force-close the BROWSER (graceful context.close can't break a hang)");
   assert.match(runMjs, /\}\s*catch\s*\(err\)\s*\{[\s\S]*timedOutPartial[\s\S]*\}\s*finally/, "the main try must catch (not re-throw) and finalize");
 });
 


### PR DESCRIPTION
context.close()가 hang 못 깸 → browser.close(). 컨테이너 재빌드.

🤖 Generated with [Claude Code](https://claude.com/claude-code)