### PR TITLE
feat(verify): find→fix→verify 원 닫기 — 머지 신호→자동 재검수 (기준평가 1)

### DIFF
--- a/apps/central-plane/src/index.ts
+++ b/apps/central-plane/src/index.ts
@@ -11,6 +11,7 @@ import { runSourceDiscovery } from "./source-discovery.js";
 import { runOssPrMiner } from "./oss-pr-miner.js";
 import { runChangelogMonitor } from "./changelog-monitor.js";
 import { runDeployTrendWatcher } from "./deploy-trend-watcher.js";
+import { runVerifySweep } from "./workspace/verify-sweep.js";
 import { runAgentSpawner, runAutoGraduation } from "./agent-spawner.js";
 import { runCveAdvisoryMiner } from "./cve-advisory-miner.js";
 import { runReengageNudges } from "./workspace/reengage.js";
@@ -274,6 +275,15 @@ export default {
       cronExpression: event.cron,
       ...result,
     }));
+    // 기준평가 1 (2026-07-22) — find→fix→verify 원 닫기: 머지된 수리 PR
+    // 신호(workspace_repair_merged)를 소비해 재검수를 자동 디스패치한다.
+    // 5분 배포 그레이스는 스윕 내부에서 처리. 실패는 스윕을 죽이지 않는다.
+    try {
+      const verify = await runVerifySweep(env);
+      console.log(JSON.stringify({ cron: "verify-sweep", cronExpression: event.cron, ...verify }));
+    } catch (err) {
+      console.error("[verify-sweep] crashed:", err);
+    }
   },
 };
 

--- a/apps/central-plane/src/routes/saas-auth.ts
+++ b/apps/central-plane/src/routes/saas-auth.ts
@@ -56,6 +56,9 @@ import {
   verifyWebhookSignature,
 } from "../gh-app.js";
 import { notifyFounderOnNewInstall } from "../notify-founder.js";
