### PR TITLE
fix(i18n): G14-b — 검수·수정·검증패널·협의체 EN locale 전면 배선

### DIFF
--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -989,6 +989,7 @@ export function createWorkspaceGitHubRoutes(
             "supported=true ONLY if the PR changes clearly fail to implement the item or clearly contradict it.",
         },
         c.env,
+        { locale: reviewLocale === "en" ? "en" : "ko" },
       );
     } catch (err) {
       console.error("[workspace/pr-review] verify-panel error (kept single):", err);

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -523,7 +523,9 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
         return new Response(JSON.stringify({
           ok: false,
           error: "plan_required",
-          message: "협의체 검수는 유료 플랜 기능이에요. 지금 플랜에서는 기본 검수(AI 2중 확인)를 사용할 수 있습니다.",
+          message: req.locale === "en"
+            ? "Council review is a paid-plan feature. On your current plan you can use the standard check (AI double-check)."
+            : "협의체 검수는 유료 플랜 기능이에요. 지금 플랜에서는 기본 검수(AI 2중 확인)를 사용할 수 있습니다.",
         }), { status: 402, headers: { "content-type": "application/json", ...headers } });
       }
       // RC-3 협의체 엔진 — 벤더 2개 미만이면 조용한 대체 대신 정직한 안내.
@@ -538,7 +540,9 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
         return new Response(JSON.stringify({
           ok: false,
           error: "council_not_ready",
-          message: "협의체 검수를 지금 진행할 수 없어요(참여 AI 부족). 기본 검수를 사용해주세요.",
+          message: req.locale === "en"
+            ? "Council review is not available right now (not enough participating AIs). Please use the standard check."
+            : "협의체 검수를 지금 진행할 수 없어요(참여 AI 부족). 기본 검수를 사용해주세요.",
         }), { status: 503, headers: { "content-type": "application/json", ...headers } });
       }
       await incrementRateLimitCount(c.env.DB, ipHash, hourUtc);
@@ -575,7 +579,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
     // RC-2 검증 패널 (A, 전원): failed 판정만 교차-벤더 2차 확인. 어떤 실패에도
     // 검수 자체를 깨지 않는다 — 패널 오류 시 원판정+single 표기로 진행.
     try {
-      result = await applyVerifyPanel(result, normalizeProductSpec(req.productSpec), c.env);
+      result = await applyVerifyPanel(result, normalizeProductSpec(req.productSpec), c.env, { locale: req.locale === "en" ? "en" : "ko" });
     } catch (err) {
       console.error("[workspace/check-draft] verify-panel error (kept single):", err);
     }

