### PR TITLE
fix(repair): 기준평가 4·5b — draft 오도 해소(GraphQL un-draft) + edit-mode 반추측 레일

### DIFF
--- a/apps/central-plane/container/server.mjs
+++ b/apps/central-plane/container/server.mjs
@@ -997,6 +997,24 @@ async function createOrReuseRepairPr({ repo, token, head, base, title, body, dra
           headers: apiHeaders,
           body: JSON.stringify({ title, body }),
         }).catch(() => {});
+        // 기준평가 V4 (2026-07-21): auto_fix가 brief-only 시절의 draft PR을
+        // 재사용하면 실코드가 실렸는데 "초안"으로 남아 오도한다. REST는
+        // un-draft 불가, GraphQL은 가능 — best effort.
+        if (draft === false && existing.draft === true && existing.node_id) {
+          await fetch("https://api.github.com/graphql", {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${token}`,
+              "content-type": "application/json",
+              "user-agent": "simsa-repair",
+            },
+            body: JSON.stringify({
+              query:
+                "mutation($id:ID!){markPullRequestReadyForReview(input:{pullRequestId:$id}){pullRequest{isDraft}}}",
+              variables: { id: existing.node_id },
+            }),
+          }).catch(() => {});
+        }
         return existing;
       }
     }

--- a/packages/agent-worker/src/prompts.ts
+++ b/packages/agent-worker/src/prompts.ts
@@ -135,6 +135,7 @@ Hard rules:
 - \`replace\` must keep the unchanged context lines from \`search\` intact and alter only what the blocker requires.
 - Fix ONLY the blockers raised. No refactoring, renaming, reformatting, or feature work.
 - Edit ONLY the excerpted files. Never invent content for regions you have not been shown — if a fix requires unseen code, skip it and say so in \`summary\`.
+- NO speculative shotgun fixes. If the evidence does not localize the cause inside the excerpts, do NOT "fix" by guesswork — broad wildcard selectors, \`!important\` style overrides, blanket try/catch, or disabling checks are all forbidden as diagnosis substitutes. Returning an empty \`edits\` array with an honest \`summary\` IS the correct outcome in that case.
 - If NO blocker is fixable from the excerpts, return an empty \`edits\` array and explain in \`summary\` what region or file the caller should excerpt next.
 - \`commitMessage\` should be a single line (≤ 72 chars), conventional-commit style where it fits. No trailing period.`;
 

--- a/packages/agent-worker/test/worker-edits.test.mjs
+++ b/packages/agent-worker/test/worker-edits.test.mjs
@@ -183,3 +183,9 @@ test("buildEditWorkerPrompt: excerpts are verbatim inside fences, line labels ou
   assert.ok(prompt.includes("398336 bytes"));
   assert.ok(prompt.includes("API base must not be localhost"));
 });
+
+test("edit-mode system prompt carries the anti-shotgun rail (기준평가 5b)", async () => {
+  const { EDIT_WORKER_SYSTEM_PROMPT } = await import("../dist/index.js");
+  assert.ok(EDIT_WORKER_SYSTEM_PROMPT.includes("NO speculative shotgun fixes"));
+  assert.ok(EDIT_WORKER_SYSTEM_PROMPT.includes("empty \`edits\` array with an honest \`summary\` IS the correct outcome"));
+});


### PR DESCRIPTION
자기평가 §3 이행: ④ auto_fix 재사용 시 draft→ready 전환(REST 불가·GraphQL로) ⑤b 실측 판독(산탄총 CSS)에 근거한 edit-mode 반추측 레일 + 테스트 7/7. 실증: 배포 후 walmart repair → PR#2 ready 전환 확인 예정. 🤖 Generated with [Claude Code](https://claude.com/claude-code)