+import { getVisualCheckById } from "../workspace/visual-check-db.js";
+import { insertUsageEvent } from "../workspace/usage-events-db.js";
+import { REPAIR_MERGED_EVENT } from "../workspace/verify-sweep.js";
 import { spawnSandbox } from "./saas.js";
 
 export function createSaasAuthRoutes(): Hono<{ Bindings: Env }> {
@@ -281,6 +284,29 @@ export function createSaasAuthRoutes(): Hono<{ Bindings: Env }> {
     // review on opened/reopened/synchronize (the head SHA changed).
     // Other actions (closed/labeled/etc.) are acknowledged but skipped.
     if (event === "pull_request") {
+      // 기준평가 1 (2026-07-22): find→fix→verify 원 닫기의 신호 수집.
+      // Simsa 수리 PR(head=fix/simsa-{runId})이 머지되면 이벤트만 기록 —
+      // 10분 크론(verify-sweep)이 배포 그레이스 후 재검수를 디스패치한다.
+      // 협의체 스폰이 아니므로 킬스위치보다 먼저, 기록 후 자체 ack.
+      {
+        const pr0 = (p["pull_request"] ?? {}) as Record<string, unknown>;
+        const head0 = (pr0["head"] ?? {}) as Record<string, unknown>;
+        const headRef = String(head0["ref"] ?? "");
+        if (action === "closed" && pr0["merged"] === true && headRef.startsWith("fix/simsa-")) {
+          const runId = headRef.slice("fix/simsa-".length);
+          const run = runId ? await getVisualCheckById(env, runId).catch(() => null) : null;
+          if (run) {
+            await insertUsageEvent(env, {
+              userKey: run.userKey,
+              projectId: run.projectId,
+              eventType: REPAIR_MERGED_EVENT,
+              metadata: { runId, prNumber: Number(pr0["number"]) || null },
+            }).catch(() => undefined);
+            console.log(`[webhook] repair PR merged → verify signal recorded (run=${runId})`);
+          }
+          return c.json({ ok: true, event, action, delivery, noted: "repair_merged" });
+        }
+      }
       // 2026-07-21 (Bae): 레거시 자동 리뷰 킬스위치 — Simsa 집중 기간 동안
       // 전 repo에서 자동 협의체 리뷰 정지. 크레딧 소모/잡 생성/샌드박스
       // 어느 것도 일어나기 전에 여기서 끊는다. 수동 /saas/review는 그대로.

--- a/apps/central-plane/src/workspace/usage-events-db.ts
+++ b/apps/central-plane/src/workspace/usage-events-db.ts
@@ -59,3 +59,32 @@ export async function insertUsageEvent(
     console.warn("[usage-events] insert failed:", err);
   }
 }
+
+/**
+ * 기준평가 1(verify 자동화) — 이벤트-큐 조회: 특정 타입의 최근 이벤트.
+ * 새 테이블 없이 usage events를 신호 큐로 재사용하기 위한 유일한 읽기 경로.
+ */
+export async function listRecentUsageEventsByType(
+  env: Env,
+  eventType: string,
+  sinceIso: string,
+  limit = 50,
+): Promise<Array<{ id: string; userKey: string; projectId: string | null; metadata: Record<string, unknown> | null; createdAt: string }>> {
+  const rows = await env.DB.prepare(
+    `SELECT id, user_key, project_id, metadata_json, created_at
+       FROM workspace_usage_events
+      WHERE event_type = ? AND created_at > ?
+      ORDER BY created_at ASC LIMIT ?`,
+  )
+    .bind(eventType, sinceIso, Math.min(limit, 200))
+    .all<{ id: string; user_key: string; project_id: string | null; metadata_json: string | null; created_at: string }>();
+  return (rows.results ?? []).map((r) => {
+    let metadata: Record<string, unknown> | null = null;
+    try {
+      metadata = r.metadata_json ? (JSON.parse(r.metadata_json) as Record<string, unknown>) : null;
+    } catch {
+      metadata = null;
+    }
+    return { id: r.id, userKey: r.user_key, projectId: r.project_id, metadata, createdAt: r.created_at };
+  });
+}

--- a/apps/central-plane/src/workspace/verify-sweep.ts
+++ b/apps/central-plane/src/workspace/verify-sweep.ts
@@ -1,0 +1,126 @@
+/**
+ * workspace/verify-sweep.ts — 기준평가 §3-1: find→fix→**verify** 원 닫기 (v1).
+ *
+ * 신호: App 설치 repo에서 수리 PR(head=fix/simsa-{runId})이 머지되면 웹훅이
+ * `workspace_repair_merged` 이벤트를 기록한다(협의체 스폰 아님 — 킬스위치
+ * 정신 준수, 기록만). 이 스윕은 10분 크론에서 그 이벤트를 소비해 **원래 런과
+ * 같은 intent/target으로 재검수를 자동 디스패치**한다.
+ *
+ * 왜 크론 경유(즉시 아님): 머지 → 유저 플랫폼(Vercel 등) 자동 배포에 시차가
+ * 있다. 머지 직후 재검수는 구버전을 검사하는 거짓 신호 — 5분 그레이스 후
+ * 스윕이 정직한 타이밍이다.
+ *
+ * 무마이그레이션 설계: 새 테이블 없이 usage events를 신호 큐로 재사용.
+ * 중복 방지는 결정론 — "이벤트 이후 그 프로젝트에 생성된 재검수 런 존재"면
+ * 소비 완료로 간주(런 행 자체가 처리 장부).
+ *
+ * 정직 한계(v1, 기록):
+ *   - App 미설치 repo는 머지 신호가 없다 → 기존 수동 "수리 확인 재검수" CTA 유지.
+ *   - 재검수 locale은 ko 고정(런 행에 locale 미저장 — 컬럼 추가는 마이그레이션
+ *     배치로 이월). EN 유저 재검수 리포트가 ko로 나올 수 있음.
+ */
+import type { Env } from "../env.js";
+import { listRecentUsageEventsByType } from "./usage-events-db.js";
+import {
+  getVisualCheckById,
+  insertQueuedVisualCheck,
+  listVisualChecks,
+  findActiveVisualCheckForProject,
+  markVisualCheckFailed,
+} from "./visual-check-db.js";
+import { dispatchInspection } from "../routes/workspace-visual-check-runs.js";
+
+export const REPAIR_MERGED_EVENT = "workspace_repair_merged";
+/** 파라미터(원칙 아님): 배포 그레이스 / 신호 유효 기간. */
+const GRACE_MS = 5 * 60 * 1000;
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export interface VerifySweepSummary {
+  scanned: number;
+  dispatched: number;
+  skipped_already_verified: number;
+  skipped_active_run: number;
+  skipped_grace: number;
+  skipped_missing_run: number;
+  dispatch_failures: number;
+}
+
+export async function runVerifySweep(
+  env: Env,
+  opts: { nowMs?: number; publicBaseUrl?: string } = {},
+): Promise<VerifySweepSummary> {
+  const summary: VerifySweepSummary = {
+    scanned: 0,
+    dispatched: 0,
+    skipped_already_verified: 0,
+    skipped_active_run: 0,
+    skipped_grace: 0,
+    skipped_missing_run: 0,
+    dispatch_failures: 0,
+  };
+  const now = opts.nowMs ?? Date.now();
+  const sinceIso = new Date(now - WINDOW_MS).toISOString();
+  const events = await listRecentUsageEventsByType(env, REPAIR_MERGED_EVENT, sinceIso).catch(() => []);
+
+  for (const ev of events) {
+    summary.scanned++;
+    const runId = typeof ev.metadata?.["runId"] === "string" ? (ev.metadata["runId"] as string) : null;
+    if (!runId) {
+      summary.skipped_missing_run++;
+      continue;
+    }
+    // 배포 그레이스: 머지 직후는 구버전 검사 위험 — 다음 스윕에서 처리.
+    if (now - Date.parse(ev.createdAt) < GRACE_MS) {
+      summary.skipped_grace++;
+      continue;
+    }
+    const origin = await getVisualCheckById(env, runId).catch(() => null);
+    if (!origin) {
+      summary.skipped_missing_run++;
+      continue;
+    }
+    // 소비 장부 = 런 행: 이벤트 이후 이 프로젝트에 생성된 런이 있으면 완료.
+    const runs = await listVisualChecks(env, origin.projectId).catch(() => []);
+    if (runs.some((r) => r.id !== runId && r.createdAt > ev.createdAt)) {
+      summary.skipped_already_verified++;
+      continue;
+    }
+    // 프로젝트당 활성 런 1개 규칙 존중 — 다음 스윕에서 재시도.
+    const active = await findActiveVisualCheckForProject(env, origin.projectId).catch(() => null);
+    if (active) {
+      summary.skipped_active_run++;
+      continue;
+    }
+
+    let run;
+    try {
+      run = await insertQueuedVisualCheck(env, {
+        projectId: origin.projectId,
+        userKey: origin.userKey,
+        targetUrl: origin.targetUrl,
+        intent: origin.intent,
+      });
+    } catch (err) {
+      console.error("[verify-sweep] insert failed:", err);
+      summary.dispatch_failures++;
+      continue;
+    }
+    const dispatch = await dispatchInspection(env, {
+      runId: run.id,
+      projectId: origin.projectId,
+      userKey: origin.userKey,
+      targetUrl: origin.targetUrl,
+      intent: origin.intent,
+      locale: "ko", // v1 한계 — 헤더 주석 참조
+      publicBaseUrl: opts.publicBaseUrl ?? env.PUBLIC_BASE_URL ?? "https://conclave-ai.seunghunbae.workers.dev",
+    });
+    if (dispatch.dispatched) {
+      summary.dispatched++;
+      console.log(`[verify-sweep] re-inspection dispatched: run=${run.id} after merged repair of ${runId}`);
+    } else {
+      summary.dispatch_failures++;
+      await markVisualCheckFailed(env, run.id, dispatch.note ?? "dispatch_failed").catch(() => undefined);
+    }
+  }
+  return summary;
+}

--- a/apps/central-plane/test/verify-sweep.test.mjs
+++ b/apps/central-plane/test/verify-sweep.test.mjs
@@ -1,0 +1,194 @@
+/**
+ * verify-sweep.test.mjs — 기준평가 §3-1: find→fix→verify 원 닫기 (v1).
+ *
+ * Pins:
+ *   - 웹훅: 머지된 fix/simsa-* PR → repair_merged 이벤트 기록 + 자체 ack
+ *     (킬스위치 on이어도 — 기록은 협의체 스폰이 아니다) · 비수리 PR은 여전히
+ *     킬스위치로 스킵 · 미머지 closed는 신호 아님
+ *   - 스윕: 5분 그레이스 · 런-행 장부 dedupe(이벤트 이후 런 존재→스킵) ·
+ *     활성 런 존중 · happy path에서 재검수 큐 삽입+디스패치 1회
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { runVerifySweep, REPAIR_MERGED_EVENT } from "../dist/workspace/verify-sweep.js";
+const { createApp } = await import("../dist/router.js");
+
+const SECRET = "whsec_test_1234";
+
+function makeDb(state) {
+  // state: { events: [...], runs: [...], writes: [] }
+  return {
+    state,
+    prepare(sql) {
+      let bound = [];
+      return {
+        bind(...args) {
+          bound = args;
+          return {
+            first: async () => {
+              if (sql.includes("workspace_visual_checks") && sql.includes("WHERE id = ?")) {
+                return state.runs.find((r) => r.id === bound[0]) ?? null;
+              }
+              if (sql.includes("status IN ('queued', 'running')")) {
+                return state.runs.find((r) => r.project_id === bound[0] && (r.status === "queued" || r.status === "running")) ?? null;
+              }
+              return null;
+            },
+            all: async () => {
+              if (sql.includes("workspace_usage_events")) {
+                return { results: state.events.filter((e) => e.event_type === bound[0] && e.created_at > bound[1]) };
+              }
+              if (sql.includes("workspace_visual_checks") && sql.includes("project_id = ?")) {
+                return { results: state.runs.filter((r) => r.project_id === bound[0]) };
+              }
+              return { results: [] };
+            },
+            run: async () => {
+              state.writes.push({ sql, bound });
+              return { success: true, meta: { changes: 1 } };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+const NOW = Date.parse("2026-07-22T12:00:00Z");
+const iso = (msAgo) => new Date(NOW - msAgo).toISOString();
+
+function runRow(over = {}) {
+  return {
+    id: "wvc_orig", project_id: "p1", user_key: "u1",
+    target_url: "https://app.example.com", intent: "예약 완주",
+    decision: "Needs Fix", works: 0, status: "done",
+    report_json: "{}", agent_prompt: null, executor: "container",
+    evidence_keys_json: "[]", error: null,
+    created_at: iso(3600_000), updated_at: iso(3600_000),
+    ...over,
+  };
+}
+
+function eventRow(over = {}) {
+  return {
+    id: "evt1", user_key: "u1", project_id: "p1",
+    event_type: REPAIR_MERGED_EVENT,
+    metadata_json: JSON.stringify({ runId: "wvc_orig" }),
+    created_at: iso(10 * 60_000), // 10분 전 — 그레이스 통과
+    ...over,
+  };
+}
+
+function makeEnv(state, inspector) {
+  return {
+    DB: makeDb(state),
+    INTERNAL_CALLBACK_TOKEN: "tok",
+    PUBLIC_BASE_URL: "https://base",
+    ...(inspector ? { INSPECTOR: inspector } : {}),
+  };
+}
+
+function acceptingInspector(calls) {
+  return {
+    idFromName: () => "id",
+    get: () => ({
+      fetch: async (_url, init) => {
+        calls.push(JSON.parse(init.body));
+        return { ok: true, text: async () => "" };
+      },
+    }),
+  };
+}
+
+test("스윕 happy path: 그레이스 지난 신호 → 재검수 큐 삽입 + 디스패치 1회", async () => {
+  const calls = [];
+  const state = { events: [eventRow()], runs: [runRow()], writes: [] };
+  const env = makeEnv(state, acceptingInspector(calls));
+  const s = await runVerifySweep(env, { nowMs: NOW });
+  assert.equal(s.dispatched, 1);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].targetUrl, "https://app.example.com");
+  assert.equal(calls[0].intent, "예약 완주");
+  assert.ok(state.writes.some((w) => /INSERT INTO workspace_visual_checks/.test(w.sql)), "재검수 런 행 삽입");
+});
+
+test("그레이스: 머지 5분 이내 신호는 이번 스윕에서 건너뛴다", async () => {
+  const state = { events: [eventRow({ created_at: iso(2 * 60_000) })], runs: [runRow()], writes: [] };
+  const s = await runVerifySweep(makeEnv(state, acceptingInspector([])), { nowMs: NOW });
+  assert.equal(s.skipped_grace, 1);
+  assert.equal(s.dispatched, 0);
+});
+
+test("장부 dedupe: 이벤트 이후 생성된 런이 있으면 소비 완료로 스킵", async () => {
+  const state = {
+    events: [eventRow()],
+    runs: [runRow(), runRow({ id: "wvc_verify", status: "done", created_at: iso(60_000) })],
+    writes: [],
+  };
+  const s = await runVerifySweep(makeEnv(state, acceptingInspector([])), { nowMs: NOW });
+  assert.equal(s.skipped_already_verified, 1);
+  assert.equal(s.dispatched, 0);
+});
+
+test("활성 런 존중: queued/running 존재 시 이번 스윕은 대기", async () => {
+  const state = {
+    events: [eventRow()],
+    runs: [runRow(), runRow({ id: "wvc_act", status: "running", created_at: iso(30 * 60_000) })],
+    writes: [],
+  };
+  const s = await runVerifySweep(makeEnv(state, acceptingInspector([])), { nowMs: NOW });
+  assert.equal(s.skipped_active_run, 1);
+  assert.equal(s.dispatched, 0);
+});
+
+// ── 웹훅 신호 ───────────────────────────────────────────────────────────────
+
+async function postWebhook(app, env, payload) {
+  const raw = JSON.stringify(payload);
+  const sig = "sha256=" + createHmac("sha256", SECRET).update(raw).digest("hex");
+  return app.request("/webhook/github", {
+    method: "POST",
+    headers: { "x-hub-signature-256": sig, "x-github-event": "pull_request", "x-github-delivery": "d", "content-type": "application/json" },
+    body: raw,
+  }, env);
+}
+
+test("웹훅: 머지된 fix/simsa-* PR → 이벤트 기록 + noted ack (킬스위치 on이어도)", async () => {
+  const app = createApp();
+  const state = { events: [], runs: [runRow()], writes: [] };
+  const env = { ...makeEnv(state), GH_APP_WEBHOOK_SECRET: SECRET, LEGACY_AUTO_REVIEW: "off" };
+  const res = await postWebhook(app, env, {
+    action: "closed",
+    pull_request: { number: 9, merged: true, head: { ref: "fix/simsa-wvc_orig" }, title: "", body: "" },
+    repository: { full_name: "acme/site" },
+    installation: { id: 1 },
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.noted, "repair_merged");
+  const w = state.writes.find((x) => /workspace_usage_events/.test(x.sql));
+  assert.ok(w && JSON.stringify(w.bound).includes(REPAIR_MERGED_EVENT));
+  assert.ok(JSON.stringify(w.bound).includes("wvc_orig"));
+});
+
+test("웹훅: 비수리 PR closed는 여전히 킬스위치 스킵 · 미머지 close는 신호 아님", async () => {
+  const app = createApp();
+  const state = { events: [], runs: [runRow()], writes: [] };
+  const env = { ...makeEnv(state), GH_APP_WEBHOOK_SECRET: SECRET, LEGACY_AUTO_REVIEW: "off" };
+
+  const r1 = await postWebhook(app, env, {
+    action: "closed",
+    pull_request: { number: 3, merged: true, head: { ref: "feature/x" }, title: "", body: "" },
+    repository: { full_name: "acme/site" }, installation: { id: 1 },
+  });
+  assert.equal((await r1.json()).skipped, "legacy_auto_review_disabled");
+
+  const r2 = await postWebhook(app, env, {
+    action: "closed",
+    pull_request: { number: 4, merged: false, head: { ref: "fix/simsa-wvc_orig" }, title: "", body: "" },
+    repository: { full_name: "acme/site" }, installation: { id: 1 },
+  });
+  assert.equal((await r2.json()).skipped, "legacy_auto_review_disabled");
+  assert.equal(state.writes.filter((x) => /usage_events/.test(x.sql)).length, 0);
+});


### PR DESCRIPTION
자기평가 §3 최우선 위반 해소 — 수리 PR이 머지·배포된 뒤 "실제로 고쳐졌는가"를 사람이 눌러야 했던 원을 닫는다.

```
수리 PR 머지(fix/simsa-*) → 웹훅: repair_merged 이벤트 기록(킬스위치 앞, 스폰 아님)
  → 10분 크론 verify-sweep: 5분 배포 그레이스 → 같은 intent/target 재검수 자동 디스패치
  → 기존 비교 표면(이전 대비 해소/잔존)이 자동으로 의미 획득
```

- **무마이그레이션**: usage events=신호 큐, 런 행=소비 장부(결정론 dedupe)
- 정직 한계 기록: App 미설치 repo=수동 CTA 유지 · 재검수 locale v1=ko(컬럼 이월)
- 테스트 6/6 + central green
- **라이브 실증 계획**: 배포 후 simsa-autofix-test PR#1(fix/simsa-* 오픈 상태) 머지 → 이벤트 기록 → 다음 크론에서 재검수 런 자동 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)