### PR TITLE
feat(inspection): E-corpus-1 ec1-dbg2 — 위상 트레이스 in-band 회수

### DIFF
--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -32,7 +32,7 @@ import { classifyActionSafety } from "./safety.mjs";
  * whether the container rollout actually picked up the new image (the #412~
  * #418 train could never rule out "old image still serving").
  */
-export const RUNNER_REV = "ec1-dbg1";
+export const RUNNER_REV = "ec1-dbg2";
 
 /** Forbidden action words handed to the planner (mirrors visual-run.mjs). */
 export const FORBIDDEN_ACTIONS = [
@@ -106,15 +106,25 @@ const STEP_NOTES = {
  * sampleQuery has NO default here on purpose: planVisualFlow picks one from the
  * locale, and a default at this seam would silently win over it.
  */
-export async function runInspection({ targetUrl, intent, outDir, sampleQuery, locale = "ko", budgetMs, runId }) {
+export async function runInspection({ targetUrl, intent, outDir, sampleQuery, locale = "ko", budgetMs, runId, onPhase }) {
   const N = STEP_NOTES[locale === "en" ? "en" : "ko"];
-  // E-corpus-1 phase log: one line per runner phase, elapsed-stamped. The whole
-  // point is that in a `wrangler tail` session the LAST line printed before
-  // silence names the exact operation that hangs. PRIVACY: never log userKey/
-  // callbackToken (not even passed in here) — runId + target host + phase only.
+  // E-corpus-1 phase log: one line per runner phase, elapsed-stamped, so the
+  // LAST entry before silence names the exact operation that hangs.
+  // ec1-dbg2: `wrangler tail`은 컨테이너 stdout을 포함하지 않는다(2026-07-20
+  // 실측) — 그래서 onPhase 콜백으로 위상을 server.mjs에 노출하고, server가
+  // hard-rail 실패 콜백의 error에 마지막 위상들을 실어 보낸다(in-band 진단).
+  // PRIVACY: never log userKey/callbackToken — runId + target host + phase only.
   const t0 = Date.now();
   const tag = `[insp ${runId ?? "?"}]`;
-  const plog = (msg) => console.log(`${tag} +${((Date.now() - t0) / 1000).toFixed(1)}s ${msg}`);
+  const plog = (msg) => {
+    const line = `+${((Date.now() - t0) / 1000).toFixed(1)}s ${msg}`;
+    console.log(`${tag} ${line}`);
+    try {
+      onPhase?.(line);
+    } catch {
+      /* diagnostics must never break the run */
+    }
+  };
   plog(`runner-rev=${RUNNER_REV} budgetMs=${budgetMs ?? "none"} locale=${locale}`);
   // E-corpus-1 (2026-07-19): soft deadline. When we cross it we stop driving NEW
   // steps and fall through to observe + verdict with whatever evidence exists —

--- a/apps/central-plane/inspector-container/server.mjs
+++ b/apps/central-plane/inspector-container/server.mjs
@@ -150,11 +150,25 @@ async function runJob(payload) {
     // Wall-clock rail: Chromium hangs (infinite spinners, slow hosts) must
     // not exceed ~4 minutes. On timeout the run is reported failed; the
     // leaked browser (if any) dies with the container's sleepAfter.
+    //
+    // ec1-dbg2 in-band diagnostics: container stdout never reaches
+    // `wrangler tail` (measured 2026-07-20), so the runner's phase log is
+    // collected HERE and, when the run fails, shipped inside the error string
+    // → markVisualCheckFailed snapshots it into report_json → readable via
+    // the normal GET. The failed row itself now names the hang point.
+    const phases = [];
+    const onPhase = (line) => {
+      phases.push(line);
+      if (phases.length > 60) phases.splice(1, 1); // keep [0] = runner-rev marker
+    };
     const result = await withTimeout(
-      runInspection({ targetUrl, intent, outDir, locale, budgetMs: INSPECTION_SOFT_BUDGET_MS, runId }),
+      runInspection({ targetUrl, intent, outDir, locale, budgetMs: INSPECTION_SOFT_BUDGET_MS, runId, onPhase }),
       INSPECTION_TIMEOUT_MS,
       `inspection timed out after ${Math.round(INSPECTION_TIMEOUT_MS / 1000)}s`,
-    );
+    ).catch((err) => {
+      const trace = [phases[0], ...phases.slice(-9)].filter(Boolean).join(" | ");
+      throw new Error(`${String(err?.message ?? err)} ||trace: ${trace}`.slice(0, 490));
+    });
 
     // 1) Upload evidence through the EXISTING Stage 261 endpoint (it
     //    validates names + sizes server-side). Failures are non-fatal —

--- a/apps/central-plane/test/inspector-invariants.test.mjs
+++ b/apps/central-plane/test/inspector-invariants.test.mjs
@@ -160,3 +160,16 @@ test("E-corpus-1: soft budget is passed to the runner and sits BELOW the hard ra
   assert.match(runMjs, /budgetMs/, "runner must accept budgetMs");
   assert.match(runMjs, /timedOutPartial/, "runner must mark partial runs");
 });
+
+test("E-corpus-1 ec1-dbg2: phase trace travels IN-BAND on failure (tail can't see container stdout)", () => {
+  // 2026-07-20 실측: `wrangler tail`은 Worker/DO 로그만 보여주고 컨테이너
+  // stdout은 포함하지 않는다. 그래서 hang 진단은 in-band로 간다 — 러너가
+  // onPhase로 위상을 노출하고, server.mjs가 hard-rail 실패의 error 문자열에
+  // `||trace:`로 마지막 위상들을 실어 보내면 markVisualCheckFailed가 그대로
+  // report_json에 스냅샷한다. 실패 행 자체가 hang 지점을 보고하는 계약.
+  const runMjs = readFileSync(path.join(ROOT, "inspector-container/inspector-run.mjs"), "utf8");
+  assert.match(runMjs, /onPhase/, "runner must expose the phase stream via onPhase");
+  assert.match(runMjs, /RUNNER_REV\s*=/, "runner must carry a rev marker (in-band rollout verification)");
+  assert.match(serverMjs, /onPhase/, "server must collect the runner's phase stream");
+  assert.match(serverMjs, /\|\|trace:/, "server must embed the phase trace in the failure error string");
+});


### PR DESCRIPTION
## 라이브 실측 결과 (이 PR의 근거)

#421(위상 로그) 배포 + 롤아웃 10분 대기 후 `wrangler tail` 켠 채 F7 검수를 실행했다:

- **tail에는 컨테이너 stdout이 전혀 안 나온다** — Worker/DO 로그("Port 8080 is ready", "container started")만 보이고, server.mjs의 `[run ...]`도 러너의 `[insp ...]`도 없음. "tail로 hang 지점 특정" 계획은 CF Containers에서 관측 경로 자체가 막혀 있었다.
- F7은 5번째 247s 실패. 단, **hard rail(240s)이 정시에 발화해 실패 콜백이 옴** (1:16:05+240s=1:20:09) — 컨테이너 node 프로세스는 살아 있고 runInspection promise만 안 풀린다.

## 변경 — 관측을 in-band로

- 러너 `plog` → `onPhase` 콜백으로도 위상 방출(진단 오류는 런에 무영향). `RUNNER_REV=ec1-dbg2`.
- server.mjs가 위상을 수집(60개 링, [0]=rev 마커 보존), hard-rail 실패 시 error에 `||trace: rev | 마지막 9개 위상` 탑재(490자 캡) → `markVisualCheckFailed`가 report_json에 스냅샷 → 일반 GET으로 판독.
- 인바리언트 테스트: onPhase/||trace:/RUNNER_REV 계약 고정.

## 효과

다음 F7 실행의 실패 행이 스스로 보고한다: (a) 롤아웃 반영 여부(rev 마커 유무 — #412~#418 트레인이 끝내 판별 못 한 변수) (b) hang 직전 작업 (c) killTimer 발화/browser.close() resolve 여부.

## 검증

- inspector-invariants 12/12, node --check 2파일
- 동작 변경 없음(진단 수집만) — 성공 경로 payload 불변

🤖 Generated with [Claude Code](https://claude.com/claude-code)