### PR TITLE
docs: HANDOFF 0720 추가3 — Test B 완결·#435~#437 당일 머지배포·#428 판독 종결

### DIFF
--- a/docs/HANDOFF-2026-07-20.md
+++ b/docs/HANDOFF-2026-07-20.md
@@ -108,3 +108,36 @@ Bae가 실사용에서 연속 지적("App 설치했는데 연결 실패" · "모
 
 ★교훈(QA 체계): API 프로브는 CORS·locale·발견성을 구조적으로 못 본다 —
 **배포 게이트에 journey-audit(실브라우저 완주) 포함**을 표준으로.
+
+## [추가 3] 심야 2부 — Test B 완결 + #435~#437 당일 머지·배포 (Fable 세션)
+
+- **★Test B(private repo auto_fix) 라이브 실증 완결**: 원인은 미설치가 아니라
+  **설치(129987651, 5월)의 Repository access에 eventbadge 1개만 선택**돼 있던 것
+  (D1 gh_app_installations 실측으로 확정 — #430 tail의 `installation lookup 404`
+  실체). Bae가 simsa-autofix-test 추가 → 재링크(private:true) → repair →
+  **mode=auto_fix · done 21초 · `simsa-repair[bot]` 커밋 9ea1a4a0 · PR #1**.
+  OAuth(public_repo)는 이 repo를 못 보므로 #422 App 토큰 경로의 성공 증명.
+- **#435** `fix(saas)`: installation_repositories 웹훅 무시 → selected_repo_ids
+  가 설치 시점 고정(위 진단 중 발견). added/removed 병합·all→NULL 정규화·행
+  부재 시 재구축. 소비처 전수: 현재 게이팅 미사용(무해하나 소비자 생기면 버그).
+  **central 배포 success** + Bae 행 백필(`[1188037554,1305786142]`).
+- **#436** `fix(dashboard)`: journey-audit P2 2건 — ①참여 팝업을 /projects
+  목록으로 격리(개요·checks 가림 해소) ②code 갈래 빈 검수카드가 연결 전인데
+  "첫 검수 실행하기"(URL 문) 밀던 것 → `inspectionEmptyStateDoor` 순수 분리,
+  연결부터 안내(null은 fail-open, transient-null-hard-false 준수). facts 페치
+  페이지 레벨 리프팅(커맨드센터/검수카드 사실 공유).
+- **#437** `feat(dashboard)`: **F-5 경량 의도 인터뷰** — code 스텝1에 "꼭
+  작동해야 하는 건 뭔가요? (선택)" 1문항. composeCodeIntent(순수)로 한줄설명과
+  합성해 생성 입력·D1 idea에 사용. 둘 다 빈칸 → LLM 스킵(기존 동작 보존).
+  하드 게이트 없음. **dashboard CLI 배포(--archive=tgz) + vercel ls 확인 +
+  실브라우저 실증**: 문항 렌더 ✓ 힌트 ✓ 위저드 팝업 부재 ✓.
+- **#428 판독 종결**: apply-walmart repair 재실행 → error=
+  `worker_returned_no_rewrites; oversize_skipped: index.html(389KB)` — 워커
+  정상, 스냅샷 상한으로 실코드 부재가 원인(어제 worker_call_failed는 일시).
+  근본 해결 = 대형 단일파일 diff-재작성 트레인(미착수 유지).
+
+### 남은 것
+- 대형 단일파일 auto_fix diff-재작성 트레인(설계부터) · G14-b 서버 EN화 ·
+  D14 월요 크론 리뷰(`GET /admin/deploy-trends`, 7/21) · G6-2 토스(Bae 가입
+  대기) · 실유저 트래픽.
+- F-5 후속 관찰: mustWork 입력률·생성 항목의 앱 적합도(실유저 코퍼스에서).


### PR DESCRIPTION
HANDOFF-2026-07-20에 [추가 3] 심야 2부 기록.

- Test B(private repo auto_fix) 라이브 실증 완결 — 진범은 App **설치의 repo 선택**(eventbadge만), 재설치 불필요
- #435 installation_repositories 웹훅 반영(+D1 백필) — central 배포 success
- #436 journey-audit P2 2건 / #437 F-5 경량 의도 인터뷰 — dashboard CLI 배포 + 실브라우저 실증
- #428 판독 종결: worker_returned_no_rewrites; oversize_skipped(389KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)