### PR TITLE
fix(repair): ClaudeWorker baseURL 1급 옵션 — 컨테이너 SDK 해석 실패 수정

### DIFF
--- a/apps/central-plane/container/server.mjs
+++ b/apps/central-plane/container/server.mjs
@@ -687,19 +687,14 @@ async function attemptAutoFix({ workDir, payload, anthropicApiKey, anthropicBase
 
   // The worker agent — same dist layout the autofix path uses for cli.
   const { ClaudeWorker } = await import("file:///app/packages/agent-worker/dist/index.js");
-  // 2026-07-21 — when the Worker forwarded a CF AI Gateway base URL, build the
-  // Anthropic client against it (direct egress 403s intermittently). The
-  // factory mirrors agent-worker's default one, adding only baseURL.
+  // 2026-07-21 — when the Worker forwarded a CF AI Gateway base URL, aim the
+  // worker's Anthropic client at it (direct egress 403s intermittently).
+  // baseURL is a first-class ClaudeWorker option: the SDK import must happen
+  // inside agent-worker's own module context — a dynamic import from THIS
+  // file fails resolution ("Cannot find package '@anthropic-ai/sdk'", 실측).
   const worker = new ClaudeWorker({
     apiKey: anthropicApiKey,
-    ...(anthropicBaseUrl
-      ? {
-          clientFactory: async (key) => {
-            const mod = await import("@anthropic-ai/sdk");
-            return new mod.default({ apiKey: key, baseURL: anthropicBaseUrl });
-          },
-        }
-      : {}),
+    ...(anthropicBaseUrl ? { baseURL: anthropicBaseUrl } : {}),
   });
 
   for (let iteration = 0; iteration < AUTO_FIX_MAX_ITERATIONS; iteration++) {

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -29,7 +29,15 @@ export interface ClaudeWorkerOptions {
   /** For tests or alternate providers — inject a Messages-compatible client. */
   client?: AnthropicLike;
   /** Factory used when `client` is not supplied. Defaults to lazy-loading @anthropic-ai/sdk. */
-  clientFactory?: (apiKey: string) => Promise<AnthropicLike>;
+  clientFactory?: (apiKey: string, baseURL?: string) => Promise<AnthropicLike>;
+  /**
+   * Optional Anthropic-compatible base URL (e.g. a CF AI Gateway provider
+   * endpoint). First-class here — NOT via a caller-side clientFactory —
+   * because @anthropic-ai/sdk must resolve from THIS package's context;
+   * a dynamic import from an app entrypoint fails module resolution
+   * (2026-07-21 실측: container server.mjs "Cannot find package").
+   */
+  baseURL?: string;
 }
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
@@ -40,12 +48,12 @@ const DEFAULT_MODEL = "claude-sonnet-4-6";
  */
 const DEFAULT_MAX_TOKENS = 16_384;
 
-async function defaultClientFactory(apiKey: string): Promise<AnthropicLike> {
+async function defaultClientFactory(apiKey: string, baseURL?: string): Promise<AnthropicLike> {
   const mod = (await import("@anthropic-ai/sdk")) as unknown as {
-    default: new (opts: { apiKey: string }) => AnthropicLike;
+    default: new (opts: { apiKey: string; baseURL?: string }) => AnthropicLike;
   };
   const Ctor = mod.default;
-  return new Ctor({ apiKey });
+  return new Ctor(baseURL ? { apiKey, baseURL } : { apiKey });
 }
 
 /**
@@ -70,7 +78,8 @@ export class ClaudeWorker {
   private readonly model: string;
   private readonly maxTokens: number;
   private readonly gate: EfficiencyGate;
-  private readonly clientFactory: (apiKey: string) => Promise<AnthropicLike>;
+  private readonly clientFactory: (apiKey: string, baseURL?: string) => Promise<AnthropicLike>;
+  private readonly baseURL: string | undefined;
   private clientPromise: Promise<AnthropicLike> | null;
 
   constructor(opts: ClaudeWorkerOptions = {}) {
@@ -85,12 +94,13 @@ export class ClaudeWorker {
     this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
     this.gate = opts.gate ?? new EfficiencyGate();
     this.clientFactory = opts.clientFactory ?? defaultClientFactory;
+    this.baseURL = opts.baseURL;
     this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
   }
 
   private async getClient(): Promise<AnthropicLike> {
     if (!this.clientPromise) {
-      this.clientPromise = this.clientFactory(this.apiKey);
+      this.clientPromise = this.clientFactory(this.apiKey, this.baseURL);
     }
     return this.clientPromise;
   }

--- a/packages/agent-worker/test/worker-edits.test.mjs
+++ b/packages/agent-worker/test/worker-edits.test.mjs
@@ -153,6 +153,27 @@ test("parseEditToolUse: rejects malformed entries and missing tool block", () =>
   );
 });
 
+test("baseURL option flows into the client factory (CF AI Gateway routing)", async () => {
+  // 2026-07-21 — the SDK import must live in agent-worker's module context;
+  // callers pass baseURL as an option and every factory receives it as the
+  // second argument (the default factory forwards it to the Anthropic ctor).
+  const gate = new EfficiencyGate({ perPrUsd: 1 });
+  const seen = [];
+  const client = makeMockClient([editResponse()]);
+  const worker = new ClaudeWorker({
+    apiKey: "test-key",
+    gate,
+    baseURL: "https://gateway.ai.cloudflare.com/v1/acct/simsa/anthropic",
+    clientFactory: async (key, baseURL) => {
+      seen.push({ key, baseURL });
+      return client;
+    },
+  });
+  await worker.workEdits(editCtx);
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].baseURL, "https://gateway.ai.cloudflare.com/v1/acct/simsa/anthropic");
+});
+
 test("buildEditWorkerPrompt: excerpts are verbatim inside fences, line labels outside", () => {
   const prompt = buildEditWorkerPrompt(editCtx);
   assert.ok(prompt.includes("### lines 800-820"));


### PR DESCRIPTION
## 배경 (라이브 실측)

#442 배포 후 walmart repair 재실행: `edit_worker_call_failed: Cannot find package '@anthropic-ai/sdk' imported from /app/server.mjs` — 게이트웨이 배선의 caller-측 `clientFactory`가 server.mjs 컨텍스트에서 SDK를 dynamic import하는데, 그 경로에선 패키지 해석이 안 된다. SDK import는 agent-worker 자신의 모듈 컨텍스트에 있어야 한다.

## 변경

- **agent-worker**: `ClaudeWorkerOptions.baseURL` 1급 옵션. default factory가 Anthropic ctor에 전달, 모든 `clientFactory`는 `(apiKey, baseURL?)` 시그니처(하위호환). `work()`/`workEdits()` 공통.
- **container**: SDK import 없는 `baseURL` 옵션 사용으로 교체.
- 테스트 1: 커스텀 팩토리가 baseURL 수신.

## 검증

- agent-worker + central-plane test/typecheck/lint **6/6 green** (`--force`)
- 배포 후 walmart repair 재실행으로 게이트웨이 경유 auto_fix 실증 예정

컨테이너 재빌드 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)