### PR TITLE
feat(evidence): Train M-1a — 해자 라이브 연결: evidence API (design locked)

### DIFF
--- a/apps/central-plane/src/routes/workspace-visual-checks.ts
+++ b/apps/central-plane/src/routes/workspace-visual-checks.ts
@@ -18,6 +18,8 @@ import { Hono } from "hono";
 import { corsMiddleware } from "./cors.js";
 import type { Env } from "../env.js";
 import { getProject } from "../workspace/db.js";
+import { listProjectReviewRuns } from "../workspace/pr-review-db.js";
+import { assembleLiveEvidence } from "../workspace/evidence-live.js";
 import {
   insertVisualCheck,
   listVisualChecks,
@@ -272,6 +274,66 @@ export function createWorkspaceVisualChecksRoutes(): Hono<{ Bindings: Env }> {
         createdAt: owned.run.createdAt,
       },
     });
+  });
+
+  // ── GET /workspace/projects/:id/evidence/:runId ────────────────────────────
+  // Train M-1a (2026-07-21, design locked): "왜 이 판정인가" 증거 체인.
+  // 저장된 사실(스펙/items · 시각 런 · 최신 PR 리뷰 결과)을 GET 시점에
+  // acceptance-graph로 재도출(on-demand — 저장 없음·네트워크 없음·결정론).
+  // 새 판정을 만들지 않는다: 이미 내려진 판정에 근거를 붙일 뿐이다.
+  app.get("/workspace/projects/:id/evidence/:runId", async (c) => {
+    const projectId = c.req.param("id");
+    const runId = c.req.param("runId");
+    const userKey = c.req.query("userKey") ?? "";
+    if (!userKey) return c.json({ ok: false, error: "userKey_required" }, 400);
+
+    const owned = await requireOwnedRun(c.env, projectId, runId, userKey);
+    if (!owned.ok) return c.json({ ok: false, error: owned.error }, owned.status);
+
+    try {
+      const project = await getProject(c.env, projectId);
+      const parse = (v: unknown): unknown => {
+        if (typeof v !== "string") return v ?? null;
+        try {
+          return JSON.parse(v);
+        } catch {
+          return null;
+        }
+      };
+      // A finished review = terminal verdict status with a stored result.
+      const latest = (await listProjectReviewRuns(c.env, projectId, { limit: 5 })).find(
+        (r) => (r.status === "passed" || r.status === "failed" || r.status === "inconclusive") && r.resultJson,
+      );
+      let latestReview: { repoFullName?: string; prNumber?: number; results?: Array<{ itemId?: string; title?: string; status?: string }> } | null = null;
+      if (latest) {
+        const parsed = parse(latest.resultJson) as { results?: Array<{ itemId?: string; title?: string; status?: string }> } | null;
+        latestReview = {
+          repoFullName: latest.repoFullName,
+          prNumber: latest.prNumber,
+          results: parsed?.results ?? [],
+        };
+      }
+
+      const evidence = assembleLiveEvidence({
+        projectId,
+        entryPath: project?.entryPath ?? null,
+        productSpec: (project ? parse(project.productSpec) : null) as never,
+        items: (project ? parse(project.items) : null) as never,
+        run: {
+          id: owned.run.id,
+          intent: owned.run.intent,
+          decision: owned.run.decision,
+          works: owned.run.works,
+          reportJson: owned.run.reportJson,
+        },
+        latestReview,
+      });
+
+      return c.json({ ok: true, evidence });
+    } catch (err) {
+      console.error("[workspace/evidence GET] failed:", err);
+      return c.json({ ok: false, error: "query_failed" }, 500);
+    }
   });
 
   return app;