--- a/apps/central-plane/src/workspace/check.ts
+++ b/apps/central-plane/src/workspace/check.ts
@@ -119,12 +119,51 @@ const USER_LABEL: Record<CheckItemStatus, CheckResultItem["userLabel"]> = {
 
 export function buildCheckPrompt(req: WorkspaceCheckDraftRequest): string {
   const specText = JSON.stringify(req.productSpec, null, 2);
+  const none = req.locale === "en" ? "(none)" : "(없음)";
   const itemsText = req.items
     .map(
       (item) =>
-        `- id: ${item.id}\n  title: ${item.title}\n  criteria: ${item.criteria.join(", ") || "(없음)"}`,
+        `- id: ${item.id}\n  title: ${item.title}\n  criteria: ${item.criteria.join(", ") || none}`,
     )
     .join("\n");
+
+  // G14-b: the prompt follows the user's UI language — an EN user must never
+  // receive Korean verdict prose. locale is absent on legacy callers → ko.
+  if (req.locale === "en") {
+    return `Review the product spec and the must-have items below, and judge each item's status.
+
+[Product spec]
+${specText}
+
+[Items]
+${itemsText}
+
+Judgment criteria:
+- passed: the item is specific, has 2 or more done-criteria, and matches the spec's included scope
+- failed: the item falls in the spec's excluded scope, or conflicts with a decided direction
+- inconclusive: the item looks important but its done-criteria are missing or vague (also when "permissions", "data", or "failure handling" is not covered)
+- needs_decision: the item is directly tied to one of the spec's undecided questions (openQuestions)
+
+Rules:
+- Write ALL user-facing text in English
+- reason: 1–2 sentences, specific
+- evidence: sentences quoted from the product spec (empty array if none)
+- nextAction: one line the user can act on
+
+Respond ONLY with JSON in this shape (no markdown, no prose):
+{
+  "results": [
+    {
+      "itemId": "req_001",
+      "status": "passed",
+      "userLabel": "통과",
+      "reason": "...",
+      "evidence": ["..."],
+      "nextAction": "..."
+    }
+  ]
+}`;
+  }
 
   return `제품 설명서와 꼭 들어가야 할 항목들을 검토해서 각 항목의 상태를 판단해주세요.
 
@@ -177,10 +216,48 @@ async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | u
 
 // ─── Mock fallback heuristics ─────────────────────────────────────────────────
 
+/** G14-b: heuristic fallback prose per locale — the fallback path must match the
+ *  user's language just like the LLM path (userLabel stays the KO wire literal;
+ *  the dashboard localizes its display via statusLabel). */
+const HEURISTIC_COPY = {
+  ko: {
+    excludedReason: "이 항목은 이번 버전의 제외 범위에 있는 기능과 관련됩니다.",
+    excludedNext: "제품 설명서의 포함/제외 범위를 다시 확인하거나, 이번 버전에서 제외하세요.",
+    openQReason: "이 항목은 아직 결정되지 않은 제품 방향과 연결됩니다.",
+    openQNext: "제품 설명서의 결정 필요 항목을 먼저 확정하고 다시 확인하세요.",
+    noCriteriaReason: "완성 기준이 없어서 실제로 구현이 됐는지 확인하기 어렵습니다.",
+    noCriteriaNext: "완성 기준을 2개 이상 구체적으로 추가하세요.",
+    oneCriterionReason: "완성 기준이 1개뿐입니다. 확인 가능한 기준이 더 필요합니다.",
+    oneCriterionNext: "완성 기준을 최소 2개로 늘리고, 권한·데이터·실패 상황도 포함해 주세요.",
+    securityReason: "권한이나 데이터 보안과 관련된 항목인데 완성 기준이 부족합니다.",
+    securityNext: "접근 제어 조건과 비정상 접근 시 동작을 완성 기준에 추가하세요.",
+    passedReason: "항목이 구체적이고 완성 기준이 충분합니다.",
+    passedNext: "다음 단계에서 실제 구현 후 검증하세요.",
+    noItemsWarning: "확인할 항목이 없습니다.",
+  },
+  en: {
+    excludedReason: "This item relates to a feature that is in this version's excluded scope.",
+    excludedNext: "Re-check the spec's included/excluded scope, or drop this item from this version.",
+    openQReason: "This item is tied to a product direction that has not been decided yet.",
+    openQNext: "Settle the spec's open decisions first, then run the check again.",
+    noCriteriaReason: "There are no done-criteria, so it is hard to confirm this was actually built.",
+    noCriteriaNext: "Add at least 2 specific done-criteria.",
+    oneCriterionReason: "There is only one done-criterion. More checkable criteria are needed.",
+    oneCriterionNext: "Grow the done-criteria to at least 2, covering permissions, data, and failure cases.",
+    securityReason: "This item involves permissions or data safety, but its done-criteria are too thin.",
+    securityNext: "Add access-control conditions and what happens on unauthorized access to the criteria.",
+    passedReason: "The item is specific and its done-criteria are sufficient.",
+    passedNext: "Verify it against the real build in the next step.",
+    noItemsWarning: "There are no items to check.",
+  },
+} as const;
+
 function checkItemHeuristic(
   item: CheckableItem,
   spec: ProductSpecForCheck,
+  locale: "ko" | "en",
 ): Omit<CheckResultItem, "title"> {
+  const copy = HEURISTIC_COPY[locale];
   const titleLower = item.title.toLowerCase();
 
   // Check excluded features — require full phrase OR ≥2 content words to match
@@ -202,11 +279,11 @@ function checkItemHeuristic(
       itemId: item.id,
       status: "failed",
       userLabel: "안 맞음",
-      reason: "이 항목은 이번 버전의 제외 범위에 있는 기능과 관련됩니다.",
+      reason: copy.excludedReason,
       evidence: spec.excluded.filter((ex) =>
         ex.split(/[\s,·]+/).some((w) => w.length > 1 && titleLower.includes(w.toLowerCase())),
       ),
-      nextAction: "제품 설명서의 포함/제외 범위를 다시 확인하거나, 이번 버전에서 제외하세요.",
+      nextAction: copy.excludedNext,
     };
   }
 
@@ -224,11 +301,11 @@ function checkItemHeuristic(
       itemId: item.id,
       status: "needs_decision",
       userLabel: "결정 필요",
-      reason: "이 항목은 아직 결정되지 않은 제품 방향과 연결됩니다.",
+      reason: copy.openQReason,
       evidence: spec.openQuestions.filter((q) =>
         q.split(/[\s,·]+/).some((w) => w.length > 1 && titleLower.includes(w.toLowerCase())),
       ),
-      nextAction: "제품 설명서의 결정 필요 항목을 먼저 확정하고 다시 확인하세요.",
+      nextAction: copy.openQNext,
     };
   }
 
@@ -238,9 +315,9 @@ function checkItemHeuristic(
       itemId: item.id,
       status: "inconclusive",
       userLabel: "확인 부족",
-      reason: "완성 기준이 없어서 실제로 구현이 됐는지 확인하기 어렵습니다.",
+      reason: copy.noCriteriaReason,
       evidence: [],
-      nextAction: "완성 기준을 2개 이상 구체적으로 추가하세요.",
+      nextAction: copy.noCriteriaNext,
     };
   }
   if (item.criteria.length === 1) {
@@ -248,23 +325,26 @@ function checkItemHeuristic(
       itemId: item.id,
       status: "inconclusive",
       userLabel: "확인 부족",
-      reason: "완성 기준이 1개뿐입니다. 확인 가능한 기준이 더 필요합니다.",
+      reason: copy.oneCriterionReason,
       evidence: [],
-      nextAction: "완성 기준을 최소 2개로 늘리고, 권한·데이터·실패 상황도 포함해 주세요.",
+      nextAction: copy.oneCriterionNext,
     };
   }
 
   // Check if permissions/data/failure are covered for critical items
+  // (EN titles need EN keywords — the KO-only regex silently skipped this rule
+  //  for English items.)
   const needsSecurityCheck =
-    /사용자|권한|접근|개인|로그인/.test(titleLower) && item.criteria.length < 3;
+    /사용자|권한|접근|개인|로그인|user|permission|access|login|account|privacy|private/.test(titleLower) &&
+    item.criteria.length < 3;
   if (needsSecurityCheck) {
     return {
       itemId: item.id,
       status: "inconclusive",
       userLabel: "확인 부족",
-      reason: "권한이나 데이터 보안과 관련된 항목인데 완성 기준이 부족합니다.",
+      reason: copy.securityReason,
       evidence: [],
-      nextAction: "접근 제어 조건과 비정상 접근 시 동작을 완성 기준에 추가하세요.",
+      nextAction: copy.securityNext,
     };
   }
 
@@ -277,15 +357,15 @@ function checkItemHeuristic(
     itemId: item.id,
     status: "passed",
     userLabel: "통과",
-    reason: "항목이 구체적이고 완성 기준이 충분합니다.",
+    reason: copy.passedReason,
     evidence: relatedDecision ? [relatedDecision] : [],
-    nextAction: "다음 단계에서 실제 구현 후 검증하세요.",
+    nextAction: copy.passedNext,
   };
 }
 
 function buildMockCheckFallback(req: WorkspaceCheckDraftRequest): WorkspaceCheckDraftResponse {
   const results: CheckResultItem[] = req.items.map((item) => ({
-    ...checkItemHeuristic(item, req.productSpec),
+    ...checkItemHeuristic(item, req.productSpec, req.locale === "en" ? "en" : "ko"),
     title: item.title,
   }));
 
@@ -329,7 +409,7 @@ export async function generateCheckDraft(
       source: "mock-fallback",
       summary: { passed: 0, failed: 0, inconclusive: 0, needsDecision: 0 },
       results: [],
-      warnings: ["확인할 항목이 없습니다."],
+      warnings: [HEURISTIC_COPY[req.locale === "en" ? "en" : "ko"].noItemsWarning],
     };
   }
 

--- a/apps/central-plane/src/workspace/council-review.ts
+++ b/apps/central-plane/src/workspace/council-review.ts
@@ -53,6 +53,13 @@ const USER_LABEL: Record<CheckItemStatus, CheckResultItem["userLabel"]> = {
   needs_decision: "결정 필요",
 };
 
+/** G14-b: split-요약 등 사용자 노출 프로즈에 쓰는 언어별 status 표현.
+ *  (wire의 userLabel 자체는 KO 리터럴 유지 — 표시는 dashboard statusLabel이 담당) */
+const STATUS_WORD: Record<"ko" | "en", Record<CheckItemStatus, string>> = {
+  ko: { passed: "통과", failed: "안 맞음", inconclusive: "확인 부족", needs_decision: "결정 필요" },
+  en: { passed: "passed", failed: "doesn't match", inconclusive: "needs checking", needs_decision: "needs a decision" },
+};
+
 const VALID_STATUS = new Set<string>(["passed", "failed", "inconclusive", "needs_decision"]);
 
 function parseVerdicts(text: string): VendorVerdicts | null {
@@ -161,6 +168,29 @@ function rebuttalPrompt(
   opinions: Map<VendorId, VendorVerdicts>,
 ): string {
   const items = req.items.filter((i) => itemIds.includes(i.id));
+  // G14-b: 라운드2 프롬프트도 사용자 언어를 따른다 (라운드1은 buildCheckPrompt가 담당).
+  if (req.locale === "en") {
+    const lines: string[] = [
+      "The reviewers' first-round verdicts disagree on the items below. Read each reviewer's judgment and re-decide your final verdict yourself. If you agree, adopt that verdict; if you still see it differently, keep yours with your reasoning.",
+      "",
+      `[Product spec]`,
+      JSON.stringify(req.productSpec),
+      "",
+    ];
+    for (const item of items) {
+      lines.push(`[Item ${item.id}] ${item.title} (done-criteria: ${item.criteria.join(", ") || "none"})`);
+      for (const [vendor, verdicts] of opinions) {
+        const v = verdicts.get(item.id);
+        if (v) lines.push(`- reviewer ${vendor}: ${v.status} — ${v.reason}`);
+      }
+      lines.push("");
+    }
+    lines.push(
+      `For these items only, respond ONLY with JSON in this shape (no markdown, no prose):`,
+      `{"results":[{"itemId":"...","status":"passed|failed|inconclusive|needs_decision","reason":"1–2 sentences in English","evidence":[],"nextAction":"one line"}]}`,
+    );
+    return lines.join("\n");
+  }
   const lines: string[] = [
     "다음 항목들에 대해 검토자들의 1차 판정이 갈렸습니다. 각 검토자의 판단을 읽고, 스스로 최종 판정을 다시 내려주세요. 동의하면 그 판정으로, 여전히 다르게 보면 근거와 함께 자신의 판정을 유지하세요.",
     "",
@@ -207,11 +237,11 @@ function majorityFor(
 }
 
 /** split 항목의 각 관점을 쉬운 말 한 줄로. */
-function splitSummary(itemId: string, opinions: Map<VendorId, VendorVerdicts>): string {
+function splitSummary(itemId: string, opinions: Map<VendorId, VendorVerdicts>, locale: "ko" | "en"): string {
   const parts: string[] = [];
   for (const [vendor, verdicts] of opinions) {
     const v = verdicts.get(itemId);
-    if (v) parts.push(`${USER_LABEL[v.status]}(${vendor}: ${v.reason.slice(0, 80)})`);
+    if (v) parts.push(`${STATUS_WORD[locale][v.status]}(${vendor}: ${v.reason.slice(0, 80)})`);
   }
   return parts.join(" / ");
 }
@@ -277,11 +307,12 @@ export async function runCouncilCheck(
   }
 
   // ── Final merge ────────────────────────────────────────────────────────────
+  const locale: "ko" | "en" = req.locale === "en" ? "en" : "ko";
   let stillSplit = 0;
   const results: CheckResultItem[] = req.items.map((item) => {
     const maj = majorityFor(item.id, opinions);
     if (maj) {
-      // 다수 판정 벤더 중 anthropic 우선(한국어 사유 품질), 없으면 합의 벤더 아무나.
+      // 다수 판정 벤더 중 anthropic 우선(사유 프로즈 품질), 없으면 합의 벤더 아무나.
       const src =
         (opinions.get("anthropic")?.get(item.id)?.status === maj.status
           ? opinions.get("anthropic")?.get(item.id)
@@ -291,7 +322,8 @@ export async function runCouncilCheck(
         title: item.title,
         status: maj.status,
         userLabel: USER_LABEL[maj.status],
-        reason: src?.reason ?? "협의체가 합의한 판정입니다.",
+        reason:
+          src?.reason ?? (locale === "en" ? "The council agreed on this verdict." : "협의체가 합의한 판정입니다."),
         evidence: src?.evidence ?? [],
         nextAction: src?.nextAction ?? "",
         verification: "council_agreed",
@@ -303,9 +335,15 @@ export async function runCouncilCheck(
       title: item.title,
       status: "inconclusive",
       userLabel: "확인 부족",
-      reason: `협의체 의견이 끝까지 갈렸습니다 — ${splitSummary(item.id, opinions)}. 이런 항목은 직접 확인해보는 것이 가장 정확합니다.`,
+      reason:
+        locale === "en"
+          ? `The council stayed split on this one — ${splitSummary(item.id, opinions, locale)}. For items like this, checking it yourself is the most reliable.`
+          : `협의체 의견이 끝까지 갈렸습니다 — ${splitSummary(item.id, opinions, locale)}. 이런 항목은 직접 확인해보는 것이 가장 정확합니다.`,
       evidence: [],
-      nextAction: "항목 기준을 더 구체적으로 적거나, 실제 화면에서 직접 확인해보세요.",
+      nextAction:
+        locale === "en"
+          ? "Make the item's criteria more specific, or check it directly on the real screen."
+          : "항목 기준을 더 구체적으로 적거나, 실제 화면에서 직접 확인해보세요.",
       verification: "council_split",
     };
   });

--- a/apps/central-plane/src/workspace/fix.ts
+++ b/apps/central-plane/src/workspace/fix.ts
@@ -55,6 +55,52 @@ export type WorkspaceFixSuggestionResponse = {
 // ─── Prompt ───────────────────────────────────────────────────────────────────
 
 function buildFixPrompt(req: WorkspaceFixSuggestionRequest): string {
+  // G14-b: prompt follows the user's UI language (legacy callers without locale → ko).
+  if (req.locale === "en") {
+    return `A problem was found in the item below. Write a fix suggestion and a brief to hand to a coding AI.
+
+[Problem item]
+Title: ${req.item.title}
+Status: ${req.item.status}
+Current done-criteria: ${req.item.criteria.join(", ") || "(none)"}
+
+[Check result]
+Reason: ${req.checkResult.reason}
+Evidence: ${req.checkResult.evidence.join(", ") || "(none)"}
+Next action: ${req.checkResult.nextAction}
+
+[Product spec (summary)]
+${JSON.stringify(req.productSpec, null, 2).slice(0, 800)}
+
+Writing rules:
+- Write ALL text in English
+- No developer jargon like PRD, Requirement, or Acceptance Criteria
+- tasks start with a concrete action verb (e.g. "Add", "Change", "Remove")
+- doneWhen are checkable behavior criteria (e.g. "clicking the button does ~")
+- doNotDo lists what is out of scope for this fix
+- verifyBy lists how to confirm the feature is done
+
+Respond ONLY with JSON in this shape:
+{
+  "plainSummary": "1–2 line summary in English",
+  "productSpecPatch": {
+    "addDecisions": ["decisions to add to the product spec"],
+    "addCriteria": ["done-criteria to add"],
+    "addOpenQuestions": ["things still to decide (if any)"],
+    "removeOrClarify": ["existing content to change or remove (if any)"]
+  },
+  "builderBrief": {
+    "title": "brief title",
+    "goal": "goal in 1–2 sentences",
+    "context": ["background notes"],
+    "tasks": ["task 1", "task 2", "..."],
+    "doneWhen": ["done criterion 1", "done criterion 2"],
+    "doNotDo": ["do not 1", "do not 2"],
+    "verifyBy": ["how to verify 1", "how to verify 2"]
+  }
+}`;
+  }
+
   return `다음 항목에서 문제가 발견됐습니다. 수정 제안과 개발 AI에게 줄 지시서를 만들어주세요.
 
 [문제 항목]
@@ -115,7 +161,98 @@ async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | u
 
 // ─── Mock fallback ────────────────────────────────────────────────────────────
 
+/** G14-b: EN mirror of the deterministic fallback — same branch logic, English prose. */
+function buildMockFixFallbackEn(req: WorkspaceFixSuggestionRequest): WorkspaceFixSuggestionResponse {
+  const { item, checkResult } = req;
+  const isFailedScope = item.status === "failed";
+  const isVague = item.status === "inconclusive";
+
+  let plainSummary: string;
+  let addDecisions: string[];
+  let addCriteria: string[];
+  let addOpenQuestions: string[];
+  let tasks: string[];
+  let doneWhen: string[];
+  let doNotDo: string[];
+
+  if (isFailedScope) {
+    plainSummary = `This item (${item.title}) does not match the product spec's current scope. Either update the spec or drop the item from this version.`;
+    addDecisions = [`${item.title} — decide whether it ships in this version`];
+    addCriteria = [];
+    addOpenQuestions = [`Decide whether ${item.title} ships in this version or moves to the next one`];
+    tasks = [
+      "Re-check the product spec's included/excluded scope.",
+      "If you decide to include this item, add it to the spec's included scope.",
+      "If you decide to exclude it, delete the item or move it to the next-version list.",
+    ];
+    doneWhen = ["The product spec and this item agree.", "The include/exclude decision is recorded."];
+    doNotDo = ["Do not build the feature right away.", "Do not write code before the scope decision is made."];
+  } else if (isVague) {
+    plainSummary = `This item (${item.title}) lacks done-criteria, so it is hard to confirm it was actually built. Add specific criteria.`;
+    addDecisions = [];
+    addCriteria = [
+      `${item.title} — normal behavior criterion (e.g. a given input produces a given result)`,
+      `${item.title} — failure behavior criterion (e.g. an error shows a helpful message)`,
+      `${item.title} — permission/access criterion (if applicable)`,
+    ];
+    addOpenQuestions = [];
+    tasks = [
+      "Write at least 2 specific done-criteria for this item.",
+      "Cover normal behavior, failure behavior, and permission conditions where they apply.",
+      "Update the criteria, then run the check again.",
+    ];
+    doneWhen = [
+      `${item.title} has 2 or more done-criteria.`,
+      'Each criterion is checkable, phrased as "~ should happen".',
+    ];
+    doNotDo = ['Do not write criteria as vague impressions ("works fine", "looks good").'];
+  } else {
+    // needs_decision
+    plainSummary = `This item (${item.title}) is tied to something not decided yet. Settle the direction first, then pick the implementation.`;
+    addDecisions = [`Decision related to ${item.title}`];
+    addCriteria = [];
+    addOpenQuestions = [checkResult.nextAction || `${item.title} — the concrete direction still needs a decision`];
+    tasks = [
+      `Settle the related decision first: ${checkResult.reason}`,
+      "Record the decision in the product spec's decisions.",
+      "After deciding, update this item's done-criteria.",
+    ];
+    doneWhen = ["The related decision is recorded in the product spec.", "This item's done-criteria reflect the decision."];
+    doNotDo = ["Do not implement arbitrarily without the decision.", "Do not build multiple options at once."];
+  }
+
+  return {
+    ok: true,
+    source: "mock-fallback",
+    itemId: item.id,
+    suggestion: {
+      plainSummary,
+      productSpecPatch: {
+        addDecisions,
+        addCriteria,
+        addOpenQuestions,
+      },
+      builderBrief: {
+        title: item.title,
+        goal: plainSummary,
+        context: [
+          `Current state: ${checkResult.reason}`,
+          ...(checkResult.evidence.length > 0 ? [`Evidence: ${checkResult.evidence.join(", ")}`] : []),
+        ],
+        tasks,
+        doneWhen,
+        doNotDo,
+        verifyBy: [
+          "Re-read the product spec and confirm it agrees with this item.",
+          "Test each done-criterion directly, one by one.",
+        ],
+      },
+    },
+  };
+}
+
 function buildMockFixFallback(req: WorkspaceFixSuggestionRequest): WorkspaceFixSuggestionResponse {
+  if (req.locale === "en") return buildMockFixFallbackEn(req);
   const { item, checkResult } = req;
   const isFailedScope = item.status === "failed";
   const isVague = item.status === "inconclusive";

--- a/apps/central-plane/src/workspace/verify-panel.ts
+++ b/apps/central-plane/src/workspace/verify-panel.ts
@@ -66,9 +66,11 @@ export type VerifyPanelOpts = {
   openaiModel?: string;
   anthropicModel?: string;
   fetchImpl?: typeof fetch;
+  /** G14-b: 2차 소견·강등 사유가 따르는 사용자 언어 (기본 ko). */
+  locale?: "ko" | "en";
 };
 
-type SecondOpinion = { supported: boolean; noteKo: string };
+type SecondOpinion = { supported: boolean; note: string };
 
 /** G5: 컨텍스트 일반화 — 스펙 검수와 PR 리뷰가 같은 패널을 쓴다. */
 export type VerifyPanelContext = {
@@ -82,7 +84,13 @@ export type VerifyPanelContext = {
 
 const CONTEXT_TEXT_CAP = 16_000;
 
-function opinionPrompt(ctx: VerifyPanelContext, item: CheckResultItem): string {
+function opinionPrompt(ctx: VerifyPanelContext, item: CheckResultItem, locale: "ko" | "en"): string {
+  // The wire key stays `note_ko` for compatibility; only the requested language
+  // of the note changes (G14-b — the note is shown to the user on downgrade).
+  const noteInstruction =
+    locale === "en"
+      ? '{"supported": true, "note_ko": "<one sentence of reasoning, in English>"}'
+      : '{"supported": true, "note_ko": "<판단 근거 한 문장, 한국어>"}';
   return `You are an INDEPENDENT second reviewer. A first reviewer marked an item as "failed". Decide independently whether the evidence supports that verdict.
 
 [${ctx.label}]
@@ -97,7 +105,7 @@ first evidence: ${JSON.stringify(item.evidence)}
 Rule: ${ctx.judgeRule} If it is unclear, arguable, or the evidence is weak, supported=false.
 
 Answer with JSON only (no markdown):
-{"supported": true, "note_ko": "<판단 근거 한 문장, 한국어>"}`;
+${noteInstruction}`;
 }
 
 /** check-draft(스펙 검수)의 기존 컨텍스트 — 동작·문구 불변. */
@@ -116,9 +124,10 @@ function parseOpinion(text: string): SecondOpinion | null {
   try {
     const o = JSON.parse(m[0]) as Record<string, unknown>;
     if (typeof o["supported"] !== "boolean") return null;
+    const rawNote = typeof o["note_ko"] === "string" ? o["note_ko"] : typeof o["note"] === "string" ? o["note"] : "";
     return {
       supported: o["supported"],
-      noteKo: typeof o["note_ko"] === "string" ? o["note_ko"].slice(0, 300) : "",
+      note: rawNote.slice(0, 300),
     };
   } catch {
     return null;
@@ -249,6 +258,7 @@ export async function applyVerifyPanelWithContext<
   const openaiModel = opts.openaiModel ?? "gpt-5.4";
   const anthropicModel = opts.anthropicModel ?? "claude-sonnet-5";
   const fetchImpl = opts.fetchImpl ?? fetch;
+  const locale: "ko" | "en" = opts.locale === "en" ? "en" : "ko";
 
   const failedIdx = response.results
     .map((r, i) => (r.status === "failed" ? i : -1))
@@ -263,7 +273,7 @@ export async function applyVerifyPanelWithContext<
       if (!item) return;
       const opinion = await secondOpinion(
         env,
-        opinionPrompt(ctx, item),
+        opinionPrompt(ctx, item, locale),
         { timeoutMs, openaiModel, anthropicModel },
         fetchImpl,
       );
@@ -281,7 +291,10 @@ export async function applyVerifyPanelWithContext<
         status: "inconclusive",
         userLabel: "확인 부족",
         verification: "downgraded",
-        reason: `두 AI의 판단이 갈렸습니다. 1차 판단: ${item.reason} / 2차 판단: ${opinion.noteKo || "충돌 근거가 분명하지 않습니다."} 직접 한 번 확인해보세요.`,
+        reason:
+          locale === "en"
+            ? `The two AIs disagreed. First opinion: ${item.reason} / Second opinion: ${opinion.note || "the conflicting evidence is unclear."} Please check this one yourself.`
+            : `두 AI의 판단이 갈렸습니다. 1차 판단: ${item.reason} / 2차 판단: ${opinion.note || "충돌 근거가 분명하지 않습니다."} 직접 한 번 확인해보세요.`,
       };
     }),
   );

--- a/apps/central-plane/test/council-review-en.test.mjs
+++ b/apps/central-plane/test/council-review-en.test.mjs
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// G14-b (2026-08-20): RC-3 협의체의 EN locale — 라운드2 반박 프롬프트와
+// 합의/미합의 사용자 문구가 사용자 언어를 따른다. locale 분기 이전 코드에서는
+// 실패한다(옛 코드는 EN 요청에도 한국어 split 문구 반환).
+
+const { runCouncilCheck } = await import("../dist/workspace/council-review.js");
+
+const HANGUL = /[가-힣]/;
+
+const REQ_EN = {
+  productSpec: {
+    productName: "Todo app", oneLine: "manage todos", targetUsers: [], problem: "p",
+    included: ["add todo"], excluded: ["payments"], userFlow: [], decisions: [], openQuestions: [],
+  },
+  items: [
+    { id: "r1", title: "Add a todo", status: "not_started", criteria: ["a", "b"] },
+  ],
+  locale: "en",
+};
+
+const verdictJsonEn = (map) =>
+  JSON.stringify({
+    results: Object.entries(map).map(([itemId, status]) => ({
+      itemId, status, reason: `${status}-reason`, evidence: [], nextAction: "n",
+    })),
+  });
+
+function stubFetch(answers, calls = {}, bodies = []) {
+  return async (url, init) => {
+    const u = String(url);
+    bodies.push(String(init?.body ?? ""));
+    const vendor = u.includes("anthropic") ? "anthropic" : u.includes("openai") ? "openai" : "gemini";
+    const n = (calls[vendor] = (calls[vendor] ?? 0) + 1);
+    const spec = answers[vendor]?.[n - 1];
+    if (!spec || spec === "fail") return new Response("err", { status: 500 });
+    const text = verdictJsonEn(spec);
+    if (vendor === "anthropic") {
+      return new Response(JSON.stringify({ content: [{ type: "text", text }] }), { status: 200 });
+    }
+    if (vendor === "openai") {
+      return new Response(JSON.stringify({ choices: [{ message: { content: text } }] }), { status: 200 });
+    }
+    return new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text }] } }] }), { status: 200 });
+  };
+}
+
+const ENV3 = { ANTHROPIC_API_KEY: "a", OPENAI_API_KEY: "o", GEMINI_API_KEY: "g" };
+
+describe("runCouncilCheck — EN locale (G14-b)", () => {
+  it("persistent split → EN split reason/nextAction, no Hangul", async () => {
+    // Three vendors disagree in both rounds → council_split.
+    const out = await runCouncilCheck(REQ_EN, ENV3, {
+      fetchImpl: stubFetch({
+        anthropic: [{ r1: "passed" }, { r1: "passed" }],
+        openai: [{ r1: "failed" }, { r1: "failed" }],
+        gemini: [{ r1: "inconclusive" }, { r1: "inconclusive" }],
+      }),
+    });
+    assert.equal(out.ok, true);
+    const r = out.results[0];
+    assert.equal(r.verification, "council_split");
+    assert.match(r.reason, /stayed split/);
+    assert.doesNotMatch(r.reason, HANGUL);
+    assert.doesNotMatch(r.nextAction, HANGUL);
+  });
+
+  it("locale=en round-2 rebuttal prompt is English", async () => {
+    const bodies = [];
+    await runCouncilCheck(REQ_EN, ENV3, {
+      fetchImpl: stubFetch({
+        anthropic: [{ r1: "passed" }, { r1: "passed" }],
+        openai: [{ r1: "failed" }, { r1: "passed" }],
+        gemini: [{ r1: "inconclusive" }, { r1: "passed" }],
+      }, {}, bodies),
+    });
+    // round 2 = last three request bodies
+    const round2 = bodies.slice(-3);
+    for (const b of round2) {
+      assert.match(b, /re-decide your final verdict/);
+      assert.doesNotMatch(b, /판정이 갈렸습니다/);
+    }
+  });
+
+  it("KO split copy unchanged for locale=ko (legacy)", async () => {
+    const out = await runCouncilCheck({ ...REQ_EN, locale: "ko" }, ENV3, {
+      fetchImpl: stubFetch({
+        anthropic: [{ r1: "passed" }, { r1: "passed" }],
+        openai: [{ r1: "failed" }, { r1: "failed" }],
+        gemini: [{ r1: "inconclusive" }, { r1: "inconclusive" }],
+      }),
+    });
+    assert.match(out.results[0].reason, /협의체 의견이 끝까지 갈렸습니다/);
+  });
+});

--- a/apps/central-plane/test/verify-panel-en.test.mjs
+++ b/apps/central-plane/test/verify-panel-en.test.mjs
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// G14-b (2026-08-20): RC-2 검증 패널의 EN locale — 2차 소견 요청 언어와 강등
+// 사유 문구가 사용자 언어를 따른다. locale 옵션 도입 전 코드에서는 실패한다.
+
+const { applyVerifyPanel } = await import("../dist/workspace/verify-panel.js");
+
+const HANGUL = /[가-힣]/;
+
+const EN_SPEC = {
+  productName: "Test app", oneLine: "test", targetUsers: [], problem: "p",
+  included: ["feature A"], excluded: ["payments"], userFlow: [], decisions: [], openQuestions: [],
+};
+
+const enItem = (id, status) => ({
+  itemId: id, status, title: `item ${id}`,
+  userLabel: status === "failed" ? "안 맞음" : "통과",
+  reason: "conflicts with excluded scope", evidence: ["payments"], nextAction: "check",
+});
+
+const resp = (results) => ({
+  ok: true, source: "llm",
+  summary: {
+    passed: results.filter((r) => r.status === "passed").length,
+    failed: results.filter((r) => r.status === "failed").length,
+    inconclusive: results.filter((r) => r.status === "inconclusive").length,
+    needsDecision: 0,
+  },
+  results,
+});
+
+function stubFetch(opinion, prompts = []) {
+  return async (url, init) => {
+    prompts.push(String(init?.body ?? ""));
+    return new Response(JSON.stringify({
+      choices: [{ message: { content: JSON.stringify(opinion) } }],
+    }), { status: 200 });
+  };
+}
+
+const ENV = { OPENAI_API_KEY: "k" };
+
+describe("applyVerifyPanel — EN locale (G14-b)", () => {
+  it("locale=en → second-opinion prompt asks for an English note", async () => {
+    const prompts = [];
+    await applyVerifyPanel(
+      resp([enItem("a", "failed")]), EN_SPEC, ENV,
+      { locale: "en", fetchImpl: stubFetch({ supported: true, note_ko: "agree" }, prompts) },
+    );
+    assert.equal(prompts.length, 1);
+    assert.match(prompts[0], /in English/);
+    assert.doesNotMatch(prompts[0], /한국어/);
+  });
+
+  it("locale=en disagreement → downgrade reason is English, no Hangul", async () => {
+    const out = await applyVerifyPanel(
+      resp([enItem("a", "failed")]), EN_SPEC, ENV,
+      { locale: "en", fetchImpl: stubFetch({ supported: false, note_ko: "the evidence is weak" }) },
+    );
+    const r = out.results[0];
+    assert.equal(r.status, "inconclusive");
+    assert.equal(r.verification, "downgraded");
+    assert.match(r.reason, /First opinion/);
+    assert.match(r.reason, /the evidence is weak/);
+    assert.doesNotMatch(r.reason, HANGUL);
+  });
+
+  it("a `note` key (instead of note_ko) is also accepted from the second reviewer", async () => {
+    const out = await applyVerifyPanel(
+      resp([enItem("a", "failed")]), EN_SPEC, ENV,
+      { locale: "en", fetchImpl: stubFetch({ supported: false, note: "scope reading differs" }) },
+    );
+    assert.match(out.results[0].reason, /scope reading differs/);
+  });
+
+  it("KO default unchanged when locale omitted (legacy callers)", async () => {
+    const out = await applyVerifyPanel(
+      resp([enItem("a", "failed")]), EN_SPEC, ENV,
+      { fetchImpl: stubFetch({ supported: false, note_ko: "충돌 근거 약함" }) },
+    );
+    assert.match(out.results[0].reason, /1차 판단/);
+    assert.match(out.results[0].reason, /충돌 근거 약함/);
+  });
+});

--- a/apps/central-plane/test/workspace-check-en.test.mjs
+++ b/apps/central-plane/test/workspace-check-en.test.mjs
@@ -1,0 +1,74 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// G14-b (2026-08-20): EN 유저가 한국어 검수 판정을 받던 하드코딩 제거.
+// 프롬프트와 휴리스틱 폴백 모두 locale을 따른다. 이 테스트들은 locale 분기
+// 이전 코드로 되돌리면 실패한다(옛 코드는 EN 요청에도 한국어 프로즈 반환).
+
+const { generateCheckDraft, buildCheckPrompt } = await import("../dist/workspace/check.js");
+
+const HANGUL = /[가-힣]/;
+
+const EN_SPEC = {
+  productName: "Meeting summarizer",
+  oneLine: "Record a meeting and get a summary with action items",
+  targetUsers: ["busy teams"],
+  problem: "Writing up meetings takes too long.",
+  included: ["audio upload", "summary generation", "action item extraction"],
+  excluded: ["live recording", "video calls"],
+  userFlow: ["upload", "summarize", "review"],
+  decisions: ["only confirmed action items are exported"],
+  openQuestions: ["decide the file size cap"],
+};
+
+const EN_ITEMS = [
+  { id: "req_001", title: "Users can upload an audio file", status: "not_started", criteria: ["mp3 supported", "error message shown on failure"] },
+  { id: "req_002", title: "Uploaded audio becomes text", status: "not_started", criteria: [] },
+  { id: "req_003", title: "Provide live recording", status: "not_started", criteria: ["live mic input"] },
+  { id: "req_004", title: "Show the file size cap", status: "not_started", criteria: ["cap notice shown"] },
+];
+
+describe("workspace check-draft — EN locale (G14-b)", () => {
+  it("EN prompt asks for English output and drops the Korean-only instruction", () => {
+    const en = buildCheckPrompt({ productSpec: EN_SPEC, items: EN_ITEMS, locale: "en" });
+    assert.match(en, /Write ALL user-facing text in English/);
+    assert.doesNotMatch(en, /한국어로 작성/);
+    // KO path unchanged (regression guard)
+    const ko = buildCheckPrompt({ productSpec: EN_SPEC, items: EN_ITEMS, locale: "ko" });
+    assert.match(ko, /모든 사용자 대상 텍스트는 한국어로 작성/);
+  });
+
+  it("EN heuristic fallback prose (reason/nextAction) contains no Hangul", async () => {
+    const result = await generateCheckDraft({ productSpec: EN_SPEC, items: EN_ITEMS, locale: "en" }, undefined);
+    assert.equal(result.ok, true);
+    assert.equal(result.source, "mock-fallback");
+    for (const r of result.results) {
+      assert.doesNotMatch(r.reason, HANGUL, `reason for ${r.itemId} leaked Korean: ${r.reason}`);
+      assert.doesNotMatch(r.nextAction, HANGUL, `nextAction for ${r.itemId} leaked Korean: ${r.nextAction}`);
+    }
+    // branch coverage stays intact in EN: excluded → failed, no criteria → inconclusive
+    assert.equal(result.results.find((r) => r.itemId === "req_003").status, "failed");
+    assert.equal(result.results.find((r) => r.itemId === "req_002").status, "inconclusive");
+  });
+
+  it("EN security keywords trigger the thin-criteria rule (KO-only regex missed them)", async () => {
+    const items = [
+      { id: "sec_1", title: "Only the signed-in user can access their own data", status: "not_started", criteria: ["owner check", "redirect on logout"] },
+    ];
+    const result = await generateCheckDraft({ productSpec: EN_SPEC, items, locale: "en" }, undefined);
+    assert.equal(result.results[0].status, "inconclusive", "permission item with thin criteria must not silently pass in EN");
+  });
+
+  it("empty items warning is localized", async () => {
+    const en = await generateCheckDraft({ productSpec: EN_SPEC, items: [], locale: "en" }, undefined);
+    assert.doesNotMatch(en.warnings[0], HANGUL);
+    const ko = await generateCheckDraft({ productSpec: EN_SPEC, items: [], locale: "ko" }, undefined);
+    assert.equal(ko.warnings[0], "확인할 항목이 없습니다.");
+  });
+
+  it("KO fallback prose unchanged when locale omitted (legacy callers)", async () => {
+    const result = await generateCheckDraft({ productSpec: EN_SPEC, items: EN_ITEMS }, undefined);
+    const noCriteria = result.results.find((r) => r.itemId === "req_002");
+    assert.equal(noCriteria.reason, "완성 기준이 없어서 실제로 구현이 됐는지 확인하기 어렵습니다.");
+  });
+});

--- a/apps/central-plane/test/workspace-fix-en.test.mjs
+++ b/apps/central-plane/test/workspace-fix-en.test.mjs
@@ -1,0 +1,91 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// G14-b (2026-08-20): 수정 제안(fix-suggestion)의 EN locale 지원 — 프롬프트와
+// 결정론 폴백 모두. locale 분기 이전 코드에서는 실패한다.
+
+const { generateFixSuggestion } = await import("../dist/workspace/fix.js");
+
+const HANGUL = /[가-힣]/;
+
+const EN_CHECK_RESULT = {
+  reason: "This item is in the excluded scope.",
+  evidence: ["live recording — excluded in this version"],
+  nextAction: "Re-check the spec's included/excluded scope.",
+};
+
+const EN_SPEC = { productName: "Meeting summarizer", excluded: ["live recording"], openQuestions: ["decide the file size cap"] };
+
+function assertNoHangulDeep(suggestion) {
+  const strings = [
+    suggestion.plainSummary,
+    suggestion.builderBrief.title,
+    suggestion.builderBrief.goal,
+    ...suggestion.productSpecPatch.addDecisions,
+    ...suggestion.productSpecPatch.addCriteria,
+    ...suggestion.productSpecPatch.addOpenQuestions,
+    ...suggestion.builderBrief.context,
+    ...suggestion.builderBrief.tasks,
+    ...suggestion.builderBrief.doneWhen,
+    ...suggestion.builderBrief.doNotDo,
+    ...suggestion.builderBrief.verifyBy,
+  ];
+  for (const s of strings) assert.doesNotMatch(s, HANGUL, `Korean leaked into: ${s}`);
+}
+
+describe("workspace fix-suggestion — EN locale (G14-b)", () => {
+  it("failed item → EN fallback with no Hangul", async () => {
+    const result = await generateFixSuggestion(
+      {
+        item: { id: "req_003", title: "Provide live recording", status: "failed", criteria: ["live mic input"] },
+        checkResult: EN_CHECK_RESULT,
+        productSpec: EN_SPEC,
+        locale: "en",
+      },
+      undefined,
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.source, "mock-fallback");
+    assertNoHangulDeep(result.suggestion);
+  });
+
+  it("inconclusive item → EN fallback with no Hangul", async () => {
+    const result = await generateFixSuggestion(
+      {
+        item: { id: "req_002", title: "Uploaded audio becomes text", status: "inconclusive", criteria: [] },
+        checkResult: EN_CHECK_RESULT,
+        productSpec: EN_SPEC,
+        locale: "en",
+      },
+      undefined,
+    );
+    assert.equal(result.ok, true);
+    assertNoHangulDeep(result.suggestion);
+  });
+
+  it("needs_decision item → EN fallback with no Hangul", async () => {
+    const result = await generateFixSuggestion(
+      {
+        item: { id: "req_004", title: "Show the file size cap", status: "needs_decision", criteria: ["cap notice"] },
+        checkResult: EN_CHECK_RESULT,
+        productSpec: EN_SPEC,
+        locale: "en",
+      },
+      undefined,
+    );
+    assert.equal(result.ok, true);
+    assertNoHangulDeep(result.suggestion);
+  });
+
+  it("KO fallback unchanged when locale omitted (legacy callers)", async () => {
+    const result = await generateFixSuggestion(
+      {
+        item: { id: "req_002", title: "업로드된 녹음을 텍스트로 바꿔야 함", status: "inconclusive", criteria: [] },
+        checkResult: { reason: "완성 기준이 없습니다.", evidence: [], nextAction: "기준을 추가하세요." },
+        productSpec: EN_SPEC,
+      },
+      undefined,
+    );
+    assert.match(result.suggestion.plainSummary, HANGUL);
+  });
+});

--- a/apps/dashboard/src/lib/workspace-check-api.ts
+++ b/apps/dashboard/src/lib/workspace-check-api.ts
@@ -150,17 +150,22 @@ export async function callCheckDraftApi(
     const resp = await fetch(`${CENTRAL_PLANE_URL}/workspace/check-draft`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      // 서버 검수 프롬프트가 아직 KO-only — locale 전달은 G14-b(서버 EN화)와 함께.
-      body: JSON.stringify({ ...input, locale: "ko" }),
+      // G14-b: 서버 검수(check/council/panel)가 EN을 지원한다 — UI 언어를 따른다.
+      body: JSON.stringify({ ...input, locale: readStoredLocale(typeof window !== "undefined" ? window.localStorage : null) }),
       // council(협의체)은 다중 모델 2라운드라 기본 검수보다 오래 걸린다.
       signal: AbortSignal.timeout(input.reviewMode === "council" ? 90000 : 25000),
     });
     if (resp.status === 429) {
-      let msg = "잠시 후 다시 시도해주세요. 확인 요청이 너무 많이 발생했어요.";
+      // 서버 429는 body 파싱 전에 나가 locale을 모른다(KO 고정) — EN UI에서는
+      // 서버 문구 대신 클라이언트 EN 문구를 쓴다.
+      const en = readStoredLocale(typeof window !== "undefined" ? window.localStorage : null) === "en";
+      let msg = en
+        ? "Please try again in a moment — too many check requests right now."
+        : "잠시 후 다시 시도해주세요. 확인 요청이 너무 많이 발생했어요.";
       let retryAfterSeconds: number | undefined;
       try {
         const b = (await resp.json()) as { message?: string; retryAfterSeconds?: number };
-        if (b.message) msg = b.message;
+        if (b.message && !en) msg = b.message;
         if (b.retryAfterSeconds) retryAfterSeconds = b.retryAfterSeconds;
       } catch { /* ignore */ }
       return { ok: false, error: "rate_limited", message: msg, retryAfterSeconds };
@@ -171,7 +176,14 @@ export async function callCheckDraftApi(
       try {
         const b = (await resp.json()) as { error?: string; message?: string };
         if (b.error === "plan_required" || b.error === "council_not_ready") {
-          return { ok: false, error: "plan", message: b.message ?? "이 검수 방식은 지금 플랜에서 사용할 수 없어요." };
+          const en = readStoredLocale(typeof window !== "undefined" ? window.localStorage : null) === "en";
+          return {
+            ok: false,
+            error: "plan",
+            message: b.message ?? (en
+              ? "This review mode isn't available on your current plan."
+              : "이 검수 방식은 지금 플랜에서 사용할 수 없어요."),
+          };
         }
       } catch { /* fall through */ }
       return { ok: false, error: "server", message: `HTTP ${resp.status}` };
@@ -411,14 +423,17 @@ export async function callFixSuggestionApi(
     const resp = await fetch(`${CENTRAL_PLANE_URL}/workspace/fix-suggestion`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ ...input, locale: "ko" }),
+      // G14-b: 서버 수정 제안이 EN을 지원한다 — UI 언어를 따른다.
+      body: JSON.stringify({ ...input, locale: readStoredLocale(typeof window !== "undefined" ? window.localStorage : null) }),
       signal: AbortSignal.timeout(25000),
     });
     if (resp.status === 429) {
-      let msg = "잠시 후 다시 시도해주세요.";
+      // 서버 429는 locale을 모른다(파싱 전) — EN UI는 클라이언트 EN 문구.
+      const en = readStoredLocale(typeof window !== "undefined" ? window.localStorage : null) === "en";
+      let msg = en ? "Please try again in a moment." : "잠시 후 다시 시도해주세요.";
       try {
         const b = (await resp.json()) as { message?: string };
-        if (b.message) msg = b.message;
+        if (b.message && !en) msg = b.message;
       } catch { /* ignore */ }
       return { ok: false, error: "rate_limited", message: msg };
     }


### PR DESCRIPTION
## 무엇
EN 유저가 한국어 검수 판정을 받던 마지막 하드코딩(갭 #1)을 제거합니다.

- **check.ts**: EN 프롬프트 분기 + 휴리스틱 폴백 EN 카피 테이블 + 보안 키워드 regex EN 확장(user/permission/access/login/…)
- **fix.ts**: EN 프롬프트 + 결정론 폴백 EN 미러(buildMockFixFallbackEn)
- **verify-panel.ts (RC-2)**: `locale` 옵션 — 2차 소견 요청 언어, 강등 사유 EN/KO, `note` 키 호환 수용
- **council-review.ts (RC-3)**: 라운드2 반박 프롬프트 EN, 합의/미합의(split) 사용자 문구 EN/KO
- **routes/workspace.ts**: verify-panel에 locale 전달, 협의체 402/403 메시지 EN/KO
- **routes/workspace-github.ts**: PR 리뷰 verify-panel에 reviewLocale 전달
- **dashboard workspace-check-api.ts**: `locale:"ko"` 하드코딩 2곳(check-draft/fix-suggestion) → `readStoredLocale`, 429 문구 클라이언트 EN 대체(서버 429는 body 파싱 전이라 locale 불가)

## 회귀 전수 검색
`rg 'locale: "ko"' apps/ --glob '!test'` 잔여 2곳은 의도적 이월:
- `verify-sweep.ts:114` — 런 행에 locale 미저장(v1 헤더 주석), **후속 PR에서 migration 0065와 함께**
- `export.ts` — 빌더팩 EN화, 별도 PR (locale 파라미터 선언만 있고 미사용)

## 검증
- 신규 테스트 4파일 16케이스 — **locale 분기 이전 코드로 되돌리면 실패** (EN 요청에 한국어 프로즈 반환)
- central-plane 전체 1,925 pass / 0 fail, dashboard 포함 turbo 6 tasks green
- userLabel은 KO wire 리터럴 유지(표시는 dashboard statusLabel이 로컬라이즈) — API 계약 불변

🤖 Generated with [Claude Code](https://claude.com/claude-code)