### PR TITLE
fix(repair): repair PR에 [skip conclave] — 레거시 협의체 App 중복 리뷰 차단

### DIFF
--- a/apps/central-plane/container/coerce-result.mjs
+++ b/apps/central-plane/container/coerce-result.mjs
@@ -193,6 +193,12 @@ export function buildRepairPrContent(payload) {
     );
   }
   bodyLines.push("### 수리 지시서", "", "```", agentPrompt, "```", "");
+  // Simsa repair PRs must NOT be re-reviewed by the legacy Conclave council
+  // App (users who installed it get double reviews + double credit burn on
+  // every repair PR — 2026-07-21 실측: simsa-autofix-test PR#1). The webhook
+  // honors [skip conclave] in the body; an HTML comment keeps it invisible
+  // to the non-developer reading the PR.
+  bodyLines.push("<!-- [skip conclave] -->", "");
 
   const briefContent = [
     "# SIMSA-FIX-BRIEF",

--- a/apps/central-plane/src/workspace/repair-brief.ts
+++ b/apps/central-plane/src/workspace/repair-brief.ts
@@ -749,6 +749,12 @@ export function buildAutoFixPrContent(input: {
     "> **주의: 자동 생성된 수정입니다.** 머지 전에 반드시 코드 리뷰와 실제 동작 확인을 해주세요.",
     "> 수리 근거(검수 증거 + 지시서)는 이 브랜치의 `SIMSA-FIX-BRIEF.md`에 있습니다.",
     "",
+    // Simsa repair PRs must NOT be re-reviewed by the legacy Conclave council
+    // App (double review + double credit burn on repos where users installed
+    // it — 2026-07-21 실측: simsa-autofix-test PR#1). The pull_request webhook
+    // honors [skip conclave]; the HTML comment keeps it invisible in render.
+    "<!-- [skip conclave] -->",
+    "",
   );
   if (input.envCause === true) {
     lines.push(

--- a/apps/central-plane/test/repair-oversize-edits.test.mjs
+++ b/apps/central-plane/test/repair-oversize-edits.test.mjs
@@ -159,6 +159,16 @@ test("applyExactEdits: partial application — good edit lands, bad edit reports
 
 // ─── PR honesty note ────────────────────────────────────────────────────────
 
+test("buildAutoFixPrContent: body carries [skip conclave] (legacy council must not double-review)", () => {
+  const { body } = buildAutoFixPrContent({
+    runId: "wvc_x",
+    findings: [],
+    changedFiles: ["a.js"],
+  });
+  assert.match(body, /\[skip conclave\]/i);
+  assert.ok(body.includes("<!-- [skip conclave] -->"), "marker stays invisible via HTML comment");
+});
+
 test("buildAutoFixPrContent: editedOversizeFiles adds the excerpt honesty note", () => {
   const { body } = buildAutoFixPrContent({
     runId: "wvc_x",

--- a/apps/central-plane/test/workspace-repair-jobs.test.mjs
+++ b/apps/central-plane/test/workspace-repair-jobs.test.mjs
@@ -691,6 +691,18 @@ test("container helpers: buildRepairPrContent is honest (no auto-fix claim), car
   assert.ok(plain.title.length < 80);
 });
 
+test("repair PR bodies carry [skip conclave] so the legacy council App never double-reviews them", () => {
+  // Lock-step with the webhook's escape hatch: saas-auth.ts tests the PR
+  // title/body against /\[skip conclave\]/i. A Simsa repair PR re-reviewed
+  // by the legacy Conclave App is double review + double credit burn
+  // (2026-07-21 실측: simsa-autofix-test PR#1의 Conclave AI Council 체크런).
+  const webhookRegex = /\[skip conclave\]/i;
+  const brief = buildRepairPrContent({ intent: "테스트", agentPrompt: AGENT_PROMPT, envCause: false });
+  assert.match(brief.body, webhookRegex, "brief-only draft PR body must carry the marker");
+  // Invisible to the non-developer: wrapped in an HTML comment.
+  assert.ok(brief.body.includes("<!-- [skip conclave] -->"));
+});
+
 // ─── Stage 270: auto-repair execution (mode + changed_files + key forwarding) ─
 
 test("Stage 270 dispatch: ANTHROPIC_API_KEY forwarded via x-anthropic-key HEADER, never in the payload body", async () => {


### PR DESCRIPTION
## 배경 (Bae 지적: "모든 repo에 conclave-ai-review가 붙어서 충돌 아니냐")

사실관계 실측:
- **3SVS/simsa에는 App 미설치** — 오늘 PR들(#435~#439)엔 typecheck CI만. 충돌 없음.
- **simsa-autofix-test**: Test B를 위해 App을 설치한 순간부터, Simsa repair PR#1에 구 Conclave 협의체가 자동 리뷰(`Conclave AI Council` 체크런 + 코멘트 2건). **Simsa가 만든 수리 PR을 레거시 제품이 재리뷰**하는 중복 — 크레딧 이중 소모, 제품 방향(Conclave EOL)과 불일치.
- 이 충돌 클래스는 App을 설치한 **모든 실유저 repo**에서 재현된다.

## 수정

웹훅(saas-auth.ts)에 이미 존재하는 `[skip conclave]` 이스케이프 해치를 repair PR 본문 두 곳에 탑재:
- `buildRepairPrContent`(brief_only draft) + `buildAutoFixPrContent`(auto_fix)
- `<!-- [skip conclave] -->` HTML 주석 — 비개발자 렌더링엔 안 보이고 정규식 `/\[skip conclave\]/i`엔 매치

## 검증

- 웹훅 정규식과 락스텝 테스트 2건(본문 매치 + HTML 주석 형태)
- central-plane build/test/lint green (45/45 affected, 전체 suite 포함)

배포 시 컨테이너 재빌드 필요(coerce-result.mjs가 이미지 내 파일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)