--- a/apps/central-plane/src/workspace/evidence-live.ts
+++ b/apps/central-plane/src/workspace/evidence-live.ts
@@ -1,0 +1,261 @@
+/**
+ * workspace/evidence-live.ts — Train M-1a (2026-07-21, design locked).
+ *
+ * 해자 라이브 연결의 서버 절반: 검수가 이미 저장해 둔 사실들(프로젝트의
+ * product_spec/items · 시각 검수 런의 intent/works/decision/report_json ·
+ * 최신 PR 리뷰 런의 per-item 결과)을 acceptance-graph 노드로 **결정론적으로
+ * 조립**해 deriveEvidencePack → classifyGateDecision까지 내린다.
+ *
+ * 원칙 (PRD §5 불변식):
+ *   - 판정을 새로 만들지 않는다 — 이미 저장된 사실에 근거를 붙일 뿐.
+ *   - 숫자 점수 없음(DECISION_STATES만) · 근거 없으면 Not Verified.
+ *   - Browser Evidence ≠ AI Opinion: 시각 런의 관찰(콘솔에러·실패 인터랙션·
+ *     스크린샷 수)은 visual 노드로, 리포트의 해석성 발견(what/why)은
+ *     crossReview(reviewer="simsa-visual")의 findings로 분리해 나른다.
+ *   - 저장 안 함 · 네트워크 없음 — GET 시점에 저장된 행에서 재도출(on-demand).
+ *     같은 입력 → 같은 pack (derivation 로직이 업그레이드되면 결과도 최신).
+ *
+ * PURE: 이 모듈은 이미 로드된 행만 받는다. DB 로드·소유권 체크는 라우트 몫.
+ */
+import {
+  createAcceptanceGraph,
+  type AcceptanceGraph,
+  type GateDecisionNode,
+} from "../acceptance-graph.js";
+import {
+  deriveEvidencePack,
+  classifyGateDecision,
+  type EvidencePack,
+} from "../evidence-pack.js";
+
+/** 이 조립이 소비하는 최소 행 형태 (라우트가 실제 DB 타입에서 투영). */
+export interface LiveEvidenceInput {
+  projectId: string;
+  entryPath?: string | null;
+  /** workspace_projects.product_spec_json 파싱 결과 (없으면 null). */
+  productSpec?: {
+    productName?: string;
+    oneLine?: string;
+    problem?: string;
+    targetUsers?: string[];
+    included?: string[];
+    excluded?: string[];
+    userFlow?: string[];
+    openQuestions?: string[];
+  } | null;
+  /** workspace_projects.items_json 파싱 결과. */
+  items?: Array<{ id?: string; title?: string }> | null;
+  /** 시각 검수 런 (근거를 붙일 대상). */
+  run: {
+    id: string;
+    intent: string;
+    decision: string;
+    works: boolean | null;
+    /** report_json 원문 — 관대하게 파싱, 실패해도 조립은 계속. */
+    reportJson?: string | null;
+  };
+  /** 최신 PR 리뷰 런의 result_json 파싱 결과 (없으면 null). */
+  latestReview?: {
+    repoFullName?: string;
+    prNumber?: number;
+    results?: Array<{ itemId?: string; title?: string; status?: string }>;
+  } | null;
+}
+
+export interface LiveEvidence {
+  pack: EvidencePack;
+  gate: GateDecisionNode;
+  /** UI 3열 체인용: 기준 ↔ 관찰 사실 ↔ 판정. */
+  criteria: Array<{
+    id: string;
+    text: string;
+    status: "verified" | "broken" | "not_verified";
+    /** 이 기준을 판정한 관찰 소스 (PR 리뷰 항목명 등). 없으면 빈 배열. */
+    observedBy: string[];
+  }>;
+  /** Browser Evidence (사실만 — 해석 아님). */
+  browserFacts: {
+    works: boolean | null;
+    decision: string;
+    consoleErrors: string[];
+    failedInteractions: string[];
+    screenshotCount: number;
+  };
+  /** AI Opinion (해석 — "측정된 사실 아님" 라벨로 렌더할 것). */
+  interpretations: string[];
+}
+
+const arr = <T>(v: T[] | null | undefined): T[] => (Array.isArray(v) ? v : []);
+
+/** report_json에서 관찰/해석을 관대하게 추출. 어떤 형태여도 throw하지 않는다. */
+export function parseReportFacts(reportJson: string | null | undefined): {
+  consoleErrors: string[];
+  failedInteractions: string[];
+  screenshotCount: number;
+  interpretations: string[];
+} {
+  const out = {
+    consoleErrors: [] as string[],
+    failedInteractions: [] as string[],
+    screenshotCount: 0,
+    interpretations: [] as string[],
+  };
+  if (!reportJson) return out;
+  let r: unknown;
+  try {
+    r = JSON.parse(reportJson);
+  } catch {
+    return out;
+  }
+  if (!r || typeof r !== "object") return out;
+  const rec = r as Record<string, unknown>;
+
+  const strArr = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+
+  out.consoleErrors = strArr(rec["consoleErrors"]).slice(0, 20);
+  // 스텝 관찰에서 실패성 사실 수집 (여러 리포트 버전에 관대).
+  const steps = Array.isArray(rec["steps"]) ? rec["steps"] : [];
+  for (const s of steps) {
+    if (s && typeof s === "object") {
+      const st = s as Record<string, unknown>;
+      if (st["ok"] === false && typeof st["label"] === "string") {
+        out.failedInteractions.push(st["label"]);
+      }
+      if (typeof st["screenshot"] === "string") out.screenshotCount++;
+    }
+  }
+  const evidence = rec["evidence"];
+  if (evidence && typeof evidence === "object") {
+    const shots = (evidence as Record<string, unknown>)["screenshots"];
+    if (Array.isArray(shots)) out.screenshotCount = Math.max(out.screenshotCount, shots.length);
+  }
+  // findings의 what/why는 해석(AI Opinion) — 사실과 분리해 나른다.
+  const findings = Array.isArray(rec["findings"]) ? rec["findings"] : [];
+  for (const f of findings) {
+    if (f && typeof f === "object") {
+      const fr = f as Record<string, unknown>;
+      if (typeof fr["what"] === "string" && fr["what"]) out.interpretations.push(fr["what"]);
+    }
+  }
+  return out;
+}
+
+/**
+ * 저장된 사실 → acceptance graph → evidence pack → gate. 결정론.
+ * 판정 원칙 매핑:
+ *   - 스펙/items → prd 노드 (acceptanceCriteria = items)
+ *   - PR 리뷰 per-item 결과 → implementation.tests (passed→pass, failed→fail,
+ *     그 외→skipped; criteriaIds=[itemId]) — per-criterion verified/broken의 근거
+ *   - 시각 런 → visual 노드 (notVerified = works가 null일 때만 — false는
+ *     "실패를 확인함"이지 미검증이 아니다) + works=false의 해석 발견은
+ *     crossReview(simsa-visual)의 unresolvedBlockers → gate가 Needs Fix로.
+ */
+export function assembleLiveEvidence(input: LiveEvidenceInput): LiveEvidence {
+  const spec = input.productSpec ?? null;
+  const items = arr(input.items).filter(
+    (i): i is { id: string; title: string } =>
+      !!i && typeof i.id === "string" && typeof i.title === "string",
+  );
+  const facts = parseReportFacts(input.run.reportJson);
+
+  const review = input.latestReview ?? null;
+  const reviewResults = arr(review?.results).filter(
+    (r): r is { itemId: string; title?: string; status: string } =>
+      !!r && typeof r.itemId === "string" && typeof r.status === "string",
+  );
+
+  const graph = createAcceptanceGraph({
+    projectId: input.projectId,
+    intent: {
+      id: `run-${input.run.id}`,
+      summary: input.run.intent || spec?.oneLine || "",
+      targetFirstUser: arr(spec?.targetUsers)[0] ?? "",
+      desiredBehaviorChange: spec?.problem || spec?.oneLine || "",
+      sourceRefs: [`visual-check:${input.run.id}`],
+    },
+    prd: spec
+      ? {
+          summary: spec.oneLine ?? "",
+          requirements: arr(spec.included),
+          userFlows: arr(spec.userFlow),
+          acceptanceCriteria: items.map((i) => ({ id: i.id, text: i.title })),
+          outOfScope: arr(spec.excluded),
+          unknowns: arr(spec.openQuestions),
+          sourceRefs: [`project:${input.projectId}`],
+        }
+      : null,
+    implementation: review
+      ? {
+          repo: review.repoFullName ?? null,
+          prNumber: typeof review.prNumber === "number" ? review.prNumber : null,
+          tests: reviewResults.map((r) => ({
+            name: r.title || r.itemId,
+            status: r.status === "passed" ? "pass" : r.status === "failed" ? "fail" : "skipped",
+            criteriaIds: [r.itemId],
+          })),
+          sourceRefs: review.prNumber != null ? [`pr:${review.prNumber}`] : [],
+        }
+      : null,
+    crossReviews:
+      input.run.works === false && facts.interpretations.length > 0
+        ? [
+            {
+              reviewer: "simsa-visual",
+              role: "visual-inspection",
+              findings: facts.interpretations,
+              severity: "high",
+              unresolvedBlockers: facts.interpretations,
+            },
+          ]
+        : [],
+    visual: {
+      failedInteractions: facts.failedInteractions,
+      screenshots: Array.from({ length: facts.screenshotCount }, (_, i) => `screenshot-${i + 1}`),
+      consoleErrors: facts.consoleErrors,
+      // works=null → 검증 불가(정직하게 notVerified). works=false는 "실패를
+      // 눈으로 확인함" — 증거가 있으므로 notVerified가 아니다.
+      notVerified: input.run.works === null,
+    },
+  });
+
+  const pack = deriveEvidencePack(graph);
+  const gate = classifyGateDecision(pack);
+
+  // 3열 체인: 기준별 상태 + 그 상태를 만든 관찰 소스.
+  const testByCriterion = new Map<string, string[]>();
+  for (const r of reviewResults) {
+    const list = testByCriterion.get(r.itemId) ?? [];
+    list.push(r.title || r.itemId);
+    testByCriterion.set(r.itemId, list);
+  }
+  const statusById = new Map<string, "verified" | "broken" | "not_verified">();
+  for (const line of pack.verified) {
+    const m = /^criterion ([^:]+):/.exec(line);
+    if (m && m[1]) statusById.set(m[1], "verified");
+  }
+  for (const line of pack.broken) {
+    const m = /^criterion ([^:]+):/.exec(line);
+    if (m && m[1]) statusById.set(m[1], "broken");
+  }
+  const criteria = items.map((i) => ({
+    id: i.id,
+    text: i.title,
+    status: statusById.get(i.id) ?? ("not_verified" as const),
+    observedBy: testByCriterion.get(i.id) ?? [],
+  }));
+
+  return {
+    pack,
+    gate,
+    criteria,
+    browserFacts: {
+      works: input.run.works,
+      decision: input.run.decision,
+      consoleErrors: facts.consoleErrors,
+      failedInteractions: facts.failedInteractions,
+      screenshotCount: facts.screenshotCount,
+    },
+    interpretations: facts.interpretations,
+  };
+}

