### PR TITLE
fix(dashboard): Train U 배치1 — 카탈로그 i18n·검수카드 문 플립·checks 단일 primary

### DIFF
--- a/apps/dashboard/src/app/projects/[id]/checks/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/checks/page.tsx
@@ -242,11 +242,16 @@ export default function ChecksPage() {
 
   // Exactly ONE filled primary on the page (UIUX #5 / #2), state-driven — see
   // checksPrimaryCta. The real code review outranks the draft spec pre-check.
+  // Mirrors the section-render gate below (#328) — a hidden PR section's CTA
+  // must never be picked as the screen primary (journey-audit v2 기준선).
+  const prSectionVisible = entryPath !== "idea" || latestPrReview != null || linkedPulls.length > 0;
   const primaryCta = checksPrimaryCta({
+    prSectionVisible,
     prReviewLoaded: prLoadPhase === "done",
     hasPrReview: Boolean(latestPrReview),
     prNeedsAction,
     draftNeedsAction: needsAction,
+    draftHasResults: Boolean(results),
   });
   const btnClass = (isPrimary: boolean) => (isPrimary ? "btn btn-md btn-primary" : "btn btn-md btn-secondary");
 
@@ -445,7 +450,11 @@ export default function ChecksPage() {
           <div className="card p-8 text-center">
             <p className="mb-1 text-sm font-medium text-gray-700">{t.checks.emptyTitle}</p>
             <p className="mb-5 text-xs text-gray-500">{t.checks.emptyDesc}</p>
-            <button onClick={runCheck} className="btn btn-md btn-primary">{t.checks.runCheck}</button>
+            {/* journey-audit v2 기준선: 이 버튼이 btn-primary 하드코딩으로 상태
+                기계를 우회해 화면에 filled primary가 2개였다(실측 cta=2).
+                이제 run_precheck일 때만 primary — connect_pr이 주인공인 상태
+                (code 갈래·PR 미연결)에선 secondary로 물러난다. */}
+            <button onClick={runCheck} className={btnClass(primaryCta === "run_precheck")}>{t.checks.runCheck}</button>
           </div>
         )}
 

