### PR TITLE
feat(saas): 레거시 Conclave 자동 리뷰 전면 오프 — LEGACY_AUTO_REVIEW 킬스위치

### DIFF
--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -118,6 +118,14 @@ export interface Env {
   OPENAI_API_KEY?: string;
   GEMINI_API_KEY?: string;
   /**
+   * 2026-07-21 (Bae 결정) — 레거시 Conclave 자동 리뷰 킬스위치. "off"면
+   * pull_request 웹훅의 자동 협의체 리뷰와 설치 시 웰컴 리뷰를 크레딧 소모
+   * 전에 스킵한다(설치 기록·파운더 알림·수동 /saas/review는 그대로).
+   * Simsa 집중 기간 동안 wrangler.toml [vars]로 "off" 고정 — 한 줄 되돌리면
+   * 재가동. 미설정/다른 값 = 기존 동작(enabled).
+   */
+  LEGACY_AUTO_REVIEW?: string;
+  /**
    * 2026-07-09 — Langfuse minimal wiring (Simsa flow observability).
    * All three must be set for traces to be sent; otherwise the workspace
    * routes silently skip Langfuse (fail-open — never blocks a user call).

--- a/apps/central-plane/src/routes/saas-auth.ts
+++ b/apps/central-plane/src/routes/saas-auth.ts
@@ -131,11 +131,17 @@ export function createSaasAuthRoutes(): Hono<{ Bindings: Env }> {
           // Fire-and-forget: find the most recently updated open PR across
           // the newly accessible repos and kick off a welcome review so
           // the installer sees a result without having to open a new PR.
-          const webhookRepos = (p["repositories"] ?? []) as Array<{ id: number; full_name: string; updated_at?: string }>;
-          const publicBaseUrl = env.PUBLIC_BASE_URL ?? new URL(c.req.url).origin;
-          autoReviewOnInstall(env, installationId, user.id, webhookRepos, publicBaseUrl).catch(
-            (err) => console.error(`[webhook] autoReviewOnInstall failed: ${(err as Error).message}`),
-          );
+          // 2026-07-21 (Bae): 킬스위치가 off면 웰컴 리뷰도 스킵 — 설치 기록·
+          // 유저 생성·파운더 알림은 위에서 이미 끝났고 그대로 유지된다.
+          if (env.LEGACY_AUTO_REVIEW === "off") {
+            console.log(`[webhook] install ${installationId}: welcome review skipped (legacy auto-review off)`);
+          } else {
+            const webhookRepos = (p["repositories"] ?? []) as Array<{ id: number; full_name: string; updated_at?: string }>;
+            const publicBaseUrl = env.PUBLIC_BASE_URL ?? new URL(c.req.url).origin;
+            autoReviewOnInstall(env, installationId, user.id, webhookRepos, publicBaseUrl).catch(
+              (err) => console.error(`[webhook] autoReviewOnInstall failed: ${(err as Error).message}`),
+            );
+          }
         } else {
           console.log(`[webhook] install ${installationId} created (no account info)`);
         }
@@ -275,6 +281,12 @@ export function createSaasAuthRoutes(): Hono<{ Bindings: Env }> {
     // review on opened/reopened/synchronize (the head SHA changed).
     // Other actions (closed/labeled/etc.) are acknowledged but skipped.
     if (event === "pull_request") {
+      // 2026-07-21 (Bae): 레거시 자동 리뷰 킬스위치 — Simsa 집중 기간 동안
+      // 전 repo에서 자동 협의체 리뷰 정지. 크레딧 소모/잡 생성/샌드박스
+      // 어느 것도 일어나기 전에 여기서 끊는다. 수동 /saas/review는 그대로.
+      if (env.LEGACY_AUTO_REVIEW === "off") {
+        return c.json({ ok: true, event, action, delivery, skipped: "legacy_auto_review_disabled" });
+      }
       const reviewable = action === "opened" || action === "reopened" || action === "synchronize";
       if (!reviewable) {
         return c.json({ ok: true, event, action, delivery, skipped: "non_reviewable_action" });

--- a/apps/central-plane/test/webhook-legacy-auto-review-off.test.mjs
+++ b/apps/central-plane/test/webhook-legacy-auto-review-off.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * webhook-legacy-auto-review-off.test.mjs — 2026-07-21 (Bae 결정)
+ *
+ * LEGACY_AUTO_REVIEW="off" kill switch: while Simsa is the product focus,
+ * the legacy Conclave council must not auto-review PRs anywhere.
+ *
+ * Pins:
+ *   - pull_request webhook with the switch off → acknowledged as
+ *     skipped:"legacy_auto_review_disabled" BEFORE any DB read, credit
+ *     consumption, job creation, or sandbox spawn (DB stub throws if touched).
+ *   - switch absent → the handler proceeds past the gate (default-on:
+ *     other deployments keep their behavior).
+ *   - signature verification still runs first (unsigned → 401 either way).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+
+const { createApp } = await import("../dist/router.js");
+
+const SECRET = "whsec_test_1234";
+
+/** DB stub that fails the test if ANY query runs (the skip must be free). */
+function explodingDb() {
+  return {
+    prepare() {
+      throw new Error("DB must not be touched when the kill switch is off");
+    },
+  };
+}
+
+/** DB stub that answers "no installation row" (default-on path probe). */
+function nullDb() {
+  return {
+    prepare() {
+      return {
+        bind() {
+          return {
+            first: async () => null,
+            all: async () => ({ results: [] }),
+            run: async () => ({ success: true, meta: { changes: 0 } }),
+          };
+        },
+      };
+    },
+  };
+}
+
+async function postWebhook(app, env, event, payload) {
+  const raw = JSON.stringify(payload);
+  const sig = "sha256=" + createHmac("sha256", SECRET).update(raw).digest("hex");
+  return app.request(
+    "/webhook/github",
+    {
+      method: "POST",
+      headers: {
+        "x-hub-signature-256": sig,
+        "x-github-event": event,
+        "x-github-delivery": "d_test",
+        "content-type": "application/json",
+      },
+      body: raw,
+    },
+    env,
+  );
+}
+
+const PR_PAYLOAD = {
+  action: "opened",
+  pull_request: { number: 7, title: "feat: x", body: "" },
+  repository: { full_name: "acme/site" },
+  installation: { id: 42 },
+};
+
+test("kill switch off: pull_request acked as disabled, DB never touched", async () => {
+  const app = createApp();
+  const env = {
+    ENVIRONMENT: "test",
+    GH_APP_WEBHOOK_SECRET: SECRET,
+    LEGACY_AUTO_REVIEW: "off",
+    DB: explodingDb(),
+  };
+  const res = await postWebhook(app, env, "pull_request", PR_PAYLOAD);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.skipped, "legacy_auto_review_disabled");
+});
+
+test("switch absent: handler proceeds past the gate (default-on)", async () => {
+  const app = createApp();
+  const env = {
+    ENVIRONMENT: "test",
+    GH_APP_WEBHOOK_SECRET: SECRET,
+    DB: nullDb(),
+  };
+  const res = await postWebhook(app, env, "pull_request", PR_PAYLOAD);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  // Reached the installation lookup (past the kill-switch gate) and skipped
+  // there because our stub has no rows — proving the gate did not block.
+  assert.equal(body.skipped, "user_not_linked");
+});
+
+test("signature verification still runs before the switch (unsigned → 401)", async () => {
+  const app = createApp();
+  const env = {
+    ENVIRONMENT: "test",
+    GH_APP_WEBHOOK_SECRET: SECRET,
+    LEGACY_AUTO_REVIEW: "off",
+    DB: explodingDb(),
+  };
+  const res = await app.request(
+    "/webhook/github",
+    {
+      method: "POST",
+      headers: { "x-github-event": "pull_request", "content-type": "application/json" },
+      body: JSON.stringify(PR_PAYLOAD),
+    },
+    env,
+  );
+  assert.equal(res.status, 401);
+});

