### PR TITLE
feat(repair): worker_call_failed 에러 상세 in-band (redact 경유)

### DIFF
--- a/apps/central-plane/container/server.mjs
+++ b/apps/central-plane/container/server.mjs
@@ -511,7 +511,9 @@ async function runRepairJob(payload, anthropicApiKey) {
         modeReason = "no_anthropic_key";
       } else {
         const d = buildBriefOnlyDiagnosis(diag);
-        modeReason = d.modeReason;
+        // diag.reason이 워커 에러 메시지를 담을 수 있다 — 콜백에 나가기 전
+        // 토큰을 반드시 걸러낸다(에러 문자열은 신뢰 경계 밖으로 취급).
+        modeReason = redactSecret(d.modeReason, githubToken);
         briefPrNote = d.prNote;
       }
     }
@@ -721,7 +723,10 @@ async function attemptAutoFix({ workDir, payload, anthropicApiKey, diag = { skip
       });
     } catch (err) {
       console.error(`[repair ${jobId}] worker call failed (iter ${iteration}):`, err?.message ?? err);
-      diag.reason = "worker_call_failed";
+      // 실패 클래스만으론 진단이 안 된다(apply-walmart 실측 — 원인 불명의
+      // worker_call_failed). 메시지 앞부분을 싣는다; 토큰류는 runRepairJob이
+      // 콜백 직전에 redactSecret으로 걸러낸다.
+      diag.reason = `worker_call_failed: ${String(err?.message ?? err).slice(0, 100)}`;
       continue;
     }
     if (!Array.isArray(outcome.rewrites) || outcome.rewrites.length === 0) {


### PR DESCRIPTION
apply-walmart 라이브 실증에서 modeReason이 `worker_call_failed` 클래스명까지만 보고 — 원인 특정 불가. 에러 메시지 앞 100자를 diag에 싣고 콜백 직전 `redactSecret`으로 토큰을 걸러낸다. 다음 자연 발생 repair 런부터 상세가 in-band로 드러난다. 테스트 43/43 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)