### PR TITLE
fix(dashboard): Train U 배치2 — MCP 카탈로그 i18n (EN 잔여 한글 소거)

### DIFF
--- a/apps/dashboard/src/components/ServiceMcpSetup.tsx
+++ b/apps/dashboard/src/components/ServiceMcpSetup.tsx
@@ -68,7 +68,7 @@ export function ServiceMcpSetup({ projectId, spec }: { projectId: string; spec: 
 
   // Which agent's MCP connect steps to show (settings has no target selector).
   const [agentId, setAgentId] = useState<string>("claude_code");
-  const deployTools: McpTool[] = detectMcpTools();
+  const deployTools: McpTool[] = detectMcpTools(locale);
 
   function setEnvValue(serviceId: string, key: string, value: string) {
     setServices((prev) =>

--- a/apps/dashboard/src/lib/mcp-catalog.d.mts
+++ b/apps/dashboard/src/lib/mcp-catalog.d.mts
@@ -3,8 +3,6 @@ export interface McpTool {
   label: string;
   /** why a non-dev needs this, one plain sentence */
   purpose: string;
-  /** how to connect it once, in their editor */
-  connectHint: string;
   /** the "we never see your token" reassurance */
   authNote: string;
   /** the MCP server name to register it under */
@@ -16,6 +14,6 @@ export interface McpTool {
 
 export declare const MCP_CATALOG: McpTool[];
 
-export declare function mcpToolById(id: string): McpTool | null;
+export declare function mcpToolById(id: string, locale?: "en" | "ko"): McpTool | null;
 
-export declare function detectMcpTools(): McpTool[];
+export declare function detectMcpTools(locale?: "en" | "ko"): McpTool[];

--- a/apps/dashboard/src/lib/mcp-catalog.mjs
+++ b/apps/dashboard/src/lib/mcp-catalog.mjs
@@ -28,40 +28,76 @@
  * the stable fact and lives here; the command is not hardcoded to Claude Code.
  */
 
-/** @type {McpTool[]} */
-export const MCP_CATALOG = [
+// Bilingual source (2026-07-21, journey-audit v2 재감사: EN 화면 잔여 한글
+// 177자의 출처가 이 카탈로그였다). 사용자 대면 문자열만 {ko,en}; id/url은 중립.
+const MCP_SOURCE = [
   {
     id: "github",
-    label: "GitHub — 코드 저장소",
-    purpose: "만든 코드를 저장하고 올려두는 곳입니다. 개발 AI가 여기에 코드를 올려야 나중에 Simsa에서 확인할 수 있어요.",
+    label: { ko: "GitHub — 코드 저장소", en: "GitHub — code storage" },
+    purpose: {
+      ko: "만든 코드를 저장하고 올려두는 곳입니다. 개발 AI가 여기에 코드를 올려야 나중에 Simsa에서 확인할 수 있어요.",
+      en: "Where your app's code is stored. Your dev AI pushes code here so Simsa can review it later.",
+    },
     // Official GitHub remote MCP server (OAuth). Verified 2026-07.
     mcpName: "github",
     serverUrl: "https://api.githubcopilot.com/mcp/",
-    authNote: "로그인은 에디터에서 한 번만 하면 됩니다. 토큰이나 비밀번호를 Simsa에 넣지 마세요 — 저희는 받지도, 저장하지도 않습니다.",
+    authNote: {
+      ko: "로그인은 에디터에서 한 번만 하면 됩니다. 토큰이나 비밀번호를 Simsa에 넣지 마세요 — 저희는 받지도, 저장하지도 않습니다.",
+      en: "You sign in once, inside your editor. Never paste tokens or passwords into Simsa — we don't accept or store them.",
+    },
     docsUrl: "https://github.com/github/github-mcp-server",
   },
   {
     id: "vercel",
-    label: "Vercel — 인터넷에 배포",
-    purpose: "만든 앱을 인터넷에 올려 접속 주소(URL)를 만드는 곳입니다. 개발 AI가 여기로 배포하면 바로 주소가 나와요.",
+    label: { ko: "Vercel — 인터넷에 배포", en: "Vercel — put it online" },
+    purpose: {
+      ko: "만든 앱을 인터넷에 올려 접속 주소(URL)를 만드는 곳입니다. 개발 AI가 여기로 배포하면 바로 주소가 나와요.",
+      en: "Puts your app on the internet and gives it a URL. When your dev AI deploys here, you get an address right away.",
+    },
     // Official Vercel remote MCP server (OAuth, public beta). Verified 2026-07.
     mcpName: "vercel",
     serverUrl: "https://mcp.vercel.com",
-    authNote: "로그인은 에디터에서 한 번만. 배포 토큰을 Simsa에 넣지 마세요 — 저희는 받지도, 저장하지도 않습니다.",
+    authNote: {
+      ko: "로그인은 에디터에서 한 번만. 배포 토큰을 Simsa에 넣지 마세요 — 저희는 받지도, 저장하지도 않습니다.",
+      en: "Sign in once, in your editor. Never paste deploy tokens into Simsa — we don't accept or store them.",
+    },
     docsUrl: "https://vercel.com/docs/mcp/vercel-mcp",
   },
 ];
+
+/** @param {"en"|"ko"|undefined} locale */
+function norm(locale) {
+  return locale === "en" ? "en" : "ko";
+}
+
+/** @param {(typeof MCP_SOURCE)[number]} src @param {"en"|"ko"} loc @returns {McpTool} */
+function resolve(src, loc) {
+  return {
+    id: src.id,
+    label: src.label[loc],
+    purpose: src.purpose[loc],
+    authNote: src.authNote[loc],
+    mcpName: src.mcpName,
+    serverUrl: src.serverUrl,
+    ...(src.docsUrl ? { docsUrl: src.docsUrl } : {}),
+  };
+}
+
+/** Backward-compat KO view. Prefer the function forms with an explicit locale.
+ * @type {McpTool[]} */
+export const MCP_CATALOG = MCP_SOURCE.map((s) => resolve(s, "ko"));
 
 /**
  * Return a fresh clone of a tool entry by id (so callers never mutate the
  * shared catalog).
  * @param {string} id
+ * @param {"en"|"ko"} [locale]
  * @returns {McpTool | null}
  */
-export function mcpToolById(id) {
-  const found = MCP_CATALOG.find((t) => t.id === id);
+export function mcpToolById(id, locale) {
+  const found = MCP_SOURCE.find((t) => t.id === id);
   if (!found) return null;
-  return { ...found };
+  return resolve(found, norm(locale));
 }
 
 /**
@@ -72,8 +108,10 @@ export function mcpToolById(id) {
  * refinement (e.g. skipping the repo tool for a throwaway prototype) but is not
  * used today.
  *
+ * @param {"en"|"ko"} [locale]
  * @returns {McpTool[]}
  */
-export function detectMcpTools() {
-  return MCP_CATALOG.map((t) => ({ ...t }));
+export function detectMcpTools(locale) {
+  const loc = norm(locale);
+  return MCP_SOURCE.map((t) => resolve(t, loc));
 }

--- a/apps/dashboard/test/mcp-catalog.test.mjs
+++ b/apps/dashboard/test/mcp-catalog.test.mjs
@@ -66,3 +66,22 @@ describe("mcp-catalog", () => {
     assert.equal(mcpToolById("nope"), null);
   });
 });
+
+// v2 (2026-07-21, journey-audit 재감사): EN 화면 잔여 한글 177자의 출처가 이
+// 카탈로그였다 — EN 해석은 무한글 전수, 기본값은 KO(기존 호출자 무변경).
+describe("mcp-catalog: locale resolution", () => {
+  it('locale "en" resolves every user-facing string without Hangul', () => {
+    for (const tool of detectMcpTools("en")) {
+      for (const text of [tool.label, tool.purpose, tool.authNote]) {
+        assert.ok(!/[가-힣]/.test(text), `Hangul leaked in EN copy of ${tool.id}: ${text}`);
+      }
+    }
+  });
+
+  it("locale omitted defaults to KO; ids/urls are locale-neutral", () => {
+    assert.ok(/코드 저장소/.test(mcpToolById("github").label));
+    assert.ok(/code storage/.test(mcpToolById("github", "en").label));
+    assert.equal(mcpToolById("vercel").serverUrl, mcpToolById("vercel", "en").serverUrl);
+    assert.deepEqual(detectMcpTools("ko").map((t) => t.id), detectMcpTools("en").map((t) => t.id));
+  });
+});


### PR DESCRIPTION
배치1(#447) 재감사: EN 랜딩 한글 누수 **478→177자** — 잔여 출처는 `mcp-catalog.mjs`(GitHub/Vercel 카드 카피 ≈177자). service-catalog(#447)와 동일 패턴으로 ko/en 병기 + locale 파라미터(기본 ko). 머지·배포 후 재감사에서 **koLeak ≈0** 기대.

- 테스트: EN 무한글 전수 + 기본값 KO + id/url locale-중립 (9/9)
- dashboard 3/3 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)