--- a/apps/central-plane/wrangler.toml
+++ b/apps/central-plane/wrangler.toml
@@ -13,6 +13,11 @@ database_id = "28be7ec4-9c46-4b78-8d07-11f344021dd0"
 
 [vars]
 ENVIRONMENT = "production"
+# 2026-07-21 (Bae 결정) — 레거시 Conclave 자동 리뷰 전면 정지(Simsa 집중 기간).
+# pull_request 웹훅 자동 협의체 리뷰 + 설치 웰컴 리뷰를 크레딧 소모 전에 스킵.
+# 설치 기록·파운더 알림·수동 /saas/review·Simsa repair는 영향 없음.
+# 재가동 = 이 줄을 지우고(또는 "on") deploy-central-plane 1회.
+LEGACY_AUTO_REVIEW = "off"
 # Stage 271 — public sign-up OPEN (Bae approved 2026-07-02: "env 변경도 저건 승인할게").
 # Was fail-closed (unset → disabled) since Stage 241. Sign-in/session were never gated
 # by this policy; only POST /api/auth/sign-up/* is affected.


### PR DESCRIPTION
## 배경 (Bae 결정 2026-07-21)

> "모든 곳에서 conclave-ai 자동 리뷰를 일단 끄고 simsa를 테스트하면서 진행"

Test B용 App 설치에서 Simsa repair PR이 구 협의체에 재리뷰되는 중복(#440)을 계기로, 자동 리뷰 파이프라인 자체를 정지한다. 삭제가 아닌 **킬스위치** — 베타 유저 설치(nogl-prod 120 repo 등)의 기록·온보딩 데이터는 그대로 두고, 재가동은 1줄+배포 1회.

## 동작

| 항목 | 스위치 off 시 |
|---|---|
| `pull_request` 웹훅 자동 협의체 리뷰 | ⏹ **크레딧 소모 전** ack(`skipped: legacy_auto_review_disabled`) |
| 설치 시 웰컴 리뷰 | ⏹ 스킵 (설치 기록·유저 생성·파운더 알림은 유지) |
| 수동 `/saas/review`·`/saas/autofix` (CLI 명시 호출) | ✅ 유지 |
| Simsa repair / 검수 | ✅ 무영향 |
| `check_run` 배포실패 주석 | 선행 잡이 없어지므로 자연 무동작 |

프로덕션은 `wrangler.toml [vars] LEGACY_AUTO_REVIEW = "off"`로 고정. 미설정/다른 값 = 기존 동작(다른 배포 환경 무영향).

## 검증

- 테스트 3: ①off → **DB 폭발 스텁으로 무접촉 스킵 증명**(크레딧/잡/스폰 이전 차단) ②스위치 부재 → 게이트 통과해 기존 경로 진행(default-on) ③서명 검증 선행 유지(무서명 401)
- central-plane build/test/lint green

머지 후 deploy-central-plane 1회로 발효.

🤖 Generated with [Claude Code](https://claude.com/claude-code)