--- a/apps/central-plane/test/evidence-live.test.mjs
+++ b/apps/central-plane/test/evidence-live.test.mjs
@@ -1,0 +1,118 @@
+/**
+ * evidence-live.test.mjs — Train M-1a (design locked 2026-07-21).
+ *
+ * Pins:
+ *   - 결정론: 같은 입력 → 같은 pack/gate (두 번 조립해 deepEqual)
+ *   - PR 리뷰 per-item 결과 → per-criterion verified/broken (3열 체인 근거)
+ *   - works=false + 리포트 findings → crossReview 블로커 → gate "Needs Fix"
+ *   - works=null → visual notVerified (정직) / works=false는 notVerified 아님
+ *   - Browser facts와 interpretations(AI Opinion) 분리 운반
+ *   - 숫자 점수 금지: receipt가 assertNoNumericScores 통과
+ *   - parseReportFacts: corrupt JSON에도 throw 없음
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { assembleLiveEvidence, parseReportFacts } from "../dist/workspace/evidence-live.js";
+import { createReceipt, assertNoNumericScores } from "../dist/evidence-pack.js";
+
+const BASE = {
+  projectId: "proj_1",
+  productSpec: {
+    productName: "빵집 예약",
+    oneLine: "동네 빵집 픽업 예약 앱",
+    problem: "전화 예약이 불편하다",
+    targetUsers: ["동네 주민"],
+    included: ["예약 생성", "픽업 시간 선택"],
+    excluded: ["결제"],
+    openQuestions: [],
+  },
+  items: [
+    { id: "item-1", title: "예약을 만들 수 있다" },
+    { id: "item-2", title: "픽업 시간을 고를 수 있다" },
+    { id: "item-3", title: "예약 목록을 볼 수 있다" },
+  ],
+};
+
+const REVIEW = {
+  repoFullName: "acme/bakery",
+  prNumber: 4,
+  results: [
+    { itemId: "item-1", title: "예약을 만들 수 있다", status: "passed" },
+    { itemId: "item-2", title: "픽업 시간을 고를 수 있다", status: "failed" },
+    // item-3: 리뷰가 다루지 않음 → not_verified
+  ],
+};
+
+const RUN_OK = { id: "wvc_1", intent: "예약 완주 확인", decision: "Ready", works: true, reportJson: null };
+
+test("결정론: 같은 입력 → 같은 evidence (전 필드 deepEqual)", () => {
+  const a = assembleLiveEvidence({ ...BASE, run: RUN_OK, latestReview: REVIEW });
+  const b = assembleLiveEvidence({ ...BASE, run: RUN_OK, latestReview: REVIEW });
+  assert.deepEqual(a, b);
+});
+
+test("PR 리뷰 per-item 결과 → per-criterion 상태 + observedBy (3열 체인)", () => {
+  const ev = assembleLiveEvidence({ ...BASE, run: RUN_OK, latestReview: REVIEW });
+  const byId = new Map(ev.criteria.map((c) => [c.id, c]));
+  assert.equal(byId.get("item-1").status, "verified");
+  assert.equal(byId.get("item-2").status, "broken");
+  assert.equal(byId.get("item-3").status, "not_verified");
+  assert.deepEqual(byId.get("item-1").observedBy, ["예약을 만들 수 있다"]);
+  assert.deepEqual(byId.get("item-3").observedBy, []);
+});
+
+test("works=false + findings → 시각 검수가 블로커로, gate=Needs Fix", () => {
+  const report = JSON.stringify({
+    findings: [{ what: "예약 버튼을 눌러도 아무 일도 일어나지 않아요" }],
+    steps: [{ label: "예약 시도", ok: false, screenshot: "s1.png" }],
+    consoleErrors: ["TypeError: reserve is not a function"],
+  });
+  const ev = assembleLiveEvidence({
+    ...BASE,
+    run: { id: "wvc_2", intent: "예약 완주", decision: "Needs Fix", works: false, reportJson: report },
+    latestReview: null,
+  });
+  assert.equal(ev.gate.decision, "Needs Fix");
+  assert.ok(ev.pack.broken.some((b) => b.includes("예약 버튼")));
+  // works=false는 "실패를 확인함" — visual notVerified가 아니다.
+  assert.equal(ev.pack.visualEvidence.notVerified, false);
+  // Browser facts(사실)와 interpretations(해석) 분리.
+  assert.deepEqual(ev.browserFacts.consoleErrors, ["TypeError: reserve is not a function"]);
+  assert.deepEqual(ev.browserFacts.failedInteractions, ["예약 시도"]);
+  assert.deepEqual(ev.interpretations, ["예약 버튼을 눌러도 아무 일도 일어나지 않아요"]);
+});
+
+test("works=null → visual notVerified (근거 없으면 Not Verified, 절대 Pass 아님)", () => {
+  const ev = assembleLiveEvidence({
+    ...BASE,
+    run: { id: "wvc_3", intent: "확인", decision: "Not Judged", works: null, reportJson: null },
+    latestReview: null,
+  });
+  assert.equal(ev.pack.visualEvidence.notVerified, true);
+  assert.ok(ev.pack.notVerified.some((n) => n.includes("visual")));
+  assert.notEqual(ev.gate.decision, "Ready");
+});
+
+test("숫자 점수 금지: receipt가 assertNoNumericScores 통과", () => {
+  const ev = assembleLiveEvidence({ ...BASE, run: RUN_OK, latestReview: REVIEW });
+  const receipt = createReceipt(ev.pack, "release_gate");
+  assert.equal(assertNoNumericScores(receipt), true);
+});
+
+test("스펙/items 부재 → acceptanceCriteriaMissing, 조작 없이 정직한 gate", () => {
+  const ev = assembleLiveEvidence({
+    projectId: "proj_bare",
+    productSpec: null,
+    items: null,
+    run: RUN_OK,
+    latestReview: null,
+  });
+  assert.equal(ev.pack.riskFlags.acceptanceCriteriaMissing, true);
+  assert.equal(ev.criteria.length, 0);
+});
+
+test("parseReportFacts: corrupt/이상 형태에도 throw 없음", () => {
+  assert.deepEqual(parseReportFacts(null).consoleErrors, []);
+  assert.deepEqual(parseReportFacts("{not json").interpretations, []);
+  assert.equal(parseReportFacts(JSON.stringify({ steps: "nope", findings: 42 })).screenshotCount, 0);
+});


### PR DESCRIPTION
Train M(design lock approved, Bae 2026-07-21) 1단계 — PRD §15.6 "자체 해자 dormant" 해소의 서버 절반.

## 무엇

`GET /workspace/projects/:id/evidence/:runId` — 검수가 이미 저장한 사실들을 GET 시점에 acceptance-graph로 **결정론 조립**해 evidence pack + gate decision + 3열 체인 데이터([기준]↔[관찰 사실]↔[판정])를 반환.

## 원칙 (불변식 §5 전수)

- **판정을 새로 만들지 않음** — 이미 내려진 판정에 근거를 붙일 뿐 (사실 소스: product_spec/items · 시각 런 · 최신 PR 리뷰 결과)
- 숫자 점수 0 (`assertNoNumericScores` 테스트 통과) · 근거 없으면 Not Verified
- **Browser Evidence ≠ AI Opinion**: 콘솔에러/실패 인터랙션/스크린샷 수(사실) vs findings.what(해석) 분리 필드
- works=null만 미검증 — works=false는 "실패를 눈으로 확인함"(증거 있음)
- 저장 없음·네트워크 없음·**스키마 무변경**(on-demand 재도출 — 도출 로직 업그레이드 시 결과도 자동 최신)

## 검증

테스트 7(결정론 deepEqual·체인 근거·Needs Fix·정직 notVerified·무점수·부재 정직·corrupt 무throw) + central 전체 green. 다음: M-1b 대시보드 "왜 이 판정?" UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)