### PR TITLE
feat(repair): 대형 단일파일 auto_fix — 발췌+정밀치환(edit-mode) 사다리 단

### DIFF
--- a/apps/central-plane/container/server.mjs
+++ b/apps/central-plane/container/server.mjs
@@ -787,7 +787,151 @@ async function attemptAutoFix({ workDir, payload, anthropicApiKey, diag = { skip
     );
     return { changedFiles, prContent };
   }
+
+  // Oversize ladder rung: the full-file loop produced nothing AND at least
+  // one candidate was skipped for size (apply-walmart class — a single huge
+  // index.html holding the app's only real code). Try the excerpt+exact-edit
+  // path before giving up. Engages ONLY here, so every previously-green path
+  // is byte-identical to before this rung existed.
+  if (diag.skippedOversize.length > 0 && Date.now() < deadline) {
+    const editFix = await attemptOversizeEditFix({
+      workDir,
+      payload,
+      brief,
+      parsed,
+      review,
+      worker,
+      repoFiles,
+      headSha,
+      diag,
+    });
+    if (editFix) return editFix;
+  }
   return null;
+}
+
+/**
+ * Excerpt + exact-edit attempt for files above AUTO_FIX_MAX_SNAPSHOT_BYTES.
+ * One bounded worker call (no iteration loop): deterministic excerpts around
+ * the brief's evidence tokens go to ClaudeWorker.workEdits; returned
+ * search/replace edits are applied ONLY when each search matches exactly
+ * once (applyExactEdits) — a bad edit is rejected, never a corrupted file.
+ * Returns { changedFiles, prContent } or null (caller resets the tree).
+ */
+async function attemptOversizeEditFix({ workDir, payload, brief, parsed, review, worker, repoFiles, headSha, diag }) {
+  const jobId = payload.jobId;
+
+  // Rank order was preserved when skippedOversize was recorded; dedupe and
+  // keep the top 2 files (excerpt budget is per-call, not per-file).
+  const seen = new Set();
+  const targets = [];
+  for (const s of diag.skippedOversize) {
+    if (seen.has(s.path)) continue;
+    seen.add(s.path);
+    targets.push(s);
+    if (targets.length >= 2) break;
+  }
+
+  const tokens = brief.extractEvidenceTokens(parsed);
+  const fileExcerpts = [];
+  const originals = {};
+  for (const t of targets) {
+    try {
+      const content = await fs.readFile(path.join(workDir, t.path), "utf8");
+      const regions = brief.buildOversizeExcerpts(content, tokens);
+      if (regions.length === 0) continue;
+      originals[t.path] = content;
+      fileExcerpts.push({
+        path: t.path,
+        totalBytes: t.bytes,
+        totalLines: content.split("\n").length,
+        regions,
+      });
+    } catch {
+      // unreadable file — skip
+    }
+  }
+  if (fileExcerpts.length === 0) {
+    diag.reason = "oversize_excerpts_empty";
+    return null;
+  }
+
+  console.log(
+    `[repair ${jobId}] oversize edit attempt: ${fileExcerpts
+      .map((f) => `${f.path}(${f.regions.length} region(s))`)
+      .join(", ")}`,
+  );
+
+  let outcome;
+  try {
+    outcome = await worker.workEdits({
+      repo: payload.repo,
+      pullNumber: 0,
+      newSha: headSha,
+      reviews: [review],
+      fileExcerpts,
+    });
+  } catch (err) {
+    console.error(`[repair ${jobId}] edit worker call failed:`, err?.message ?? err);
+    diag.reason = `edit_worker_call_failed: ${String(err?.message ?? err).slice(0, 100)}`;
+    return null;
+  }
+  if (!Array.isArray(outcome.edits) || outcome.edits.length === 0) {
+    console.log(`[repair ${jobId}] edit worker returned no edits`);
+    diag.reason = "edit_worker_returned_no_edits";
+    return null;
+  }
+
+  const { contents, applied, rejected } = brief.applyExactEdits(originals, outcome.edits);
+  if (rejected.length > 0) {
+    console.log(
+      `[repair ${jobId}] edit(s) rejected: ` + rejected.map((r) => `${r.path}:${r.reason}`).join(", "),
+    );
+  }
+  if (applied.length === 0) {
+    diag.reason = `edits_rejected: ${rejected.map((r) => r.reason).join(",")}`.slice(0, 120);
+    return null;
+  }
+
+  const appliedPaths = [...new Set(applied.map((a) => a.path))];
+  for (const p of appliedPaths) {
+    await fs.writeFile(path.join(workDir, p), contents[p], "utf8");
+  }
+
+  // Same gates as the full-file path: real change + JS syntax check.
+  const diff = await execFileP("git", ["-C", workDir, "diff", "--name-only"], {
+    timeout: 30_000,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  const changedFiles = diff.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+  if (changedFiles.length === 0) {
+    diag.reason = "edits_were_noops";
+    return null;
+  }
+  const verify = await quickSyntaxCheck(workDir, changedFiles);
+  if (!verify.ok) {
+    console.error(`[repair ${jobId}] edit syntax check failed on ${verify.file}: ${verify.detail}`);
+    diag.reason = "edit_syntax_check_failed";
+    await resetWorkTree(workDir);
+    return null;
+  }
+
+  const prContent = brief.buildAutoFixPrContent({
+    runId: payload.visualCheckId ?? jobId,
+    intent: payload.intent,
+    decision: payload.decision,
+    targetUrl: payload.targetUrl,
+    visualCheckId: payload.visualCheckId,
+    envCause: payload.envCause === true,
+    findings: parsed.findings,
+    changedFiles,
+    workerCommitMessage: outcome.message,
+    editedOversizeFiles: appliedPaths,
+  });
+  console.log(
+    `[repair ${jobId}] oversize edit applied: ${applied.length} edit(s) across ${appliedPaths.length} file(s)`,
+  );
+  return { changedFiles, prContent };
 }
 
 /**

--- a/apps/central-plane/src/workspace/repair-brief.ts
+++ b/apps/central-plane/src/workspace/repair-brief.ts
@@ -478,6 +478,196 @@ export function sanitizeRewrites(
   return { accepted, rejected };
 }
 
+// ─── Oversize files: excerpt + exact-edit path ───────────────────────────────
+// Files above the snapshot byte cap can't take the full-file rewrite contract
+// (LLM output limits make wholesale reproduction truncation-prone, and HTML
+// has no syntax gate to catch a truncated commit). Instead: deterministic
+// EXCERPTS around the brief's evidence tokens go to the worker's edit mode,
+// which returns exact search/replace pairs; applyExactEdits enforces the
+// exactly-once match rule so a bad edit is rejected, never applied.
+// (apply-walmart 실측: 389KB 단일 index.html — vibe 툴 전형 — 이 유일한
+// 실코드가 스킵돼 auto_fix가 구조적으로 불가능한 클래스였다. 2026-07-20)
+
+export interface OversizeExcerptRegion {
+  startLine: number;
+  endLine: number;
+  text: string;
+}
+
+/** Tunables for buildOversizeExcerpts — exported for tests. */
+export const OVERSIZE_EXCERPT_WINDOW_LINES = 40;
+export const OVERSIZE_EXCERPT_MAX_REGIONS = 8;
+export const OVERSIZE_EXCERPT_BUDGET_BYTES = 48 * 1024;
+
+/**
+ * Deterministically select regions of an oversize file worth showing the
+ * edit-mode worker: a ±window around every line matching an evidence token,
+ * merged when overlapping, capped by region count and total byte budget.
+ * Regions keep the file's text VERBATIM (line numbers live in metadata only)
+ * so the worker can copy exact search strings from them.
+ *
+ * Zero token matches → first window of the file (head) as a last resort:
+ * single-file vibe apps concentrate wiring near the top, and an empty
+ * excerpt list would silently skip the file entirely.
+ */
+export function buildOversizeExcerpts(
+  content: string,
+  tokens: readonly string[],
+  opts: {
+    windowLines?: number;
+    maxRegions?: number;
+    budgetBytes?: number;
+  } = {},
+): OversizeExcerptRegion[] {
+  const windowLines = opts.windowLines ?? OVERSIZE_EXCERPT_WINDOW_LINES;
+  const maxRegions = opts.maxRegions ?? OVERSIZE_EXCERPT_MAX_REGIONS;
+  const budgetBytes = opts.budgetBytes ?? OVERSIZE_EXCERPT_BUDGET_BYTES;
+
+  const lines = content.split("\n");
+  const lowerTokens = tokens.map((t) => t.toLowerCase()).filter((t) => t.length >= 2);
+
+  // 1-based line hits, in file order.
+  const hitLines: number[] = [];
+  if (lowerTokens.length > 0) {
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line === undefined) continue;
+      const lower = line.toLowerCase();
+      if (lowerTokens.some((t) => lower.includes(t))) hitLines.push(i + 1);
+    }
+  }
+  if (hitLines.length === 0) hitLines.push(1); // head-of-file fallback
+
+  // Expand each hit to a window, then merge overlaps (file order preserved).
+  const windows: Array<{ start: number; end: number }> = [];
+  for (const hit of hitLines) {
+    const start = Math.max(1, hit - windowLines);
+    const end = Math.min(lines.length, hit + windowLines);
+    const last = windows[windows.length - 1];
+    if (last && start <= last.end + 1) {
+      last.end = Math.max(last.end, end);
+    } else {
+      windows.push({ start, end });
+    }
+  }
+
+  // Emit regions under the caps. (TextEncoder over Buffer — this module is
+  // consumed by the container today, but stays runtime-neutral by design.)
+  const utf8 = new TextEncoder();
+  const regions: OversizeExcerptRegion[] = [];
+  let spent = 0;
+  for (const w of windows) {
+    if (regions.length >= maxRegions) break;
+    const text = lines.slice(w.start - 1, w.end).join("\n");
+    const bytes = utf8.encode(text).length;
+    if (spent + bytes > budgetBytes) {
+      if (regions.length === 0) {
+        // Always emit at least one region — trim to budget on a line boundary.
+        const kept: string[] = [];
+        let acc = 0;
+        for (const line of lines.slice(w.start - 1, w.end)) {
+          const b = utf8.encode(line).length + 1;
+          if (acc + b > budgetBytes) break;
+          kept.push(line);
+          acc += b;
+        }
+        if (kept.length > 0) {
+          regions.push({ startLine: w.start, endLine: w.start + kept.length - 1, text: kept.join("\n") });
+        }
+      }
+      break;
+    }
+    regions.push({ startLine: w.start, endLine: w.end, text });
+    spent += bytes;
+  }
+  return regions;
+}
+
+export interface RejectedEdit {
+  path: string;
+  reason:
+    | "unsafe_path"
+    | "denied_file"
+    | "not_excerpted_file"
+    | "empty_search"
+    | "search_not_found"
+    | "search_ambiguous"
+    | "noop_edit"
+    | "introduces_secret";
+}
+
+/**
+ * Apply exact search/replace edits to in-memory file contents, enforcing the
+ * exactly-once rule per edit:
+ *   - search must occur EXACTLY ONCE in the file's CURRENT content (earlier
+ *     accepted edits included) — 0 hits rejects as search_not_found, 2+ as
+ *     search_ambiguous. No fuzzy matching, no line arithmetic.
+ *   - path must be one of the provided files (the excerpt set), pass the
+ *     deny-list, and contain no traversal.
+ *   - replace must not introduce credential-shaped strings the original
+ *     didn't already contain.
+ * Returns updated contents plus per-edit accept/reject records. Rejected
+ * edits never touch the content — partial application is intentional (apply
+ * what verifies, report the rest).
+ */
+export function applyExactEdits(
+  files: Readonly<Record<string, string>>,
+  edits: ReadonlyArray<{ path: string; search: string; replace: string }>,
+): {
+  contents: Record<string, string>;
+  applied: Array<{ path: string; search: string }>;
+  rejected: RejectedEdit[];
+} {
+  const contents: Record<string, string> = { ...files };
+  const applied: Array<{ path: string; search: string }> = [];
+  const rejected: RejectedEdit[] = [];
+
+  for (const edit of edits) {
+    let p = String(edit.path ?? "").trim().replace(/\\/g, "/");
+    while (p.startsWith("./")) p = p.slice(2);
+    if (p.length === 0 || p.startsWith("/") || /^[A-Za-z]:/.test(p) || p.split("/").includes("..")) {
+      rejected.push({ path: edit.path, reason: "unsafe_path" });
+      continue;
+    }
+    if (isRepairFileDenied(p)) {
+      rejected.push({ path: p, reason: "denied_file" });
+      continue;
+    }
+    if (!(p in contents)) {
+      rejected.push({ path: p, reason: "not_excerpted_file" });
+      continue;
+    }
+    const search = String(edit.search ?? "");
+    if (search.length === 0) {
+      rejected.push({ path: p, reason: "empty_search" });
+      continue;
+    }
+    const replace = String(edit.replace ?? "");
+    if (search === replace) {
+      rejected.push({ path: p, reason: "noop_edit" });
+      continue;
+    }
+    const current = contents[p] ?? "";
+    const first = current.indexOf(search);
+    if (first === -1) {
+      rejected.push({ path: p, reason: "search_not_found" });
+      continue;
+    }
+    if (current.indexOf(search, first + 1) !== -1) {
+      rejected.push({ path: p, reason: "search_ambiguous" });
+      continue;
+    }
+    if (SECRET_CONTENT_PATTERN.test(replace) && !SECRET_CONTENT_PATTERN.test(files[p] ?? "")) {
+      rejected.push({ path: p, reason: "introduces_secret" });
+      continue;
+    }
+    contents[p] = current.slice(0, first) + replace + current.slice(first + search.length);
+    applied.push({ path: p, search });
+  }
+
+  return { contents, applied, rejected };
+}
+
 // ─── Auto-fix PR content ──────────────────────────────────────────────────────
 
 const SEVERITY_KO_LABEL: Record<RepairSeverity, string> = {
@@ -503,6 +693,12 @@ export function buildAutoFixPrContent(input: {
   findings: readonly RepairFinding[];
   changedFiles: readonly string[];
   workerCommitMessage?: string;
+  /**
+   * Files fixed via the oversize excerpt+edit path (too big for full-file
+   * rewrites). Named in the PR body so a reviewer knows the worker saw
+   * excerpts, not the whole file — honesty over silence.
+   */
+  editedOversizeFiles?: readonly string[];
 }): { title: string; commitMessage: string; commitBody: string; body: string } {
   const intent = (input.intent ?? "").trim() || "핵심 기능 점검";
   const shortIntent = intent.length > 60 ? `${intent.slice(0, 57)}...` : intent;
@@ -537,6 +733,16 @@ export function buildAutoFixPrContent(input: {
   }
   if (input.workerCommitMessage) {
     lines.push("", `워커 커밋 요약: ${input.workerCommitMessage}`);
+  }
+  if (input.editedOversizeFiles && input.editedOversizeFiles.length > 0) {
+    lines.push(
+      "",
+      "### 큰 파일은 필요한 부분만 고쳤어요",
+      ...input.editedOversizeFiles.map((f) => `- \`${f}\``),
+      "",
+      "위 파일은 한 번에 다시 쓰기엔 커서, 문제와 관련된 부분만 발췌해 정확히 일치하는 곳만 바꿨어요.",
+      "바꾼 곳 외의 내용은 그대로예요.",
+    );
   }
   lines.push(
     "",

--- a/apps/central-plane/test/repair-oversize-edits.test.mjs
+++ b/apps/central-plane/test/repair-oversize-edits.test.mjs
@@ -1,0 +1,179 @@
+/**
+ * repair-oversize-edits.test.mjs — the oversize excerpt + exact-edit rails
+ * (src/workspace/repair-brief.ts, same source the container compiles).
+ *
+ *   - buildOversizeExcerpts: token windows, merge, caps, head fallback,
+ *     verbatim text (line numbers never mixed in)
+ *   - applyExactEdits: exactly-once rule (not-found / ambiguous), deny-list,
+ *     traversal, secret introduction, noop, partial application
+ *   - buildAutoFixPrContent: editedOversizeFiles honesty note
+ *
+ * No network, no LLM, no filesystem beyond imports.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildOversizeExcerpts,
+  applyExactEdits,
+  buildAutoFixPrContent,
+} from "../dist/workspace/repair-brief.js";
+
+// ─── buildOversizeExcerpts ──────────────────────────────────────────────────
+
+function numberedLines(n, fill = (i) => `line ${i}`) {
+  return Array.from({ length: n }, (_, i) => fill(i + 1)).join("\n");
+}
+
+test("excerpts: a window opens around each token hit, merged when overlapping", () => {
+  const lines = Array.from({ length: 200 }, (_, i) => {
+    const n = i + 1;
+    if (n === 100) return "  fetch('/rest/v1/todos')";
+    if (n === 110) return "  const todos = [];"; // within the same merged window
+    return `line ${n}`;
+  }).join("\n");
+
+  const regions = buildOversizeExcerpts(lines, ["todos"], { windowLines: 10 });
+  assert.equal(regions.length, 1, "overlapping windows merge into one region");
+  assert.equal(regions[0].startLine, 90);
+  assert.equal(regions[0].endLine, 120);
+  assert.ok(regions[0].text.includes("fetch('/rest/v1/todos')"));
+  // Verbatim: the region text is exactly the file's lines joined by \n.
+  assert.ok(!/^\s*\d+:/.test(regions[0].text), "no line numbers inside region text");
+});
+
+test("excerpts: no token hits → head-of-file fallback window", () => {
+  const content = numberedLines(500);
+  const regions = buildOversizeExcerpts(content, ["nomatch-token"], { windowLines: 20 });
+  assert.equal(regions.length, 1);
+  assert.equal(regions[0].startLine, 1);
+  assert.ok(regions[0].endLine <= 21);
+  assert.ok(regions[0].text.startsWith("line 1"));
+});
+
+test("excerpts: region count and byte budget are enforced", () => {
+  // Hits far apart → distinct regions; cap at 2.
+  const lines = Array.from({ length: 1000 }, (_, i) => {
+    const n = i + 1;
+    return n % 100 === 0 ? `hit marker ${n}` : `line ${n}`;
+  }).join("\n");
+  const regions = buildOversizeExcerpts(lines, ["marker"], { windowLines: 3, maxRegions: 2 });
+  assert.equal(regions.length, 2);
+
+  // Tiny budget → at least one (trimmed) region still comes back.
+  const one = buildOversizeExcerpts(lines, ["marker"], { windowLines: 50, budgetBytes: 100 });
+  assert.equal(one.length, 1);
+  assert.ok(one[0].text.length <= 100);
+});
+
+// ─── applyExactEdits ────────────────────────────────────────────────────────
+
+const FILE = "index.html";
+const ORIGINAL = [
+  "<html>",
+  "<script>",
+  "const API = 'http://localhost:3000';",
+  "fetch(API + '/items');",
+  "</script>",
+  "</html>",
+].join("\n");
+
+test("applyExactEdits: unique match applies, content updated", () => {
+  const { contents, applied, rejected } = applyExactEdits(
+    { [FILE]: ORIGINAL },
+    [
+      {
+        path: FILE,
+        search: "const API = 'http://localhost:3000';",
+        replace: "const API = 'https://api.example.com';",
+      },
+    ],
+  );
+  assert.equal(rejected.length, 0);
+  assert.equal(applied.length, 1);
+  assert.ok(contents[FILE].includes("https://api.example.com"));
+  assert.ok(!contents[FILE].includes("localhost:3000"));
+});
+
+test("applyExactEdits: zero hits → search_not_found; 2+ hits → search_ambiguous", () => {
+  const dup = "a\nrepeat me\nb\nrepeat me\nc";
+  const r1 = applyExactEdits({ [FILE]: ORIGINAL }, [
+    { path: FILE, search: "not in the file", replace: "x" },
+  ]);
+  assert.equal(r1.rejected[0].reason, "search_not_found");
+  assert.equal(r1.contents[FILE], ORIGINAL, "rejected edit must not touch content");
+
+  const r2 = applyExactEdits({ [FILE]: dup }, [
+    { path: FILE, search: "repeat me", replace: "x" },
+  ]);
+  assert.equal(r2.rejected[0].reason, "search_ambiguous");
+  assert.equal(r2.contents[FILE], dup);
+});
+
+test("applyExactEdits: sequential edits see earlier accepted edits", () => {
+  const { contents, applied } = applyExactEdits({ [FILE]: ORIGINAL }, [
+    { path: FILE, search: "'http://localhost:3000'", replace: "'https://api.example.com'" },
+    // This search only exists AFTER the first edit applied.
+    { path: FILE, search: "const API = 'https://api.example.com';", replace: "const API = 'https://api.example.com'; // prod" },
+  ]);
+  assert.equal(applied.length, 2);
+  assert.ok(contents[FILE].includes("// prod"));
+});
+
+test("applyExactEdits: deny-list, traversal, unknown file, noop, empty search", () => {
+  const files = { [FILE]: ORIGINAL, ".env": "SECRET=1" };
+  const { applied, rejected } = applyExactEdits(files, [
+    { path: ".env", search: "SECRET=1", replace: "SECRET=2" },
+    { path: "../outside.txt", search: "a", replace: "b" },
+    { path: "missing.js", search: "a", replace: "b" },
+    { path: FILE, search: "fetch(API + '/items');", replace: "fetch(API + '/items');" },
+    { path: FILE, search: "", replace: "b" },
+  ]);
+  assert.equal(applied.length, 0);
+  assert.deepEqual(
+    rejected.map((r) => r.reason),
+    ["denied_file", "unsafe_path", "not_excerpted_file", "noop_edit", "empty_search"],
+  );
+});
+
+test("applyExactEdits: replace may not introduce credential-shaped strings", () => {
+  const { applied, rejected } = applyExactEdits({ [FILE]: ORIGINAL }, [
+    {
+      path: FILE,
+      search: "const API = 'http://localhost:3000';",
+      replace: "const API = 'x'; const KEY = 'sk-abcdefghijklmnopqrstuvwx';",
+    },
+  ]);
+  assert.equal(applied.length, 0);
+  assert.equal(rejected[0].reason, "introduces_secret");
+});
+
+test("applyExactEdits: partial application — good edit lands, bad edit reports", () => {
+  const { contents, applied, rejected } = applyExactEdits({ [FILE]: ORIGINAL }, [
+    { path: FILE, search: "nope, not here", replace: "x" },
+    { path: FILE, search: "fetch(API + '/items');", replace: "fetch(API + '/v2/items');" },
+  ]);
+  assert.equal(applied.length, 1);
+  assert.equal(rejected.length, 1);
+  assert.ok(contents[FILE].includes("/v2/items"));
+});
+
+// ─── PR honesty note ────────────────────────────────────────────────────────
+
+test("buildAutoFixPrContent: editedOversizeFiles adds the excerpt honesty note", () => {
+  const { body } = buildAutoFixPrContent({
+    runId: "wvc_x",
+    intent: "핵심 기능 점검",
+    findings: [],
+    changedFiles: ["index.html"],
+    editedOversizeFiles: ["index.html"],
+  });
+  assert.ok(body.includes("큰 파일은 필요한 부분만 고쳤어요"));
+  assert.ok(body.includes("`index.html`"));
+
+  const { body: without } = buildAutoFixPrContent({
+    runId: "wvc_x",
+    findings: [],
+    changedFiles: ["a.js"],
+  });
+  assert.ok(!without.includes("큰 파일은 필요한 부분만"));
+});

--- a/packages/agent-worker/src/index.ts
+++ b/packages/agent-worker/src/index.ts
@@ -1,17 +1,43 @@
 export { ClaudeWorker, WORKER_SYSTEM_PROMPT } from "./worker.js";
 export type { ClaudeWorkerOptions } from "./worker.js";
-export { buildWorkerPrompt, buildCacheablePrefix } from "./prompts.js";
+export {
+  buildWorkerPrompt,
+  buildCacheablePrefix,
+  buildEditWorkerPrompt,
+  buildEditCacheablePrefix,
+  EDIT_WORKER_SYSTEM_PROMPT,
+} from "./prompts.js";
 export {
   REWRITE_TOOL_NAME,
   REWRITE_TOOL_DESCRIPTION,
   REWRITE_TOOL_INPUT_SCHEMA,
+  EDIT_TOOL_NAME,
+  EDIT_TOOL_DESCRIPTION,
+  EDIT_TOOL_INPUT_SCHEMA,
   // backward-compat aliases
   PATCH_TOOL_NAME,
   PATCH_TOOL_DESCRIPTION,
   PATCH_TOOL_INPUT_SCHEMA,
 } from "./patch-tool.js";
-export { parseRewriteToolUse, parsePatchToolUse, looksLikeUnifiedDiff, WorkerParseError } from "./patch-parser.js";
+export {
+  parseRewriteToolUse,
+  parseEditToolUse,
+  parsePatchToolUse,
+  looksLikeUnifiedDiff,
+  WorkerParseError,
+} from "./patch-parser.js";
 export { actualCost, estimateCallCost, PRICING } from "./pricing.js";
 export type { ModelPricing, UsageBreakdown } from "./pricing.js";
 export type { AnthropicLike, AnthropicCreateParams, AnthropicResponse } from "./anthropic-types.js";
-export type { WorkerContext, WorkerOutcome, FileSnapshot, FileRewrite, WorkerRejectedAttempt } from "./types.js";
+export type {
+  WorkerContext,
+  WorkerOutcome,
+  FileSnapshot,
+  FileRewrite,
+  WorkerRejectedAttempt,
+  FileExcerpt,
+  ExcerptRegion,
+  FileEdit,
+  EditWorkerContext,
+  EditWorkerOutcome,
+} from "./types.js";

--- a/packages/agent-worker/src/patch-parser.ts
+++ b/packages/agent-worker/src/patch-parser.ts
@@ -1,6 +1,6 @@
 import type { AnthropicResponse } from "./anthropic-types.js";
-import { REWRITE_TOOL_NAME } from "./patch-tool.js";
-import type { WorkerOutcome } from "./types.js";
+import { REWRITE_TOOL_NAME, EDIT_TOOL_NAME } from "./patch-tool.js";
+import type { WorkerOutcome, EditWorkerOutcome } from "./types.js";
 
 export class WorkerParseError extends Error {
   constructor(message: string) {
@@ -65,6 +65,63 @@ export function parseRewriteToolUse(response: AnthropicResponse): Omit<WorkerOut
     rewrites,
     message: (input.commitMessage as string).trim(),
     appliedFiles: rewrites.map((r) => r.path),
+  };
+}
+
+/**
+ * Parse the edit-mode tool_use response into an EditWorkerOutcome.
+ * Same shape rules as parseRewriteToolUse; `edits` may be empty (the
+ * worker gave up — preserved as a signal). Entries with an empty path
+ * or empty search are dropped here; uniqueness-in-file is the caller's
+ * job (it has the file, we don't).
+ */
+export function parseEditToolUse(
+  response: AnthropicResponse,
+): Omit<EditWorkerOutcome, "tokensUsed" | "costUsd"> {
+  const toolUse = response.content.find(
+    (block): block is Extract<(typeof response.content)[number], { type: "tool_use" }> =>
+      block.type === "tool_use" && block.name === EDIT_TOOL_NAME,
+  );
+  if (!toolUse) {
+    throw new WorkerParseError(
+      `Worker: response did not include a ${EDIT_TOOL_NAME} tool_use block (stop_reason=${response.stop_reason ?? "?"})`,
+    );
+  }
+
+  const input = toolUse.input as {
+    edits?: unknown;
+    commitMessage?: unknown;
+    summary?: unknown;
+  };
+
+  if (typeof input.commitMessage !== "string" || input.commitMessage.trim().length === 0) {
+    throw new WorkerParseError(`Worker: submit_edits.commitMessage must be a non-empty string`);
+  }
+  if (!Array.isArray(input.edits)) {
+    throw new WorkerParseError(`Worker: submit_edits.edits must be an array`);
+  }
+  for (const entry of input.edits) {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      typeof (entry as Record<string, unknown>).path !== "string" ||
+      typeof (entry as Record<string, unknown>).search !== "string" ||
+      typeof (entry as Record<string, unknown>).replace !== "string"
+    ) {
+      throw new WorkerParseError(
+        `Worker: submit_edits.edits entries must be objects with string path, search, replace fields`,
+      );
+    }
+  }
+
+  const edits = (input.edits as Array<{ path: string; search: string; replace: string }>)
+    .map((e) => ({ path: e.path.trim(), search: e.search, replace: e.replace }))
+    .filter((e) => e.path.length > 0 && e.search.length > 0);
+
+  return {
+    edits,
+    message: (input.commitMessage as string).trim(),
+    appliedFiles: [...new Set(edits.map((e) => e.path))],
   };
 }
 

--- a/packages/agent-worker/src/patch-tool.ts
+++ b/packages/agent-worker/src/patch-tool.ts
@@ -58,3 +58,61 @@ export const REWRITE_TOOL_INPUT_SCHEMA = {
 export const PATCH_TOOL_NAME = REWRITE_TOOL_NAME;
 export const PATCH_TOOL_DESCRIPTION = REWRITE_TOOL_DESCRIPTION;
 export const PATCH_TOOL_INPUT_SCHEMA = REWRITE_TOOL_INPUT_SCHEMA;
+
+/**
+ * Edit-mode tool (oversize files). Files above the snapshot byte cap cannot
+ * take the full-file rewrite contract — LLM output limits make wholesale
+ * reproduction truncation-prone (a truncated HTML commits silently; there is
+ * no syntax gate for it). Instead the model sees EXCERPTS and returns exact
+ * search/replace pairs; the caller verifies each `search` matches exactly
+ * once before touching the file, so a bad edit is rejected, never applied.
+ * (Unified diffs stay banned — v0.14 removed them for hallucinated hunk
+ * headers; exact-match replacement has no line arithmetic to get wrong.)
+ */
+export const EDIT_TOOL_NAME = "submit_edits";
+
+export const EDIT_TOOL_DESCRIPTION =
+  "Submit exact search/replace edits for the excerpted files. Call this exactly once at the end of your analysis.";
+
+export const EDIT_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    edits: {
+      type: "array",
+      description:
+        "One entry per contiguous change. Each `search` string must be copied VERBATIM from an excerpt and must be unique within the whole file — include enough surrounding lines to make it unambiguous. The caller rejects any edit whose search text is missing or matches more than once.",
+      items: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description:
+              "Repo-relative file path, forward slashes. Must be one of the excerpted files.",
+          },
+          search: {
+            type: "string",
+            description:
+              "Exact text to find, copied verbatim from the excerpt (same whitespace, same indentation). Must occur exactly once in the file.",
+          },
+          replace: {
+            type: "string",
+            description:
+              "Replacement text. Keep the surrounding unchanged lines from `search` intact and edit only what the blocker requires.",
+          },
+        },
+        required: ["path", "search", "replace"],
+      },
+    },
+    commitMessage: {
+      type: "string",
+      description:
+        "Single-line commit subject (≤ 72 chars), conventional-commit style where it fits.",
+    },
+    summary: {
+      type: "string",
+      description:
+        "One-paragraph rationale: which blockers the edits address, which could not be addressed from the excerpts and why.",
+    },
+  },
+  required: ["edits", "commitMessage", "summary"],
+} as const;

