### PR TITLE
fix(repair): 워커 에이전트 LLM 호출을 CF AI Gateway 경유로 — 간헐 403 해소

### DIFF
--- a/apps/central-plane/container/server.mjs
+++ b/apps/central-plane/container/server.mjs
@@ -92,11 +92,18 @@ const server = createServer(async (req, res) => {
       typeof req.headers["x-anthropic-key"] === "string" && req.headers["x-anthropic-key"].length > 0
         ? req.headers["x-anthropic-key"]
         : undefined;
+    // 2026-07-21 — optional CF AI Gateway base URL for the worker-agent
+    // calls. Direct container→Anthropic egress 403s intermittently
+    // ("Request not allowed"); the gateway path doesn't. Absent → SDK default.
+    const anthropicBaseUrl =
+      typeof req.headers["x-anthropic-base-url"] === "string" && req.headers["x-anthropic-base-url"].length > 0
+        ? req.headers["x-anthropic-base-url"]
+        : undefined;
     res.writeHead(202, { "content-type": "application/json" });
     res.end(JSON.stringify({ jobId: payload.jobId, status: "accepted" }));
 
     inFlightJobs.set(payload.jobId, payload);
-    runRepairJob(payload, anthropicApiKey)
+    runRepairJob(payload, anthropicApiKey, anthropicBaseUrl)
       .catch(async (err) => {
         console.error(`[repair ${payload.jobId}] crashed:`, redactSecret(err?.message ?? String(err), payload.githubToken));
         await postCallback(payload.callbackUrl, payload.callbackToken, {
@@ -432,7 +439,7 @@ async function runJob(payload) {
  * before it leaves this process, and the Anthropic key never reaches the
  * repo, the PR, or the callback.
  */
-async function runRepairJob(payload, anthropicApiKey) {
+async function runRepairJob(payload, anthropicApiKey, anthropicBaseUrl) {
   const {
     jobId,
     repo, // "owner/name"
@@ -491,7 +498,7 @@ async function runRepairJob(payload, anthropicApiKey) {
     const diag = { skippedOversize: [], reason: null };
     if (anthropicApiKey) {
       try {
-        autoFix = await attemptAutoFix({ workDir, payload, anthropicApiKey, diag });
+        autoFix = await attemptAutoFix({ workDir, payload, anthropicApiKey, anthropicBaseUrl, diag });
       } catch (err) {
         console.error(
           `[repair ${jobId}] auto-fix crashed (falling back to brief-only):`,
@@ -642,7 +649,7 @@ async function quickSyntaxCheck(workDir, changedFiles) {
  * worker produced nothing applicable — callers reset the tree + fall back
  * to brief-only. Never leaves a dirty tree on the null path.
  */
-async function attemptAutoFix({ workDir, payload, anthropicApiKey, diag = { skippedOversize: [], reason: null } }) {
+async function attemptAutoFix({ workDir, payload, anthropicApiKey, anthropicBaseUrl, diag = { skippedOversize: [], reason: null } }) {
   const jobId = payload.jobId;
   const deadline = Date.now() + AUTO_FIX_DEADLINE_MS;
 
@@ -680,7 +687,20 @@ async function attemptAutoFix({ workDir, payload, anthropicApiKey, diag = { skip
 
   // The worker agent — same dist layout the autofix path uses for cli.
   const { ClaudeWorker } = await import("file:///app/packages/agent-worker/dist/index.js");
-  const worker = new ClaudeWorker({ apiKey: anthropicApiKey });
+  // 2026-07-21 — when the Worker forwarded a CF AI Gateway base URL, build the
+  // Anthropic client against it (direct egress 403s intermittently). The
+  // factory mirrors agent-worker's default one, adding only baseURL.
+  const worker = new ClaudeWorker({
+    apiKey: anthropicApiKey,
+    ...(anthropicBaseUrl
+      ? {
+          clientFactory: async (key) => {
+            const mod = await import("@anthropic-ai/sdk");
+            return new mod.default({ apiKey: key, baseURL: anthropicBaseUrl });
+          },
+        }
+      : {}),
+  });
 
   for (let iteration = 0; iteration < AUTO_FIX_MAX_ITERATIONS; iteration++) {
     if (Date.now() >= deadline) {

--- a/apps/central-plane/src/routes/workspace-repair-jobs.ts
+++ b/apps/central-plane/src/routes/workspace-repair-jobs.ts
@@ -175,6 +175,14 @@ export async function dispatchRepairJob(
   // container keeps the Stage 268 brief-only behavior (mode 'brief_only').
   const headers: Record<string, string> = { "content-type": "application/json" };
   if (env.ANTHROPIC_API_KEY) headers["x-anthropic-key"] = env.ANTHROPIC_API_KEY;
+  // 2026-07-21 — route the container's worker-agent calls through the CF AI
+  // Gateway. Direct container→Anthropic egress 403s intermittently
+  // ("Request not allowed" — Worker-side direct egress measured ~90% 403 on
+  // 2026-07-05; repair hit the same class today). Base URL is not a secret
+  // (wrangler.toml [vars]); absent → container keeps the direct default.
+  if (env.CF_AI_GATEWAY_ANTHROPIC_URL) {
+    headers["x-anthropic-base-url"] = env.CF_AI_GATEWAY_ANTHROPIC_URL;
+  }
   try {
     const id = env.SANDBOX.idFromName(`repair-${args.jobId}`);
     const stub = env.SANDBOX.get(id);

--- a/apps/central-plane/test/workspace-repair-jobs.test.mjs
+++ b/apps/central-plane/test/workspace-repair-jobs.test.mjs
@@ -730,6 +730,25 @@ test("Stage 270 dispatch: no ANTHROPIC_API_KEY → no x-anthropic-key header (co
   assert.equal(recorder.calls[0].headers["x-anthropic-key"], undefined);
 });
 
+test("gateway dispatch: CF_AI_GATEWAY_ANTHROPIC_URL forwarded via x-anthropic-base-url header; absent → no header", async () => {
+  // 2026-07-21 — direct container→Anthropic egress 403s intermittently
+  // ("Request not allowed"); the worker-agent call must ride the gateway.
+  const recorder = { names: [], calls: [] };
+  const env = makeEnv({ sandbox: makeSandbox(recorder) });
+  env.ANTHROPIC_API_KEY = "sk-ant-testkey-abcdefghijklmnop";
+  env.CF_AI_GATEWAY_ANTHROPIC_URL = "https://gateway.ai.cloudflare.com/v1/acct/simsa/anthropic";
+  const r = await req(env, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r.status, 202);
+  assert.equal(recorder.calls[0].headers["x-anthropic-base-url"], env.CF_AI_GATEWAY_ANTHROPIC_URL);
+
+  const recorder2 = { names: [], calls: [] };
+  const env2 = makeEnv({ sandbox: makeSandbox(recorder2) });
+  env2.ANTHROPIC_API_KEY = "sk-ant-testkey-abcdefghijklmnop";
+  const r2 = await req(env2, "POST", REPAIR_PATH, { userKey: USER });
+  assert.equal(r2.status, 202);
+  assert.equal(recorder2.calls[0].headers["x-anthropic-base-url"], undefined);
+});
+
 test("Stage 270 repair-done: mode auto_fix + changedFiles persisted; GET view exposes both", async () => {
   const env = makeEnv({ sandbox: makeSandbox({ names: [], calls: [] }) });
   const created = await req(env, "POST", REPAIR_PATH, { userKey: USER });


### PR DESCRIPTION
## 근본 문제

repair 컨테이너의 ClaudeWorker(auto_fix 워커)는 **api.anthropic.com 직행**이었다 — Worker측 generate* 호출은 이미 CF AI Gateway를 탄다(wrangler.toml 주석: 직행 egress ~90% 403 "Request not allowed", 2026-07-05 실측). 오늘 repair 라이브에서 같은 클래스가 재현됐다(walmart 런 403 → 재시도만으로 통과). auto_fix 신뢰성 결함.

## 변경

- **workspace-repair-jobs**: `CF_AI_GATEWAY_ANTHROPIC_URL` → `x-anthropic-base-url` 헤더로 전달 (키와 동일 원칙: 헤더 경유, 바디·로그 금지)
- **container**: 헤더 수신 → `ClaudeWorker` `clientFactory(baseURL)` — `work()`(full-file)와 `workEdits()`(oversize edit) 공통 적용. 헤더 부재 = SDK 기본 직행(타 배포 환경 무영향)

## 검증

- 라우트 테스트 2: 게이트웨이 URL 헤더 전달 / env 부재 시 헤더 없음
- central-plane build/test/lint green
- 배포 후: repair 재실행으로 403 클래스 소멸 확인 예정

컨테이너 재빌드 필요 — #441(킬스위치)과 함께 배포 1회로 발효.

🤖 Generated with [Claude Code](https://claude.com/claude-code)