### PR TITLE
fix(p0): CORS PUT 전멸 + 첫 방문 locale 분열 — 브라우저 전용 결함 2건

### DIFF
--- a/apps/central-plane/src/routes/cors.ts
+++ b/apps/central-plane/src/routes/cors.ts
@@ -25,6 +25,18 @@ export const ALLOWED_ORIGINS = [
   "https://trysimsa.com", // Stage 89/91: Simsa marketing domain (exact origin)
 ];
 
+/**
+ * Canonical browser-method allowlist — the SINGLE place Allow-Methods is
+ * declared. 2026-07-20 P0: PUT was missing from every declaration in the
+ * codebase, and workspace.ts's local "POST, OPTIONS" shadowed stricter routes'
+ * preflights — so the browser blocked the G8 ext-sync PUT for EVERY real
+ * user while node/curl probes (no CORS) stayed green, surfacing as a phantom
+ * "서버 저장에 실패했어요" banner. Allowing a method a route doesn't implement
+ * is harmless (404/405 + auth still apply); missing one silently kills the
+ * feature in browsers only. Keep this complete.
+ */
+export const CORS_ALLOW_METHODS = "GET, POST, PUT, PATCH, DELETE, OPTIONS";
+
 /** Returns CORS headers for `origin`; disallowed origins fall back to the first
  * allowed origin (never echoed). */
 export function corsHeaders(origin: string | null): Record<string, string> {
@@ -34,7 +46,7 @@ export function corsHeaders(origin: string | null): Record<string, string> {
       : (ALLOWED_ORIGINS[0] as string);
   return {
     "Access-Control-Allow-Origin": allowed,
-    "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+    "Access-Control-Allow-Methods": CORS_ALLOW_METHODS,
     "Access-Control-Allow-Headers": "Content-Type, Idempotency-Key, X-Simsa-User-Key",
     "Access-Control-Max-Age": "86400",
     Vary: "Origin",

--- a/apps/central-plane/src/routes/workspace-feedback.ts
+++ b/apps/central-plane/src/routes/workspace-feedback.ts
@@ -12,7 +12,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
-import { ALLOWED_ORIGINS } from "./cors.js";
+import { ALLOWED_ORIGINS, CORS_ALLOW_METHODS } from "./cors.js";
 import { sendWorkspaceTelegramMessage } from "../workspace/telegram-notify.js";
 import { sendWorkspaceEmail } from "../workspace/email-notify.js";
 import { wrapBrandedEmail } from "../workspace/email-brand.js";
@@ -27,7 +27,7 @@ function corsHeaders(origin: string | null): Record<string, string> {
       : (ALLOWED_ORIGINS[0] as string);
   return {
     "Access-Control-Allow-Origin": allowed,
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Methods": CORS_ALLOW_METHODS,
     "Access-Control-Allow-Headers": "Content-Type, Idempotency-Key, X-Simsa-User-Key",
     "Access-Control-Max-Age": "86400",
   };

--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -21,7 +21,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
-import { ALLOWED_ORIGINS } from "./cors.js";
+import { ALLOWED_ORIGINS, CORS_ALLOW_METHODS } from "./cors.js";
 import { BRAND } from "../workspace/brand.js";
 import type { FetchLike } from "../github.js";
 import { encryptToken, decryptToken } from "../crypto.js";
@@ -97,7 +97,7 @@ function corsHeaders(origin: string | null): Record<string, string> {
       : (ALLOWED_ORIGINS[0] as string);
   return {
     "Access-Control-Allow-Origin": allowed,
-    "Access-Control-Allow-Methods": "GET, POST, PATCH, OPTIONS",
+    "Access-Control-Allow-Methods": CORS_ALLOW_METHODS,
     "Access-Control-Allow-Headers": "Content-Type, Idempotency-Key, X-Simsa-User-Key",
     "Access-Control-Max-Age": "86400",
   };

--- a/apps/central-plane/src/routes/workspace-notifications.ts
+++ b/apps/central-plane/src/routes/workspace-notifications.ts
@@ -15,7 +15,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
-import { ALLOWED_ORIGINS } from "./cors.js";
+import { ALLOWED_ORIGINS, CORS_ALLOW_METHODS } from "./cors.js";
 import type { FetchLike } from "../github.js";
 import {
   upsertNotificationSettings,
@@ -53,7 +53,7 @@ function corsHeaders(origin: string | null): Record<string, string> {
       : (ALLOWED_ORIGINS[0] as string);
   return {
     "Access-Control-Allow-Origin": allowed,
-    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Methods": CORS_ALLOW_METHODS,
     "Access-Control-Allow-Headers": "Content-Type, Idempotency-Key, X-Simsa-User-Key",
     "Access-Control-Max-Age": "86400",
   };

--- a/apps/central-plane/src/routes/workspace-training-consent.ts
+++ b/apps/central-plane/src/routes/workspace-training-consent.ts
@@ -15,7 +15,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
-import { ALLOWED_ORIGINS } from "./cors.js";
+import { ALLOWED_ORIGINS, CORS_ALLOW_METHODS } from "./cors.js";
 import {
   TRAINING_CONSENT_VERSION,
   getTrainingConsent,
@@ -29,7 +29,7 @@ function corsHeaders(origin: string | null): Record<string, string> {
       : (ALLOWED_ORIGINS[0] as string);
   return {
     "Access-Control-Allow-Origin": allowed,
-    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Methods": CORS_ALLOW_METHODS,
     "Access-Control-Allow-Headers": "Content-Type, Idempotency-Key, X-Simsa-User-Key",
     "Access-Control-Max-Age": "86400",
   };

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -12,7 +12,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
-import { ALLOWED_ORIGINS } from "./cors.js";
+import { ALLOWED_ORIGINS, CORS_ALLOW_METHODS } from "./cors.js";
 import { generateIdeaToSpecDraft, toClientDraft, type IdeaToSpecDraftRequest } from "../workspace/generate.js";
 import { sendLangfuseGeneration } from "../workspace/langfuse.js";
 import { normalizeBuiltWith } from "../workspace/built-with.js";
@@ -78,7 +78,7 @@ function corsHeaders(origin: string | null): Record<string, string> {
       : (ALLOWED_ORIGINS[0] as string);
   return {
     "Access-Control-Allow-Origin": allowed,
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Methods": CORS_ALLOW_METHODS,
     "Access-Control-Allow-Headers": "Content-Type, Idempotency-Key, X-Simsa-User-Key",
     "Access-Control-Max-Age": "86400",
   };
@@ -457,7 +457,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
   // deleteProject() in workspace/db.ts.
   app.delete("/workspace/projects/:id", async (c) => {
     const origin = c.req.header("origin") ?? null;
-    const headers = { ...corsHeaders(origin), "Access-Control-Allow-Methods": "GET, DELETE, OPTIONS" };
+    const headers = { ...corsHeaders(origin), "Access-Control-Allow-Methods": CORS_ALLOW_METHODS };
     const id = c.req.param("id");
     const userKey = c.req.query("userKey") ?? "";
     if (!userKey) {
@@ -796,7 +796,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
   // Deterministic — no LLM, no rate limit. Assembles markdown files from project data.
   app.post("/workspace/export-builder-pack", async (c) => {
     const origin = c.req.header("origin") ?? null;
-    const headers = { ...corsHeaders(origin), "Access-Control-Allow-Methods": "POST, OPTIONS" };
+    const headers = { ...corsHeaders(origin), "Access-Control-Allow-Methods": CORS_ALLOW_METHODS };
 
     let body: unknown;
     try { body = await c.req.json(); } catch {
@@ -887,7 +887,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
   // Save the result of sending a builder pack to Claude Code / Codex.
   app.post("/workspace/builder-pack-outcomes", async (c) => {
     const origin = c.req.header("origin") ?? null;
-    const headers = { ...corsHeaders(origin), "Access-Control-Allow-Methods": "POST, GET, OPTIONS" };
+    const headers = { ...corsHeaders(origin), "Access-Control-Allow-Methods": CORS_ALLOW_METHODS };
 
     let body: unknown;
     try { body = await c.req.json(); } catch {
@@ -939,7 +939,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
   // Ownership-enforced: 404 not_found for missing OR not-owned project.
   app.get("/workspace/projects/:id/builder-pack-outcomes", async (c) => {
     const origin = c.req.header("origin") ?? null;
-    const headers = { ...corsHeaders(origin), "Access-Control-Allow-Methods": "POST, GET, OPTIONS" };
+    const headers = { ...corsHeaders(origin), "Access-Control-Allow-Methods": CORS_ALLOW_METHODS };
     const projectId = c.req.param("id");
     const userKey = c.req.query("userKey") ?? "";
     if (!userKey) {

--- a/apps/central-plane/test/workspace-cors.test.mjs
+++ b/apps/central-plane/test/workspace-cors.test.mjs
@@ -106,3 +106,39 @@ test("P0: oauth/start redirect through global CORS does not 500 (immutable heade
   assert.equal(res.status, 302, "GitHub auth redirect preserved");
   assert.ok(res.headers.get("location")?.includes("github.com"), "Location header survives the rebuild");
 });
+
+// ─── 2026-07-20 P0: PUT이 어떤 Allow-Methods 선언에도 없어 브라우저에서만
+// G8 ext-sync PUT이 전멸("서버 저장에 실패했어요" 유령 배너). node/curl 프로브는
+// CORS를 안 타서 8/8 green이었다. 계약: Allow-Methods 문자열 리터럴은 cors.ts의
+// CORS_ALLOW_METHODS 단일 정본만 존재하고, 정본은 완전한 메서드 목록을 갖는다.
+test("P0: Allow-Methods single source of truth — complete list, no stray literals", async () => {
+  const { readdirSync, readFileSync } = await import("node:fs");
+  const path = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+  const routesDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "../src/routes");
+
+  const { CORS_ALLOW_METHODS } = await import("../dist/routes/cors.js");
+  for (const m of ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]) {
+    assert.ok(CORS_ALLOW_METHODS.includes(m), `canonical list must include ${m}`);
+  }
+
+  for (const file of readdirSync(routesDir)) {
+    if (!file.endsWith(".ts") || file === "cors.ts") continue;
+    const src = readFileSync(path.join(routesDir, file), "utf8");
+    const literal = /"Access-Control-Allow-Methods"\s*:\s*"/.exec(src);
+    assert.ok(!literal, `${file} declares a hardcoded Allow-Methods literal — use CORS_ALLOW_METHODS from cors.ts`);
+  }
+});
+
+test("P0: /workspace/projects/:id/ext preflight allows PUT (the G8 sync method)", async () => {
+  const res = await createApp().fetch(
+    new Request("http://x/workspace/projects/proj_x/ext", {
+      method: "OPTIONS",
+      headers: { origin: APP, "access-control-request-method": "PUT" },
+    }),
+    makeEnv(),
+    CTX,
+  );
+  assert.equal(res.status, 204);
+  assert.match(res.headers.get("access-control-allow-methods") ?? "", /PUT/);
+});

--- a/apps/dashboard/src/i18n/I18nProvider.tsx
+++ b/apps/dashboard/src/i18n/I18nProvider.tsx
@@ -29,6 +29,11 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
       typeof navigator !== "undefined" ? navigator.language : null
     );
     if (initial !== locale) setLocaleState(initial);
+    // 2026-07-20 P1: 감지된 locale을 즉시 저장한다. 저장하지 않으면 UI는
+    // ko(감지)인데 API 호출부(readStoredLocale — 저장값 없음 → 기본 en)는
+    // en을 보내서, 토글을 안 건드린 한국 첫 방문 유저의 제품 설명서가
+    // 영어로 생성됐다(journey-audit 실측). UI 언어와 API 언어의 단일화.
+    writeStoredLocale(typeof window !== "undefined" ? window.localStorage : null, initial);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/tools/simsa-completion-loop-spike/journey-audit.mjs
+++ b/tools/simsa-completion-loop-spike/journey-audit.mjs
@@ -1,0 +1,157 @@
+/**
+ * journey-audit.mjs — 신규 유저 시점 "갈래 완주" QA (2026-07-20, Bae:
+ * "왜 이렇게 플로우에 허점이 많아 — 뭘 돌린 거야 QA").
+ *
+ * flow-audit.mjs(아이디어 갈래+탭 순회)가 못 걸었던 표면을 채점한다:
+ *   J1 기존-앱(code) 갈래 완주 — 무엇을 묻는가, 만들고 나면 어디로 떨어지고
+ *      다음 행동이 보이는가, GitHub 없는 유저의 막힘 안내가 있는가
+ *   J2 기획서(spec) 갈래 완주 — 붙여넣기→변환→저장 후 다음 행동
+ *   J3 checks 첫 화면 — 검수 모드 선택 가시성, 소스 없이 실행 시 막힘 안내
+ *   J4 repo 연결 여정(익명) — 연결 화면에서 비개발자가 다음 행동을 아는가
+ *
+ * 채점 축(스텝마다 기록): primaryCta(다음 행동이 버튼으로 보이는가),
+ * blockedGuidance(막혔을 때 이유+해법 카피), deadEnd(전진 CTA 부재),
+ * errorish(오류 신호). 스크립트는 측정만 하고 판정은 산출물을 읽고 내린다.
+ *
+ * Usage: node journey-audit.mjs   → journey-audit-shots/*.png + journey-audit-result.json
+ */
+import { chromium } from "playwright";
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const BASE = "https://app.trysimsa.com";
+const SHOTS = new URL("./journey-audit-shots", import.meta.url).pathname.replace(/^\/(\w):/, "$1:");
+mkdirSync(SHOTS, { recursive: true });
+
+const browser = await chromium.launch();
+const audit = { startedAt: new Date().toISOString(), journeys: [] };
+
+async function newUserPage() {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  return ctx.newPage();
+}
+
+async function facts(page, label, note = "") {
+  const f = await page.evaluate(() => {
+    const vis = (el) => el.offsetParent !== null;
+    const texts = (sel) => [...document.querySelectorAll(sel)].filter(vis).map((e) => (e.innerText || "").trim().replace(/\s+/g, " ")).filter(Boolean);
+    const buttons = texts("button, a.btn, [role=button]");
+    const body = (document.body.innerText || "").replace(/\s+/g, " ");
+    return {
+      h1: texts("h1").slice(0, 2),
+      buttons: buttons.slice(0, 24),
+      primaryCta: [...document.querySelectorAll(".btn-primary, button[class*='primary']")].filter(vis).map((e) => (e.innerText || "").trim().replace(/\s+/g, " ")).filter(Boolean).slice(0, 5),
+      bodyLen: body.length,
+      errorish: (body.match(/문제가 발생|불러오지 못|오류가|실패했|다시 시도/g) ?? []).length,
+      guidanceish: (body.match(/연결해 주세요|연결하세요|먼저|필요해요|이렇게 하세요|설치/g) ?? []).length,
+      bodyHead: body.slice(0, 400),
+    };
+  });
+  const row = { label, note, url: page.url(), ...f };
+  audit.journeys.at(-1).steps.push(row);
+  await page.screenshot({ path: `${SHOTS}/${audit.journeys.length}-${audit.journeys.at(-1).steps.length}-${label.replace(/[^\w가-힣-]/g, "_").slice(0, 40)}.png` }).catch(() => {});
+  console.log(`  [${label}] cta=${JSON.stringify(f.primaryCta)} err=${f.errorish} guide=${f.guidanceish}`);
+  return row;
+}
+
+function journey(name) {
+  audit.journeys.push({ name, steps: [], failure: null });
+  console.log(`\n▶ ${name}`);
+}
+
+// ── J1: 기존-앱(code) 갈래 완주 ────────────────────────────────────────────────
+try {
+  journey("J1 기존-앱 갈래: 만든 앱 검수받기 완주");
+  const page = await newUserPage();
+  await page.goto(`${BASE}/projects/new`, { waitUntil: "networkidle", timeout: 45000 });
+  await facts(page, "갈래 선택 화면");
+  // chooser에서 code 갈래 진입 (문구는 갈래 카드 — '이미'/'만든' 계열 텍스트)
+  const codeCard = page.getByRole("button", { name: /이미|만든|검수/ }).first();
+  if (await codeCard.count()) { await codeCard.click(); } else {
+    await page.goto(`${BASE}/projects/new?path=code`, { waitUntil: "networkidle" });
+  }
+  await page.waitForTimeout(800);
+  await facts(page, "code 갈래 스텝1 — 무엇을 묻는가");
+  // ★사이드바 검색 input이 first("input")에 걸린다 — 본문 필드는 placeholder로.
+  await page.getByPlaceholder(/나의 첫|쇼핑몰/).fill("동네 빵집 예약 테스트앱");
+  const descBox = page.locator("textarea").first();
+  if (await descBox.count()) await descBox.fill("빵을 예약하고 픽업 시간을 고르는 앱");
+  await facts(page, "code 스텝1 입력 후");
+  await page.getByRole("button", { name: /프로젝트 만들/ }).first().click();
+  await page.waitForURL(/projects\/(?!new)/, { timeout: 90000 }).catch(() => {});
+  await page.waitForTimeout(2500);
+  await facts(page, "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가");
+  // 개요로 이동해 '지금 할 일' 확인
+  const pid = (page.url().match(/projects\/([^/?#]+)/) ?? [])[1];
+  if (pid) {
+    await page.goto(`${BASE}/projects/${pid}`, { waitUntil: "networkidle", timeout: 45000 });
+    await facts(page, "개요 — 지금 할 일이 이 갈래에 맞는가");
+    await page.goto(`${BASE}/projects/${pid}/checks`, { waitUntil: "networkidle", timeout: 45000 });
+    await facts(page, "checks 첫 화면 — 모드 선택 보이는가/소스 없이 뭐라 하는가");
+    // 검수 실행 버튼을 눌러 소스 없는 막힘 안내 확인
+    const runBtn = page.getByRole("button", { name: /검수|확인/ }).first();
+    if (await runBtn.count()) {
+      await runBtn.click().catch(() => {});
+      await page.waitForTimeout(2500);
+      await facts(page, "소스 없이 검수 시도 — 막힘 안내");
+    }
+  } else {
+    audit.journeys.at(-1).failure = "프로젝트 생성 후 URL에서 id를 못 얻음";
+  }
+  await page.context().close();
+} catch (err) {
+  audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
+}
+
+// ── J2: 기획서(spec) 갈래 완주 ────────────────────────────────────────────────
+try {
+  journey("J2 기획서 갈래: 붙여넣기→변환→다음 행동");
+  const page = await newUserPage();
+  await page.goto(`${BASE}/projects/new?path=spec`, { waitUntil: "networkidle", timeout: 45000 });
+  await facts(page, "spec 갈래 스텝1");
+  await page.locator("main textarea, textarea").first().fill("제품: 반려견 산책 기록 앱\n기능: 산책 시작/종료 기록, 주간 거리 통계, 기록 공유\n대상: 반려견 보호자");
+  await page.getByRole("button", { name: /확인 항목으로 바꾸기/ }).first().click();
+  await page.waitForTimeout(1500);
+  await facts(page, "변환 중/직후");
+  // 변환은 실 LLM — 최대 60s 대기 후 저장 버튼 탐색
+  for (let i = 0; i < 12; i++) {
+    if (await page.getByRole("button", { name: /저장|프로젝트로/ }).count()) break;
+    await page.waitForTimeout(5000);
+  }
+  await facts(page, "변환 결과 화면");
+  const saveBtn = page.getByRole("button", { name: /저장|프로젝트로/ }).first();
+  if (await saveBtn.count()) {
+    await saveBtn.click();
+    await page.waitForURL(/projects\/(?!new)/, { timeout: 30000 }).catch(() => {});
+    await page.waitForTimeout(2000);
+    await facts(page, "저장 후 랜딩 — 다음 행동");
+  }
+  await page.context().close();
+} catch (err) {
+  audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
+}
+
+// ── J3+J4: repo 연결 여정 (익명 — GitHub 미연결 상태) ─────────────────────────
+try {
+  journey("J3 repo 연결 여정: GitHub 미연결 신규 유저");
+  const page = await newUserPage();
+  // 샘플 아님 실 프로젝트가 필요 — J1에서 만든 프로젝트를 재사용할 수 없어(다른 컨텍스트)
+  // 로컬-우선 앱 특성상 새로 하나 만들지 않고, 프로젝트 없이 연결 화면 관찰이 목적이므로
+  // code 갈래로 최소 생성(설명 생략) 후 settings로.
+  await page.goto(`${BASE}/projects/new?path=code`, { waitUntil: "networkidle", timeout: 45000 });
+  await page.getByPlaceholder(/나의 첫|쇼핑몰/).fill("연결 여정 테스트");
+  await page.getByRole("button", { name: /프로젝트 만들/ }).first().click();
+  await page.waitForURL(/projects\/(?!new)/, { timeout: 60000 }).catch(() => {});
+  await page.waitForTimeout(1500);
+  await facts(page, "settings/연결 화면 — 미연결 유저가 보는 것");
+  const ghBtn = page.getByRole("button", { name: /GitHub|깃허브|연결/ }).first();
+  if (await ghBtn.count()) {
+    await facts(page, "GitHub 연결 CTA 존재 확인", (await ghBtn.innerText().catch(() => "")).slice(0, 60));
+  }
+  await page.context().close();
+} catch (err) {
+  audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
+}
+
+writeFileSync(new URL("./journey-audit-result.json", import.meta.url), JSON.stringify(audit, null, 2));
+console.log("\nsaved: journey-audit-result.json / shots:", SHOTS);
+await browser.close();


### PR DESCRIPTION
## 배경

Bae: "왜 이렇게 플로우에 허점이 많아 — 뭘 돌린 거야 QA" → 신규 유저 시점 **journey-audit**(3갈래 완주+연결 여정, 신설·커밋 포함)를 프로덕션에 돌려 브라우저에서만 터지는 결함 2건을 실측으로 확정.

## 1. CORS PUT 전멸 (P0)

- Allow-Methods 선언 6곳 어디에도 **PUT 없음** + workspace.ts 로컬 `POST, OPTIONS`가 하위 라우트 프리플라이트를 그림자.
- 결과: **G8 ext 서버 동기화(PUT)가 실브라우저 유저 전원에게 차단** — "서버 저장에 실패했어요" 유령 배너(여정 재현 2/2). node/curl 프로브는 CORS를 안 타서 라이브 8/8이 전부 green이었던 관측 사각.
- 수정: `CORS_ALLOW_METHODS` 단일 정본 + 6곳 정본 참조 + 인바리언트 2건(스트레이 리터럴 금지 / ext PUT 프리플라이트 계약).

## 2. 첫 방문 locale 분열 (P1)

- UI는 `detectInitialLocale`(ko 감지)인데 API 호출부 `readStoredLocale`은 저장값 없음→기본 **en** — 토글을 안 건드린 한국 첫 방문 유저의 제품 설명서가 **영어**로 생성(여정 실측, API 직접 locale:ko는 완전 한국어 확인).
- 수정: 감지 locale 즉시 저장 — UI/API 언어 단일화.

## 검증

- central `workspace-cors` 12/12 · dashboard 549/549 · typecheck green
- 배포 후: journey-audit 재실행 → 배너 소멸 + 스펙 한국어 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)