--- a/packages/agent-worker/src/prompts.ts
+++ b/packages/agent-worker/src/prompts.ts
@@ -1,5 +1,5 @@
 import type { Blocker } from "@simsa/core";
-import type { WorkerContext } from "./types.js";
+import type { WorkerContext, EditWorkerContext } from "./types.js";
 
 export const WORKER_SYSTEM_PROMPT = `You are the Worker agent on Conclave AI. Your job is to turn council blockers into complete file rewrites that resolve those blockers.
 
@@ -123,6 +123,97 @@ export function buildWorkerPrompt(ctx: WorkerContext): string {
     `Call submit_rewrite exactly once with the complete new contents of every file that needs changing, a commit message, and a one-paragraph summary.`,
   );
   return sections.join("\n");
+}
+
+// ─── Edit mode (oversize files) ────────────────────────────────────────────
+
+export const EDIT_WORKER_SYSTEM_PROMPT = `You are the Worker agent on Conclave AI, operating in EDIT MODE. The files you must fix are too large to reproduce wholesale, so you see EXCERPTS and respond with exact search/replace edits.
+
+Hard rules:
+- You MUST respond by calling the submit_edits tool exactly once. Do not emit free-form text.
+- Each edit's \`search\` string must be copied VERBATIM from an excerpt — identical whitespace, indentation, and line breaks. The caller verifies it occurs EXACTLY ONCE in the full file; if it is missing or matches more than once, the edit is rejected. Include enough surrounding lines (3+ context lines) to make the match unique.
+- \`replace\` must keep the unchanged context lines from \`search\` intact and alter only what the blocker requires.
+- Fix ONLY the blockers raised. No refactoring, renaming, reformatting, or feature work.
+- Edit ONLY the excerpted files. Never invent content for regions you have not been shown — if a fix requires unseen code, skip it and say so in \`summary\`.
+- If NO blocker is fixable from the excerpts, return an empty \`edits\` array and explain in \`summary\` what region or file the caller should excerpt next.
+- \`commitMessage\` should be a single line (≤ 72 chars), conventional-commit style where it fits. No trailing period.`;
+
+/**
+ * Build the edit-mode user prompt: blockers + excerpted regions with their
+ * real line ranges (line numbers live in the HEADERS only — the region text
+ * stays verbatim so the model can copy it into \`search\` exactly).
+ */
+export function buildEditWorkerPrompt(ctx: EditWorkerContext): string {
+  const sections: string[] = [];
+  sections.push(`# Rework target (edit mode)`);
+  sections.push(`repo: ${ctx.repo}`);
+  sections.push(`pull: #${ctx.pullNumber}`);
+  sections.push(`head sha: ${ctx.newSha}`);
+  sections.push("");
+
+  const blockerSection = renderBlockers(ctx.reviews);
+  sections.push(`# Blockers to fix`);
+  sections.push(
+    blockerSection ||
+      `(None of the council verdicts carry blockers. Return an empty edits array and note this in summary.)`,
+  );
+  sections.push("");
+
+  if (ctx.fileExcerpts.length > 0) {
+    sections.push(`# File excerpts`);
+    sections.push(
+      `These files are too large to show in full. Each region below is VERBATIM from disk at sha ${ctx.newSha} — copy search text from these regions exactly. Regions are labeled with their real line ranges for orientation; the labels are NOT part of the file.`,
+    );
+    sections.push("");
+    for (const ex of ctx.fileExcerpts) {
+      sections.push(
+        `## ${ex.path} (${ex.totalBytes} bytes, ${ex.totalLines} lines total — showing ${ex.regions.length} region(s))`,
+      );
+      for (const region of ex.regions) {
+        sections.push(`### lines ${region.startLine}-${region.endLine}`);
+        sections.push("```");
+        sections.push(region.text);
+        sections.push("```");
+      }
+      sections.push("");
+    }
+  } else {
+    sections.push(
+      `# File excerpts\n(no excerpts provided — return an empty edits array and list what you need in summary)`,
+    );
+    sections.push("");
+  }
+
+  sections.push(
+    `Call submit_edits exactly once with your exact search/replace edits, a commit message, and a one-paragraph summary.`,
+  );
+  return sections.join("\n");
+}
+
+/** Stable cacheable prefix for edit-mode calls (mirrors buildCacheablePrefix). */
+export function buildEditCacheablePrefix(ctx: EditWorkerContext): string {
+  const parts: string[] = [EDIT_WORKER_SYSTEM_PROMPT];
+  if (ctx.answerKeys && ctx.answerKeys.length > 0) {
+    parts.push("answer-keys:\n" + ctx.answerKeys.slice(0, 8).join("\n"));
+  }
+  if (ctx.failureCatalog && ctx.failureCatalog.length > 0) {
+    parts.push("failure-catalog:\n" + ctx.failureCatalog.slice(0, 8).join("\n"));
+  }
+  if (ctx.priorBailHints && ctx.priorBailHints.length > 0) {
+    const lines = ctx.priorBailHints.slice(0, 5).map((h, i) => `${i + 1}. ${h}`);
+    parts.push(
+      [
+        "## Past worker bails — avoid these failure modes",
+        "Previous autofix runs on similar shapes hit these terminal states.",
+        "",
+        ...lines,
+      ].join("\n"),
+    );
+  }
+  if (ctx.prd) {
+    parts.push("prd:\n" + ctx.prd);
+  }
+  return parts.join("\n---\n");
 }
 
 /**

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -65,6 +65,66 @@ export interface WorkerContext {
   prd?: string;
 }
 
+// ─── Edit mode (oversize files) ────────────────────────────────────────────
+// Files too large for the full-file rewrite contract (LLM output limits make
+// wholesale reproduction truncation-prone) are served as EXCERPTS and fixed
+// via exact search/replace edits instead. The caller enforces that each
+// `search` matches exactly once before applying — a failed match rejects the
+// edit rather than corrupting the file.
+
+/** One verbatim region of an oversize file, selected around evidence tokens. */
+export interface ExcerptRegion {
+  /** 1-based first line of the region in the real file. */
+  startLine: number;
+  /** 1-based last line (inclusive). */
+  endLine: number;
+  /** The region's text EXACTLY as it appears on disk — no line numbers mixed in. */
+  text: string;
+}
+
+/** Excerpted view of a file that exceeded the snapshot byte cap. */
+export interface FileExcerpt {
+  path: string;
+  /** Size of the full file on disk, for the model's context. */
+  totalBytes: number;
+  /** Total line count of the full file. */
+  totalLines: number;
+  regions: ExcerptRegion[];
+}
+
+/** One exact-match edit. `search` must occur EXACTLY ONCE in the target file. */
+export interface FileEdit {
+  path: string;
+  /** Verbatim text to find (unique in the file). Copied exactly from an excerpt. */
+  search: string;
+  /** Replacement text. May be multi-line; empty string deletes the matched text. */
+  replace: string;
+}
+
+/** Context for an edit-mode invocation (oversize files only). */
+export interface EditWorkerContext {
+  repo: string;
+  pullNumber: number;
+  newSha: string;
+  reviews: ReviewResult[];
+  /** Excerpted views of the oversize files the blockers point at. */
+  fileExcerpts: FileExcerpt[];
+  answerKeys?: readonly string[];
+  failureCatalog?: readonly string[];
+  priorBailHints?: readonly string[];
+  prd?: string;
+}
+
+/** Result of an edit-mode invocation. Empty `edits` means the worker gave up. */
+export interface EditWorkerOutcome {
+  edits: FileEdit[];
+  message: string;
+  /** Convenience: unique paths touched by the edits. */
+  appliedFiles: string[];
+  tokensUsed?: number;
+  costUsd?: number;
+}
+
 /** Result of a worker invocation — ready to write to disk + commit. */
 export interface WorkerOutcome {
   /**

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -1,10 +1,23 @@
 import { EfficiencyGate, estimateTokens } from "@simsa/core";
 import type { AnthropicCreateParams, AnthropicLike, AnthropicResponse } from "./anthropic-types.js";
-import { REWRITE_TOOL_NAME, REWRITE_TOOL_DESCRIPTION, REWRITE_TOOL_INPUT_SCHEMA } from "./patch-tool.js";
-import { buildWorkerPrompt, buildCacheablePrefix, WORKER_SYSTEM_PROMPT } from "./prompts.js";
-import { parseRewriteToolUse } from "./patch-parser.js";
+import {
+  REWRITE_TOOL_NAME,
+  REWRITE_TOOL_DESCRIPTION,
+  REWRITE_TOOL_INPUT_SCHEMA,
+  EDIT_TOOL_NAME,
+  EDIT_TOOL_DESCRIPTION,
+  EDIT_TOOL_INPUT_SCHEMA,
+} from "./patch-tool.js";
+import {
+  buildWorkerPrompt,
+  buildCacheablePrefix,
+  buildEditWorkerPrompt,
+  buildEditCacheablePrefix,
+  WORKER_SYSTEM_PROMPT,
+} from "./prompts.js";
+import { parseRewriteToolUse, parseEditToolUse } from "./patch-parser.js";
 import { actualCost, estimateCallCost } from "./pricing.js";
-import type { WorkerContext, WorkerOutcome } from "./types.js";
+import type { WorkerContext, WorkerOutcome, EditWorkerContext, EditWorkerOutcome } from "./types.js";
 
 export interface ClaudeWorkerOptions {
   apiKey?: string;
@@ -117,6 +130,72 @@ export class ClaudeWorker {
         const latencyMs = Date.now() - started;
 
         const parsed = parseRewriteToolUse(response);
+        const cost = actualCost(model, {
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          cacheCreationTokens: response.usage.cache_creation_input_tokens,
+          cacheReadTokens: response.usage.cache_read_input_tokens,
+        });
+
+        return {
+          result: parsed,
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          costUsd: cost,
+          latencyMs,
+        };
+      },
+    );
+
+    return {
+      ...outcome.result,
+      tokensUsed: outcome.metric.inputTokens + outcome.metric.outputTokens,
+      costUsd: outcome.metric.costUsd,
+    };
+  }
+
+  /**
+   * Edit-mode invocation for files above the snapshot byte cap: the model
+   * sees excerpts (EditWorkerContext.fileExcerpts) and returns exact
+   * search/replace edits instead of full-file rewrites. Same gate, pricing,
+   * and single-tool pattern as work(); only the tool contract differs.
+   * The caller is responsible for the exactly-once match check + apply.
+   */
+  async workEdits(ctx: EditWorkerContext): Promise<EditWorkerOutcome> {
+    const cacheablePrefix = buildEditCacheablePrefix(ctx);
+    const userPrompt = buildEditWorkerPrompt(ctx);
+    const inputTokenEstimate = estimateTokens(cacheablePrefix) + estimateTokens(userPrompt);
+    const estimatedCost = estimateCallCost(this.model, inputTokenEstimate, this.maxTokens);
+
+    const outcome = await this.gate.run<Omit<EditWorkerOutcome, "tokensUsed" | "costUsd">>(
+      {
+        agent: this.id,
+        cacheablePrefix,
+        prompt: cacheablePrefix + "\n" + userPrompt,
+        estimatedCostUsd: estimatedCost,
+        forceModel: this.model,
+      },
+      async ({ model }) => {
+        const started = Date.now();
+        const client = await this.getClient();
+        const params: AnthropicCreateParams = {
+          model,
+          max_tokens: this.maxTokens,
+          system: [{ type: "text", text: cacheablePrefix, cache_control: { type: "ephemeral" } }],
+          messages: [{ role: "user", content: userPrompt }],
+          tools: [
+            {
+              name: EDIT_TOOL_NAME,
+              description: EDIT_TOOL_DESCRIPTION,
+              input_schema: EDIT_TOOL_INPUT_SCHEMA,
+            },
+          ],
+          tool_choice: { type: "tool", name: EDIT_TOOL_NAME },
+        };
+        const response: AnthropicResponse = await client.messages.create(params);
+        const latencyMs = Date.now() - started;
+
+        const parsed = parseEditToolUse(response);
         const cost = actualCost(model, {
           inputTokens: response.usage.input_tokens,
           outputTokens: response.usage.output_tokens,

--- a/packages/agent-worker/test/worker-edits.test.mjs
+++ b/packages/agent-worker/test/worker-edits.test.mjs
@@ -1,0 +1,164 @@
+// Edit mode (oversize files) — workEdits + parseEditToolUse + prompt shape.
+// Pins: single submit_edits tool call, exact context echo, empty-edits signal
+// preserved, parse validation, and that the prompt carries excerpts verbatim
+// with line labels OUTSIDE the code fences.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EfficiencyGate } from "@simsa/core";
+import {
+  ClaudeWorker,
+  parseEditToolUse,
+  buildEditWorkerPrompt,
+  WorkerParseError,
+  EDIT_TOOL_NAME,
+} from "../dist/index.js";
+
+function makeMockClient(responses) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    messages: {
+      create: async (params) => {
+        calls.push(params);
+        const r = responses[Math.min(i, responses.length - 1)];
+        i += 1;
+        return r;
+      },
+    },
+  };
+}
+
+const VALID_EDITS = [
+  {
+    path: "index.html",
+    search: "const API = 'http://localhost:3000';",
+    replace: "const API = 'https://api.example.com';",
+  },
+];
+
+function editResponse({
+  edits = VALID_EDITS,
+  commitMessage = "fix(api): point API base at production",
+  summary = "Replaces the localhost API base flagged by the blocker.",
+  inputTokens = 2_000,
+  outputTokens = 200,
+} = {}) {
+  return {
+    id: "msg_test",
+    model: "claude-sonnet-4-6",
+    content: [
+      {
+        type: "tool_use",
+        id: "tool_1",
+        name: EDIT_TOOL_NAME,
+        input: { edits, commitMessage, summary },
+      },
+    ],
+    stop_reason: "tool_use",
+    usage: { input_tokens: inputTokens, output_tokens: outputTokens, cache_read_input_tokens: 0 },
+  };
+}
+
+const editCtx = {
+  repo: "acme/x",
+  pullNumber: 0,
+  newSha: "abc123",
+  reviews: [
+    {
+      agent: "simsa",
+      verdict: "rework",
+      summary: "API base points at localhost",
+      blockers: [
+        { severity: "blocker", category: "wiring", message: "API base must not be localhost", file: "index.html", line: 812 },
+      ],
+    },
+  ],
+  fileExcerpts: [
+    {
+      path: "index.html",
+      totalBytes: 398_336,
+      totalLines: 9_120,
+      regions: [
+        {
+          startLine: 800,
+          endLine: 820,
+          text: "  <script>\n    const API = 'http://localhost:3000';\n    fetch(API + '/items');\n  </script>",
+        },
+      ],
+    },
+  ],
+};
+
+test("workEdits: returns edits, message, appliedFiles via the submit_edits tool", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([editResponse()]);
+  const worker = new ClaudeWorker({ apiKey: "test-key", gate, client });
+  const outcome = await worker.workEdits(editCtx);
+
+  assert.equal(outcome.edits.length, 1);
+  assert.equal(outcome.edits[0].path, "index.html");
+  assert.deepEqual(outcome.appliedFiles, ["index.html"]);
+  assert.equal(outcome.message, "fix(api): point API base at production");
+  assert.ok(outcome.tokensUsed > 0);
+
+  // Single-tool contract: exactly one tool, forced choice.
+  const call = client.calls[0];
+  assert.equal(call.tools.length, 1);
+  assert.equal(call.tools[0].name, EDIT_TOOL_NAME);
+  assert.deepEqual(call.tool_choice, { type: "tool", name: EDIT_TOOL_NAME });
+});
+
+test("workEdits: empty edits array is preserved as a give-up signal", async () => {
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const client = makeMockClient([editResponse({ edits: [] })]);
+  const worker = new ClaudeWorker({ apiKey: "test-key", gate, client });
+  const outcome = await worker.workEdits(editCtx);
+  assert.deepEqual(outcome.edits, []);
+  assert.deepEqual(outcome.appliedFiles, []);
+});
+
+test("parseEditToolUse: drops entries with empty path or empty search", () => {
+  const parsed = parseEditToolUse(
+    editResponse({
+      edits: [
+        { path: "", search: "a", replace: "b" },
+        { path: "index.html", search: "", replace: "b" },
+        { path: "index.html", search: "keep me", replace: "kept" },
+      ],
+    }),
+  );
+  assert.equal(parsed.edits.length, 1);
+  assert.equal(parsed.edits[0].search, "keep me");
+});
+
+test("parseEditToolUse: rejects malformed entries and missing tool block", () => {
+  assert.throws(
+    () =>
+      parseEditToolUse(
+        editResponse({ edits: [{ path: "x", search: 42, replace: "y" }] }),
+      ),
+    WorkerParseError,
+  );
+  assert.throws(
+    () =>
+      parseEditToolUse({
+        id: "m",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "no tool" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+    WorkerParseError,
+  );
+});
+
+test("buildEditWorkerPrompt: excerpts are verbatim inside fences, line labels outside", () => {
+  const prompt = buildEditWorkerPrompt(editCtx);
+  assert.ok(prompt.includes("### lines 800-820"));
+  assert.ok(prompt.includes("const API = 'http://localhost:3000';"));
+  // The verbatim region must not have line numbers injected into it.
+  assert.ok(!prompt.includes("800:"), "line numbers must not be mixed into region text");
+  assert.ok(prompt.includes("398336 bytes"));
+  assert.ok(prompt.includes("API base must not be localhost"));
+});


### PR DESCRIPTION
## 근본 문제

vibe 툴 전형의 단일 대형 HTML(apply-walmart: index.html **389KB**)이 스냅샷 상한(200KB)에 걸려 **앱의 유일한 실코드가 워커에게 한 번도 전달되지 않음** → auto_fix가 구조적으로 불가능한 클래스. #427/#428이 이를 정직하게 노출(`oversize_skipped`)까지 했고, 이 PR이 근본 해결.

## 설계 (기각한 대안 포함)

| 접근 | 판정 |
|---|---|
| 상한 인상 + 전체-파일 재작성 | ❌ LLM 출력 한도로 잘린 파일 커밋 위험, HTML은 문법 게이트 없음 (기왕 기각) |
| unified diff | ❌ v0.14에서 기각 — 헝크 헤더 오산·환각 컨텍스트 |
| **발췌 + exact search/replace** | ✅ `search`가 파일에서 **정확히 1회** 일치할 때만 적용 — 잘린 커밋이 원천 불가능, 라인 산술 없음 |

**엔게이지 조건**: 기존 full-file 루프가 빈손(null) + `skippedOversize` 존재 시에만 → **기존 green 경로는 바이트 동일(회귀 0)**.

## 변경

- **agent-worker**: `submit_edits` 툴 + `workEdits()` — 기존 `work()`와 동일한 효율게이트/프라이싱/단일툴 패턴(직접 SDK 호출 금지 규칙 준수). 발췌 라인 라벨은 헤더에만, 본문은 디스크 원문 그대로(search 복사 정확성).
- **repair-brief**: `buildOversizeExcerpts`(증거 토큰 ±40줄 윈도우 병합, 8영역/48KB 예산, 무히트 시 파일 머리 폴백) · `applyExactEdits`(exactly-once 규칙, deny-list/traversal/시크릿 도입 차단, 부분 적용) · PR 정직 노트("큰 파일은 필요한 부분만 고쳤어요")
- **container**: `attemptOversizeEditFix` 사다리 단 — 동일 게이트(실변경·JS 문법 체크), 실패 사유 in-band(`edit_worker_call_failed`/`edits_rejected`/... → modeReason)

## 검증

- 신규 테스트 15: exactly-once(0회/2회+ 기각)·순차 편집·시크릿 도입 차단·부분 적용·발췌 병합/예산/폴백·PR 노트·워커 단일툴 계약·빈 edits 신호 보존
- agent-worker + central-plane **build/test/lint 전부 green** (central 1883+)
- `node --check` container/server.mjs ok

## 배포 후 실증 계획

1. deploy-central-plane(컨테이너 재빌드 포함) 배포
2. apply-walmart repair 재실행 → 기대: `mode=auto_fix` + PR에 발췌 수정 노트 (현재는 `brief_only`/`oversize_skipped`)
3. F1/simsa-autofix-test 무회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)