### PR TITLE
feat(repair): auto_fix 정직성 — brief_only 사유 in-band + oversize 정직 노트

### DIFF
--- a/apps/central-plane/container/coerce-result.mjs
+++ b/apps/central-plane/container/coerce-result.mjs
@@ -112,6 +112,34 @@ export function classifyCloneError(stderrText) {
 }
 
 /**
+ * auto_fix 정직성 (2026-07-20) — turn the attemptAutoFix diagnosis object into
+ * (a) `modeReason` for the repair-done callback (in-band observability: WHY
+ * did this fall back to brief_only — container stdout is unreachable) and
+ * (b) an optional honest note appended to the brief-only DRAFT PR body when
+ * code files were skipped for size (the single-big-index.html vibe-app class:
+ * apply-walmart 실측 — index.html 389KB > 200KB 상한 → 워커가 앱의 유일한
+ * 실코드를 본 적도 없는데 사용자에겐 그냥 "지시서 PR"로만 보였다).
+ *
+ * Pure. diag: { skippedOversize: [{path, bytes}], reason: string|null }.
+ */
+export function buildBriefOnlyDiagnosis(diag) {
+  const skipped = Array.isArray(diag?.skippedOversize) ? diag.skippedOversize : [];
+  const reason =
+    typeof diag?.reason === "string" && diag.reason ? diag.reason : "worker_no_applicable_fix";
+  const kb = (b) => `${Math.round(b / 1024)}KB`;
+  const list = skipped.map((s) => `${s.path}(${kb(s.bytes)})`).join(", ");
+  const modeReason = skipped.length ? `${reason}; oversize_skipped: ${list}` : reason;
+  const prNote = skipped.length
+    ? [
+        "> **자동수정을 시도하지 못한 파일이 있어요.**",
+        `> ${skipped.map((s) => `\`${s.path}\`(${kb(s.bytes)})`).join(", ")} — 자동수정 크기 한도(200KB)를 넘는 파일이라 워커가 열어보지 못했어요.`,
+        "> 이 지시서(`SIMSA-FIX-BRIEF.md`)를 쓰시는 코딩 에이전트에게 그대로 전달하면 고칠 수 있어요.",
+      ].join("\n")
+    : null;
+  return { modeReason, prNote };
+}
+
+/**
  * Stage 268 — strip a secret from a message before it travels anywhere
  * (callback body, logs). Pure; no-op when the secret is empty.
  */

--- a/apps/central-plane/container/server.mjs
+++ b/apps/central-plane/container/server.mjs
@@ -26,6 +26,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import {
+  buildBriefOnlyDiagnosis,
   buildRepairPrContent,
   classifyCloneError,
   coerceResult,
@@ -485,9 +486,12 @@ async function runRepairJob(payload, anthropicApiKey) {
     // 3. Stage 270 — attempt the real fix. Any failure inside resets the
     //    tree and returns null → brief-only fallback below.
     let autoFix = null;
+    // auto_fix 정직성: attemptAutoFix가 왜 포기했는지의 out-param — brief_only
+    // 콜백의 modeReason과 draft PR 본문의 정직 노트가 여기서 나온다.
+    const diag = { skippedOversize: [], reason: null };
     if (anthropicApiKey) {
       try {
-        autoFix = await attemptAutoFix({ workDir, payload, anthropicApiKey });
+        autoFix = await attemptAutoFix({ workDir, payload, anthropicApiKey, diag });
       } catch (err) {
         console.error(
           `[repair ${jobId}] auto-fix crashed (falling back to brief-only):`,
@@ -499,7 +503,19 @@ async function runRepairJob(payload, anthropicApiKey) {
     }
     const mode = autoFix ? "auto_fix" : "brief_only";
     const changedFiles = autoFix ? autoFix.changedFiles : [];
-    console.log(`[repair ${jobId}] mode=${mode} changedFiles=${changedFiles.length}`);
+    // brief_only 폴백의 사유 — 키 부재는 diag를 거치지 않으므로 직접 명명.
+    let modeReason = null;
+    let briefPrNote = null;
+    if (!autoFix) {
+      if (!anthropicApiKey) {
+        modeReason = "no_anthropic_key";
+      } else {
+        const d = buildBriefOnlyDiagnosis(diag);
+        modeReason = d.modeReason;
+        briefPrNote = d.prNote;
+      }
+    }
+    console.log(`[repair ${jobId}] mode=${mode} changedFiles=${changedFiles.length}${modeReason ? ` reason=${modeReason}` : ""}`);
 
     // 4. Commit. Both modes carry SIMSA-FIX-BRIEF.md (the repair's evidence
     //    + instructions); auto_fix additionally commits the worker's changes.
@@ -512,6 +528,10 @@ async function runRepairJob(payload, anthropicApiKey) {
       title = prContent.title;
       body = prContent.body;
       commitArgs = ["-m", prContent.commitMessage, "-m", prContent.commitBody];
+    } else if (briefPrNote) {
+      // 정직 노트: 크기 한도로 스킵된 핵심 파일이 있으면 draft PR 본문에 밝힌다
+      // (사용자는 왜 코드 수정이 아닌 지시서인지 알 권리가 있다).
+      body = `${body}\n\n${briefPrNote}`;
     }
     await fs.writeFile(path.join(workDir, briefContent.briefFileName), briefContent.briefContent, "utf8");
     await execFileP("git", ["-C", workDir, "config", "user.name", "simsa-repair[bot]"]);
@@ -549,6 +569,7 @@ async function runRepairJob(payload, anthropicApiKey) {
       envCause: envCause === true,
       mode,
       changedFiles: changedFiles.length,
+      ...(modeReason ? { modeReason } : {}),
       durationMs: Date.now() - start,
     });
   } catch (err) {
@@ -619,7 +640,7 @@ async function quickSyntaxCheck(workDir, changedFiles) {
  * worker produced nothing applicable — callers reset the tree + fall back
  * to brief-only. Never leaves a dirty tree on the null path.
  */
-async function attemptAutoFix({ workDir, payload, anthropicApiKey }) {
+async function attemptAutoFix({ workDir, payload, anthropicApiKey, diag = { skippedOversize: [], reason: null } }) {
   const jobId = payload.jobId;
   const deadline = Date.now() + AUTO_FIX_DEADLINE_MS;
 
@@ -633,6 +654,7 @@ async function attemptAutoFix({ workDir, payload, anthropicApiKey }) {
   });
   if (decision.mode !== "auto_fix") {
     console.log(`[repair ${jobId}] auto-fix skipped: ${decision.reason}`);
+    diag.reason = decision.reason;
     return null;
   }
 
@@ -645,6 +667,7 @@ async function attemptAutoFix({ workDir, payload, anthropicApiKey }) {
   const ranked = brief.rankSnapshotCandidates(parsed, repoFiles);
   if (ranked.length === 0) {
     console.log(`[repair ${jobId}] auto-fix skipped: no snapshot candidates in repo`);
+    diag.reason = "no_snapshot_candidates";
     return null;
   }
 
@@ -670,7 +693,14 @@ async function attemptAutoFix({ workDir, payload, anthropicApiKey }) {
     for (const rel of batch) {
       try {
         const stat = await fs.stat(path.join(workDir, rel));
-        if (stat.size > AUTO_FIX_MAX_SNAPSHOT_BYTES) continue;
+        if (stat.size > AUTO_FIX_MAX_SNAPSHOT_BYTES) {
+          // auto_fix 정직성: 크기 한도로 스킵된 파일을 기록한다 — 단일 대형
+          // index.html(vibe 툴 전형)에서 워커가 앱의 유일한 실코드를 본 적도
+          // 없이 brief_only가 되는 케이스(apply-walmart 389KB 실측)를 사용자와
+          // 운영자 모두에게 드러내기 위함.
+          diag.skippedOversize.push({ path: rel, bytes: stat.size });
+          continue;
+        }
         const contents = await fs.readFile(path.join(workDir, rel), "utf8");
         fileSnapshots.push({ path: rel, contents });
         originals[rel] = contents;
@@ -691,10 +721,12 @@ async function attemptAutoFix({ workDir, payload, anthropicApiKey }) {
       });
     } catch (err) {
       console.error(`[repair ${jobId}] worker call failed (iter ${iteration}):`, err?.message ?? err);
+      diag.reason = "worker_call_failed";
       continue;
     }
     if (!Array.isArray(outcome.rewrites) || outcome.rewrites.length === 0) {
       console.log(`[repair ${jobId}] worker returned no rewrites (iter ${iteration})`);
+      diag.reason = "worker_returned_no_rewrites";
       continue;
     }
 
@@ -705,7 +737,10 @@ async function attemptAutoFix({ workDir, payload, anthropicApiKey }) {
           rejected.map((r) => `${r.path}:${r.reason}`).join(", "),
       );
     }
-    if (accepted.length === 0) continue;
+    if (accepted.length === 0) {
+      diag.reason = "rewrites_rejected_by_sanitizer";
+      continue;
+    }
 
     for (const rw of accepted) {
       await fs.writeFile(path.join(workDir, rw.path), rw.content, "utf8");
@@ -719,12 +754,14 @@ async function attemptAutoFix({ workDir, payload, anthropicApiKey }) {
     const changedFiles = diff.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
     if (changedFiles.length === 0) {
       console.log(`[repair ${jobId}] rewrites were no-ops (iter ${iteration})`);
+      diag.reason = "rewrites_were_noops";
       continue;
     }
 
     const verify = await quickSyntaxCheck(workDir, changedFiles);
     if (!verify.ok) {
       console.error(`[repair ${jobId}] syntax check failed on ${verify.file}: ${verify.detail}`);
+      diag.reason = "syntax_check_failed";
       await resetWorkTree(workDir);
       continue;
     }

--- a/apps/central-plane/src/routes/workspace-repair-jobs.ts
+++ b/apps/central-plane/src/routes/workspace-repair-jobs.ts
@@ -410,6 +410,7 @@ export function createWorkspaceRepairJobRoutes(
           envCause?: boolean;
           mode?: string;
           changedFiles?: number;
+          modeReason?: string;
           error?: string;
         }
       | null;
@@ -439,6 +440,12 @@ export function createWorkspaceRepairJobRoutes(
       changedFiles:
         typeof body.changedFiles === "number" && Number.isInteger(body.changedFiles) && body.changedFiles >= 0
           ? body.changedFiles
+          : undefined,
+      // auto_fix 정직성 (2026-07-20): brief_only 폴백 사유(in-band 진단 —
+      // 컨테이너 stdout은 tail로 볼 수 없다). brief_only일 때만 저장.
+      modeReason:
+        body.mode === "brief_only" && typeof body.modeReason === "string" && body.modeReason
+          ? body.modeReason
           : undefined,
     });
     return c.json({ ok: true, status: "done" });

--- a/apps/central-plane/src/workspace/repair-job-db.ts
+++ b/apps/central-plane/src/workspace/repair-job-db.ts
@@ -194,6 +194,15 @@ export async function markRepairJobDone(
     envCause?: boolean;
     mode?: RepairJobMode;
     changedFiles?: number;
+    /**
+     * auto_fix 정직성 (2026-07-20): WHY the container fell back to brief_only
+     * (e.g. "worker_returned_no_rewrites; oversize_skipped: index.html(389KB)").
+     * Stored in the existing `error` column on DONE rows — the dashboard only
+     * renders `error` on FAILED rows, so this is API-level diagnostics without
+     * a migration. Container stdout is unreachable (no tail), so this is the
+     * only place the fallback reason survives.
+     */
+    modeReason?: string;
   },
 ): Promise<void> {
   await env.DB.prepare(
@@ -205,6 +214,7 @@ export async function markRepairJobDone(
             env_cause = CASE WHEN ? = 1 THEN 1 ELSE env_cause END,
             mode = COALESCE(?, mode),
             changed_files = COALESCE(?, changed_files),
+            error = COALESCE(?, error),
             updated_at = ?
       WHERE id = ?`,
   )
