### PR TITLE
feat(qa): journey-audit v2 — 오픈 게이트 표준 장비 + 프로덕션 기준선 (Train J)

### DIFF
--- a/tools/simsa-completion-loop-spike/JOURNEY-AUDIT.md
+++ b/tools/simsa-completion-loop-spike/JOURNEY-AUDIT.md
@@ -1,0 +1,47 @@
+# journey-audit — 실브라우저 여정 감사 (오픈 게이트 표준 장비)
+
+> 신설 2026-07-20(P0 2건 즉발: CORS PUT 전멸·locale 분열), v2 승격 2026-07-21
+> (실행계획 Train J). **근거 교훈: node/curl 프로브는 CORS·locale·발견성을
+> 구조적으로 못 본다 — 여정은 실브라우저로만 측정된다.**
+
+## 무엇을 재나
+
+- **여정**: J0 아이디어 입구 · J1 code 갈래 완주 · J2 spec 갈래 · J3 연결 여정
+  (아이디어 갈래의 깊은 생성 플로우는 `flow-audit.mjs` 소관 — 중복 금지)
+- **축**: KO 전체 + EN(입구 전수 + code 완주) — EN은 한글 누수(koLeak)도 측정
+- **스텝별 결정론 신호**: primary CTA 수(#5 위계) · 출구 존재(UX Basics ①) ·
+  데드엔드(⑤) · 비활성 버튼(③) · 오류/안내 카피(④) · 스크린샷
+- **자동 분류**: P0(여정 실패·happy path 오류) / P1(CTA 0 또는 ≥3·EN 한글 누수)
+  / P2(비활성 이유·막힘 안내 부재). **후보 누락 방지용 기계 패스** — 최종 판정은
+  사람이 result JSON + 스크린샷을 읽고 내린다(스크립트는 측정만).
+
+## 실행
+
+```bash
+cd tools/simsa-completion-loop-spike
+node journey-audit.mjs            # KO+EN 전체 (기준선·게이트용)
+node journey-audit.mjs --ko-only  # KO만 (수정 후 빠른 재감사)
+```
+
+산출물: `journey-audit-result.json`(steps+findings) · `journey-audit-shots/*.png`
+
+## 배포 게이트 절차 (표준)
+
+유저 여정에 닿는 변경(dashboard 전반, central-plane의 유저 대면 라우트)을 배포한 뒤:
+1. `node journey-audit.mjs --ko-only` (EN 카피를 만졌으면 풀런)
+2. `findings`의 **P0 = 0** 확인 — P0가 있으면 배포 완료 선언 금지, 즉시 수정
+3. 수정한 항목은 재감사 스크린샷으로 소멸 확인 (배너/카피가 실제로 사라졌는가)
+4. P1/P2는 이슈화(실행계획 Train U 백로그로) — 조용히 버리지 않는다
+
+## 판독 규칙
+
+- `errorish > 0` (happy path) = 유저가 오류 문구를 봤다는 뜻 — 프로브 green과 무관하게 P0
+- `primaryCtaCount`는 **main 본문 한정**(사이드바 제외) — 화면의 주인공이 1개인가(#5)
+- `koLeakChars`(EN 주행)는 셸 잔재(~수십 자)와 본문 누수(수백 자)를 구분해 읽는다
+- 비활성 버튼(③)의 "이유 표시"는 기계가 못 읽는다 — 해당 스텝 스크린샷을 연다
+
+## 한계 (정직)
+
+- 로그인/GitHub OAuth 이후 여정은 익명 컨텍스트로 못 들어간다(수동 QA 영역)
+- 시각 품질("이 화면이 예쁜가")은 오라클 없음 — 스크린샷을 사람이 본다(§5 불변식 4)
+- LLM 생성 대기(spec 변환)는 최대 60s 폴링 — 그 이상 걸리면 스텝이 미완으로 기록됨

--- a/tools/simsa-completion-loop-spike/journey-audit-result.json
+++ b/tools/simsa-completion-loop-spike/journey-audit-result.json
@@ -1,0 +1,1116 @@
+{
+  "startedAt": "2026-07-20T16:52:17.710Z",
+  "version": 2,
+  "journeys": [
+    {
+      "name": "J0 아이디어 갈래 입구: 첫 화면 → 스텝1 → 인터뷰 진입",
+      "locale": "ko",
+      "steps": [
+        {
+          "label": "갈래 선택 화면",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/new",
+          "h1": [
+            "무엇부터 시작할까요?"
+          ],
+          "buttons": [
+            "«",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "아이디어만 있어요 만들고 싶은 걸 말하면 확인할 항목으로 정리해드려요.",
+            "이미 만든 앱이 있어요 코드를 연결하면 바로 검수해요.",
+            "기획서가 있어요 붙여넣으면 확인할 항목으로 바꿔드려요."
+          ],
+          "primaryCta": [],
+          "primaryCtaCount": 0,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 0,
+          "disabledLabels": [],
+          "bodyLen": 279,
+          "errorish": 0,
+          "guidanceish": 0,
+          "koLeakChars": 179,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO ← 전체 프로젝트 무엇부터 시작할까요? 지금 갖고 계신 걸 고르세요 — 어느 쪽이든 결국 '내 앱 검수'로 이어져요. 아이디어만 있어요 만들고 싶은 걸 말하면 확인할 항목으로 정리해드려요. 이미 만든 앱이 있어요 코드를 연결하면 바로 검수해요. 기획서가 있어요 붙여넣으면 확인할 항목으로 바꿔드려요."
+        },
+        {
+          "label": "idea 스텝1 — 무엇을 묻는가",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/new?path=idea",
+          "h1": [
+            "어떤 제품을 만들고 싶으신가요?"
+          ],
+          "buttons": [
+            "«",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "← 처음 선택으로 돌아가기",
+            "회의 녹음을 요약해서 할 일을 Linear로 보내주는 앱",
+            "사진을 올리면 쇼핑몰 상품 설명을 자동으로 써주는 도구",
+            "고객 문의를 분석해서 FAQ를 자동으로 정리해주는 서비스",
+            "웹사이트·웹앱",
+            "휴대폰 앱",
+            "잘 모르겠어요",
+            "있고 익숙해요",
+            "들어봤지만 잘 몰라요",
+            "처음 들어요",
+            "네",
+            "조금",
+            "아뇨",
+            "제품 설명서 만들기 →"
+          ],
+          "primaryCta": [
+            "제품 설명서 만들기 →"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "제품 설명서 만들기 →"
+          ],
+          "bodyLen": 500,
+          "errorish": 0,
+          "guidanceish": 0,
+          "koLeakChars": 307,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 1 아이디어 → 2 이해 → 3 질문 → 4 완성 ← 처음 선택으로 돌아가기 어떤 제품을 만들고 싶으신가요? 완성된 문장이 아니어도 괜찮습니다. 아이디어를 자유롭게 적어주세요. 예시로 시작하기 회의 녹음을 요약해서 할 일을 Linear로 보내주는 앱 사진을 올리면 쇼핑몰 상품 설명을 자동으로 써주는 도구 고객 문의를 분석해서 FAQ를 자동으로 정리해주는 서비스 심사에게 더 알려줄 내용이 있나요? (선택) 몇 가지만 알려주세요 (선택) — 안내를 맞춰 드려요 어디서 돌아가는 앱인가요? 웹사이트·웹앱 휴대폰 앱 잘"
+        },
+        {
+          "label": "인터뷰 첫 질문 화면",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/new?path=idea",
+          "h1": [
+            "어떤 제품을 만들고 싶으신가요?"
+          ],
+          "buttons": [
+            "«",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "← 처음 선택으로 돌아가기",
+            "회의 녹음을 요약해서 할 일을 Linear로 보내주는 앱",
+            "사진을 올리면 쇼핑몰 상품 설명을 자동으로 써주는 도구",
+            "고객 문의를 분석해서 FAQ를 자동으로 정리해주는 서비스",
+            "웹사이트·웹앱",
+            "휴대폰 앱",
+            "잘 모르겠어요",
+            "있고 익숙해요",
+            "들어봤지만 잘 몰라요",
+            "처음 들어요",
+            "네",
+            "조금",
+            "아뇨",
+            "Simsa가 이해하는 중…"
+          ],
+          "primaryCta": [
+            "Simsa가 이해하는 중…"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "Simsa가 이해하는 중…"
+          ],
+          "bodyLen": 518,
+          "errorish": 0,
+          "guidanceish": 0,
+          "koLeakChars": 316,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 1 아이디어 → 2 이해 → 3 질문 → 4 완성 ← 처음 선택으로 돌아가기 어떤 제품을 만들고 싶으신가요? 완성된 문장이 아니어도 괜찮습니다. 아이디어를 자유롭게 적어주세요. 예시로 시작하기 회의 녹음을 요약해서 할 일을 Linear로 보내주는 앱 사진을 올리면 쇼핑몰 상품 설명을 자동으로 써주는 도구 고객 문의를 분석해서 FAQ를 자동으로 정리해주는 서비스 심사에게 더 알려줄 내용이 있나요? (선택) 몇 가지만 알려주세요 (선택) — 안내를 맞춰 드려요 어디서 돌아가는 앱인가요? 웹사이트·웹앱 휴대폰 앱 잘"
+        }
+      ],
+      "failure": null
+    },
+    {
+      "name": "J1 기존-앱 갈래: 만든 앱 검수받기 완주",
+      "locale": "ko",
+      "steps": [
+        {
+          "label": "code 갈래 스텝1 — 무엇을 묻는가",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/new?path=code",
+          "h1": [
+            "앱에 대해 알려주세요"
+          ],
+          "buttons": [
+            "«",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "← 처음 선택으로 돌아가기",
+            "v0",
+            "Lovable",
+            "Bolt",
+            "Cursor",
+            "Claude Code",
+            "Replit",
+            "Windsurf",
+            "Codex",
+            "직접 코딩",
+            "프로젝트 만들고 코드 연결하기 →"
+          ],
+          "primaryCta": [
+            "프로젝트 만들고 코드 연결하기 →"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "프로젝트 만들고 코드 연결하기 →"
+          ],
+          "bodyLen": 407,
+          "errorish": 0,
+          "guidanceish": 0,
+          "koLeakChars": 219,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO ← 처음 선택으로 돌아가기 앱에 대해 알려주세요 기본 정보만 적으면 — 바로 코드를 연결하고 검수할 수 있어요. 앱 이름 이 앱을 어떤 도구로 만들었나요? 해당하는 것 모두 골라주세요. 각 도구의 방식에 맞춰 확인 품질을 높이는 데 써요. v0 Lovable Bolt Cursor Claude Code Replit Windsurf Codex 직접 코딩 무엇을 하는 앱인가요? (선택) 꼭 작동해야 하는 건 뭔가요? (선택) 2~3개면 충분해요. 적어주시면 확인 항목이 내 앱에 맞게 만들어져요. 프로젝트 만들고 코드"
+        },
+        {
+          "label": "code 스텝1 입력 후",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/new?path=code",
+          "h1": [
+            "앱에 대해 알려주세요"
+          ],
+          "buttons": [
+            "«",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "← 처음 선택으로 돌아가기",
+            "v0",
+            "Lovable",
+            "Bolt",
+            "Cursor",
+            "Claude Code",
+            "Replit",
+            "Windsurf",
+            "Codex",
+            "직접 코딩",
+            "프로젝트 만들고 코드 연결하기 →"
+          ],
+          "primaryCta": [
+            "프로젝트 만들고 코드 연결하기 →"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 0,
+          "disabledLabels": [],
+          "bodyLen": 407,
+          "errorish": 0,
+          "guidanceish": 0,
+          "koLeakChars": 219,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO ← 처음 선택으로 돌아가기 앱에 대해 알려주세요 기본 정보만 적으면 — 바로 코드를 연결하고 검수할 수 있어요. 앱 이름 이 앱을 어떤 도구로 만들었나요? 해당하는 것 모두 골라주세요. 각 도구의 방식에 맞춰 확인 품질을 높이는 데 써요. v0 Lovable Bolt Cursor Claude Code Replit Windsurf Codex 직접 코딩 무엇을 하는 앱인가요? (선택) 꼭 작동해야 하는 건 뭔가요? (선택) 2~3개면 충분해요. 적어주시면 확인 항목이 내 앱에 맞게 만들어져요. 프로젝트 만들고 코드"
+        },
+        {
+          "label": "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/proj_gr55qrvw/settings",
+          "h1": [
+            "준비와 연결"
+          ],
+          "buttons": [
+            "«",
+            "고급 +",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "GitHub 연결",
+            "키 찾는 방법",
+            "✕",
+            "키 찾는 방법",
+            "✕",
+            "+ Resend (이메일 보내기)",
+            "+ Sentry (오류 추적)",
+            "Claude Code",
+            "Codex",
+            "복사",
+            "복사",
+            "작성하고 저장하기",
+            "저장",
+            "저장",
+            "새로고침",
+            "다음: 코드 변경 →"
+          ],
+          "primaryCta": [
+            "GitHub 연결",
+            "작성하고 저장하기"
+          ],
+          "primaryCtaCount": 2,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 2,
+          "disabledLabels": [
+            "저장",
+            "저장"
+          ],
+          "bodyLen": 3315,
+          "errorish": 0,
+          "guidanceish": 2,
+          "koLeakChars": 1745,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 ✓ 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 준비와 연결 앱에 필요한 서비스와 키를 준비하고, 알림을 설정하고, 코드가 있는 곳을 연결하는 — 이 프로젝트를 위해 한 번 해두는 것들이에요. GitHub 연결 GitHub 계정을 연결하면 이 프로젝트에 쓸 저장소를 고를 수 있어요. GitHub 연결 현재 브라우저에 로그인된 GitHub 계정으로 연결됩니다. github.com에서 로그아웃 GitHu"
+        },
+        {
+          "label": "개요 — 지금 할 일이 이 갈래에 맞는가",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/proj_gr55qrvw",
+          "h1": [
+            "동네 빵집 예약 테스트앱"
+          ],
+          "buttons": [
+            "«",
+            "고급 +",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "첫 검수 실행하기",
+            "도움받기"
+          ],
+          "primaryCta": [
+            "도움받기"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "도움받기"
+          ],
+          "bodyLen": 1004,
+          "errorish": 0,
+          "guidanceish": 1,
+          "koLeakChars": 601,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 ✓ 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 동네 빵집 예약 테스트앱 고객이 원하는 시간에 빵을 예약하고 픽업하는 웹앱 지금 할 일 ✓ 준비 2 만들기·검수 3 결과·수정 1. 제품 설명서 확인 — 만들고 싶은 제품을 Simsa가 제대로 이해했는지 봐주세요. 2. 코드 저장소 연결 — AI가 만든 코드가 있는 GitHub 저장소를 연결하세요. 3. 확인 실행 — 코드 변경을 골라 검수 항목 기준으"
+        },
+        {
+          "label": "checks 첫 화면 — 모드 선택/소스 없이 안내",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/proj_gr55qrvw/checks",
+          "h1": [
+            "확인 결과"
+          ],
+          "buttons": [
+            "«",
+            "고급 +",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "기본 검수 선택됨 AI가 검수하고, 문제로 판정된 항목은 다른 AI가 한 번 더 교차 확인해요 — 모든 플랜에 포함.",
+            "협의체 검수 유료 플랜 AI 3개가 각자 검토하고, 의견이 갈리면 토론해 합의한 뒤 판정해요 — 가장 깊은 검수, 유료 플랜 전용.",
+            "확인 실행",
+            "코드 변경(PR) 연결하고 확인하기 →"
+          ],
+          "primaryCta": [
+            "확인 실행",
+            "코드 변경(PR) 연결하고 확인하기 →"
+          ],
+          "primaryCtaCount": 2,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 0,
+          "disabledLabels": [],
+          "bodyLen": 651,
+          "errorish": 0,
+          "guidanceish": 0,
+          "koLeakChars": 391,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 ✓ 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 확인 결과 확인 항목을 기준으로 제품을 확인한 결과예요. 제품 설명서 기준 사전 확인 코드를 연결하기 전에 제품 설명서와 검수 항목을 확인합니다. 어떻게 검수할까요? 기본 검수 선택됨 AI가 검수하고, 문제로 판정된 항목은 다른 AI가 한 번 더 교차 확인해요 — 모든 플랜에 포함. 협의체 검수 유료 플랜 AI 3개가 각자 검토하고, 의견이 갈리면 토론"
+        },
+        {
+          "label": "소스 없이 검수 시도 — 막힘 안내",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/proj_gr55qrvw/checks",
+          "h1": [
+            "확인 결과"
+          ],
+          "buttons": [
+            "«",
+            "고급 +",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "기본 검수 선택됨 AI가 검수하고, 문제로 판정된 항목은 다른 AI가 한 번 더 교차 확인해요 — 모든 플랜에 포함.",
+            "협의체 검수 유료 플랜 AI 3개가 각자 검토하고, 의견이 갈리면 토론해 합의한 뒤 판정해요 — 가장 깊은 검수, 유료 플랜 전용.",
+            "확인 실행",
+            "코드 변경(PR) 연결하고 확인하기 →"
+          ],
+          "primaryCta": [
+            "확인 실행",
+            "코드 변경(PR) 연결하고 확인하기 →"
+          ],
+          "primaryCtaCount": 2,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 0,
+          "disabledLabels": [],
+          "bodyLen": 653,
+          "errorish": 0,
+          "guidanceish": 2,
+          "koLeakChars": 393,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 ✓ 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 코드를 먼저 연결하세요. 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 확인 결과 확인 항목을 기준으로 제품을 확인한 결과예요. 제품 설명서 기준 사전 확인 코드를 연결하기 전에 제품 설명서와 검수 항목을 확인합니다. 어떻게 검수할까요? 기본 검수 선택됨 AI가 검수하고, 문제로 판정된 항목은 다른 AI가 한 번 더 교차 확인해요 — 모든 플랜에 포함. 협의체 검수 유료 플랜 AI 3개가 각자 검토하고, 의견이 갈리면 "
+        }
+      ],
+      "failure": null
+    },
+    {
+      "name": "J2 기획서 갈래: 붙여넣기→변환→다음 행동",
+      "locale": "ko",
+      "steps": [
+        {
+          "label": "spec 갈래 스텝1",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/new?path=spec",
+          "h1": [
+            "기획서를 붙여넣어 주세요"
+          ],
+          "buttons": [
+            "«",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "← 처음 선택으로 돌아가기",
+            "확인 항목으로 바꾸기 →"
+          ],
+          "primaryCta": [
+            "확인 항목으로 바꾸기 →"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "확인 항목으로 바꾸기 →"
+          ],
+          "bodyLen": 276,
+          "errorish": 0,
+          "guidanceish": 0,
+          "koLeakChars": 149,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO ← 처음 선택으로 돌아가기 기획서를 붙여넣어 주세요 형식은 상관없어요 — 문서, 메모, 요구사항 무엇이든. 확인할 항목으로 바꿔드려요. 파일에서 불러오기 hwpx · PDF · Word · txt/md/json/csv — 화면 아무 데나 끌어다 놓아도 돼요. 확인 항목으로 바꾸기 → 무료 베타"
+        },
+        {
+          "label": "변환 중/직후",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/new?path=spec",
+          "h1": [
+            "기획서를 붙여넣어 주세요"
+          ],
+          "buttons": [
+            "«",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "← 처음 선택으로 돌아가기",
+            "Simsa가 이해하는 중…"
+          ],
+          "primaryCta": [
+            "Simsa가 이해하는 중…"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "Simsa가 이해하는 중…"
+          ],
+          "bodyLen": 291,
+          "errorish": 0,
+          "guidanceish": 0,
+          "koLeakChars": 156,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO ← 처음 선택으로 돌아가기 기획서를 붙여넣어 주세요 형식은 상관없어요 — 문서, 메모, 요구사항 무엇이든. 확인할 항목으로 바꿔드려요. 파일에서 불러오기 hwpx · PDF · Word · txt/md/json/csv — 화면 아무 데나 끌어다 놓아도 돼요. Simsa가 이해하는 중… 아이디어를 읽고 있어요… 무료 베타"
+        },
+        {
+          "label": "변환 결과 화면",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/new?path=spec",
+          "h1": [],
+          "buttons": [
+            "«",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "v0",
+            "Lovable",
+            "Bolt",
+            "Cursor",
+            "Claude Code",
+            "Replit",
+            "Windsurf",
+            "Codex",
+            "직접 코딩",
+            "← 붙여넣기로 돌아가기",
+            "저장하고 프로젝트 시작하기 →"
+          ],
+          "primaryCta": [
+            "저장하고 프로젝트 시작하기 →"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 0,
+          "disabledLabels": [],
+          "bodyLen": 2812,
+          "errorish": 0,
+          "guidanceish": 0,
+          "koLeakChars": 1816,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 이 앱을 어떤 도구로 만들었나요? 해당하는 것 모두 골라주세요. 각 도구의 방식에 맞춰 확인 품질을 높이는 데 써요. v0 Lovable Bolt Cursor Claude Code Replit Windsurf Codex 직접 코딩 ✓ 제품 설명서 초안이 완성됐습니다 저장하면 프로젝트 페이지에서 언제든 확인할 수 있습니다. 반려견 산책 기록 웹앱 반려견과의 산책을 GPS로 기록하고, 주간 통계를 보며, 기록을 공유하는 개인용 산책 다이어리입니다. 누가 쓰는 제품 반려견을 기르는 개인 보호자, 여러 반려견을 함께 "
+        },
+        {
+          "label": "저장 후 랜딩 — 다음 행동",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/proj_gseombua",
+          "h1": [
+            "반려견 산책 기록 웹앱"
+          ],
+          "buttons": [
+            "«",
+            "고급 +",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "첫 검수 실행하기",
+            "도움받기"
+          ],
+          "primaryCta": [
+            "도움받기"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "도움받기"
+          ],
+          "bodyLen": 1011,
+          "errorish": 0,
+          "guidanceish": 1,
+          "koLeakChars": 638,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 반려견 산책 기록 웹앱 개요 ✓ 준비 아이디어 제품 설명서 확인 항목 2 만들기·검수 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 반려견 산책 기록 웹앱 반려견과의 산책을 GPS로 기록하고, 주간 통계를 보며, 기록을 공유하는 개인용 산책 다이어리입니다. 지금 할 일 ✓ 준비 2 만들기·검수 3 결과·수정 1. 제품 설명서 확인 — 만들고 싶은 제품을 Simsa가 제대로 이해했는지 봐주세요. 2. 코드 저장소 연결 — AI가 만든 코드가 있는 GitHub 저장소를 연결하세요. 3. 확인 실행 — 코"
+        }
+      ],
+      "failure": null
+    },
+    {
+      "name": "J3 repo 연결 여정: GitHub 미연결 신규 유저",
+      "locale": "ko",
+      "steps": [
+        {
+          "label": "settings/연결 화면 — 미연결 유저가 보는 것",
+          "note": "",
+          "locale": "ko",
+          "url": "https://app.trysimsa.com/projects/proj_gshpwt63/settings",
+          "h1": [
+            "준비와 연결"
+          ],
+          "buttons": [
+            "«",
+            "고급 +",
+            "도움말 · 피드백",
+            "M 워크스페이스 로그인 → ⌃",
+            "EN",
+            "KO",
+            "GitHub 연결",
+            "키 찾는 방법",
+            "✕",
+            "+ Supabase (데이터 저장·로그인)",
+            "+ Resend (이메일 보내기)",
+            "+ Sentry (오류 추적)",
+            "Claude Code",
+            "Codex",
+            "복사",
+            "복사",
+            "작성하고 저장하기",
+            "저장",
+            "저장",
+            "새로고침",
+            "다음: 코드 변경 →"
+          ],
+          "primaryCta": [
+            "GitHub 연결",
+            "작성하고 저장하기"
+          ],
+          "primaryCtaCount": 2,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 2,
+          "disabledLabels": [
+            "저장",
+            "저장"
+          ],
+          "bodyLen": 2960,
+          "errorish": 0,
+          "guidanceish": 2,
+          "koLeakChars": 1605,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 연결 여정 테스트 개요 1 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 준비와 연결 앱에 필요한 서비스와 키를 준비하고, 알림을 설정하고, 코드가 있는 곳을 연결하는 — 이 프로젝트를 위해 한 번 해두는 것들이에요. GitHub 연결 GitHub 계정을 연결하면 이 프로젝트에 쓸 저장소를 고를 수 있어요. GitHub 연결 현재 브라우저에 로그인된 GitHub 계정으로 연결됩니다. github.com에서 로그아웃 GitHub이 처"
+        }
+      ],
+      "failure": null
+    },
+    {
+      "name": "J0 아이디어 갈래 입구: 첫 화면 → 스텝1 → 인터뷰 진입",
+      "locale": "en",
+      "steps": [
+        {
+          "label": "갈래 선택 화면",
+          "note": "",
+          "locale": "en",
+          "url": "https://app.trysimsa.com/projects/new",
+          "h1": [
+            "What do you have to start with?"
+          ],
+          "buttons": [
+            "«",
+            "Help & feedback",
+            "M Workspace Sign in → ⌃",
+            "EN",
+            "KO",
+            "I just have an idea Describe what you want to build. We'll turn it into things to check.",
+            "I already built an app Connect the code and review it right away.",
+            "I have a plan or spec Paste it in and we'll turn it into things to check."
+          ],
+          "primaryCta": [],
+          "primaryCtaCount": 0,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 0,
+          "disabledLabels": [],
+          "bodyLen": 498,
+          "errorish": 0,
+          "guidanceish": 1,
+          "koLeakChars": 8,
+          "bodyHead": "Simsa « ＋ New project ALL PROJECTS 회의록 자동 요약 앱Example Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO ← All projects What do you have to start with? Pick whatever fits — you'll end up in the same place: your app, reviewed. I just have an idea Describe what you want to build. We'll turn it into things to check. I already built an app Connect the code a"
+        },
+        {
+          "label": "idea 스텝1 — 무엇을 묻는가",
+          "note": "",
+          "locale": "en",
+          "url": "https://app.trysimsa.com/projects/new?path=idea",
+          "h1": [
+            "What do you want to build?"
+          ],
+          "buttons": [
+            "«",
+            "Help & feedback",
+            "M Workspace Sign in → ⌃",
+            "EN",
+            "KO",
+            "← Back to the three choices",
+            "An app that summarizes meeting recordings and sends the action items to Linear",
+            "A tool where uploading a photo auto-writes the e-commerce product description",
+            "A service that analyzes customer questions and organizes the FAQ automatically",
+            "Website / web app",
+            "Phone app",
+            "Not sure",
+            "Yes, comfortable",
+            "Heard of it",
+            "First time",
+            "Yes",
+            "A little",
+            "No",
+            "Create product brief →"
+          ],
+          "primaryCta": [
+            "Create product brief →"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "Create product brief →"
+          ],
+          "bodyLen": 873,
+          "errorish": 0,
+          "guidanceish": 1,
+          "koLeakChars": 8,
+          "bodyHead": "Simsa « ＋ New project ALL PROJECTS 회의록 자동 요약 앱Example Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO 1 Idea → 2 Understand → 3 Questions → 4 Done ← Back to the three choices What do you want to build? A rough sentence is fine — write your idea freely. Start from an example An app that summarizes meeting recordings and sends the action items to Linear"
+        },
+        {
+          "label": "인터뷰 첫 질문 화면",
+          "note": "",
+          "locale": "en",
+          "url": "https://app.trysimsa.com/projects/new?path=idea",
+          "h1": [
+            "What do you want to build?"
+          ],
+          "buttons": [
+            "«",
+            "Help & feedback",
+            "M Workspace Sign in → ⌃",
+            "EN",
+            "KO",
+            "← Back to the three choices",
+            "An app that summarizes meeting recordings and sends the action items to Linear",
+            "A tool where uploading a photo auto-writes the e-commerce product description",
+            "A service that analyzes customer questions and organizes the FAQ automatically",
+            "Website / web app",
+            "Phone app",
+            "Not sure",
+            "Yes, comfortable",
+            "Heard of it",
+            "First time",
+            "Yes",
+            "A little",
+            "No",
+            "Simsa is reading…"
+          ],
+          "primaryCta": [
+            "Simsa is reading…"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "Simsa is reading…"
+          ],
+          "bodyLen": 895,
+          "errorish": 0,
+          "guidanceish": 1,
+          "koLeakChars": 8,
+          "bodyHead": "Simsa « ＋ New project ALL PROJECTS 회의록 자동 요약 앱Example Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO 1 Idea → 2 Understand → 3 Questions → 4 Done ← Back to the three choices What do you want to build? A rough sentence is fine — write your idea freely. Start from an example An app that summarizes meeting recordings and sends the action items to Linear"
+        }
+      ],
+      "failure": null
+    },
+    {
+      "name": "J1 기존-앱 갈래: 만든 앱 검수받기 완주",
+      "locale": "en",
+      "steps": [
+        {
+          "label": "code 갈래 스텝1 — 무엇을 묻는가",
+          "note": "",
+          "locale": "en",
+          "url": "https://app.trysimsa.com/projects/new?path=code",
+          "h1": [
+            "Tell us about your app"
+          ],
+          "buttons": [
+            "«",
+            "Help & feedback",
+            "M Workspace Sign in → ⌃",
+            "EN",
+            "KO",
+            "← Back to the three choices",
+            "v0",
+            "Lovable",
+            "Bolt",
+            "Cursor",
+            "Claude Code",
+            "Replit",
+            "Windsurf",
+            "Codex",
+            "Hand-coded",
+            "Create project & connect code →"
+          ],
+          "primaryCta": [
+            "Create project & connect code →"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "Create project & connect code →"
+          ],
+          "bodyLen": 618,
+          "errorish": 0,
+          "guidanceish": 2,
+          "koLeakChars": 8,
+          "bodyHead": "Simsa « ＋ New project ALL PROJECTS 회의록 자동 요약 앱Example Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO ← Back to the three choices Tell us about your app Just the basics — then connect the code and review right away. App name Which tool did you build this with? Pick any that apply. This helps us tailor reviews to how each tool works. v0 Lovable Bolt Cu"
+        },
+        {
+          "label": "code 스텝1 입력 후",
+          "note": "",
+          "locale": "en",
+          "url": "https://app.trysimsa.com/projects/new?path=code",
+          "h1": [
+            "Tell us about your app"
+          ],
+          "buttons": [
+            "«",
+            "Help & feedback",
+            "M Workspace Sign in → ⌃",
+            "EN",
+            "KO",
+            "← Back to the three choices",
+            "v0",
+            "Lovable",
+            "Bolt",
+            "Cursor",
+            "Claude Code",
+            "Replit",
+            "Windsurf",
+            "Codex",
+            "Hand-coded",
+            "Create project & connect code →"
+          ],
+          "primaryCta": [
+            "Create project & connect code →"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 0,
+          "disabledLabels": [],
+          "bodyLen": 618,
+          "errorish": 0,
+          "guidanceish": 2,
+          "koLeakChars": 8,
+          "bodyHead": "Simsa « ＋ New project ALL PROJECTS 회의록 자동 요약 앱Example Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO ← Back to the three choices Tell us about your app Just the basics — then connect the code and review right away. App name Which tool did you build this with? Pick any that apply. This helps us tailor reviews to how each tool works. v0 Lovable Bolt Cu"
+        },
+        {
+          "label": "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가",
+          "note": "",
+          "locale": "en",
+          "url": "https://app.trysimsa.com/projects/proj_gtek266g/settings",
+          "h1": [
+            "Prep & connections"
+          ],
+          "buttons": [
+            "«",
+            "ADVANCED +",
+            "Help & feedback",
+            "M Workspace Sign in → ⌃",
+            "EN",
+            "KO",
+            "Connect GitHub",
+            "How to get the keys",
+            "✕",
+            "How to get the keys",
+            "✕",
+            "How to get the keys",
+            "✕",
+            "+ Sentry (오류 추적)",
+            "Claude Code",
+            "Codex",
+            "Copy",
+            "Copy",
+            "Save setup",
+            "Save",
+            "Save",
+            "Refresh",
+            "Next: Code changes →"
+          ],
+          "primaryCta": [
+            "Connect GitHub",
+            "Save setup"
+          ],
+          "primaryCtaCount": 2,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 2,
+          "disabledLabels": [
+            "Save",
+            "Save"
+          ],
+          "bodyLen": 5183,
+          "errorish": 0,
+          "guidanceish": 14,
+          "koLeakChars": 478,
+          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview ✓ Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Review results Visual checks ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Prep & connections Get the app's service"
+        },
+        {
+          "label": "개요 — 지금 할 일이 이 갈래에 맞는가",
+          "note": "",
+          "locale": "en",
+          "url": "https://app.trysimsa.com/projects/proj_gtek266g",
+          "h1": [
+            "Bakery reservation test app"
+          ],
+          "buttons": [
+            "«",
+            "ADVANCED +",
+            "Help & feedback",
+            "M Workspace Sign in → ⌃",
+            "EN",
+            "KO",
+            "Run your first inspection",
+            "Get help"
+          ],
+          "primaryCta": [
+            "Get help"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "Get help"
+          ],
+          "bodyLen": 1964,
+          "errorish": 0,
+          "guidanceish": 4,
+          "koLeakChars": 0,
+          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview ✓ Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Review results Visual checks ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Bakery reservation test app A simple onl"
+        },
+        {
+          "label": "checks 첫 화면 — 모드 선택/소스 없이 안내",
+          "note": "",
+          "locale": "en",
+          "url": "https://app.trysimsa.com/projects/proj_gtek266g/checks",
+          "h1": [
+            "Review results"
+          ],
+          "buttons": [
+            "«",
+            "ADVANCED +",
+            "Help & feedback",
+            "M Workspace Sign in → ⌃",
+            "EN",
+            "KO",
+            "Standard check Selected One AI checks, a second AI cross-verifies every problem call — included on every plan.",
+            "Council check Paid plan Three AIs review independently, debate disagreements, and agree before the verdict — the deepest check, on the paid plan.",
+            "Run check",
+            "Connect and review code changes →"
+          ],
+          "primaryCta": [
+            "Run check",
+            "Connect and review code changes →"
+          ],
+          "primaryCtaCount": 2,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 0,
+          "disabledLabels": [],
+          "bodyLen": 1180,
+          "errorish": 0,
+          "guidanceish": 4,
+          "koLeakChars": 0,
+          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview ✓ Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Review results Visual checks ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Review results The results of checking y"
+        },
+        {
+          "label": "소스 없이 검수 시도 — 막힘 안내",
+          "note": "",
+          "locale": "en",
+          "url": "https://app.trysimsa.com/projects/proj_gtek266g/checks",
+          "h1": [
+            "Review results"
+          ],
+          "buttons": [
+            "«",
+            "ADVANCED +",
+            "Help & feedback",
+            "M Workspace Sign in → ⌃",
+            "EN",
+            "KO",
+            "Standard check Selected One AI checks, a second AI cross-verifies every problem call — included on every plan.",
+            "Council check Paid plan Three AIs review independently, debate disagreements, and agree before the verdict — the deepest check, on the paid plan.",
+            "Run check",
+            "Connect and review code changes →"
+          ],
+          "primaryCta": [
+            "Run check",
+            "Connect and review code changes →"
+          ],
+          "primaryCtaCount": 2,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 0,
+          "disabledLabels": [],
+          "bodyLen": 1176,
+          "errorish": 0,
+          "guidanceish": 6,
+          "koLeakChars": 0,
+          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview ✓ Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Connect your code first. ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Review results The results of checking your "
+        }
+      ],
+      "failure": null
+    },
+    {
+      "name": "J2e 기획서 갈래 입구(EN)",
+      "locale": "en",
+      "steps": [
+        {
+          "label": "spec 갈래 스텝1 (EN)",
+          "note": "",
+          "locale": "en",
+          "url": "https://app.trysimsa.com/projects/new?path=spec",
+          "h1": [
+            "Paste your plan"
+          ],
+          "buttons": [
+            "«",
+            "Help & feedback",
+            "M Workspace Sign in → ⌃",
+            "EN",
+            "KO",
+            "← Back to the three choices",
+            "Turn it into a checklist →"
+          ],
+          "primaryCta": [
+            "Turn it into a checklist →"
+          ],
+          "primaryCtaCount": 1,
+          "hasExit": true,
+          "deadEnd": false,
+          "disabledCount": 1,
+          "disabledLabels": [
+            "Turn it into a checklist →"
+          ],
+          "bodyLen": 405,
+          "errorish": 0,
+          "guidanceish": 0,
+          "koLeakChars": 8,
+          "bodyHead": "Simsa « ＋ New project ALL PROJECTS 회의록 자동 요약 앱Example Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO ← Back to the three choices Paste your plan Any format works — a doc, bullet notes, a spec. We'll turn it into things to check. Load from file hwpx · PDF · Word · txt/md/json/csv — or drop a file anywhere on the screen. Turn it into a checklist → Free"
+        }
+      ],
+      "failure": null
+    }
+  ],
+  "findings": [
+    {
+      "sev": "P1",
+      "journey": "J0 아이디어 갈래 입구: 첫 화면 → 스텝1 → 인터뷰 진입",
+      "locale": "ko",
+      "step": "갈래 선택 화면",
+      "what": "primary CTA 0 — 다음 행동이 버튼으로 안 보임"
+    },
+    {
+      "sev": "P2",
+      "journey": "J0 아이디어 갈래 입구: 첫 화면 → 스텝1 → 인터뷰 진입",
+      "locale": "ko",
+      "step": "idea 스텝1 — 무엇을 묻는가",
+      "what": "비활성 버튼 1개(제품 설명서 만들기 →) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J0 아이디어 갈래 입구: 첫 화면 → 스텝1 → 인터뷰 진입",
+      "locale": "ko",
+      "step": "인터뷰 첫 질문 화면",
+      "what": "비활성 버튼 1개(Simsa가 이해하는 중…) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J1 기존-앱 갈래: 만든 앱 검수받기 완주",
+      "locale": "ko",
+      "step": "code 갈래 스텝1 — 무엇을 묻는가",
+      "what": "비활성 버튼 1개(프로젝트 만들고 코드 연결하기 →) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J1 기존-앱 갈래: 만든 앱 검수받기 완주",
+      "locale": "ko",
+      "step": "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가",
+      "what": "비활성 버튼 2개(저장/저장) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J1 기존-앱 갈래: 만든 앱 검수받기 완주",
+      "locale": "ko",
+      "step": "개요 — 지금 할 일이 이 갈래에 맞는가",
+      "what": "비활성 버튼 1개(도움받기) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J2 기획서 갈래: 붙여넣기→변환→다음 행동",
+      "locale": "ko",
+      "step": "spec 갈래 스텝1",
+      "what": "비활성 버튼 1개(확인 항목으로 바꾸기 →) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J2 기획서 갈래: 붙여넣기→변환→다음 행동",
+      "locale": "ko",
+      "step": "변환 중/직후",
+      "what": "비활성 버튼 1개(Simsa가 이해하는 중…) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J2 기획서 갈래: 붙여넣기→변환→다음 행동",
+      "locale": "ko",
+      "step": "저장 후 랜딩 — 다음 행동",
+      "what": "비활성 버튼 1개(도움받기) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J3 repo 연결 여정: GitHub 미연결 신규 유저",
+      "locale": "ko",
+      "step": "settings/연결 화면 — 미연결 유저가 보는 것",
+      "what": "비활성 버튼 2개(저장/저장) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P1",
+      "journey": "J0 아이디어 갈래 입구: 첫 화면 → 스텝1 → 인터뷰 진입",
+      "locale": "en",
+      "step": "갈래 선택 화면",
+      "what": "primary CTA 0 — 다음 행동이 버튼으로 안 보임"
+    },
+    {
+      "sev": "P2",
+      "journey": "J0 아이디어 갈래 입구: 첫 화면 → 스텝1 → 인터뷰 진입",
+      "locale": "en",
+      "step": "idea 스텝1 — 무엇을 묻는가",
+      "what": "비활성 버튼 1개(Create product brief →) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J0 아이디어 갈래 입구: 첫 화면 → 스텝1 → 인터뷰 진입",
+      "locale": "en",
+      "step": "인터뷰 첫 질문 화면",
+      "what": "비활성 버튼 1개(Simsa is reading…) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J1 기존-앱 갈래: 만든 앱 검수받기 완주",
+      "locale": "en",
+      "step": "code 갈래 스텝1 — 무엇을 묻는가",
+      "what": "비활성 버튼 1개(Create project & connect code →) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P1",
+      "journey": "J1 기존-앱 갈래: 만든 앱 검수받기 완주",
+      "locale": "en",
+      "step": "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가",
+      "what": "EN 주행 한글 누수 478자"
+    },
+    {
+      "sev": "P2",
+      "journey": "J1 기존-앱 갈래: 만든 앱 검수받기 완주",
+      "locale": "en",
+      "step": "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가",
+      "what": "비활성 버튼 2개(Save/Save) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J1 기존-앱 갈래: 만든 앱 검수받기 완주",
+      "locale": "en",
+      "step": "개요 — 지금 할 일이 이 갈래에 맞는가",
+      "what": "비활성 버튼 1개(Get help) — 이유 표시 스크린샷 확인"
+    },
+    {
+      "sev": "P2",
+      "journey": "J2e 기획서 갈래 입구(EN)",
+      "locale": "en",
+      "step": "spec 갈래 스텝1 (EN)",
+      "what": "비활성 버튼 1개(Turn it into a checklist →) — 이유 표시 스크린샷 확인"
+    }
+  ]
+}

--- a/tools/simsa-completion-loop-spike/journey-audit.mjs
+++ b/tools/simsa-completion-loop-spike/journey-audit.mjs
@@ -1,157 +1,268 @@
 /**
- * journey-audit.mjs — 신규 유저 시점 "갈래 완주" QA (2026-07-20, Bae:
- * "왜 이렇게 플로우에 허점이 많아 — 뭘 돌린 거야 QA").
+ * journey-audit.mjs — 신규 유저 시점 "갈래 완주" QA. (2026-07-20 신설, Bae:
+ * "왜 이렇게 플로우에 허점이 많아 — 뭘 돌린 거야 QA")
  *
- * flow-audit.mjs(아이디어 갈래+탭 순회)가 못 걸었던 표면을 채점한다:
- *   J1 기존-앱(code) 갈래 완주 — 무엇을 묻는가, 만들고 나면 어디로 떨어지고
- *      다음 행동이 보이는가, GitHub 없는 유저의 막힘 안내가 있는가
- *   J2 기획서(spec) 갈래 완주 — 붙여넣기→변환→저장 후 다음 행동
- *   J3 checks 첫 화면 — 검수 모드 선택 가시성, 소스 없이 실행 시 막힘 안내
- *   J4 repo 연결 여정(익명) — 연결 화면에서 비개발자가 다음 행동을 아는가
+ * v2 (2026-07-21, Train J — 실행계획 2026-07-21): 1회성 관찰 스크립트에서
+ * **오픈 게이트 표준 측정 장비**로 승격. 추가된 것:
+ *   - 스텝별 결정론 채점: UX Basics 5 신호(출구·데드엔드·비활성 이유·오류 안내)
+ *     + primary CTA 위계(화면당 1개 — uiux-redesign-instructions #5 기준)
+ *   - EN 축: locale=en으로 동일 여정 재주행, 한글 누수(koLeak) 측정
+ *   - P0/P1/P2 자동 분류(findings) — 최종 판정은 사람이 산출물을 읽고 내리되,
+ *     기계가 후보를 빠뜨리지 않게 한다
+ *   - J0 아이디어 갈래 입구(깊은 생성 플로우는 flow-audit.mjs 담당 — 중복 금지)
  *
- * 채점 축(스텝마다 기록): primaryCta(다음 행동이 버튼으로 보이는가),
- * blockedGuidance(막혔을 때 이유+해법 카피), deadEnd(전진 CTA 부재),
- * errorish(오류 신호). 스크립트는 측정만 하고 판정은 산출물을 읽고 내린다.
+ * 측정 원칙: 스크립트는 사실만 기록한다(카운트·존재 여부·스크린샷). "좋다/나쁘다"는
+ * findings 규칙(결정론)과 사람의 판독으로 분리한다.
  *
- * Usage: node journey-audit.mjs   → journey-audit-shots/*.png + journey-audit-result.json
+ * Usage:
+ *   node journey-audit.mjs            → KO+EN 전체 (기본)
+ *   node journey-audit.mjs --ko-only  → KO만 (빠른 재감사)
+ * 산출물: journey-audit-shots/*.png · journey-audit-result.json (steps+findings)
+ * 배포 게이트 절차: ./JOURNEY-AUDIT.md
  */
 import { chromium } from "playwright";
 import { mkdirSync, writeFileSync } from "node:fs";
 
 const BASE = "https://app.trysimsa.com";
+const KO_ONLY = process.argv.includes("--ko-only");
 const SHOTS = new URL("./journey-audit-shots", import.meta.url).pathname.replace(/^\/(\w):/, "$1:");
 mkdirSync(SHOTS, { recursive: true });
 
 const browser = await chromium.launch();
-const audit = { startedAt: new Date().toISOString(), journeys: [] };
+const audit = { startedAt: new Date().toISOString(), version: 2, journeys: [], findings: [] };
 
-async function newUserPage() {
+async function newUserPage(locale = "ko") {
   const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-  return ctx.newPage();
+  // I18nProvider가 읽는 저장 키(dictionary.mjs LOCALE_STORAGE_KEY)를 앱 로드 전에
+  // 심는다 — EN 축은 "EN 유저의 첫 여정"을 재현한다.
+  await ctx.addInitScript((loc) => {
+    try { window.localStorage.setItem("conclave:locale", loc); } catch {}
+  }, locale);
+  const page = await ctx.newPage();
+  page._simsaLocale = locale;
+  return page;
 }
 
+/**
+ * 스텝 사실 수집 + 결정론 채점 신호. 모든 값은 측정이며 판정이 아니다.
+ *  - primaryCtaCount: 화면의 primary 버튼 수 (#5 기준: 정확히 1이 이상적)
+ *  - hasExit: 뒤로/← 링크·버튼 또는 사이드바 내비 존재 (UX Basics ①)
+ *  - deadEnd: 전진 가능한 액션 요소가 0 (UX Basics ⑤)
+ *  - disabledCount: 비활성 버튼 수 — 이유 표시는 스크린샷으로 사람이 확인 (③)
+ *  - errorish/guidanceish: 오류·안내 카피 신호 (④)
+ *  - koLeakChars: (EN 주행에서만 의미) 본문의 한글 문자 수 — EN 커버리지 누수
+ */
 async function facts(page, label, note = "") {
   const f = await page.evaluate(() => {
     const vis = (el) => el.offsetParent !== null;
     const texts = (sel) => [...document.querySelectorAll(sel)].filter(vis).map((e) => (e.innerText || "").trim().replace(/\s+/g, " ")).filter(Boolean);
     const buttons = texts("button, a.btn, [role=button]");
     const body = (document.body.innerText || "").replace(/\s+/g, " ");
+    const primaries = [...document.querySelectorAll(".btn-primary, button[class*='primary']")].filter(vis).map((e) => (e.innerText || "").trim().replace(/\s+/g, " ")).filter(Boolean);
+    // main 본문 한정 primary — 사이드바/글로벌 셸 제외한 화면 자체의 위계.
+    const mainPrimaries = [...document.querySelectorAll("main .btn-primary, main button[class*='primary']")].filter(vis).map((e) => (e.innerText || "").trim().replace(/\s+/g, " ")).filter(Boolean);
+    const exits = [...document.querySelectorAll("a, button")].filter(vis).filter((e) => /←|뒤로|돌아가|back/i.test((e.innerText || "").trim()));
+    const sidebarNav = document.querySelector("nav, aside") !== null;
+    const disabled = [...document.querySelectorAll("button[disabled], [aria-disabled='true']")].filter((e) => e.offsetParent !== null).map((e) => (e.innerText || "").trim().replace(/\s+/g, " ").slice(0, 40));
     return {
       h1: texts("h1").slice(0, 2),
       buttons: buttons.slice(0, 24),
-      primaryCta: [...document.querySelectorAll(".btn-primary, button[class*='primary']")].filter(vis).map((e) => (e.innerText || "").trim().replace(/\s+/g, " ")).filter(Boolean).slice(0, 5),
+      primaryCta: primaries.slice(0, 6),
+      primaryCtaCount: mainPrimaries.length || primaries.length,
+      hasExit: exits.length > 0 || sidebarNav,
+      deadEnd: buttons.length === 0,
+      disabledCount: disabled.length,
+      disabledLabels: disabled.slice(0, 5),
       bodyLen: body.length,
-      errorish: (body.match(/문제가 발생|불러오지 못|오류가|실패했|다시 시도/g) ?? []).length,
-      guidanceish: (body.match(/연결해 주세요|연결하세요|먼저|필요해요|이렇게 하세요|설치/g) ?? []).length,
+      errorish: (body.match(/문제가 발생|불러오지 못|오류가|실패했|다시 시도|something went wrong|failed to/gi) ?? []).length,
+      guidanceish: (body.match(/연결해 주세요|연결하세요|먼저|필요해요|이렇게 하세요|설치|connect|first|install/gi) ?? []).length,
+      koLeakChars: (body.match(/[가-힣]/g) ?? []).length,
       bodyHead: body.slice(0, 400),
     };
   });
-  const row = { label, note, url: page.url(), ...f };
+  const row = { label, note, locale: page._simsaLocale ?? "ko", url: page.url(), ...f };
   audit.journeys.at(-1).steps.push(row);
-  await page.screenshot({ path: `${SHOTS}/${audit.journeys.length}-${audit.journeys.at(-1).steps.length}-${label.replace(/[^\w가-힣-]/g, "_").slice(0, 40)}.png` }).catch(() => {});
-  console.log(`  [${label}] cta=${JSON.stringify(f.primaryCta)} err=${f.errorish} guide=${f.guidanceish}`);
+  const shotName = `${audit.journeys.length}-${audit.journeys.at(-1).steps.length}-${(page._simsaLocale ?? "ko")}-${label.replace(/[^\w가-힣-]/g, "_").slice(0, 40)}.png`;
+  await page.screenshot({ path: `${SHOTS}/${shotName}` }).catch(() => {});
+  console.log(`  [${row.locale}|${label}] cta=${f.primaryCtaCount} exit=${f.hasExit} dis=${f.disabledCount} err=${f.errorish} ko=${f.koLeakChars}`);
   return row;
 }
 
-function journey(name) {
-  audit.journeys.push({ name, steps: [], failure: null });
-  console.log(`\n▶ ${name}`);
+function journey(name, locale = "ko") {
+  audit.journeys.push({ name, locale, steps: [], failure: null });
+  console.log(`\n▶ [${locale}] ${name}`);
 }
 
-// ── J1: 기존-앱(code) 갈래 완주 ────────────────────────────────────────────────
-try {
-  journey("J1 기존-앱 갈래: 만든 앱 검수받기 완주");
-  const page = await newUserPage();
-  await page.goto(`${BASE}/projects/new`, { waitUntil: "networkidle", timeout: 45000 });
-  await facts(page, "갈래 선택 화면");
-  // chooser에서 code 갈래 진입 (문구는 갈래 카드 — '이미'/'만든' 계열 텍스트)
-  const codeCard = page.getByRole("button", { name: /이미|만든|검수/ }).first();
-  if (await codeCard.count()) { await codeCard.click(); } else {
-    await page.goto(`${BASE}/projects/new?path=code`, { waitUntil: "networkidle" });
-  }
-  await page.waitForTimeout(800);
-  await facts(page, "code 갈래 스텝1 — 무엇을 묻는가");
-  // ★사이드바 검색 input이 first("input")에 걸린다 — 본문 필드는 placeholder로.
-  await page.getByPlaceholder(/나의 첫|쇼핑몰/).fill("동네 빵집 예약 테스트앱");
-  const descBox = page.locator("textarea").first();
-  if (await descBox.count()) await descBox.fill("빵을 예약하고 픽업 시간을 고르는 앱");
-  await facts(page, "code 스텝1 입력 후");
-  await page.getByRole("button", { name: /프로젝트 만들/ }).first().click();
-  await page.waitForURL(/projects\/(?!new)/, { timeout: 90000 }).catch(() => {});
-  await page.waitForTimeout(2500);
-  await facts(page, "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가");
-  // 개요로 이동해 '지금 할 일' 확인
-  const pid = (page.url().match(/projects\/([^/?#]+)/) ?? [])[1];
-  if (pid) {
-    await page.goto(`${BASE}/projects/${pid}`, { waitUntil: "networkidle", timeout: 45000 });
-    await facts(page, "개요 — 지금 할 일이 이 갈래에 맞는가");
-    await page.goto(`${BASE}/projects/${pid}/checks`, { waitUntil: "networkidle", timeout: 45000 });
-    await facts(page, "checks 첫 화면 — 모드 선택 보이는가/소스 없이 뭐라 하는가");
-    // 검수 실행 버튼을 눌러 소스 없는 막힘 안내 확인
-    const runBtn = page.getByRole("button", { name: /검수|확인/ }).first();
-    if (await runBtn.count()) {
-      await runBtn.click().catch(() => {});
-      await page.waitForTimeout(2500);
-      await facts(page, "소스 없이 검수 시도 — 막힘 안내");
+// ── 여정 정의 (KO/EN 공용 — locale은 컨텍스트가 결정) ─────────────────────────
+
+async function runIdeaEntry(locale) {
+  // J0 — 아이디어 갈래 입구만 (깊은 생성은 flow-audit.mjs 소관, 중복 금지).
+  try {
+    journey("J0 아이디어 갈래 입구: 첫 화면 → 스텝1 → 인터뷰 진입", locale);
+    const page = await newUserPage(locale);
+    await page.goto(`${BASE}/projects/new`, { waitUntil: "networkidle", timeout: 45000 });
+    await facts(page, "갈래 선택 화면");
+    await page.goto(`${BASE}/projects/new?path=idea`, { waitUntil: "networkidle", timeout: 45000 });
+    await facts(page, "idea 스텝1 — 무엇을 묻는가");
+    const ideaBox = page.locator("main textarea, textarea").first();
+    if (await ideaBox.count()) {
+      await ideaBox.fill(locale === "en" ? "A neighborhood bakery pickup-reservation app" : "동네 빵집 픽업 예약 앱");
+      const next = page.locator("main .btn-primary, main button[class*='primary']").first();
+      if (await next.count()) {
+        await next.click().catch(() => {});
+        await page.waitForTimeout(3000);
+        await facts(page, "인터뷰 첫 질문 화면");
+      }
     }
-  } else {
-    audit.journeys.at(-1).failure = "프로젝트 생성 후 URL에서 id를 못 얻음";
+    await page.context().close();
+  } catch (err) {
+    audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
   }
-  await page.context().close();
-} catch (err) {
-  audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
 }
 
-// ── J2: 기획서(spec) 갈래 완주 ────────────────────────────────────────────────
-try {
-  journey("J2 기획서 갈래: 붙여넣기→변환→다음 행동");
-  const page = await newUserPage();
-  await page.goto(`${BASE}/projects/new?path=spec`, { waitUntil: "networkidle", timeout: 45000 });
-  await facts(page, "spec 갈래 스텝1");
-  await page.locator("main textarea, textarea").first().fill("제품: 반려견 산책 기록 앱\n기능: 산책 시작/종료 기록, 주간 거리 통계, 기록 공유\n대상: 반려견 보호자");
-  await page.getByRole("button", { name: /확인 항목으로 바꾸기/ }).first().click();
-  await page.waitForTimeout(1500);
-  await facts(page, "변환 중/직후");
-  // 변환은 실 LLM — 최대 60s 대기 후 저장 버튼 탐색
-  for (let i = 0; i < 12; i++) {
-    if (await page.getByRole("button", { name: /저장|프로젝트로/ }).count()) break;
-    await page.waitForTimeout(5000);
+async function runCodeJourney(locale) {
+  try {
+    journey("J1 기존-앱 갈래: 만든 앱 검수받기 완주", locale);
+    const page = await newUserPage(locale);
+    await page.goto(`${BASE}/projects/new?path=code`, { waitUntil: "networkidle", timeout: 45000 });
+    await facts(page, "code 갈래 스텝1 — 무엇을 묻는가");
+    // ★사이드바 검색 input이 first("input")에 걸린다 — 본문 필드는 placeholder로.
+    const nameInput = page.locator("main input[type='text']").first();
+    await nameInput.fill(locale === "en" ? "Bakery reservation test app" : "동네 빵집 예약 테스트앱");
+    const descBox = page.locator("main textarea").first();
+    if (await descBox.count()) await descBox.fill(locale === "en" ? "Reserve bread and pick a pickup time" : "빵을 예약하고 픽업 시간을 고르는 앱");
+    await facts(page, "code 스텝1 입력 후");
+    await page.locator("main .btn-primary, main button[class*='primary']").last().click();
+    await page.waitForURL(/projects\/(?!new)/, { timeout: 90000 }).catch(() => {});
+    await page.waitForTimeout(2500);
+    await facts(page, "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가");
+    const pid = (page.url().match(/projects\/([^/?#]+)/) ?? [])[1];
+    if (pid) {
+      await page.goto(`${BASE}/projects/${pid}`, { waitUntil: "networkidle", timeout: 45000 });
+      await facts(page, "개요 — 지금 할 일이 이 갈래에 맞는가");
+      await page.goto(`${BASE}/projects/${pid}/checks`, { waitUntil: "networkidle", timeout: 45000 });
+      await facts(page, "checks 첫 화면 — 모드 선택/소스 없이 안내");
+      const runBtn = page.getByRole("button", { name: /검수|확인|run|check/i }).first();
+      if (await runBtn.count()) {
+        await runBtn.click().catch(() => {});
+        await page.waitForTimeout(2500);
+        await facts(page, "소스 없이 검수 시도 — 막힘 안내");
+      }
+    } else {
+      audit.journeys.at(-1).failure = "프로젝트 생성 후 URL에서 id를 못 얻음";
+    }
+    await page.context().close();
+  } catch (err) {
+    audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
   }
-  await facts(page, "변환 결과 화면");
-  const saveBtn = page.getByRole("button", { name: /저장|프로젝트로/ }).first();
-  if (await saveBtn.count()) {
-    await saveBtn.click();
-    await page.waitForURL(/projects\/(?!new)/, { timeout: 30000 }).catch(() => {});
-    await page.waitForTimeout(2000);
-    await facts(page, "저장 후 랜딩 — 다음 행동");
-  }
-  await page.context().close();
-} catch (err) {
-  audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
 }
 
-// ── J3+J4: repo 연결 여정 (익명 — GitHub 미연결 상태) ─────────────────────────
-try {
-  journey("J3 repo 연결 여정: GitHub 미연결 신규 유저");
-  const page = await newUserPage();
-  // 샘플 아님 실 프로젝트가 필요 — J1에서 만든 프로젝트를 재사용할 수 없어(다른 컨텍스트)
-  // 로컬-우선 앱 특성상 새로 하나 만들지 않고, 프로젝트 없이 연결 화면 관찰이 목적이므로
-  // code 갈래로 최소 생성(설명 생략) 후 settings로.
-  await page.goto(`${BASE}/projects/new?path=code`, { waitUntil: "networkidle", timeout: 45000 });
-  await page.getByPlaceholder(/나의 첫|쇼핑몰/).fill("연결 여정 테스트");
-  await page.getByRole("button", { name: /프로젝트 만들/ }).first().click();
-  await page.waitForURL(/projects\/(?!new)/, { timeout: 60000 }).catch(() => {});
-  await page.waitForTimeout(1500);
-  await facts(page, "settings/연결 화면 — 미연결 유저가 보는 것");
-  const ghBtn = page.getByRole("button", { name: /GitHub|깃허브|연결/ }).first();
-  if (await ghBtn.count()) {
-    await facts(page, "GitHub 연결 CTA 존재 확인", (await ghBtn.innerText().catch(() => "")).slice(0, 60));
+async function runSpecJourney(locale) {
+  try {
+    journey("J2 기획서 갈래: 붙여넣기→변환→다음 행동", locale);
+    const page = await newUserPage(locale);
+    await page.goto(`${BASE}/projects/new?path=spec`, { waitUntil: "networkidle", timeout: 45000 });
+    await facts(page, "spec 갈래 스텝1");
+    await page.locator("main textarea, textarea").first().fill(
+      locale === "en"
+        ? "Product: dog-walk logger\nFeatures: start/stop walk logging, weekly distance stats, share a walk\nAudience: dog owners"
+        : "제품: 반려견 산책 기록 앱\n기능: 산책 시작/종료 기록, 주간 거리 통계, 기록 공유\n대상: 반려견 보호자",
+    );
+    await page.locator("main .btn-primary, main button[class*='primary']").first().click();
+    await page.waitForTimeout(1500);
+    await facts(page, "변환 중/직후");
+    for (let i = 0; i < 12; i++) {
+      if (await page.getByRole("button", { name: /저장|프로젝트로|save|create project/i }).count()) break;
+      await page.waitForTimeout(5000);
+    }
+    await facts(page, "변환 결과 화면");
+    const saveBtn = page.getByRole("button", { name: /저장|프로젝트로|save|create project/i }).first();
+    if (await saveBtn.count()) {
+      await saveBtn.click();
+      await page.waitForURL(/projects\/(?!new)/, { timeout: 30000 }).catch(() => {});
+      await page.waitForTimeout(2000);
+      await facts(page, "저장 후 랜딩 — 다음 행동");
+    }
+    await page.context().close();
+  } catch (err) {
+    audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
   }
-  await page.context().close();
-} catch (err) {
-  audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
+}
+
+async function runConnectJourney(locale) {
+  try {
+    journey("J3 repo 연결 여정: GitHub 미연결 신규 유저", locale);
+    const page = await newUserPage(locale);
+    await page.goto(`${BASE}/projects/new?path=code`, { waitUntil: "networkidle", timeout: 45000 });
+    await page.locator("main input[type='text']").first().fill(locale === "en" ? "Connect journey test" : "연결 여정 테스트");
+    await page.locator("main .btn-primary, main button[class*='primary']").last().click();
+    await page.waitForURL(/projects\/(?!new)/, { timeout: 60000 }).catch(() => {});
+    await page.waitForTimeout(1500);
+    await facts(page, "settings/연결 화면 — 미연결 유저가 보는 것");
+    await page.context().close();
+  } catch (err) {
+    audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
+  }
+}
+
+// ── 실행: KO 전체 + (기본) EN 축 ──────────────────────────────────────────────
+
+await runIdeaEntry("ko");
+await runCodeJourney("ko");
+await runSpecJourney("ko");
+await runConnectJourney("ko");
+
+if (!KO_ONLY) {
+  await runIdeaEntry("en");
+  await runCodeJourney("en");
+  // spec/connect의 EN은 code 여정이 셸·생성·랜딩을 이미 커버 — 입구만 본다.
+  try {
+    journey("J2e 기획서 갈래 입구(EN)", "en");
+    const page = await newUserPage("en");
+    await page.goto(`${BASE}/projects/new?path=spec`, { waitUntil: "networkidle", timeout: 45000 });
+    await facts(page, "spec 갈래 스텝1 (EN)");
+    await page.context().close();
+  } catch (err) {
+    audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
+  }
+}
+
+// ── P0/P1/P2 자동 분류 (결정론 — 후보를 빠뜨리지 않기 위한 기계 패스) ─────────
+// 사람이 산출물(스크린샷 포함)을 읽고 최종 판정한다. 규칙:
+//   P0: 여정 실패(예외/막힘) · happy path에서 오류 카피 노출
+//   P1: 액션 스텝인데 primary 0 · 한 화면 primary ≥3(#5 위계 위반 후보)
+//       · EN 주행에서 한글 누수 큼(>80자: 셸 잔재 이상의 본문 누수)
+//   P2: 비활성 버튼 존재(이유 표시는 스크린샷 확인 필요) · 막힘 스텝인데 안내 신호 0
+for (const j of audit.journeys) {
+  if (j.failure) {
+    audit.findings.push({ sev: "P0", journey: j.name, locale: j.locale, step: "(journey)", what: `여정 실패: ${j.failure}` });
+  }
+  for (const s of j.steps) {
+    const isBlockedStep = /막힘|시도/.test(s.label);
+    if (s.errorish > 0 && !isBlockedStep) {
+      audit.findings.push({ sev: "P0", journey: j.name, locale: s.locale, step: s.label, what: `happy path 오류 카피 ${s.errorish}건 노출` });
+    }
+    if (s.primaryCtaCount === 0 && !/입력 후|변환 중/.test(s.label)) {
+      audit.findings.push({ sev: "P1", journey: j.name, locale: s.locale, step: s.label, what: "primary CTA 0 — 다음 행동이 버튼으로 안 보임" });
+    }
+    if (s.primaryCtaCount >= 3) {
+      audit.findings.push({ sev: "P1", journey: j.name, locale: s.locale, step: s.label, what: `primary CTA ${s.primaryCtaCount}개 — #5 위계 위반 후보` });
+    }
+    if (s.locale === "en" && s.koLeakChars > 80) {
+      audit.findings.push({ sev: "P1", journey: j.name, locale: "en", step: s.label, what: `EN 주행 한글 누수 ${s.koLeakChars}자` });
+    }
+    if (s.disabledCount > 0) {
+      audit.findings.push({ sev: "P2", journey: j.name, locale: s.locale, step: s.label, what: `비활성 버튼 ${s.disabledCount}개(${s.disabledLabels.join("/")}) — 이유 표시 스크린샷 확인` });
+    }
+    if (isBlockedStep && s.guidanceish === 0) {
+      audit.findings.push({ sev: "P2", journey: j.name, locale: s.locale, step: s.label, what: "막힘 스텝인데 안내 카피 신호 0" });
+    }
+  }
 }
 
 writeFileSync(new URL("./journey-audit-result.json", import.meta.url), JSON.stringify(audit, null, 2));
-console.log("\nsaved: journey-audit-result.json / shots:", SHOTS);
+const bySev = { P0: 0, P1: 0, P2: 0 };
+for (const f of audit.findings) bySev[f.sev]++;
+console.log(`\nfindings: P0=${bySev.P0} P1=${bySev.P1} P2=${bySev.P2}`);
+console.log("saved: journey-audit-result.json / shots:", SHOTS);
 await browser.close();


### PR DESCRIPTION
실행계획 2026-07-21 **Train J** 이행.

## 장비 확장 (v2)

- 스텝별 결정론 채점: UX Basics 신호(출구·데드엔드·비활성·오류/안내) + **primary CTA 수**(main 한정, 지시서 #5 기준) + 스크린샷 아카이브
- **EN 축**: `conclave:locale=en` 사전 주입 재주행 + 한글 누수(koLeak) 측정
- **P0/P1/P2 자동 분류** — 후보 누락 방지용 기계 패스(최종 판정은 사람이 JSON+스크린샷 판독)
- J0 아이디어 갈래 입구 추가 · `JOURNEY-AUDIT.md` 런북(배포 게이트 절차 표준화)

## 프로덕션 기준선 (KO+EN 12여정 22스텝)

**P0 = 0** (7/20 수정 유지 확인) · P1=3 · P2=15 → 스크린샷 판독 결과:

| 확정 | 내용 | 후속 |
|---|---|---|
| P1 | EN 화면에서 prep 서비스 카드만 한국어 478자 (카탈로그 카피 i18n 누락) | Train U 수정 |
| P1 | 개요 검수카드 문이 facts 확정 전 "run" 렌더 후 "connect"로 플립 (#436 잔여 — 플립 CTA 안티패턴) | Train U 수정 |
| P2 | checks 빈 화면 primary 2개 (#5 위계 후보) | Train U 수정 |
| 기각 | 비활성 버튼 다수 — 라벨/문맥이 이유 전달 확인 | — |
| 규칙 | chooser 화면 primary-0은 3문 설계상 정상 | 규칙 예외 반영 예정 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)