### PR TITLE
feat(inspection): E-corpus-2 — 위치권한 게이트 통과 + F8 픽스처

### DIFF
--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -32,7 +32,7 @@ import { classifyActionSafety } from "./safety.mjs";
  * whether the container rollout actually picked up the new image (the #412~
  * #418 train could never rule out "old image still serving").
  */
-export const RUNNER_REV = "ec1-fix1";
+export const RUNNER_REV = "ec2-fix1";
 
 /** Forbidden action words handed to the planner (mirrors visual-run.mjs). */
 export const FORBIDDEN_ACTIONS = [
@@ -144,6 +144,12 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
   const context = await browser.newContext({
     viewport: { width: 1280, height: 800 },
     recordVideo: { dir: videoDir, size: { width: 1280, height: 800 } },
+    // E-corpus-2 (2026-07-20): 위치권한 게이트 앱(golf-now류)은 권한 요청이
+    // 미해결로 남으면 차단 화면에 갇혀 검수가 "무엇을 눌러야 할지 못 찾음"에서
+    // 끝난다. 결정론 가짜 좌표(서울시청)를 부여해 권한 뒤의 실제 플로우를
+    // 관찰한다. 위치는 읽기전용 신호 — forbidden-action 안전 레일과 무관.
+    permissions: ["geolocation"],
+    geolocation: { latitude: 37.5665, longitude: 126.978 },
   });
   const page = await context.newPage();
   plog("launch:done");

--- a/apps/central-plane/test/inspector-invariants.test.mjs
+++ b/apps/central-plane/test/inspector-invariants.test.mjs
@@ -177,6 +177,15 @@ test("E-corpus-1 ec1-fix1: finally must never hold the report hostage", () => {
   );
 });
 
+test("E-corpus-2: runner grants deterministic geolocation so permission-gated apps show their real flow", () => {
+  // golf-now류: 권한 요청이 미해결이면 차단 화면에서 검수가 끝난다(C1 실측
+  // "무엇을 눌러 시작해야 할지 못 찾음"). 가짜 좌표 부여는 읽기전용 신호라
+  // 안전 레일과 무관 — 픽스처 F8(/geo-gated)이 판별쌍.
+  const runMjs = readFileSync(path.join(ROOT, "inspector-container/inspector-run.mjs"), "utf8");
+  assert.match(runMjs, /permissions:\s*\["geolocation"\]/, "context must grant geolocation");
+  assert.match(runMjs, /geolocation:\s*\{\s*latitude/, "context must set deterministic coords");
+});
+
 test("E-corpus-1 ec1-dbg2: phase trace travels IN-BAND on failure (tail can't see container stdout)", () => {
   // 2026-07-20 실측: `wrangler tail`은 Worker/DO 로그만 보여주고 컨테이너
   // stdout은 포함하지 않는다. 그래서 hang 진단은 in-band로 간다 — 러너가

--- a/tools/simsa-inspection-fixtures/eval-run.mjs
+++ b/tools/simsa-inspection-fixtures/eval-run.mjs
@@ -39,6 +39,11 @@ const TARGETS = [
   // 러너가 hard 레일에 걸려 빈손 실패하던 클래스. 부분 리포트로 not-false여야.
   { id: "F7", url: `${FIXTURES}/heavy-site`, expected: "working", nullOk: true,
     intent: "기록을 입력하고 추가를 누르면 목록에 저장되어 나타나야 한다" },
+  // E-corpus-2 (2026-07-20): 위치권한 게이트 뒤에 작동 앱 — 러너가 결정론
+  // 좌표로 게이트를 통과해 실플로우(UAR+interacted)에 도달해야 한다. 수정 전엔
+  // 차단 화면만 보고 "무엇을 눌러야 할지 못 찾음"(Needs Clarification)으로 끝남.
+  { id: "F8", url: `${FIXTURES}/geo-gated`, expected: "working", nullOk: true,
+    intent: "산책 기록을 입력하고 추가를 누르면 목록에 저장되어 나타나야 한다" },
   { id: "R1", url: "https://app.trysimsa.com", expected: "working", nullOk: true,
     intent: "방문자가 이 제품이 무엇인지 이해하고 시작할 수 있어야 한다" },
   // 실제-타겟 확장 (2026-07-17, Bae "실유저 vibe 앱 재확인"): 빠르게 만들어

--- a/tools/simsa-inspection-fixtures/src/index.mjs
+++ b/tools/simsa-inspection-fixtures/src/index.mjs
@@ -183,6 +183,46 @@ const OPTIMISTIC_GHOST = SHELL(
 </script>`,
 );
 
+// F8 — GEO-GATED working app (E-corpus-2, 2026-07-20): the entire UI sits
+// behind a geolocation request, mimicking golf-now. Permission unresolved/
+// denied → full-screen blocker with NO usable CTA (the runner used to end at
+// "무엇을 눌러 시작해야 할지 못 찾음"). Permission granted (the runner now
+// injects deterministic Seoul coords) → a working localStorage flow appears.
+// Ground truth: working — the differentiator is whether the inspector gets
+// PAST the permission gate to the real flow.
+const GEO_GATED = SHELL(
+  "동네 산책 기록 🚶",
+  `<div id="blocker">
+  <h1>🚶 동네 산책 기록</h1>
+  <p class="sub">위치 권한을 허용해야 이용할 수 있어요. 브라우저의 위치 권한 요청을 확인해주세요.</p>
+</div>
+<div id="app" style="display:none">
+  <h1>🚶 동네 산책 기록</h1>
+  <p class="sub" id="here">현재 위치를 확인했어요</p>
+  <div class="row"><input id="w" placeholder="예: 한강공원 한 바퀴"><button id="add">추가</button></div>
+  <ul id="list"></ul>
+</div>
+<script>
+  const saved = JSON.parse(localStorage.getItem("walks") || "[]");
+  const list = document.getElementById("list");
+  const render = () => { list.innerHTML = saved.length ? saved.map(t => "<li>👟 " + t + "</li>").join("") : "<li>💬 (아직 기록이 없습니다)</li>"; };
+  navigator.geolocation.getCurrentPosition(
+    (pos) => {
+      document.getElementById("blocker").style.display = "none";
+      document.getElementById("app").style.display = "block";
+      document.getElementById("here").textContent = "현재 위치 (" + pos.coords.latitude.toFixed(2) + ", " + pos.coords.longitude.toFixed(2) + ") 근처를 기록해요";
+      render();
+      document.getElementById("add").addEventListener("click", () => {
+        const v = document.getElementById("w").value.trim() || "산책";
+        saved.push(v); localStorage.setItem("walks", JSON.stringify(saved));
+        document.getElementById("w").value = ""; render();
+      });
+    },
+    () => { /* denied → blocker stays: no usable CTA anywhere */ },
+  );
+</script>`,
+);
+
 const INDEX = SHELL(
   "Simsa inspection fixtures",
   `<h1>Simsa inspection fixtures</h1>
@@ -195,6 +235,7 @@ const INDEX = SHELL(
   <li><a href="/blank">F5 /blank — 빈 페이지</a></li>
   <li><a href="/optimistic-ghost">F6 /optimistic-ghost — 화면만 추가, 저장 없음</a></li>
   <li><a href="/heavy-site">F7 /heavy-site — 무거운 랜딩(작동함, E-corpus-1)</a></li>
+  <li><a href="/geo-gated">F8 /geo-gated — 위치권한 게이트(작동함, E-corpus-2)</a></li>
 </ul>`,
 );
 
@@ -207,6 +248,7 @@ const ROUTES = {
   "/blank": BLANK,
   "/optimistic-ghost": OPTIMISTIC_GHOST,
   "/heavy-site": HEAVY_SITE,
+  "/geo-gated": GEO_GATED,
 };
 
 export default {


### PR DESCRIPTION
## 문제

golf-now류 위치권한 게이트 앱(C1 실측): 권한 요청이 미해결이면 차단 화면에서 검수가 끝나 "무엇을 눌러 시작해야 할지 못 찾음"(Needs Clarification)이 된다 — 오판은 아니지만 실플로우를 못 본다.

## 수정

- 러너 브라우저 컨텍스트에 `permissions:["geolocation"]` + 결정론 좌표(서울시청). 권한 게이트 뒤의 실제 플로우를 관찰. 위치는 읽기전용 신호 — forbidden-action 안전 레일과 무관. `RUNNER_REV=ec2-fix1`.
- 판별쌍 픽스처 **F8 /geo-gated**(전체 UI가 위치권한 뒤에 있는 작동 앱, localStorage 저장) — 픽스처 워커 배포 완료.
- eval 타겟 F8 추가, 인바리언트 14/14.

## 실증 계획 (머지·배포 후)

- F8: 수정 전 기대=차단 화면 종착 → 수정 후 기대=**게이트 통과·interacted·UAR 도달**
- F1 무회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)