### PR TITLE
fix(saas): installation_repositories 웹훅 반영 — selected_repo_ids stale 해소

### DIFF
--- a/apps/central-plane/src/db/saas.ts
+++ b/apps/central-plane/src/db/saas.ts
@@ -397,6 +397,62 @@ export async function upsertInstallation(
     .run();
 }
 
+/** Apply an `installation_repositories` webhook (repos added/removed on an
+ *  existing installation) to gh_app_installations. GitHub sends only the
+ *  delta plus the new repository_selection, so we merge with the stored
+ *  list. `repository_selection === "all"` normalizes the list to NULL
+ *  (= no filter). Returns false when the installation row is missing
+ *  (install webhook missed) so the caller can rebuild from the payload.
+ *
+ *  2026-07-20 실측: 이 이벤트를 무시해 selected_repo_ids가 설치 시점에
+ *  고정돼 있었다(추가된 repo가 D1에 안 보임). 게이팅에는 아직 안 쓰는
+ *  컬럼이지만, stale 데이터는 다음 소비자가 생기는 순간 버그가 된다. */
+export async function applyInstallationRepoChange(
+  env: Env,
+  input: {
+    installationId: number;
+    repoSelection: "all" | "selected";
+    addedRepoIds: number[];
+    removedRepoIds: number[];
+  },
+): Promise<boolean> {
+  const row = await env.DB.prepare(
+    `SELECT selected_repo_ids FROM gh_app_installations
+      WHERE installation_id = ? AND removed_at IS NULL`,
+  )
+    .bind(input.installationId)
+    .first<{ selected_repo_ids: string | null }>();
+  if (!row) return false;
+
+  let selected: string | null;
+  if (input.repoSelection === "all") {
+    selected = null;
+  } else {
+    let current: number[] = [];
+    if (row.selected_repo_ids) {
+      try {
+        const parsed: unknown = JSON.parse(row.selected_repo_ids);
+        if (Array.isArray(parsed)) {
+          current = parsed.filter((n): n is number => typeof n === "number");
+        }
+      } catch {
+        // corrupt stored list → rebuild from this delta alone
+      }
+    }
+    const removed = new Set(input.removedRepoIds);
+    const merged = new Set(current.filter((id) => !removed.has(id)));
+    for (const id of input.addedRepoIds) merged.add(id);
+    selected = JSON.stringify([...merged]);
+  }
+
+  await env.DB.prepare(
+    `UPDATE gh_app_installations SET repo_selection = ?, selected_repo_ids = ? WHERE installation_id = ?`,
+  )
+    .bind(input.repoSelection, selected, input.installationId)
+    .run();
+  return true;
+}
+
 export async function suspendInstallation(env: Env, installationId: number): Promise<void> {
   const now = new Date().toISOString();
   await env.DB.prepare(`UPDATE gh_app_installations SET suspended_at = ? WHERE installation_id = ?`)

--- a/apps/central-plane/src/routes/saas-auth.ts
+++ b/apps/central-plane/src/routes/saas-auth.ts
@@ -24,6 +24,7 @@
 import { Hono } from "hono";
 import type { Env } from "../env.js";
 import {
+  applyInstallationRepoChange,
   approveDeviceCode,
   cancelMarketplaceSubscription,
   clearPendingMarketplaceChange,
@@ -146,6 +147,46 @@ export function createSaasAuthRoutes(): Hono<{ Bindings: Env }> {
       } else if (action === "unsuspend") {
         await unsuspendInstallation(env, installationId);
       }
+      return c.json({ ok: true, event, action, delivery });
+    }
+
+    // Repo-access edits on an existing installation ("Only select
+    // repositories" add/remove, or flipping to "All repositories").
+    // Ignoring this left selected_repo_ids frozen at install time
+    // (2026-07-20 실측: Bae's row still showed the single repo picked
+    // back in May). The column isn't consumed by gating yet, but stale
+    // data becomes a bug the moment a consumer appears.
+    if (event === "installation_repositories") {
+      const inst = (p["installation"] ?? {}) as Record<string, unknown>;
+      const installationId = Number(inst["id"]);
+      const repoSelection = String(inst["repository_selection"] ?? "selected") === "all" ? "all" as const : "selected" as const;
+      const addedRaw = (p["repositories_added"] ?? []) as Array<{ id: number }>;
+      const removedRaw = (p["repositories_removed"] ?? []) as Array<{ id: number }>;
+      const addedRepoIds = Array.isArray(addedRaw) ? addedRaw.map((r) => Number(r.id)).filter(Number.isFinite) : [];
+      const removedRepoIds = Array.isArray(removedRaw) ? removedRaw.map((r) => Number(r.id)).filter(Number.isFinite) : [];
+
+      const applied = await applyInstallationRepoChange(env, {
+        installationId,
+        repoSelection,
+        addedRepoIds,
+        removedRepoIds,
+      });
+      if (!applied) {
+        // Row missing — the install webhook was missed or the row was
+        // marked removed. Rebuild from this payload's installation object.
+        const account = (inst["account"] ?? {}) as Record<string, unknown>;
+        await upsertInstallation(env, {
+          installationId,
+          accountLogin: String(account["login"] ?? ""),
+          accountId: Number(account["id"] ?? 0),
+          targetType: String(inst["target_type"] ?? "User") === "Organization" ? "Organization" : "User",
+          repoSelection,
+          selectedRepoIds: repoSelection === "selected" && addedRepoIds.length > 0 ? addedRepoIds : null,
+        });
+      }
+      console.log(
+        `[webhook] installation_repositories ${action} inst=${installationId} +${addedRepoIds.length} -${removedRepoIds.length} sel=${repoSelection}${applied ? "" : " (row rebuilt)"}`,
+      );
       return c.json({ ok: true, event, action, delivery });
     }
 

--- a/apps/central-plane/test/installation-repos-webhook.test.mjs
+++ b/apps/central-plane/test/installation-repos-webhook.test.mjs
@@ -1,0 +1,152 @@
+/**
+ * installation_repositories webhook — data-layer tests for
+ * applyInstallationRepoChange (db/saas.ts). Pins the merge semantics:
+ *   - added ids merge into the stored selected_repo_ids
+ *   - removed ids drop out
+ *   - repository_selection = "all" normalizes the list to NULL
+ *   - missing row → false (caller rebuilds via upsertInstallation)
+ *   - corrupt stored JSON → rebuilt from the delta alone
+ *
+ * Why this exists: the webhook ignored this event entirely, so
+ * selected_repo_ids stayed frozen at install time (2026-07-20 실측 —
+ * a row still showed the single repo picked back in May).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyInstallationRepoChange } from "../dist/db/saas.js";
+
+function makeMockDb({ rows = [] } = {}) {
+  const state = { rows: rows.map((r) => ({ ...r })) };
+  return {
+    state,
+    prepare(sql) {
+      let bound = [];
+      const handlers = {
+        async first() {
+          if (/SELECT selected_repo_ids FROM gh_app_installations/.test(sql)) {
+            const row = state.rows.find(
+              (r) => r.installation_id === bound[0] && !r.removed_at,
+            );
+            return row ? { selected_repo_ids: row.selected_repo_ids } : null;
+          }
+          return null;
+        },
+        async run() {
+          if (/UPDATE gh_app_installations SET repo_selection/.test(sql)) {
+            const [sel, selectedJson, id] = bound;
+            const row = state.rows.find((r) => r.installation_id === id);
+            if (row) {
+              row.repo_selection = sel;
+              row.selected_repo_ids = selectedJson;
+            }
+            return { success: true, meta: { changes: row ? 1 : 0 } };
+          }
+          return { success: true, meta: { changes: 0 } };
+        },
+      };
+      return {
+        bind(...args) {
+          bound = args;
+          return handlers;
+        },
+      };
+    },
+  };
+}
+
+const env = (db) => ({ DB: db });
+
+const ROW = {
+  installation_id: 129987651,
+  account_login: "someone",
+  repo_selection: "selected",
+  selected_repo_ids: "[1188037554]",
+  removed_at: null,
+};
+
+test("added repo ids merge into the stored list", async () => {
+  const db = makeMockDb({ rows: [ROW] });
+  const ok = await applyInstallationRepoChange(env(db), {
+    installationId: 129987651,
+    repoSelection: "selected",
+    addedRepoIds: [1305786142],
+    removedRepoIds: [],
+  });
+  assert.equal(ok, true);
+  assert.deepEqual(JSON.parse(db.state.rows[0].selected_repo_ids), [1188037554, 1305786142]);
+  assert.equal(db.state.rows[0].repo_selection, "selected");
+});
+
+test("removed repo ids drop out of the stored list", async () => {
+  const db = makeMockDb({
+    rows: [{ ...ROW, selected_repo_ids: "[1188037554,1305786142]" }],
+  });
+  const ok = await applyInstallationRepoChange(env(db), {
+    installationId: 129987651,
+    repoSelection: "selected",
+    addedRepoIds: [],
+    removedRepoIds: [1188037554],
+  });
+  assert.equal(ok, true);
+  assert.deepEqual(JSON.parse(db.state.rows[0].selected_repo_ids), [1305786142]);
+});
+
+test("re-added id does not duplicate", async () => {
+  const db = makeMockDb({ rows: [ROW] });
+  const ok = await applyInstallationRepoChange(env(db), {
+    installationId: 129987651,
+    repoSelection: "selected",
+    addedRepoIds: [1188037554],
+    removedRepoIds: [],
+  });
+  assert.equal(ok, true);
+  assert.deepEqual(JSON.parse(db.state.rows[0].selected_repo_ids), [1188037554]);
+});
+
+test('selection flipped to "all" normalizes the list to NULL', async () => {
+  const db = makeMockDb({ rows: [ROW] });
+  const ok = await applyInstallationRepoChange(env(db), {
+    installationId: 129987651,
+    repoSelection: "all",
+    addedRepoIds: [99, 100],
+    removedRepoIds: [],
+  });
+  assert.equal(ok, true);
+  assert.equal(db.state.rows[0].selected_repo_ids, null);
+  assert.equal(db.state.rows[0].repo_selection, "all");
+});
+
+test("missing installation row → false, nothing written", async () => {
+  const db = makeMockDb({ rows: [] });
+  const ok = await applyInstallationRepoChange(env(db), {
+    installationId: 42,
+    repoSelection: "selected",
+    addedRepoIds: [1],
+    removedRepoIds: [],
+  });
+  assert.equal(ok, false);
+  assert.equal(db.state.rows.length, 0);
+});
+
+test("removed_at row is treated as missing", async () => {
+  const db = makeMockDb({ rows: [{ ...ROW, removed_at: "2026-07-01T00:00:00Z" }] });
+  const ok = await applyInstallationRepoChange(env(db), {
+    installationId: 129987651,
+    repoSelection: "selected",
+    addedRepoIds: [1],
+    removedRepoIds: [],
+  });
+  assert.equal(ok, false);
+});
+
+test("corrupt stored JSON → list rebuilt from the delta alone", async () => {
+  const db = makeMockDb({ rows: [{ ...ROW, selected_repo_ids: "not-json{" }] });
+  const ok = await applyInstallationRepoChange(env(db), {
+    installationId: 129987651,
+    repoSelection: "selected",
+    addedRepoIds: [7, 8],
+    removedRepoIds: [],
+  });
+  assert.equal(ok, true);
+  assert.deepEqual(JSON.parse(db.state.rows[0].selected_repo_ids), [7, 8]);
+});


### PR DESCRIPTION
## 배경 (2026-07-20 Test B 진단 중 실측)

GitHub App 설치 후 **repository access를 편집(repo 추가/제거)** 하면 GitHub이 `installation_repositories` 웹훅을 보내는데, 핸들러가 이 이벤트를 무시해 `gh_app_installations.selected_repo_ids`가 **설치 시점에 고정**돼 있었다. Bae 계정 설치 행(129987651)이 5월에 고른 repo 1개(eventbadge)로 굳어 있었고, 오늘 simsa-autofix-test 추가가 D1에 반영되지 않음을 확인.

소비처 전수 검색 결과 이 컬럼은 현재 저장·파싱만 되고 게이팅에는 안 쓰임(설치 조회는 전부 installation_id/account_login 기준) — **현재는 무해하나, 소비자가 생기는 순간 버그가 되는 stale 데이터**라 지금 닫는다.

## 변경

- `db/saas.ts` — `applyInstallationRepoChange`: 저장 목록에 added/removed 델타 병합, `repository_selection="all"`이면 NULL 정규화(=필터 없음), 행 부재 시 `false` 반환
- `routes/saas-auth.ts` — `installation_repositories` 이벤트 분기. 행 부재(설치 웹훅 유실)면 payload의 installation 객체로 `upsertInstallation` 재구축. 관측 로그 1줄
- `test/installation-repos-webhook.test.mjs` — 병합/제거/중복 방지/all-정규화/행 부재/removed_at/corrupt-JSON 7건

## 검증

- central-plane `pnpm test` **1873/1873 green** (신규 7건 포함)
- fail-safe 계약 유지: 웹훅 서명 검증은 기존 공통 경로 그대로, 새 분기는 D1 쓰기만

🤖 Generated with [Claude Code](https://claude.com/claude-code)