--- a/apps/dashboard/src/app/projects/[id]/page.tsx
+++ b/apps/dashboard/src/app/projects/[id]/page.tsx
@@ -424,6 +424,14 @@ function VisualChecksOverviewCard({
   const run =
     action.kind === "runFirst" ? null : (checks.find((c) => c.id === action.runId) ?? null);
 
+  // Journey-audit v2 기준선 (2026-07-21): on the code branch the empty-state
+  // door depends on the repo fact — rendering the default door while it's
+  // unknown made the CTA flip "run"→"connect" ~2s after paint (실측). Hold the
+  // whole card until the door is decidable; a moment without the card beats a
+  // CTA that changes under the user's cursor.
+  const door = run === null ? inspectionEmptyStateDoor({ entryPath, hasRepo, hasDeployUrl }) : null;
+  if (door === "wait") return null;
+
   return (
     <section className="mb-8">
       <div className="mb-2 flex items-center justify-between">
@@ -440,9 +448,9 @@ function VisualChecksOverviewCard({
           // Journey-audit P2 (2026-07-20): on the CODE branch with nothing
           // connected (repo confirmed absent, no deploy URL), "run your first
           // inspection" pointed at the URL-based door the user can't use yet.
-          // Branch-fit: walk them to connect first. Unknown facts (null) keep
-          // the default door — fail-open, never a wrong lock.
-          inspectionEmptyStateDoor({ entryPath, hasRepo, hasDeployUrl }) === "connect" ? (
+          // Branch-fit: walk them to connect first. ("wait" is handled above —
+          // the card holds until the door is decidable, never flips.)
+          door === "connect" ? (
             <>
               <p className="text-sm leading-relaxed text-gray-600">
                 {t.visualChecks.overview.emptyLeadCodeNoSource}

--- a/apps/dashboard/src/components/ServiceMcpSetup.tsx
+++ b/apps/dashboard/src/components/ServiceMcpSetup.tsx
@@ -41,13 +41,20 @@ type SpecLike = {
 };
 
 export function ServiceMcpSetup({ projectId, spec }: { projectId: string; spec: SpecLike }) {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const toast = useToast();
   // Seed from the store (values entered earlier) or fresh detection from the
-  // spec — the single shared seed both this panel and export use.
+  // spec — the single shared seed both this panel and export use. Copy is
+  // resolved in the CURRENT locale (journey-audit v2 P1: EN 화면에 이 카드만
+  // 한국어로 남던 누수); stored VALUES survive locale switches.
   const [services, setServices] = useState<CatalogService[]>(
-    () => seedServiceSetup(projectId, spec) as CatalogService[],
+    () => seedServiceSetup(projectId, spec, locale) as CatalogService[],
   );
+  // Locale switch re-resolves the copy without losing entered values.
+  useEffect(() => {
+    setServices(seedServiceSetup(projectId, spec, locale) as CatalogService[]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [locale]);
   // Persist every change (browser-only) so the values reach the builder pack.
   useEffect(() => { saveServiceValues(projectId, services); }, [projectId, services]);
 
@@ -75,14 +82,14 @@ export function ServiceMcpSetup({ projectId, spec }: { projectId: string; spec: 
   function addService(serviceId: string) {
     setServices((prev) => {
       if (prev.some((s) => s.id === serviceId)) return prev;
-      const svc = catalogServiceById(serviceId);
+      const svc = catalogServiceById(serviceId, locale);
       return svc ? [...prev, svc] : prev;
     });
   }
   function removeService(serviceId: string) {
     setServices((prev) => prev.filter((s) => s.id !== serviceId));
   }
-  const addableServices = allCatalogServices().filter(
+  const addableServices = allCatalogServices(locale).filter(
     (c) => !services.some((s) => s.id === c.id),
   );
 

--- a/apps/dashboard/src/lib/checks-cta.d.mts
+++ b/apps/dashboard/src/lib/checks-cta.d.mts
@@ -1,6 +1,8 @@
 export declare function checksPrimaryCta(facts: {
+  prSectionVisible: boolean;
   prReviewLoaded: boolean;
   hasPrReview: boolean;
   prNeedsAction: number;
   draftNeedsAction: number;
-}): "connect_pr" | "pr_fix" | "draft_fix" | "none";
+  draftHasResults: boolean;
+}): "connect_pr" | "pr_fix" | "draft_fix" | "run_precheck" | "none";

--- a/apps/dashboard/src/lib/checks-cta.mjs
+++ b/apps/dashboard/src/lib/checks-cta.mjs
@@ -8,14 +8,23 @@
  * the most-forward actionable step, with the real code review outranking the
  * draft pre-check. Everything else recedes to secondary.
  *
+ * v2 (2026-07-21, journey-audit 기준선): the pre-check EMPTY state's "확인
+ * 실행" button hard-coded btn-primary and bypassed this machine — the screen
+ * showed two filled primaries (실측 cta=2). Two new facts close that hole:
+ *   - prSectionVisible: the PR section is gated off on idea-branch projects
+ *     (#328 mirror) — a hidden section's CTA must never be the screen primary.
+ *   - draftHasResults: when nothing is actionable elsewhere and the pre-check
+ *     hasn't run, running it IS the primary ("run_precheck").
+ *
  * Pure, no I/O.
  *
- * @param {{ prReviewLoaded: boolean, hasPrReview: boolean, prNeedsAction: number, draftNeedsAction: number }} facts
- * @returns {"connect_pr" | "pr_fix" | "draft_fix" | "none"}
+ * @param {{ prSectionVisible: boolean, prReviewLoaded: boolean, hasPrReview: boolean, prNeedsAction: number, draftNeedsAction: number, draftHasResults: boolean }} facts
+ * @returns {"connect_pr" | "pr_fix" | "draft_fix" | "run_precheck" | "none"}
  */
-export function checksPrimaryCta({ prReviewLoaded, hasPrReview, prNeedsAction, draftNeedsAction }) {
-  if (prReviewLoaded && !hasPrReview) return "connect_pr"; // no real review yet → get one
+export function checksPrimaryCta({ prSectionVisible, prReviewLoaded, hasPrReview, prNeedsAction, draftNeedsAction, draftHasResults }) {
+  if (prSectionVisible && prReviewLoaded && !hasPrReview) return "connect_pr"; // no real review yet → get one
   if (hasPrReview && prNeedsAction > 0) return "pr_fix"; // real review has issues → fix them
   if (draftNeedsAction > 0) return "draft_fix"; // only the pre-check has issues
+  if (!draftHasResults) return "run_precheck"; // nothing anywhere yet → run the pre-check
   return "none";
 }

--- a/apps/dashboard/src/lib/service-catalog.d.mts
+++ b/apps/dashboard/src/lib/service-catalog.d.mts
@@ -21,7 +21,9 @@ export interface CatalogService {
 
 export declare const SERVICE_CATALOG: CatalogService[];
 
-export declare function catalogServiceById(id: string): CatalogService | null;
+export type CatalogLocale = "en" | "ko";
+
+export declare function catalogServiceById(id: string, locale?: CatalogLocale): CatalogService | null;
 
 export declare function detectServices(
   spec:
@@ -34,8 +36,9 @@ export declare function detectServices(
       }
     | null
     | undefined,
+  locale?: CatalogLocale,
 ): CatalogService[];
 
 export declare function hasAnyValue(services: CatalogService[]): boolean;
 
-export declare function allCatalogServices(): CatalogService[];
+export declare function allCatalogServices(locale?: CatalogLocale): CatalogService[];

--- a/apps/dashboard/src/lib/service-catalog.mjs
+++ b/apps/dashboard/src/lib/service-catalog.mjs
@@ -12,6 +12,10 @@
  * step key-finding guides, env var descriptions), with `value` left empty for
  * the UI to fill.
  *
+ * i18n (2026-07-21, journey-audit v2 기준선 P1): entries are authored bilingual
+ * (ko/en) and every public function takes an optional `locale` (default "ko" —
+ * 기존 호출자 무변경). EN 주행에서 이 카드만 한국어 478자가 남던 누수의 근본 수정.
+ *
  * The output shape mirrors `BuilderPackService` in
  * apps/central-plane/src/workspace/export.ts so a detected+filled service can be
  * passed straight through to the pack .env baking.
@@ -35,99 +39,195 @@
  * @property {CatalogEnvVar[]} envVars
  */
 
-/** @type {CatalogService[]} */
-export const SERVICE_CATALOG = [
+/** @typedef {"en" | "ko"} CatalogLocale */
+
+// Bilingual source of truth. Shape per entry: every user-facing string is
+// { ko, en }; ids/keys/urls are locale-neutral.
+const CATALOG_SOURCE = [
   {
     id: "app-url",
-    label: "앱 주소",
-    why: "앱이 자기 주소를 알아야 공유 링크·리디렉션이 깨지지 않습니다. 가입 없이 값만 넣으면 됩니다.",
-    setupSteps: [
-      "가입이 필요 없는 항목입니다.",
-      "만드는 동안에는 http://localhost:3000 을 그대로 두세요.",
-      "배포한 뒤에는 실제 도메인(예: https://내앱.vercel.app)으로 바꾸면 됩니다.",
-    ],
+    label: { ko: "앱 주소", en: "App URL" },
+    why: {
+      ko: "앱이 자기 주소를 알아야 공유 링크·리디렉션이 깨지지 않습니다. 가입 없이 값만 넣으면 됩니다.",
+      en: "Your app needs to know its own address so share links and redirects don't break. No sign-up — just fill in the value.",
+    },
+    setupSteps: {
+      ko: [
+        "가입이 필요 없는 항목입니다.",
+        "만드는 동안에는 http://localhost:3000 을 그대로 두세요.",
+        "배포한 뒤에는 실제 도메인(예: https://내앱.vercel.app)으로 바꾸면 됩니다.",
+      ],
+      en: [
+        "No sign-up needed for this one.",
+        "While building, leave it as http://localhost:3000.",
+        "After deploying, change it to your real domain (e.g. https://myapp.vercel.app).",
+      ],
+    },
     envVars: [
       {
         key: "NEXT_PUBLIC_APP_URL",
-        description:
-          "앱이 자기 자신을 가리키는 주소입니다. 공유 링크·리디렉션 등에 쓰입니다. 처음엔 localhost, 배포 후엔 실제 도메인.",
-        example: "http://localhost:3000",
+        description: {
+          ko: "앱이 자기 자신을 가리키는 주소입니다. 공유 링크·리디렉션 등에 쓰입니다. 처음엔 localhost, 배포 후엔 실제 도메인.",
+          en: "The address your app uses to refer to itself — used for share links and redirects. localhost at first, your real domain after deploying.",
+        },
+        example: { ko: "http://localhost:3000", en: "http://localhost:3000" },
       },
     ],
   },
   {
     id: "supabase",
-    label: "Supabase (데이터 저장·로그인)",
-    why: "회원가입·로그인이나 글·기록 같은 데이터를 저장하려면 데이터베이스가 필요합니다. Supabase는 무료로 시작할 수 있습니다.",
+    label: { ko: "Supabase (데이터 저장·로그인)", en: "Supabase (data & sign-in)" },
+    why: {
+      ko: "회원가입·로그인이나 글·기록 같은 데이터를 저장하려면 데이터베이스가 필요합니다. Supabase는 무료로 시작할 수 있습니다.",
+      en: "Sign-ups, logins, and saved data (posts, records) need a database. Supabase has a free tier to start with.",
+    },
     setupUrl: "https://supabase.com",
-    setupSteps: [
-      "https://supabase.com 에 접속해 GitHub 계정으로 가입합니다.",
-      "New project 를 눌러 프로젝트를 하나 만듭니다(이름·비밀번호·지역 선택).",
-      "왼쪽 아래 톱니바퀴(Project Settings) → API 메뉴로 이동합니다.",
-      "Project URL 을 복사해 NEXT_PUBLIC_SUPABASE_URL 에 넣습니다.",
-      "같은 화면의 anon public 키를 복사해 NEXT_PUBLIC_SUPABASE_ANON_KEY 에 넣습니다.",
-      "관리자 기능이 필요하면 Project API keys 에서 service_role 의 Reveal 을 눌러 복사합니다. 이 키는 서버에서만 씁니다.",
-    ],
+    setupSteps: {
+      ko: [
+        "https://supabase.com 에 접속해 GitHub 계정으로 가입합니다.",
+        "New project 를 눌러 프로젝트를 하나 만듭니다(이름·비밀번호·지역 선택).",
+        "왼쪽 아래 톱니바퀴(Project Settings) → API 메뉴로 이동합니다.",
+        "Project URL 을 복사해 NEXT_PUBLIC_SUPABASE_URL 에 넣습니다.",
+        "같은 화면의 anon public 키를 복사해 NEXT_PUBLIC_SUPABASE_ANON_KEY 에 넣습니다.",
+        "관리자 기능이 필요하면 Project API keys 에서 service_role 의 Reveal 을 눌러 복사합니다. 이 키는 서버에서만 씁니다.",
+      ],
+      en: [
+        "Go to https://supabase.com and sign up with your GitHub account.",
+        "Press New project and create one (name, password, region).",
+        "Open the gear at bottom-left (Project Settings) → API.",
+        "Copy the Project URL into NEXT_PUBLIC_SUPABASE_URL.",
+        "Copy the anon public key on the same screen into NEXT_PUBLIC_SUPABASE_ANON_KEY.",
+        "If you need admin features, press Reveal next to service_role under Project API keys and copy it. That key is server-only.",
+      ],
+    },
     envVars: [
       {
         key: "NEXT_PUBLIC_SUPABASE_URL",
-        description: "Supabase 프로젝트 주소입니다. Project Settings → API 의 Project URL.",
-        example: "https://xxxxxxxx.supabase.co",
+        description: {
+          ko: "Supabase 프로젝트 주소입니다. Project Settings → API 의 Project URL.",
+          en: "Your Supabase project address — Project Settings → API → Project URL.",
+        },
+        example: { ko: "https://xxxxxxxx.supabase.co", en: "https://xxxxxxxx.supabase.co" },
       },
       {
         key: "NEXT_PUBLIC_SUPABASE_ANON_KEY",
-        description:
-          "브라우저에서 쓰는 공개 키(anon public)입니다. 공개돼도 되는 키라 프론트에 넣어도 됩니다.",
-        example: "eyJhbGciOiJI...(공개 anon 키)",
+        description: {
+          ko: "브라우저에서 쓰는 공개 키(anon public)입니다. 공개돼도 되는 키라 프론트에 넣어도 됩니다.",
+          en: "The public browser key (anon public). Safe to expose, so it can go in the frontend.",
+        },
+        example: { ko: "eyJhbGciOiJI...(공개 anon 키)", en: "eyJhbGciOiJI...(public anon key)" },
       },
       {
         key: "SUPABASE_SERVICE_ROLE_KEY",
-        description:
-          "관리자 권한 키(service_role)입니다. 절대 브라우저/프론트엔드에 넣지 말고 서버에서만 쓰세요.",
+        description: {
+          ko: "관리자 권한 키(service_role)입니다. 절대 브라우저/프론트엔드에 넣지 말고 서버에서만 쓰세요.",
+          en: "The admin key (service_role). Never put it in the browser/frontend — server only.",
+        },
         secret: true,
-        example: "eyJhbGciOiJI...(service_role · 서버 전용)",
+        example: { ko: "eyJhbGciOiJI...(service_role · 서버 전용)", en: "eyJhbGciOiJI...(service_role · server only)" },
       },
     ],
   },
   {
     id: "resend",
-    label: "Resend (이메일 보내기)",
-    why: "가입 확인·비밀번호 재설정·알림 메일을 보내려면 이메일 발송 서비스가 필요합니다. Resend는 무료 한도로 시작할 수 있습니다.",
+    label: { ko: "Resend (이메일 보내기)", en: "Resend (sending email)" },
+    why: {
+      ko: "가입 확인·비밀번호 재설정·알림 메일을 보내려면 이메일 발송 서비스가 필요합니다. Resend는 무료 한도로 시작할 수 있습니다.",
+      en: "Sign-up confirmations, password resets, and notification emails need an email service. Resend has a free tier.",
+    },
     setupUrl: "https://resend.com",
-    setupSteps: [
-      "https://resend.com 에 가입합니다(GitHub 계정으로 가능).",
-      "왼쪽 메뉴의 API Keys → Create API Key 를 누릅니다.",
-      "만들어진 키(re_ 로 시작)를 복사해 RESEND_API_KEY 에 넣습니다. 이 키는 서버에서만 씁니다.",
-      "메일을 실제로 보내려면 나중에 도메인 인증이 필요할 수 있습니다(테스트는 인증 없이 가능).",
-    ],
+    setupSteps: {
+      ko: [
+        "https://resend.com 에 가입합니다(GitHub 계정으로 가능).",
+        "왼쪽 메뉴의 API Keys → Create API Key 를 누릅니다.",
+        "만들어진 키(re_ 로 시작)를 복사해 RESEND_API_KEY 에 넣습니다. 이 키는 서버에서만 씁니다.",
+        "메일을 실제로 보내려면 나중에 도메인 인증이 필요할 수 있습니다(테스트는 인증 없이 가능).",
+      ],
+      en: [
+        "Sign up at https://resend.com (GitHub account works).",
+        "Open API Keys in the left menu → Create API Key.",
+        "Copy the new key (starts with re_) into RESEND_API_KEY. Server-only.",
+        "Sending real mail may later require domain verification (testing works without it).",
+      ],
+    },
     envVars: [
       {
         key: "RESEND_API_KEY",
-        description: "이메일을 보낼 때 쓰는 Resend API 키입니다. 서버 전용이라 프론트엔드에 넣지 마세요.",
+        description: {
+          ko: "이메일을 보낼 때 쓰는 Resend API 키입니다. 서버 전용이라 프론트엔드에 넣지 마세요.",
+          en: "The Resend API key used to send email. Server-only — don't put it in the frontend.",
+        },
         secret: true,
-        example: "re_xxxxxxxx (서버 전용)",
+        example: { ko: "re_xxxxxxxx (서버 전용)", en: "re_xxxxxxxx (server only)" },
       },
     ],
   },
   {
     id: "sentry",
-    label: "Sentry (오류 추적)",
-    why: "앱에서 나는 오류를 자동으로 모아 알려줍니다. 사용자가 겪은 문제를 놓치지 않고 고칠 수 있어요. 무료 한도로 시작할 수 있습니다.",
+    label: { ko: "Sentry (오류 추적)", en: "Sentry (error tracking)" },
+    why: {
+      ko: "앱에서 나는 오류를 자동으로 모아 알려줍니다. 사용자가 겪은 문제를 놓치지 않고 고칠 수 있어요. 무료 한도로 시작할 수 있습니다.",
+      en: "Collects and reports your app's errors automatically, so problems users hit never slip by. Free tier available.",
+    },
     setupUrl: "https://sentry.io",
-    setupSteps: [
-      "https://sentry.io 에 가입하고 프로젝트를 하나 만듭니다(플랫폼은 만드는 앱에 맞게 선택).",
-      "프로젝트 설정(Settings) → Client Keys (DSN) 로 이동합니다.",
-      "DSN 주소를 복사해 NEXT_PUBLIC_SENTRY_DSN 에 넣습니다. DSN은 공개돼도 되는 값입니다.",
-    ],
+    setupSteps: {
+      ko: [
+        "https://sentry.io 에 가입하고 프로젝트를 하나 만듭니다(플랫폼은 만드는 앱에 맞게 선택).",
+        "프로젝트 설정(Settings) → Client Keys (DSN) 로 이동합니다.",
+        "DSN 주소를 복사해 NEXT_PUBLIC_SENTRY_DSN 에 넣습니다. DSN은 공개돼도 되는 값입니다.",
+      ],
+      en: [
+        "Sign up at https://sentry.io and create a project (pick the platform matching your app).",
+        "Open project Settings → Client Keys (DSN).",
+        "Copy the DSN into NEXT_PUBLIC_SENTRY_DSN. The DSN is safe to expose.",
+      ],
+    },
     envVars: [
       {
         key: "NEXT_PUBLIC_SENTRY_DSN",
-        description: "오류를 Sentry로 보내는 주소(DSN)입니다. 공개돼도 되는 값이라 프론트에 넣어도 됩니다.",
-        example: "https://xxxx@oyyy.ingest.sentry.io/zzzz",
+        description: {
+          ko: "오류를 Sentry로 보내는 주소(DSN)입니다. 공개돼도 되는 값이라 프론트에 넣어도 됩니다.",
+          en: "The address (DSN) errors are sent to. Safe to expose, so it can go in the frontend.",
+        },
+        example: { ko: "https://xxxx@oyyy.ingest.sentry.io/zzzz", en: "https://xxxx@oyyy.ingest.sentry.io/zzzz" },
       },
     ],
   },
 ];
+
+/** @param {"en"|"ko"|undefined} locale */
+function norm(locale) {
+  return locale === "en" ? "en" : "ko";
+}
+
+/**
+ * Resolve one bilingual entry to the flat CatalogService shape for a locale.
+ * @param {(typeof CATALOG_SOURCE)[number]} src
+ * @param {CatalogLocale} loc
+ * @returns {CatalogService}
+ */
+function resolve(src, loc) {
+  return {
+    id: src.id,
+    label: src.label[loc],
+    why: src.why[loc],
+    ...(src.setupUrl ? { setupUrl: src.setupUrl } : {}),
+    ...(src.setupSteps ? { setupSteps: [...src.setupSteps[loc]] } : {}),
+    envVars: src.envVars.map((v) => ({
+      key: v.key,
+      description: v.description[loc],
+      ...(v.secret ? { secret: true } : {}),
+      ...(v.example ? { example: v.example[loc] } : {}),
+    })),
+  };
+}
+
+/**
+ * Backward-compat view of the catalog (KO). Prefer the function forms with an
+ * explicit locale — this exists so pre-i18n imports keep working.
+ * @type {CatalogService[]}
+ */
+export const SERVICE_CATALOG = CATALOG_SOURCE.map((s) => resolve(s, "ko"));
 
 /** Case-insensitive keyword groups that hint a service is needed. */
 const DATA_KEYWORDS = [
@@ -170,19 +270,13 @@ const DATA_KEYWORDS = [
  * Deep-clone a catalog entry so the UI can attach `value` per env var without
  * mutating the shared catalog.
  * @param {string} id
+ * @param {"en"|"ko"} [locale]
  * @returns {CatalogService | null}
  */
-export function catalogServiceById(id) {
-  const found = SERVICE_CATALOG.find((s) => s.id === id);
+export function catalogServiceById(id, locale) {
+  const found = CATALOG_SOURCE.find((s) => s.id === id);
   if (!found) return null;
-  return {
-    id: found.id,
-    label: found.label,
-    why: found.why,
-    ...(found.setupUrl ? { setupUrl: found.setupUrl } : {}),
-    ...(found.setupSteps ? { setupSteps: [...found.setupSteps] } : {}),
-    envVars: found.envVars.map((v) => ({ ...v })),
-  };
+  return resolve(found, norm(locale));
 }
 
 /** Email-sending keywords → Resend. */
@@ -201,12 +295,14 @@ const ERROR_KEYWORDS = ["오류", "에러", "버그", "모니터링", "예외", 
  * Never invents keys or values — only picks catalog entries.
  *
  * @param {{ oneLine?: string, problem?: string, included?: string[], userFlow?: string[], productName?: string } | null | undefined} spec
+ * @param {"en"|"ko"} [locale]
  * @returns {CatalogService[]}
  */
-export function detectServices(spec) {
+export function detectServices(spec, locale) {
+  const loc = norm(locale);
   /** @type {CatalogService[]} */
   const out = [];
-  const appUrl = catalogServiceById("app-url");
+  const appUrl = catalogServiceById("app-url", loc);
   if (appUrl) out.push(appUrl);
 
   const parts = [
@@ -219,24 +315,28 @@ export function detectServices(spec) {
   const text = parts.join(" ").toLowerCase();
 
   if (DATA_KEYWORDS.some((k) => text.includes(k.toLowerCase()))) {
-    const supabase = catalogServiceById("supabase");
+    const supabase = catalogServiceById("supabase", loc);
     if (supabase) out.push(supabase);
   }
   if (EMAIL_KEYWORDS.some((k) => text.includes(k.toLowerCase()))) {
-    const resend = catalogServiceById("resend");
+    const resend = catalogServiceById("resend", loc);
     if (resend) out.push(resend);
   }
   if (ERROR_KEYWORDS.some((k) => text.includes(k.toLowerCase()))) {
-    const sentry = catalogServiceById("sentry");
+    const sentry = catalogServiceById("sentry", loc);
     if (sentry) out.push(sentry);
   }
 
   return out;
 }
 
-/** All services a user can add from the picker (full catalog, cloned). */
-export function allCatalogServices() {
-  return SERVICE_CATALOG.map((s) => catalogServiceById(s.id)).filter(Boolean);
+/**
+ * All services a user can add from the picker (full catalog, cloned).
+ * @param {"en"|"ko"} [locale]
+ */
+export function allCatalogServices(locale) {
+  const loc = norm(locale);
+  return CATALOG_SOURCE.map((s) => catalogServiceById(s.id, loc)).filter(Boolean);
 }
 
 /**

--- a/apps/dashboard/src/lib/service-values-store.d.mts
+++ b/apps/dashboard/src/lib/service-values-store.d.mts
@@ -7,4 +7,5 @@ export declare function seedServiceSetup(
     | { oneLine?: string; problem?: string; included?: string[]; userFlow?: string[]; productName?: string }
     | null
     | undefined,
+  locale?: "en" | "ko",
 ): unknown[];

--- a/apps/dashboard/src/lib/service-values-store.mjs
+++ b/apps/dashboard/src/lib/service-values-store.mjs
@@ -12,7 +12,7 @@
  * never lingers on the device indefinitely. Keyed per project.
  */
 
-import { detectServices } from "./service-catalog.mjs";
+import { detectServices, catalogServiceById } from "./service-catalog.mjs";
 
 const KEY_PREFIX = "conclave:service-values:";
 
@@ -80,12 +80,33 @@ export function clearServiceValues(projectId) {
  *   2. spec detection (email→Resend, error→Sentry, …) still reaches the panel
  *      on its new screen (detection fallback).
  *
+ * i18n (2026-07-21): the stored blob wins on WHICH services + their values, but
+ * the copy (labels/steps/descriptions) is re-resolved from the catalog in the
+ * CURRENT locale — otherwise a user who saved under KO keeps seeing KO after
+ * switching to EN (journey-audit v2 P1의 같은 클래스).
+ *
  * @param {string} projectId
  * @param {Parameters<typeof detectServices>[0]} spec
+ * @param {"en"|"ko"} [locale]
  * @returns {unknown[]}
  */
-export function seedServiceSetup(projectId, spec) {
+export function seedServiceSetup(projectId, spec, locale) {
   const stored = loadServiceValues(projectId);
-  if (Array.isArray(stored) && stored.length > 0) return stored;
-  return detectServices(spec);
+  if (!Array.isArray(stored) || stored.length === 0) return detectServices(spec, locale);
+  return stored.map((s) => {
+    const fresh = catalogServiceById(s?.id, locale);
+    if (!fresh) return s; // unknown/legacy id — pass through untouched
+    const valueByKey = new Map(
+      (Array.isArray(s?.envVars) ? s.envVars : [])
+        .filter((v) => v && typeof v.key === "string")
+        .map((v) => [v.key, v.value]),
+    );
+    return {
+      ...fresh,
+      envVars: fresh.envVars.map((v) => {
+        const value = valueByKey.get(v.key);
+        return typeof value === "string" && value.length > 0 ? { ...v, value } : v;
+      }),
+    };
+  });
 }

--- a/apps/dashboard/src/lib/visual-check-view.d.mts
+++ b/apps/dashboard/src/lib/visual-check-view.d.mts
@@ -16,7 +16,7 @@ export function inspectionEmptyStateDoor(facts: {
   entryPath?: "idea" | "code" | "spec" | null;
   hasRepo?: boolean | null;
   hasDeployUrl?: boolean | null;
-}): "connect" | "run";
+}): "connect" | "run" | "wait";
 
 export function relativeTimeLabel(iso: string, locale: string, now?: number): string;
 

--- a/apps/dashboard/src/lib/visual-check-view.mjs
+++ b/apps/dashboard/src/lib/visual-check-view.mjs
@@ -95,18 +95,24 @@ export function overviewNextAction(checks) {
  * Journey-audit P2 (2026-07-20) — which door the overview inspection card's
  * EMPTY state offers. On the CODE branch with the repo CONFIRMED absent and
  * no deploy URL, "run your first inspection" points at the URL-based door the
- * user can't use yet — walk them to connect first instead. Unknown facts
- * (null — fetch pending/failed) keep the default door: fail-open, a wrong
- * "connect" nudge on an already-connected project is worse than the generic
- * lead (transient-null-hard-false).
+ * user can't use yet — walk them to connect first instead.
+ *
+ * v2 기준선 (2026-07-21): on the code branch an UNKNOWN repo fact must not
+ * render the default door either — the baseline caught the card showing
+ * "run" for ~2s then flipping to "connect" once the repo fetch settled
+ * (실측 스크린샷). A CTA that flips is worse than a moment without one
+ * (same principle as nextProjectAction). So code + hasRepo null → "wait"
+ * (caller renders nothing until the fact settles). Non-code branches keep
+ * the default door on unknowns — their door never depends on the repo fact.
  *
  * @param {{ entryPath?: "idea" | "code" | "spec" | null, hasRepo?: boolean | null, hasDeployUrl?: boolean | null }} facts
- * @returns {"connect" | "run"}
+ * @returns {"connect" | "run" | "wait"}
  */
 export function inspectionEmptyStateDoor(facts) {
   const f = facts ?? {};
-  if (f.entryPath === "code" && f.hasRepo === false && f.hasDeployUrl !== true) {
-    return "connect";
+  if (f.entryPath === "code" && f.hasDeployUrl !== true) {
+    if (f.hasRepo === false) return "connect";
+    if (f.hasRepo == null) return "wait";
   }
   return "run";
 }

--- a/apps/dashboard/test/checks-cta.test.mjs
+++ b/apps/dashboard/test/checks-cta.test.mjs
@@ -2,50 +2,73 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { checksPrimaryCta } from "../src/lib/checks-cta.mjs";
 
+// v2 (2026-07-21): +prSectionVisible (hidden PR section can't own the primary)
+// +draftHasResults (empty pre-check → run_precheck is the primary).
+const BASE = { prSectionVisible: true, prReviewLoaded: true, hasPrReview: false, prNeedsAction: 0, draftNeedsAction: 0, draftHasResults: true };
+
 describe("checks-cta: exactly one state-driven primary", () => {
   it("no PR review yet → connect_pr (get the real review)", () => {
-    assert.equal(
-      checksPrimaryCta({ prReviewLoaded: true, hasPrReview: false, prNeedsAction: 0, draftNeedsAction: 5 }),
-      "connect_pr",
-    );
+    assert.equal(checksPrimaryCta({ ...BASE, draftNeedsAction: 5 }), "connect_pr");
   });
 
   it("real PR review with issues → pr_fix (outranks the draft pre-check)", () => {
     assert.equal(
-      checksPrimaryCta({ prReviewLoaded: true, hasPrReview: true, prNeedsAction: 2, draftNeedsAction: 3 }),
+      checksPrimaryCta({ ...BASE, hasPrReview: true, prNeedsAction: 2, draftNeedsAction: 3 }),
       "pr_fix",
     );
   });
 
   it("PR review all passed but draft has issues → draft_fix", () => {
     assert.equal(
-      checksPrimaryCta({ prReviewLoaded: true, hasPrReview: true, prNeedsAction: 0, draftNeedsAction: 3 }),
+      checksPrimaryCta({ ...BASE, hasPrReview: true, prNeedsAction: 0, draftNeedsAction: 3 }),
       "draft_fix",
     );
   });
 
   it("nothing actionable → none (no filled primary)", () => {
     assert.equal(
-      checksPrimaryCta({ prReviewLoaded: true, hasPrReview: true, prNeedsAction: 0, draftNeedsAction: 0 }),
+      checksPrimaryCta({ ...BASE, hasPrReview: true }),
       "none",
     );
   });
 
   it("PR still loading → not connect_pr; falls back to draft state", () => {
     assert.equal(
-      checksPrimaryCta({ prReviewLoaded: false, hasPrReview: false, prNeedsAction: 0, draftNeedsAction: 4 }),
+      checksPrimaryCta({ ...BASE, prReviewLoaded: false, draftNeedsAction: 4 }),
+      "draft_fix",
+    );
+  });
+
+  // journey-audit v2 기준선 (실측 cta=2): the pre-check empty state used to
+  // hard-code its own primary and bypass this machine.
+  it("empty pre-check + connect available → connect_pr wins, run stays secondary", () => {
+    assert.equal(checksPrimaryCta({ ...BASE, draftHasResults: false }), "connect_pr");
+  });
+
+  it("empty pre-check + PR section HIDDEN (idea branch) → run_precheck is the primary", () => {
+    assert.equal(
+      checksPrimaryCta({ ...BASE, prSectionVisible: false, draftHasResults: false }),
+      "run_precheck",
+    );
+  });
+
+  it("hidden PR section never yields connect_pr", () => {
+    assert.equal(
+      checksPrimaryCta({ ...BASE, prSectionVisible: false, draftNeedsAction: 2 }),
       "draft_fix",
     );
   });
 
   it("never returns two primaries — the result is a single tag", () => {
-    // Exhaustive-ish: every combination yields exactly one of the four tags.
     const tags = new Set();
-    for (const prReviewLoaded of [true, false])
-      for (const hasPrReview of [true, false])
-        for (const prNeedsAction of [0, 2])
-          for (const draftNeedsAction of [0, 3])
-            tags.add(checksPrimaryCta({ prReviewLoaded, hasPrReview, prNeedsAction, draftNeedsAction }));
-    for (const tag of tags) assert.ok(["connect_pr", "pr_fix", "draft_fix", "none"].includes(tag));
+    for (const prSectionVisible of [true, false])
+      for (const prReviewLoaded of [true, false])
+        for (const hasPrReview of [true, false])
+          for (const prNeedsAction of [0, 2])
+            for (const draftNeedsAction of [0, 3])
+              for (const draftHasResults of [true, false])
+                tags.add(checksPrimaryCta({ prSectionVisible, prReviewLoaded, hasPrReview, prNeedsAction, draftNeedsAction, draftHasResults }));
+    for (const tag of tags)
+      assert.ok(["connect_pr", "pr_fix", "draft_fix", "run_precheck", "none"].includes(tag));
   });
 });

--- a/apps/dashboard/test/service-catalog.test.mjs
+++ b/apps/dashboard/test/service-catalog.test.mjs
@@ -147,3 +147,46 @@ describe("service-catalog", () => {
     assert.notEqual(SERVICE_CATALOG[0].label, "mutated");
   });
 });
+
+// v2 (2026-07-21, journey-audit 기준선 P1): the catalog is bilingual — the EN
+// journey's prep card was the only Korean left on the screen (실측 478자).
+describe("service-catalog: locale resolution", () => {
+  it('locale "en" resolves every user-facing string without Hangul', () => {
+    for (const svc of allCatalogServices("en")) {
+      const texts = [
+        svc.label,
+        svc.why,
+        ...(svc.setupSteps ?? []),
+        ...svc.envVars.flatMap((v) => [v.description, v.example ?? ""]),
+      ];
+      for (const text of texts) {
+        assert.ok(!/[가-힣]/.test(text), `Hangul leaked in EN copy of ${svc.id}: ${text}`);
+      }
+    }
+  });
+
+  it("locale omitted defaults to KO (backward compat — 기존 호출자 무변경)", () => {
+    assert.equal(catalogServiceById("app-url").label, "앱 주소");
+    assert.equal(catalogServiceById("app-url", "en").label, "App URL");
+  });
+
+  it("EN/KO entries mirror structure: same ids, keys, secret flags, urls", () => {
+    const ko = allCatalogServices("ko");
+    const en = allCatalogServices("en");
+    assert.deepEqual(ko.map((s) => s.id), en.map((s) => s.id));
+    for (let i = 0; i < ko.length; i++) {
+      assert.equal(ko[i].setupUrl, en[i].setupUrl);
+      assert.deepEqual(
+        ko[i].envVars.map((v) => ({ key: v.key, secret: v.secret ?? false })),
+        en[i].envVars.map((v) => ({ key: v.key, secret: v.secret ?? false })),
+      );
+      assert.equal((ko[i].setupSteps ?? []).length, (en[i].setupSteps ?? []).length);
+    }
+  });
+
+  it("detectServices honors locale for the resolved copy", () => {
+    const en = detectServices({ oneLine: "an app that sends a verify email on sign up" }, "en");
+    const resend = en.find((s) => s.id === "resend");
+    assert.ok(resend && !/[가-힣]/.test(resend.label));
+  });
+});

--- a/apps/dashboard/test/service-values-store.test.mjs
+++ b/apps/dashboard/test/service-values-store.test.mjs
@@ -59,10 +59,33 @@ describe("service-values-store (browser-only, sessionStorage)", () => {
   });
 
   // A2b safety check 1: values entered in prep survive the move to export.
-  it("seedServiceSetup returns the STORED values when present (survives the move)", () => {
+  // v2 (2026-07-21 i18n): the stored blob decides WHICH services + their
+  // VALUES, but the copy is re-resolved from the catalog in the current
+  // locale — a KO-saved blob must not pin the labels after switching to EN.
+  it("seedServiceSetup keeps STORED values, re-resolves copy per locale", () => {
     const stored = [{ id: "supabase", envVars: [{ key: "SUPABASE_SERVICE_ROLE_KEY", value: "svc_real" }] }];
     saveServiceValues("proj_1", stored);
-    const seeded = seedServiceSetup("proj_1", { oneLine: "무엇이든" });
+
+    const seededKo = seedServiceSetup("proj_1", { oneLine: "무엇이든" });
+    assert.equal(seededKo.length, 1);
+    assert.equal(seededKo[0].id, "supabase");
+    const roleKo = seededKo[0].envVars.find((v) => v.key === "SUPABASE_SERVICE_ROLE_KEY");
+    assert.equal(roleKo.value, "svc_real", "entered value survives");
+    assert.ok(/데이터/.test(seededKo[0].label), "KO copy resolved");
+    // Catalog vars the stored blob didn't carry come back (full entry restored).
+    assert.ok(seededKo[0].envVars.some((v) => v.key === "NEXT_PUBLIC_SUPABASE_URL"));
+
+    const seededEn = seedServiceSetup("proj_1", { oneLine: "anything" }, "en");
+    const roleEn = seededEn[0].envVars.find((v) => v.key === "SUPABASE_SERVICE_ROLE_KEY");
+    assert.equal(roleEn.value, "svc_real", "value survives locale switch");
+    assert.ok(/data/.test(seededEn[0].label), "EN copy resolved");
+    assert.ok(!/[가-힣]/.test(seededEn[0].label), "no Hangul in EN label");
+  });
+
+  it("seedServiceSetup passes unknown/legacy service ids through untouched", () => {
+    const stored = [{ id: "custom-thing", label: "커스텀", envVars: [{ key: "X", value: "1" }] }];
+    saveServiceValues("proj_legacy", stored);
+    const seeded = seedServiceSetup("proj_legacy", null, "en");
     assert.deepEqual(seeded, stored);
   });
 

--- a/apps/dashboard/test/visual-check-view.test.mjs
+++ b/apps/dashboard/test/visual-check-view.test.mjs
@@ -238,9 +238,23 @@ describe("inspectionEmptyStateDoor", () => {
     );
   });
 
-  it("unknown repo fact (null) stays fail-open → run", () => {
+  it("code branch + unknown repo fact (null) → wait (never a door that flips)", () => {
+    // v2 기준선 (2026-07-21 실측): rendering the default door while the repo
+    // fetch settles made the CTA flip "run"→"connect" ~2s after paint. On the
+    // code branch an undecidable door holds the card instead.
     assert.equal(
       inspectionEmptyStateDoor({ entryPath: "code", hasRepo: null, hasDeployUrl: null }),
+      "wait",
+    );
+    // A confirmed deploy URL decides the door regardless of the repo fact.
+    assert.equal(
+      inspectionEmptyStateDoor({ entryPath: "code", hasRepo: null, hasDeployUrl: true }),
+      "run",
+    );
+    // Non-code branches keep the default door on unknowns (their door never
+    // depends on the repo fact).
+    assert.equal(
+      inspectionEmptyStateDoor({ entryPath: "idea", hasRepo: null, hasDeployUrl: null }),
       "run",
     );
   });

--- a/tools/simsa-completion-loop-spike/journey-audit.mjs
+++ b/tools/simsa-completion-loop-spike/journey-audit.mjs
@@ -242,7 +242,10 @@ for (const j of audit.journeys) {
     if (s.errorish > 0 && !isBlockedStep) {
       audit.findings.push({ sev: "P0", journey: j.name, locale: s.locale, step: s.label, what: `happy path 오류 카피 ${s.errorish}건 노출` });
     }
-    if (s.primaryCtaCount === 0 && !/입력 후|변환 중/.test(s.label)) {
+    // 갈래 선택(chooser)은 3개의 동등한 문 설계라 primary-0이 정상 — 기준선
+    // 판독(2026-07-21)에서 거짓 양성으로 확정, 규칙 예외. (추천 배지는 D16이
+    // 별도로 담당한다.)
+    if (s.primaryCtaCount === 0 && !/입력 후|변환 중|갈래 선택/.test(s.label)) {
       audit.findings.push({ sev: "P1", journey: j.name, locale: s.locale, step: s.label, what: "primary CTA 0 — 다음 행동이 버튼으로 안 보임" });
     }
     if (s.primaryCtaCount >= 3) {


### PR DESCRIPTION
journey-audit v2 기준선(#446) 판독 확정 3건 수정 — 실행계획 2026-07-21 Train U.

| 기준선 발견 | 수정 |
|---|---|
| P1: EN 여정에서 prep 서비스 카드만 한국어 478자 | 카탈로그 ko/en 병기 + 전 함수 locale 파라미터(기본 ko, 기존 호출자 무변경) + seedServiceSetup이 값은 유지·카피만 locale 재해석 |
| P1: 개요 검수카드 CTA가 "run"→"connect"로 ~2s 뒤 플립 | code+repo미확정 → "wait"(카드 보류) — 플립 CTA보다 잠깐의 부재 |
| P2: checks 화면 filled primary 2개 | 빈 사전확인 버튼의 하드코딩 primary를 상태기계로 편입(`prSectionVisible`+`draftHasResults`+`run_precheck`) |
| 규칙: chooser primary-0 거짓양성 | 3문 설계 예외 반영 |

검증: 61/61 (EN 무한글 전수 포함) + dashboard 3/3 green. 머지 후 CLI 배포 → **journey-audit 재감사로 3건 소멸 실증** 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)