### PR TITLE
feat(dashboard): 비공개 repo 연결 안내 — 설치 계정/저장소 선택 함정 가이드

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/settings/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/settings/page.tsx
@@ -607,20 +607,30 @@ export default function SettingsPage() {
                 {lookupPhase === "loading" ? t.github.finding : t.github.connect}
               </button>
             </div>
-            {lookupPhase === "error" && lookupError && (
+            {/* 2026-07-20 (Bae 실측): 비공개 repo의 not_found에서 "공개 저장소인지
+                확인" 빨간 한 줄은 public-강요로 읽혔고, App 설치의 두 함정(계정
+                선택·Repository access 선택)을 안내하지 않아 설치하고도 연결에
+                실패했다. installUrl이 있으면 빨간 에러 대신 구조화된 안내로. */}
+            {lookupPhase === "error" && lookupError && !lookupInstallUrl && (
               <p className="mt-2 text-xs text-red-500">{lookupError}</p>
             )}
             {lookupPhase === "error" && lookupInstallUrl && (
-              <p className="mt-1 text-xs">
+              <div className="callout callout-info mt-2 text-xs leading-relaxed">
+                <p className="font-medium">{t.github.privateGuideTitle}</p>
+                <ol className="mt-1.5 list-decimal space-y-1 pl-4">
+                  <li>{t.github.privateGuideStep1}</li>
+                  <li>{t.github.privateGuideStep2}</li>
+                </ol>
+                <p className="mt-1.5 text-gray-500">{t.github.privateGuideAlready}</p>
                 <a
                   href={lookupInstallUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-brand-700 underline hover:text-brand-800"
+                  className="btn btn-secondary btn-sm mt-2 inline-block"
                 >
                   {t.github.appInstallLink} →
                 </a>
-              </p>
+              </div>
             )}
           </div>
 

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -1097,6 +1097,10 @@ export type Dictionary = {
     errorPrivate: string;
     appInstallHint: string;
     appInstallLink: string;
+    privateGuideTitle: string;
+    privateGuideStep1: string;
+    privateGuideStep2: string;
+    privateGuideAlready: string;
     errorNotConnected: string;
     errorInvalidName: string;
     reposLoadError: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -1197,6 +1197,14 @@ const EN = {
     errorPrivate: "This looks like a private repository. Private repositories can be connected by installing our GitHub App on them. Alternatively, make the repository public: on GitHub, open the repository → Settings → General → Danger Zone → Change visibility → Public.",
     appInstallHint: "This private repository needs our GitHub App. Install it on the repository (or its organization), then try connecting again.",
     appInstallLink: "Install the GitHub App",
+    privateGuideTitle:
+      "Can't see the repository? If the name is right, it's probably private — private repositories work too, once our GitHub App is installed:",
+    privateGuideStep1:
+      "On the install screen, pick the account that OWNS the repository (your personal account vs. an organization — this is the step most people miss).",
+    privateGuideStep2:
+      "Under \"Repository access\", make sure this repository is selected (or choose \"All repositories\").",
+    privateGuideAlready:
+      "Already installed but still failing? The App is likely installed on a different account, or this repository isn't selected — check GitHub Settings → Installations, then try again here (no waiting needed).",
     errorNotConnected: "Connect your GitHub account first.",
     errorInvalidName: "Use the owner/repo format, e.g. 3SVS/My-first-product.",
     reposLoadError: "We could not load repositories. Reconnect GitHub or enter a repository manually.",
@@ -3672,6 +3680,14 @@ const KO = {
     errorPrivate: "비공개 저장소인 것 같아요. 비공개 저장소는 GitHub App을 설치하면 연결할 수 있어요. 또는 저장소를 공개로 바꾸세요: GitHub에서 저장소를 열고 Settings → General → Danger Zone → Change visibility → Public을 선택하세요.",
     appInstallHint: "이 비공개 저장소에는 GitHub App 설치가 필요해요. 저장소(또는 조직)에 App을 설치한 뒤 다시 연결해 보세요.",
     appInstallLink: "GitHub App 설치하기",
+    privateGuideTitle:
+      "저장소가 안 보이나요? 이름이 맞다면 비공개 저장소일 수 있어요 — 비공개 저장소도 GitHub App만 설치하면 연결됩니다:",
+    privateGuideStep1:
+      "설치 화면에서 저장소를 갖고 있는 계정(개인 계정 vs 조직)을 정확히 선택하세요 — 여기서 가장 많이 헷갈려요.",
+    privateGuideStep2:
+      "\"Repository access\"에서 이 저장소가 선택돼 있는지 확인하세요 (또는 \"All repositories\" 선택).",
+    privateGuideAlready:
+      "이미 설치했는데도 안 되나요? 다른 계정에 설치됐거나 저장소가 선택 안 됐을 가능성이 커요 — GitHub 설정 → Installations에서 확인한 뒤 여기서 바로 다시 시도하면 됩니다(기다릴 필요 없음).",
     errorNotConnected: "먼저 GitHub 계정을 연결하세요.",
     errorInvalidName: "owner/repo 형식으로 입력하세요. 예: 3SVS/My-first-product.",
     reposLoadError: "저장소를 불러오지 못했어요. GitHub를 다시 연결하거나 저장소를 직접 입력하세요.",


### PR DESCRIPTION
## 근거 (라이브 계측)

#430 계측 배포 후 tail 재현: `installation lookup 404 (app_id=3620556)` — 서버 자격·JWT 정상(app_id 일치), **GitHub 자체가 "이 repo에 앱 미설치"라고 응답**. 즉 설치가 다른 계정(개인 vs 조직)에 되었거나 Repository access에서 저장소가 선택되지 않은 케이스 — 사용자가 정확히 이 두 함정에서 실패한다.

## 변경

- not_found+installUrl 실패를 빨간 한 줄("공개 저장소인지 확인" — public 강요로 읽힘) 대신 **구조화 안내 callout**으로: "비공개도 연결됩니다" 명시 + ①저장소 소유 계정 선택 ②Repository access 선택 체크리스트 + "이미 설치했는데 안 되면 Installations에서 확인, 재시도 즉시 반영" + 설치 버튼.
- KO/EN 4키. 549/549 · typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)