@@ -217,6 +227,7 @@ export async function markRepairJobDone(
       typeof input.changedFiles === "number" && Number.isInteger(input.changedFiles) && input.changedFiles >= 0
         ? input.changedFiles
         : null,
+      typeof input.modeReason === "string" && input.modeReason ? input.modeReason.slice(0, 300) : null,
       new Date().toISOString(),
       id,
     )

--- a/apps/central-plane/test/workspace-repair-jobs.test.mjs
+++ b/apps/central-plane/test/workspace-repair-jobs.test.mjs
@@ -70,8 +70,9 @@ function makeDb({ projects = new Map(), checks = [], repos = [], connections = [
               return { meta: { changes: row ? 1 : 0 } };
             }
             if (sql.includes("workspace_repair_jobs") && sql.includes("SET status = 'done'")) {
-              // Stage 270 — markRepairJobDone also binds mode + changed_files.
-              const [pr_url, pr_number, branch_name, env_flag, mode, changed_files, updated_at, id] = args;
+              // Stage 270 — markRepairJobDone binds mode + changed_files;
+              // 2026-07-20 — plus mode_reason (stored into error via COALESCE).
+              const [pr_url, pr_number, branch_name, env_flag, mode, changed_files, mode_reason, updated_at, id] = args;
               const row = jobs.find((r) => r.id === id);
               if (row) {
                 row.status = "done";
@@ -81,6 +82,7 @@ function makeDb({ projects = new Map(), checks = [], repos = [], connections = [
                 if (env_flag === 1) row.env_cause = 1;
                 row.mode = mode ?? row.mode ?? null;
                 row.changed_files = changed_files ?? row.changed_files ?? null;
+                row.error = mode_reason ?? row.error ?? null;
                 row.updated_at = updated_at;
               }
               return { meta: { changes: row ? 1 : 0 } };
@@ -755,6 +757,55 @@ test("Stage 270 repair-done: brief_only fallback persists mode with changedFiles
   assert.equal(r.status, 200);
   assert.equal(env.DB._jobs[0].mode, "brief_only");
   assert.equal(env.DB._jobs[0].changed_files, 0);
+});
+
+test("repair-done modeReason (2026-07-20): brief_only stores WHY in error; auto_fix drops it", async () => {
+  // in-band 진단: 컨테이너 stdout은 tail로 볼 수 없으므로 brief_only 폴백
+  // 사유가 살아남는 유일한 곳이 이 error 컬럼이다(done 행의 error는 대시보드
+  // 실패 카드에 렌더되지 않음 — API 전용 진단).
+  const env = makeEnv({ sandbox: makeSandbox({ names: [], calls: [] }) });
+  const created = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  const jobId = created.json.repair.id;
+
+  const reason = "worker_returned_no_rewrites; oversize_skipped: index.html(389KB)";
+  const r = await req(
+    env, "POST", "/internal/repair-done",
+    { jobId, ok: true, prUrl: "https://github.com/acme/golf-now/pull/41", prNumber: 41, mode: "brief_only", changedFiles: 0, modeReason: reason },
+    { authorization: `Bearer ${TOKEN}` },
+  );
+  assert.equal(r.status, 200);
+  assert.equal(env.DB._jobs[0].error, reason);
+
+  // auto_fix에서는 modeReason이 와도 버린다(성공엔 사유가 필요 없다).
+  const env2 = makeEnv({ sandbox: makeSandbox({ names: [], calls: [] }) });
+  const created2 = await req(env2, "POST", REPAIR_PATH, { userKey: USER });
+  const r2 = await req(
+    env2, "POST", "/internal/repair-done",
+    { jobId: created2.json.repair.id, ok: true, mode: "auto_fix", changedFiles: 1, modeReason: "should_be_dropped" },
+    { authorization: `Bearer ${TOKEN}` },
+  );
+  assert.equal(r2.status, 200);
+  assert.equal(env2.DB._jobs[0].error, null);
+});
+
+test("buildBriefOnlyDiagnosis (pure): oversize files surface in modeReason + honest PR note; plain reason passes through", async () => {
+  const { buildBriefOnlyDiagnosis } = await import("../container/coerce-result.mjs");
+  const withSkip = buildBriefOnlyDiagnosis({
+    skippedOversize: [{ path: "index.html", bytes: 398473 }],
+    reason: "worker_returned_no_rewrites",
+  });
+  assert.match(withSkip.modeReason, /^worker_returned_no_rewrites; oversize_skipped: index\.html\(389KB\)$/);
+  assert.match(withSkip.prNote, /자동수정을 시도하지 못한 파일/);
+  assert.match(withSkip.prNote, /index\.html/);
+  assert.match(withSkip.prNote, /SIMSA-FIX-BRIEF\.md/);
+
+  const plain = buildBriefOnlyDiagnosis({ skippedOversize: [], reason: "no_findings" });
+  assert.equal(plain.modeReason, "no_findings");
+  assert.equal(plain.prNote, null);
+
+  const empty = buildBriefOnlyDiagnosis({});
+  assert.equal(empty.modeReason, "worker_no_applicable_fix");
+  assert.equal(empty.prNote, null);
 });
 
 test("Stage 270 repair-done: invalid mode / negative or non-int changedFiles are dropped; legacy callback (no fields) stays null", async () => {


### PR DESCRIPTION
## 발견 (apply-walmart 라이브 재실증)

어제 brief_only로 빠졌던 apply-walmart를 #422(진단 사다리) 후 재시도 → 여전히 brief_only, 20초 미만. 원인 추적 결과 **진단력 문제가 아니었습니다**: `index.html`이 389KB로 스냅샷 상한(200KB)을 넘어 attemptAutoFix가 **앱의 유일한 실코드 파일을 조용히 스킵** — 워커는 부속 파일(py/ts)만 보고 올바르게 빈 rewrites를 반환한 것.

이 클래스(단일 대형 HTML)는 v0/Lovable류 vibe 툴의 전형 출력이라 실사용에서 반복될 패턴입니다.

## 왜 상한을 안 올리나

워커는 전체-파일 재작성을 냅니다. 389KB 재작성은 출력 토큰 한도에서 잘리고, html은 quickSyntaxCheck 대상도 아니라 **잘린 파일이 그대로 커밋될 위험**이 있습니다. 대형 파일 자동수정은 diff-기반 재작성 별도 트레인으로 남기고, 이 PR은 **정직성**을 넣습니다.

## 변경

- `attemptAutoFix` diag out-param: 포기 사유 + oversize 스킵 목록([{path,bytes}]).
- brief_only 콜백에 `modeReason` → done 행의 error 컬럼에 저장(failed 카드만 error를 렌더하므로 사용자 무영향, API 진단용·마이그레이션 없음). 컨테이너 stdout은 tail 불가(오늘 실측)라 이게 폴백 사유가 살아남는 유일한 경로.
- oversize 스킵 시 draft PR 본문에 정직 노트: "한도 초과라 열어보지 못했어요 — 지시서를 에이전트에게 전달해주세요."
- `buildBriefOnlyDiagnosis` 순수 + 테스트 3건, repair-done 계약 2건. **43/43.**

## 검증 계획

머지·배포 후 apply-walmart 재트리거 → done 행 error에 `oversize_skipped: index.html(389KB)` + PR 본문 노트 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)