### PR TITLE
fix(dashboard): journey-audit P2 2건 — 참여 팝업 격리 + code 갈래 빈 검수카드 갈래맞춤

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/page.tsx
@@ -36,7 +36,7 @@ import {
   listVisualChecks,
   type VisualCheckListItem,
 } from "@/lib/workspace-visual-checks-api";
-import { overviewNextAction, relativeTimeLabel, verdictLabel } from "@/lib/visual-check-view.mjs";
+import { inspectionEmptyStateDoor, overviewNextAction, relativeTimeLabel, verdictLabel } from "@/lib/visual-check-view.mjs";
 import type { VerdictTone } from "@/lib/visual-check-view.mjs";
 import type { Dictionary, Locale } from "@/i18n/dictionary.mjs";
 import { nextProjectAction, computeProjectSteps } from "@/lib/project-steps.mjs";
@@ -63,6 +63,29 @@ export default function ProjectOverviewPage() {
     if (consumeProjectSyncFailed(id)) setSyncFailed(true);
   }, [id]);
   const { t, locale } = useI18n();
+
+  // Confirmed project facts, fetched ONCE at the page level so the command
+  // center and the inspection card can never disagree about what's connected
+  // (journey-audit P2, 2026-07-20: the inspection card pushed a code-branch
+  // project toward URL inspection while nothing was connected yet).
+  const [hasRepo, setHasRepo] = useState<boolean | null>(null);
+  const [hasReviewRun, setHasReviewRun] = useState<boolean | null>(null);
+  const [hasDeployUrl, setHasDeployUrl] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const uk = getUserKey();
+    fetchProjectRepoSettled(fetchProjectRepo, id, uk)
+      .then((res) => { if (!cancelled) setHasRepo(repoConnectedFact(res)); })
+      .catch(() => {});
+    listProjectReviewHistory(id, uk, { limit: 1 })
+      .then((res) => { if (!cancelled) setHasReviewRun(res.ok ? res.runs.length > 0 : null); })
+      .catch(() => {});
+    listProjectSources(id, uk)
+      .then((res) => { if (!cancelled) setHasDeployUrl(res.ok ? res.sources.some((s) => s.type === "website") : null); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [id]);
+  const entryPath = loadExtendedProjectData(id)?.entryPath ?? null;
   // Locally-created projects live in localStorage (client-only); mock demos are
   // bundled. Read on the client so real projects resolve.
   const project = getLocalProject(id) ?? getProject(id);
@@ -103,6 +126,10 @@ export default function ProjectOverviewPage() {
         t={t}
         hasItems={project.requirements.length > 0}
         showExplainer={!hasReviewActivity}
+        hasRepo={hasRepo}
+        hasReviewRun={hasReviewRun}
+        hasDeployUrl={hasDeployUrl}
+        entryPath={entryPath}
       />
 
       {/* Stage 183 — Plan Map ("Where are we?") read-only entry */}
@@ -118,7 +145,14 @@ export default function ProjectOverviewPage() {
       </Link>
 
       {/* Stage 272 — inspection status at a glance + the single next action */}
-      <VisualChecksOverviewCard projectId={id} t={t} locale={locale} />
+      <VisualChecksOverviewCard
+        projectId={id}
+        t={t}
+        locale={locale}
+        entryPath={entryPath}
+        hasRepo={hasRepo}
+        hasDeployUrl={hasDeployUrl}
+      />
 
       {/* G2 — 막힘 도우미: 만들기 도중의 유일한 도움 입구 (복귀 이메일이 여기로 안내) */}
       <div className="mb-8">
@@ -234,34 +268,22 @@ function CommandCenterCard({
   t,
   hasItems,
   showExplainer,
+  hasRepo,
+  hasReviewRun,
+  hasDeployUrl,
+  entryPath,
 }: {
   projectId: string;
   t: Dictionary;
   hasItems: boolean;
   showExplainer: boolean;
-}) {
-  const [hasRepo, setHasRepo] = useState<boolean | null>(null);
-  const [hasReviewRun, setHasReviewRun] = useState<boolean | null>(null);
+  hasRepo: boolean | null;
+  hasReviewRun: boolean | null;
   // A connected deploy/website URL — the builder path's alternative to a repo,
   // so an idea-only project reaches its results without connecting GitHub.
-  const [hasDeployUrl, setHasDeployUrl] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const uk = getUserKey();
-    fetchProjectRepoSettled(fetchProjectRepo, projectId, uk)
-      .then((res) => { if (!cancelled) setHasRepo(repoConnectedFact(res)); })
-      .catch(() => {});
-    listProjectReviewHistory(projectId, uk, { limit: 1 })
-      .then((res) => { if (!cancelled) setHasReviewRun(res.ok ? res.runs.length > 0 : null); })
-      .catch(() => {});
-    listProjectSources(projectId, uk)
-      .then((res) => { if (!cancelled) setHasDeployUrl(res.ok ? res.sources.some((s) => s.type === "website") : null); })
-      .catch(() => {});
-    return () => { cancelled = true; };
-  }, [projectId]);
-
-  const entryPath = loadExtendedProjectData(projectId)?.entryPath ?? null;
+  hasDeployUrl: boolean | null;
+  entryPath: "idea" | "code" | "spec" | null;
+}) {
   const next = nextProjectAction({ hasItems, hasRepo, hasReviewRun, hasDeployUrl, entryPath });
 
   const copy: Record<string, { label: string; desc: string }> = {
@@ -359,10 +381,16 @@ function VisualChecksOverviewCard({
   projectId,
   t,
   locale,
+  entryPath,
+  hasRepo,
+  hasDeployUrl,
 }: {
   projectId: string;
   t: Dictionary;
   locale: Locale;
+  entryPath: "idea" | "code" | "spec" | null;
+  hasRepo: boolean | null;
+  hasDeployUrl: boolean | null;
 }) {
   const [checks, setChecks] = useState<VisualCheckListItem[] | null>(null);
   const [userKey, setUserKey] = useState<string>("");
@@ -409,17 +437,36 @@ function VisualChecksOverviewCard({
       </div>
       <div className="card p-5">
         {run === null ? (
-          <>
-            <p className="text-sm leading-relaxed text-gray-600">
-              {t.visualChecks.overview.emptyLead}
-            </p>
-            <Link
-              href={`/projects/${projectId}/visual-checks`}
-              className="btn btn-secondary btn-sm mt-3"
-            >
-              {t.visualChecks.overview.runFirst}
-            </Link>
-          </>
+          // Journey-audit P2 (2026-07-20): on the CODE branch with nothing
+          // connected (repo confirmed absent, no deploy URL), "run your first
+          // inspection" pointed at the URL-based door the user can't use yet.
+          // Branch-fit: walk them to connect first. Unknown facts (null) keep
+          // the default door — fail-open, never a wrong lock.
+          inspectionEmptyStateDoor({ entryPath, hasRepo, hasDeployUrl }) === "connect" ? (
+            <>
+              <p className="text-sm leading-relaxed text-gray-600">
+                {t.visualChecks.overview.emptyLeadCodeNoSource}
+              </p>
+              <Link
+                href={`/projects/${projectId}/settings`}
+                className="btn btn-secondary btn-sm mt-3"
+              >
+                {t.visualChecks.overview.connectFirst}
+              </Link>
+            </>
+          ) : (
+            <>
+              <p className="text-sm leading-relaxed text-gray-600">
+                {t.visualChecks.overview.emptyLead}
+              </p>
+              <Link
+                href={`/projects/${projectId}/visual-checks`}
+                className="btn btn-secondary btn-sm mt-3"
+              >
+                {t.visualChecks.overview.runFirst}
+              </Link>
+            </>
+          )
         ) : (
           <>
             <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">

--- a/apps/dashboard/src/components/ImproveSimsaPrompt.tsx
+++ b/apps/dashboard/src/components/ImproveSimsaPrompt.tsx
@@ -25,10 +25,12 @@ export function ImproveSimsaPrompt() {
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const pathname = usePathname();
-  // Flow-audit B-3 (2026-07-17): never show over the creation wizard — the
-  // popup physically covered the last question's options and the progress
-  // button. The invite waits until the user has a project.
-  const onWizard = pathname?.startsWith("/projects/new") ?? false;
+  // Flow-audit B-3 (2026-07-17) banned it from the creation wizard; the
+  // journey-audit P2 (2026-07-20) showed it still floated over the project
+  // overview and checks screens — exactly where a fresh user is orienting.
+  // The invite now shows ONLY on the project list (nothing critical to
+  // cover there); Settings keeps the permanent consent UI for everyone else.
+  const onProjectList = pathname === "/projects";
 
   useEffect(() => {
     let cancelled = false;
@@ -75,7 +77,7 @@ export function ImproveSimsaPrompt() {
     }
   }
 
-  if (!open || onWizard) return null;
+  if (!open || !onProjectList) return null;
 
   return (
     <div className="fixed bottom-4 right-4 z-50 w-[calc(100%-2rem)] max-w-sm">

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -2212,6 +2212,8 @@ export type Dictionary = {
     };
     overview: {
       emptyLead: string;
+      emptyLeadCodeNoSource: string;
+      connectFirst: string;
       runFirst: string;
       inProgress: string;
       viewReport: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -2365,6 +2365,12 @@ const EN = {
     overview: {
       emptyLead:
         "No inspections have run yet. Simsa opens your live app in a real browser and reports what works in plain language.",
+      // Journey-audit P2 (2026-07-20): a code-branch project with nothing
+      // connected was told "run your first inspection" — a URL-based door it
+      // can't use yet. Branch-fit copy walks it to connect first.
+      emptyLeadCodeNoSource:
+        "Nothing is connected yet. Connect your GitHub repository to review code changes — or connect your app's URL for a live-screen inspection.",
+      connectFirst: "Connect your code",
       runFirst: "Run your first inspection",
       inProgress: "View the inspection in progress",
       viewReport: "View the report",
@@ -4837,6 +4843,11 @@ const KO = {
     overview: {
       emptyLead:
         "아직 실행된 검수가 없어요. Simsa가 라이브 앱을 실제 브라우저로 열어 무엇이 작동하는지 쉬운 말로 알려드려요.",
+      // Journey-audit P2 (2026-07-20): 코드 갈래인데 아무것도 연결 전이면
+      // "첫 검수 실행하기"(URL 검수 문)가 아니라 연결부터 안내한다.
+      emptyLeadCodeNoSource:
+        "아직 연결된 게 없어요. GitHub 저장소를 연결하면 코드 변경을 검수하고, 앱 주소(URL)를 연결하면 화면 검수도 할 수 있어요.",
+      connectFirst: "코드 연결하기",
       runFirst: "첫 검수 실행하기",
       inProgress: "진행 중인 검수 보기",
       viewReport: "리포트 보기",

--- a/apps/dashboard/src/lib/visual-check-view.d.mts
+++ b/apps/dashboard/src/lib/visual-check-view.d.mts
@@ -12,6 +12,12 @@ export type OverviewNextAction =
 
 export function overviewNextAction(checks: unknown): OverviewNextAction;
 
+export function inspectionEmptyStateDoor(facts: {
+  entryPath?: "idea" | "code" | "spec" | null;
+  hasRepo?: boolean | null;
+  hasDeployUrl?: boolean | null;
+}): "connect" | "run";
+
 export function relativeTimeLabel(iso: string, locale: string, now?: number): string;
 
 export function verdictLabel(

--- a/apps/dashboard/src/lib/visual-check-view.mjs
+++ b/apps/dashboard/src/lib/visual-check-view.mjs
@@ -92,6 +92,26 @@ export function overviewNextAction(checks) {
 }
 
 /**
+ * Journey-audit P2 (2026-07-20) — which door the overview inspection card's
+ * EMPTY state offers. On the CODE branch with the repo CONFIRMED absent and
+ * no deploy URL, "run your first inspection" points at the URL-based door the
+ * user can't use yet — walk them to connect first instead. Unknown facts
+ * (null — fetch pending/failed) keep the default door: fail-open, a wrong
+ * "connect" nudge on an already-connected project is worse than the generic
+ * lead (transient-null-hard-false).
+ *
+ * @param {{ entryPath?: "idea" | "code" | "spec" | null, hasRepo?: boolean | null, hasDeployUrl?: boolean | null }} facts
+ * @returns {"connect" | "run"}
+ */
+export function inspectionEmptyStateDoor(facts) {
+  const f = facts ?? {};
+  if (f.entryPath === "code" && f.hasRepo === false && f.hasDeployUrl !== true) {
+    return "connect";
+  }
+  return "run";
+}
+
+/**
  * Stage 272 — localized "3 minutes ago"-style label for the overview card.
  * `now` is injectable for deterministic tests. Unparseable dates return ""
  * (the card simply omits the timestamp).

--- a/apps/dashboard/test/visual-check-view.test.mjs
+++ b/apps/dashboard/test/visual-check-view.test.mjs
@@ -8,6 +8,7 @@ import {
   splitEvidenceKeys,
   buildEvidenceUrl,
   overviewNextAction,
+  inspectionEmptyStateDoor,
   relativeTimeLabel,
 } from "../src/lib/visual-check-view.mjs";
 import { getDictionary } from "../src/i18n/dictionary.mjs";
@@ -208,5 +209,52 @@ describe("visual-check-view: buildEvidenceUrl", () => {
     const url = buildEvidenceUrl("https://api.example.com///", "p", "r", "screenshots/a.png", "u");
     assert.ok(url.startsWith("https://api.example.com/workspace/projects/p/"));
     assert.ok(!url.includes("com//workspace"));
+  });
+});
+
+// Journey-audit P2 (2026-07-20): the overview inspection card's empty state
+// must fit the branch — a code-entry project with nothing connected gets the
+// "connect" door, everything else (and every unknown) keeps the default.
+describe("inspectionEmptyStateDoor", () => {
+  it("code branch + repo confirmed absent + no deploy URL → connect", () => {
+    assert.equal(
+      inspectionEmptyStateDoor({ entryPath: "code", hasRepo: false, hasDeployUrl: false }),
+      "connect",
+    );
+    assert.equal(
+      inspectionEmptyStateDoor({ entryPath: "code", hasRepo: false, hasDeployUrl: null }),
+      "connect",
+    );
+  });
+
+  it("repo connected or deploy URL present → run (never a wrong connect nudge)", () => {
+    assert.equal(
+      inspectionEmptyStateDoor({ entryPath: "code", hasRepo: true, hasDeployUrl: false }),
+      "run",
+    );
+    assert.equal(
+      inspectionEmptyStateDoor({ entryPath: "code", hasRepo: false, hasDeployUrl: true }),
+      "run",
+    );
+  });
+
+  it("unknown repo fact (null) stays fail-open → run", () => {
+    assert.equal(
+      inspectionEmptyStateDoor({ entryPath: "code", hasRepo: null, hasDeployUrl: null }),
+      "run",
+    );
+  });
+
+  it("non-code branches always keep the default door", () => {
+    assert.equal(
+      inspectionEmptyStateDoor({ entryPath: "idea", hasRepo: false, hasDeployUrl: false }),
+      "run",
+    );
+    assert.equal(
+      inspectionEmptyStateDoor({ entryPath: "spec", hasRepo: false, hasDeployUrl: false }),
+      "run",
+    );
+    assert.equal(inspectionEmptyStateDoor({}), "run");
+    assert.equal(inspectionEmptyStateDoor(null), "run");
   });
 });


### PR DESCRIPTION
## 배경

journey-audit(2026-07-20, HANDOFF [추가 2])의 잔여 P2 두 건.

## 1) 참여 팝업이 개요·checks를 가림

"Simsa 개선에 참여하기" 플로팅 초대가 프로젝트 개요·checks 등 **신규 유저가 방향을 잡는 화면 위에** 떴다(audit bodyHead 전 페이지에서 재현). 초대는 이제 **전체 프로젝트 목록(/projects)에서만** 렌더 — 가릴 핵심 콘텐츠가 없는 유일한 허브. 정식 동의 UI는 설정 페이지에 그대로. 기존 B-3(위저드 금지) 규칙은 목록-한정 규칙에 자연 포섭.

## 2) code 갈래 빈 검수 카드가 잘못된 문을 안내

code 갈래(이미 만든 앱) 새 프로젝트: 아무것도 연결 전인데 개요의 검수 카드가 "첫 검수 실행하기" → URL 검수 문으로 밀었다(연결된 URL이 없어 못 쓰는 문).

- 빈 상태의 문 선택을 순수 함수 `inspectionEmptyStateDoor`로 분리: **code 갈래 + repo 확인-부재(false) + URL 없음 → "코드 연결하기"(settings)**
- 미확정 사실(null)은 fail-open으로 기본 문 유지 — transient-null-hard-false 패턴 준수(잘못된 connect 유도가 generic 안내보다 나쁨)
- facts(hasRepo/hasReviewRun/hasDeployUrl) 페치를 페이지 레벨로 리프팅 — 커맨드센터와 검수 카드가 **같은 사실**을 공유(카드 간 모순 차단)

## 검증

- `inspectionEmptyStateDoor` 테스트 4케이스: 연결문 / 연결돼 있으면 오도 금지 / null fail-open / 타갈래 무영향
- dictionary EN/KO 키 패리티(i18n.test 구조 비교 통과)
- dashboard typecheck + test + lint **3/3 green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)