### PR TITLE
fix(inspection): E-corpus-1 근본수정 ec1-fix1 — finally close hang 레이스 무력화

### DIFF
--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -32,7 +32,7 @@ import { classifyActionSafety } from "./safety.mjs";
  * whether the container rollout actually picked up the new image (the #412~
  * #418 train could never rule out "old image still serving").
  */
-export const RUNNER_REV = "ec1-dbg2";
+export const RUNNER_REV = "ec1-fix1";
 
 /** Forbidden action words handed to the planner (mirrors visual-run.mjs). */
 export const FORBIDDEN_ACTIONS = [
@@ -384,18 +384,35 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
       stepOutcomes.push({ label: N.actionFailed(String(err?.message ?? err).slice(0, 100)), ok: false });
     }
   } finally {
-    if (killTimer) clearTimeout(killTimer);
+    // ec1-fix1 (2026-07-20, in-band 트레이스로 확정): F7 hang의 실제 지점은
+    // 검수 중이 아니라 여기 — context.close()가 recordVideo 파이널라이즈에서
+    // 영영 안 풀린다(0.25 vCPU + 무거운 애니메이션 페이지; 검수 자체는 +50s에
+    // 정상 완료, 트레이스 마지막 라인 "finally:context.close start" 후 190s
+    // 침묵 → hard rail). 이전 코드는 close 전에 killTimer부터 해제해 구조
+    // 수단까지 없앴다(#412~#418이 전부 빗나간 이유 — "검수 중 hang" 가정).
+    //
+    // 수정: close류는 전부 raceOrNull(타임아웃 레이스)로 감싸 리포트 반환을
+    // 절대 막지 않는다. 못 죽인 Chromium은 per-run 컨테이너의 sleepAfter와
+    // 함께 죽는다(원래 계약). killTimer는 close 시도가 끝난 뒤에 해제한다.
     plog("finally:context.close start");
-    try { await context.close(); } catch { /* killTimer가 이미 닫았을 수 있음 */ }
+    await raceOrNull(context.close().catch(() => {}), 15000, "finally:context.close", plog);
     plog("finally:browser.close start");
-    try { await browser.close(); } catch { /* ignore */ }
+    await raceOrNull(browser.close().catch(() => {}), 10000, "finally:browser.close", plog);
+    if (killTimer) clearTimeout(killTimer);
     plog("finally:closed");
   }
 
-  // Save the recorded video next to the screenshots.
+  // Save the recorded video next to the screenshots. context.close()가 위에서
+  // 타임아웃했다면 비디오는 파이널라이즈 안 됐을 수 있다 — path() 대기도
+  // 레이스로 캡(비디오는 선택 증거, 리포트를 볼모로 잡지 않는다).
   try {
     plog("video:path start");
-    const vp = await page.video()?.path();
+    const vp = await raceOrNull(
+      Promise.resolve(page.video()?.path()).catch(() => null),
+      5000,
+      "video:path",
+      plog,
+    );
     if (vp && existsSync(vp)) {
       const dest = join(videoDir, "flow.webm");
       copyFileSync(vp, dest);
@@ -427,6 +444,24 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
   const agentPrompt = buildAgentFixPrompt(reportInput, locale);
 
   return { report, agentPrompt, decision, works: report.works, evidenceFiles };
+}
+
+/**
+ * ec1-fix1: resolve `promise` or fall through as null after `ms` — never
+ * throws, never blocks. Cleanup(close/video) 경로 전용: 리포트 반환이 어떤
+ * Playwright 정리 작업의 볼모도 되지 않게 하는 레이스.
+ */
+function raceOrNull(promise, ms, label, plog) {
+  let timer;
+  return Promise.race([
+    promise,
+    new Promise((resolve) => {
+      timer = setTimeout(() => {
+        plog?.(`${label}:TIMEOUT after ${ms}ms — proceeding without it`);
+        resolve(null);
+      }, ms);
+    }),
+  ]).finally(() => clearTimeout(timer));
 }
 
 /** Host-only URL for log lines (never the full URL — query strings can carry tokens). */

--- a/apps/central-plane/test/inspector-invariants.test.mjs
+++ b/apps/central-plane/test/inspector-invariants.test.mjs
@@ -161,6 +161,22 @@ test("E-corpus-1: soft budget is passed to the runner and sits BELOW the hard ra
   assert.match(runMjs, /timedOutPartial/, "runner must mark partial runs");
 });
 
