### PR TITLE
feat(dashboard): F-5 기존-앱 갈래 경량 의도 인터뷰 — "꼭 작동해야 하는 것" 1문항

### DIFF
--- a/apps/dashboard/src/app/projects/new/page.tsx
+++ b/apps/dashboard/src/app/projects/new/page.tsx
@@ -28,6 +28,7 @@ import { SimsaStampThinking } from "@/components/SimsaStampThinking";
 import { useToast } from "@/components/Toast";
 import { BranchGlyph } from "@/components/brand/BranchGlyph";
 import { buildStepper, rotatingWaitLine } from "@/lib/wizard-steps.mjs";
+import { composeCodeIntent } from "@/lib/code-intent.mjs";
 
 type Step = 1 | 2 | 3 | 4;
 
@@ -57,7 +58,7 @@ export default function NewProjectPage() {
 function NewProjectInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const toast = useToast();
   const [step, setStep] = useState<Step>(1);
   const [ideaText, setIdeaText] = useState("");
@@ -92,6 +93,8 @@ function NewProjectInner() {
   // Code branch: skip the idea step entirely (that's the branch's normal path).
   const [appName, setAppName] = useState("");
   const [codeDesc, setCodeDesc] = useState("");
+  // F-5 — the lightweight intent interview's one extra question (optional).
+  const [codeMustWork, setCodeMustWork] = useState("");
   const [isCreatingCode, setIsCreatingCode] = useState(false);
 
   function toggleBuiltWith(tool: string) {
@@ -323,9 +326,13 @@ function NewProjectInner() {
     setIsCreatingCode(true);
     setRateLimitMsg(null);
 
+    // F-5 — compose the one-liner + "꼭 작동해야 하는 것" into the generation
+    // input. Either field alone is enough; both empty → no LLM call, project
+    // starts without draft items (this branch's pre-F-5 normal path).
+    const intent = composeCodeIntent({ desc: codeDesc, mustWork: codeMustWork, locale });
     let generated: IdeaToSpecDraftResponse | null = null;
-    if (codeDesc.trim()) {
-      const res = await callWorkspaceApi({ idea: codeDesc.trim() });
+    if (intent) {
+      const res = await callWorkspaceApi({ idea: intent });
       // Honest failure: if generation fails the project is simply created
       // without draft items (normal for this branch) — never with mock items
       // silently saved as if they were real.
@@ -373,7 +380,7 @@ function NewProjectInner() {
       id,
       userKey: getUserKey(),
       title: name,
-      idea: codeDesc.trim(),
+      idea: intent,
       understood: generated?.understood ?? {},
       productSpec: generated?.productSpec ?? {},
       items: generated?.items ?? [],
@@ -563,6 +570,18 @@ function NewProjectInner() {
                 onChange={(e) => setCodeDesc(e.target.value)}
                 placeholder={t.branch.codeDescPlaceholder}
                 rows={2}
+                className="input mb-6 resize-none rounded-lg"
+              />
+
+              {/* F-5 — 경량 의도 인터뷰: 선택 질문 하나로 확인 항목이 "내 앱
+                  기준"이 되게 한다. 하드 게이트 없음 — 빈칸이어도 생성 진행. */}
+              <label className="mb-1 block text-xs font-semibold text-gray-600">{t.branch.codeMustWorkLabel}</label>
+              <p className="mb-2 text-xs text-gray-500">{t.branch.codeMustWorkHint}</p>
+              <textarea
+                value={codeMustWork}
+                onChange={(e) => setCodeMustWork(e.target.value)}
+                placeholder={t.branch.codeMustWorkPlaceholder}
+                rows={3}
                 className="input mb-8 resize-none rounded-lg"
               />
 

--- a/apps/dashboard/src/i18n/dictionary.d.mts
+++ b/apps/dashboard/src/i18n/dictionary.d.mts
@@ -313,6 +313,9 @@ export type Dictionary = {
     codeNamePlaceholder: string;
     codeDescLabel: string;
     codeDescPlaceholder: string;
+    codeMustWorkLabel: string;
+    codeMustWorkHint: string;
+    codeMustWorkPlaceholder: string;
     codeCreate: string;
     codeCreating: string;
     specStepTitle: string;

--- a/apps/dashboard/src/i18n/dictionary.mjs
+++ b/apps/dashboard/src/i18n/dictionary.mjs
@@ -380,6 +380,11 @@ const EN = {
     codeNamePlaceholder: "e.g. My first shop",
     codeDescLabel: "What does it do? (optional)",
     codeDescPlaceholder: "One line is enough — we'll draft a checklist from it. You can skip this.",
+    // F-5 (2026-07-20) — lightweight intent interview: one extra optional
+    // question so the review checks YOUR app, not a generic one.
+    codeMustWorkLabel: "What absolutely must work? (optional)",
+    codeMustWorkHint: "2–3 things. This turns the checklist into checks written for your app.",
+    codeMustWorkPlaceholder: "e.g. sign-in, create a booking, checkout — one per line or comma-separated",
     codeCreate: "Create project & connect code",
     codeCreating: "Creating…",
     specStepTitle: "Paste your plan",
@@ -2863,6 +2868,11 @@ const KO = {
     codeNamePlaceholder: "예: 나의 첫 쇼핑몰",
     codeDescLabel: "무엇을 하는 앱인가요? (선택)",
     codeDescPlaceholder: "한 줄이면 충분해요 — 이걸로 확인 항목 초안을 만들어 드려요. 건너뛰어도 돼요.",
+    // F-5 (2026-07-20) — 경량 의도 인터뷰: 선택 질문 하나로 검수가
+    // "내 앱 기준"이 되게 한다. 하드 게이트 없음, 빈칸 허용 유지.
+    codeMustWorkLabel: "꼭 작동해야 하는 건 뭔가요? (선택)",
+    codeMustWorkHint: "2~3개면 충분해요. 적어주시면 확인 항목이 내 앱에 맞게 만들어져요.",
+    codeMustWorkPlaceholder: "예: 로그인, 예약 만들기, 결제 — 줄바꿈이나 쉼표로 구분",
     codeCreate: "프로젝트 만들고 코드 연결하기",
     codeCreating: "만드는 중…",
     specStepTitle: "기획서를 붙여넣어 주세요",

--- a/apps/dashboard/src/lib/code-intent.d.mts
+++ b/apps/dashboard/src/lib/code-intent.d.mts
@@ -1,0 +1,6 @@
+// Type declarations for code-intent.mjs (F-5 lightweight intent interview).
+export function composeCodeIntent(input: {
+  desc?: string | null;
+  mustWork?: string | null;
+  locale?: "en" | "ko";
+}): string;

--- a/apps/dashboard/src/lib/code-intent.mjs
+++ b/apps/dashboard/src/lib/code-intent.mjs
@@ -1,0 +1,40 @@
+// F-5 (2026-07-20) — the CODE branch's lightweight intent interview.
+//
+// The code branch ("이미 만든 앱이 있어요") deliberately skips the full idea
+// interview — that is its normal path, not a deficit. But a project created
+// with zero intent gives the review nothing app-specific to check (Bae,
+// journey-audit follow-up: "기존-앱 갈래 스킵이 맞나"). The lightweight answer
+// is ONE extra optional question — "꼭 작동해야 하는 것" — composed with the
+// one-line description into the spec-generation input. No hard gate: both
+// fields stay optional, an empty interview still creates the project.
+//
+// PURE — no LLM, no network, no storage. The server generates in the user's
+// saved locale; this only shapes the input text.
+
+/**
+ * Compose the spec-generation input from the code branch's two optional
+ * fields. Returns "" when there is nothing to generate from (caller skips
+ * the LLM call — the project simply starts without draft items, exactly
+ * the pre-F-5 behavior).
+ *
+ * mustWork is split on newlines and commas so "로그인, 예약" and one-per-line
+ * both work; blank fragments are dropped.
+ *
+ * @param {{ desc?: string | null, mustWork?: string | null, locale?: "en" | "ko" }} input
+ * @returns {string}
+ */
+export function composeCodeIntent(input) {
+  const f = input ?? {};
+  const desc = String(f.desc ?? "").trim();
+  const items = String(f.mustWork ?? "")
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (!desc && items.length === 0) return "";
+  if (items.length === 0) return desc;
+
+  const label = f.locale === "ko" ? "꼭 작동해야 하는 것" : "Must work";
+  const bullets = items.map((s) => `- ${s}`).join("\n");
+  return desc ? `${desc}\n\n${label}:\n${bullets}` : `${label}:\n${bullets}`;
+}

--- a/apps/dashboard/test/code-intent.test.mjs
+++ b/apps/dashboard/test/code-intent.test.mjs
@@ -1,0 +1,36 @@
+// F-5 — composeCodeIntent: the code branch's lightweight intent composer.
+// Pins: both-empty → "" (caller skips the LLM call, pre-F-5 behavior kept),
+// newline/comma splitting, locale label, desc-only passthrough.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { composeCodeIntent } from "../src/lib/code-intent.mjs";
+
+describe("composeCodeIntent", () => {
+  it("both fields empty → empty string (no generation call)", () => {
+    assert.equal(composeCodeIntent({}), "");
+    assert.equal(composeCodeIntent({ desc: "  ", mustWork: " \n , " }), "");
+    assert.equal(composeCodeIntent(null), "");
+  });
+
+  it("desc only → passthrough, trimmed", () => {
+    assert.equal(composeCodeIntent({ desc: " 동네 빵집 예약 앱 " }), "동네 빵집 예약 앱");
+  });
+
+  it("mustWork splits on newlines AND commas, drops blanks", () => {
+    const out = composeCodeIntent({ mustWork: "로그인, 예약 만들기\n결제,, \n", locale: "ko" });
+    assert.equal(out, "꼭 작동해야 하는 것:\n- 로그인\n- 예약 만들기\n- 결제");
+  });
+
+  it("desc + mustWork compose with a blank line between", () => {
+    const out = composeCodeIntent({ desc: "빵집 예약 앱", mustWork: "로그인", locale: "ko" });
+    assert.equal(out, "빵집 예약 앱\n\n꼭 작동해야 하는 것:\n- 로그인");
+  });
+
+  it("en locale uses the English label (and is the default)", () => {
+    assert.equal(
+      composeCodeIntent({ mustWork: "sign-in", locale: "en" }),
+      "Must work:\n- sign-in",
+    );
+    assert.equal(composeCodeIntent({ mustWork: "sign-in" }), "Must work:\n- sign-in");
+  });
+});


### PR DESCRIPTION
## 설계 (경량 — 풀 인터뷰가 아닌 이유)

code 갈래("이미 만든 앱이 있어요")는 아이디어 인터뷰를 건너뛰는 게 **그 갈래의 정상 경로**다(진행지도도 준비 단계를 선택으로 취급). 하지만 의도 0으로 만든 프로젝트는 확인 항목이 비거나 generic해져 검수가 "내 앱 기준"이 못 된다 — Bae 실사용 지적("기존-앱 갈래 스킵이 맞나", HANDOFF-2026-07-20 [추가 2] F-5).

D17식 4~12문항을 이식하는 대신 **선택 질문 1개**만 추가한다:

> **꼭 작동해야 하는 건 뭔가요? (선택)** — "2~3개면 충분해요. 적어주시면 확인 항목이 내 앱에 맞게 만들어져요."

- **하드 게이트 없음**: 빈칸이어도 프로젝트 생성·코드 연결 흐름 그대로 (데드엔드 > 약한 체크리스트).
- 한줄설명(기존)과 합성해 스펙 생성 입력으로 전달 — 필수 동작이 곧 확인 항목의 근거가 된다.
- 둘 다 빈칸이면 LLM 호출 자체를 스킵 — **F-5 이전 동작 보존** (항목 없이 시작, 이 갈래의 정상 경로).

## 변경

- `lib/code-intent.mjs` — `composeCodeIntent` 순수 합성(줄바꿈/쉼표 분리, locale 라벨, 빈값 → "")
- `projects/new` code 스텝1 — textarea 1개 추가, 생성 호출·`saveProjectToDb.idea` 모두 합성 텍스트 사용
- dictionary EN/KO + d.mts — `codeMustWorkLabel/Hint/Placeholder` (비개발자 언어)
- test — composeCodeIntent 5케이스 (빈값 스킵 계약 포함)

## 검증

- dashboard typecheck + test + lint **3/3 green** (i18n 키 패리티 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)