### PR TITLE
feat(shares): Train M-2 — result_shared 이벤트 슬롯 채움

### DIFF
--- a/apps/central-plane/src/routes/shares.ts
+++ b/apps/central-plane/src/routes/shares.ts
@@ -15,6 +15,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
+import { insertUsageEvent } from "../workspace/usage-events-db.js";
 import { corsHeaders, corsMiddleware } from "./cors.js";
 
 const MAX_PAYLOAD_BYTES = 60_000;
@@ -85,6 +86,15 @@ export function createShareRoutes(): Hono<{ Bindings: Env }> {
     )
       .bind(id, share.userKey, share.projectId, share.payloadJson, new Date().toISOString())
       .run();
+
+    // Train M-2 (2026-07-21, design locked): PRD §9.4가 예약해 둔 result_shared
+    // 이벤트 슬롯을 실제로 채운다 — 공유가 성장 신호의 1차 지표. 비치명(non-fatal).
+    await insertUsageEvent(c.env, {
+      userKey: share.userKey,
+      ...(share.projectId ? { projectId: share.projectId } : {}),
+      eventType: "workspace_result_shared",
+      metadata: { shareId: id },
+    }).catch(() => undefined);
 
     return new Response(JSON.stringify({ ok: true, shareId: id }), { status: 200, headers: { "content-type": "application/json", ...headers } });
   });

--- a/apps/central-plane/test/workspace-shares.test.mjs
+++ b/apps/central-plane/test/workspace-shares.test.mjs
@@ -36,3 +36,54 @@ describe("sanitizeSharePayload — G11", () => {
     assert.equal(out.projectId, null);
   });
 });
+
+// ── Train M-2 (2026-07-21, design locked): result_shared 이벤트 슬롯 ─────────
+const { createShareRoutes } = await import("../dist/routes/shares.js");
+
+describe("POST /workspace/shares — result_shared usage event (M-2)", () => {
+  function makeDb() {
+    const writes = [];
+    return {
+      writes,
+      prepare(sql) {
+        let bound = [];
+        return {
+          bind(...args) {
+            bound = args;
+            return {
+              first: async () => (/COUNT\(\*\)/.test(sql) ? { n: 0 } : null),
+              run: async () => {
+                writes.push({ sql, bound });
+                return { success: true, meta: { changes: 1 } };
+              },
+              all: async () => ({ results: [] }),
+            };
+          },
+        };
+      },
+    };
+  }
+
+  it("share 생성 시 workspace_result_shared 이벤트가 shareId 메타와 함께 기록된다", async () => {
+    const app = createShareRoutes();
+    const db = makeDb();
+    const res = await app.request(
+      "/workspace/shares",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ userKey: "u1", projectId: "p1", payload: { title: "빵집 예약" } }),
+      },
+      { DB: db },
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+
+    const eventWrite = db.writes.find((w) => /usage_events/i.test(w.sql));
+    assert.ok(eventWrite, "usage event insert must fire");
+    const flat = JSON.stringify(eventWrite.bound);
+    assert.ok(flat.includes("workspace_result_shared"));
+    assert.ok(flat.includes(body.shareId), "metadata carries the shareId");
+  });
+});


### PR DESCRIPTION
Train M 마지막 조각 — §9.4 예약 슬롯의 실기록. 공유 생성 시 `workspace_result_shared` usage event(+shareId 메타), 비치명. 테스트 5/5 + central green.

이로써 **Train M 완결**: M-1a evidence API(#455) + M-1b "왜 이 판정?" UI(#456) + M-2 이벤트 슬롯. 라이브 실증: evidence API 2케이스(무점수·정직 강등·해석 추출 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)