+test("E-corpus-1 ec1-fix1: finally must never hold the report hostage", () => {
+  // 2026-07-20 in-band 트레이스 확정: F7 hang의 실지점 = finally의
+  // context.close() (recordVideo 파이널라이즈, 0.25 vCPU). 게다가 이전 코드는
+  // close 전에 killTimer를 해제해 구조 수단까지 없앴다. 계약: ①close류는
+  // 타임아웃 레이스(raceOrNull)로 감싼다 ②killTimer 해제는 close 시도 뒤
+  // ③video path 대기도 레이스 — 리포트는 어떤 정리 작업의 볼모도 아니다.
+  const runMjs = readFileSync(path.join(ROOT, "inspector-container/inspector-run.mjs"), "utf8");
+  assert.match(runMjs, /raceOrNull\(context\.close\(\)/, "context.close must be timeout-raced");
+  assert.match(runMjs, /raceOrNull\(browser\.close\(\)/, "browser.close must be timeout-raced");
+  assert.match(runMjs, /raceOrNull\(\s*Promise\.resolve\(page\.video\(\)/, "video path wait must be timeout-raced");
+  assert.ok(
+    !/clearTimeout\(killTimer\)[\s\S]*plog\("finally:context\.close start"\)/.test(runMjs),
+    "killTimer must NOT be disarmed before the close attempts",
+  );
+});
+
 test("E-corpus-1 ec1-dbg2: phase trace travels IN-BAND on failure (tail can't see container stdout)", () => {
   // 2026-07-20 실측: `wrangler tail`은 Worker/DO 로그만 보여주고 컨테이너
   // stdout은 포함하지 않는다. 그래서 hang 진단은 in-band로 간다 — 러너가

--- a/docs/simsa-corpus-eval-2026-07-19.md
+++ b/docs/simsa-corpus-eval-2026-07-19.md
@@ -70,3 +70,33 @@ evidence로 리포트를 만들게 하는 구조. 이는 컨테이너 라이브 
 정확성 회귀 없음(오판 0, works=null 유지) — 커버리지 한계일 뿐. 다음 스텝:
 ①wrangler tail로 F7 검수의 마지막 로그 라인 = hang 직전 작업 특정 ②롤아웃 반영
 여부부터 확인(내 강화 로그가 찍히는지).
+
+## 근본 원인 확정 — 5·6차 라이브 계측 (2026-07-20)
+
+관측 경로부터 실측으로 바로잡았다:
+
+1. **`wrangler tail`은 컨테이너 stdout을 포함하지 않는다** (Worker/DO 로그만).
+   "tail로 hang 지점 특정" 계획은 CF Containers에선 성립 불가 → 위상 로그를
+   실패 콜백 error에 실어 report_json으로 회수하는 **in-band 트레이스**(#423)로
+   전환. RUNNER_REV 마커가 롤아웃 반영도 in-band로 검증한다.
+2. 로컬 대조 실험(`heavy-hang-repro.mjs`): 로컬에선 동일 조건(heavy-site+
+   recordVideo+$$eval 부하)에서 browser.close()가 0.1s에 resolve — killTimer
+   설계 자체는 유효, hang은 컨테이너 환경 특이(0.25 vCPU).
+
+6차 실행의 트레이스 (`ec1-dbg2`):
+
+```
++0.0s runner-rev=ec1-dbg2 budgetMs=200000 | ... | +50.4s step:3/3 observe done
+| +50.4s finally:context.close start   ← 마지막 라인, 이후 190s 침묵 → 240s rail
+```
+
+**진범 = finally의 `context.close()`** — 검수 자체는 +50s에 정상 완료됐고,
+recordVideo 파이널라이즈가 0.25 vCPU + 무거운 애니메이션 페이지에서 영영 안
+풀린다. 결정적으로 이전 코드는 close 전에 `clearTimeout(killTimer)`를 먼저
+실행해 유일한 구조 수단까지 해제했다. #412~#418 4차 트레인이 전부 빗나간
+이유 = "검수 중 hang" 가정(실제는 "종료 중 hang").
+
+**수정(ec1-fix1)**: finally의 context.close/browser.close와 video path 대기를
+전부 타임아웃 레이스(`raceOrNull` 15s/10s/5s)로 감싸 리포트 반환을 어떤 정리
+작업의 볼모로도 잡지 않는다. killTimer 해제는 close 시도 이후로 이동. 못 죽인
+Chromium은 per-run 컨테이너 sleepAfter와 함께 죽는다(원래 계약).


### PR DESCRIPTION
## 근본 원인 (in-band 트레이스로 확정)

6차 F7 실행의 트레이스(#423의 `||trace:` 회수):

```
+0.0s runner-rev=ec1-dbg2 budgetMs=200000 | ... | +50.4s step:3/3 observe done
| +50.4s finally:context.close start   ← 마지막 라인, 이후 190s 침묵 → 240s hard rail
```

- **검수는 50초에 정상 완료.** hang은 검수 중이 아니라 **종료 중** — `context.close()`의 recordVideo 파이널라이즈가 0.25 vCPU + 무거운 애니메이션 페이지에서 영영 안 풀림.
- 이전 코드는 close 전에 `clearTimeout(killTimer)`를 먼저 실행 → 유일한 구조 수단 해제. **#412~#418 4차 트레인이 전부 빗나간 이유**("검수 중 hang" 가정).
- 로컬 대조실험: 동일 조건에서 close가 0.1s resolve → 컨테이너 환경 특이 확인.

## 수정

- finally: `context.close()`(15s) / `browser.close()`(10s)를 `raceOrNull` 타임아웃 레이스로 캡 — 리포트 반환을 어떤 정리 작업의 볼모로도 잡지 않음. killTimer 해제는 close 시도 뒤로 이동.
- `page.video().path()` 대기도 5s 레이스(비디오는 선택 증거).
- 못 죽인 Chromium은 per-run 컨테이너의 sleepAfter와 함께 죽는다(원래 계약, 주석 명시).
- `RUNNER_REV=ec1-fix1` · 인바리언트 테스트에 레이스 3종 + killTimer 순서 계약 고정 · 코퍼스 이벨 문서에 근본 원인 절 추가.

## 검증 계획

- 로컬: invariants 13/13, node --check ✅
- 배포 후: F7 → **~60s에 정상 리포트**(빈손 4분 실패 소멸) + F1 무회귀 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)