### PR TITLE
feat(verify): 0065 — 재검수 locale 영속 (verify-sweep v1 한계 해소)

### DIFF
--- a/apps/central-plane/migrations/0065_visual_check_locale.sql
+++ b/apps/central-plane/migrations/0065_visual_check_locale.sql
@@ -1,0 +1,9 @@
+-- 0065_visual_check_locale.sql (2026-08-20)
+--
+-- G14-b 후속: 재검수 locale 영속. verify-sweep(find→fix→verify 원)이 원 런의
+-- 언어로 재검수를 디스패치할 수 있도록 런 행에 locale을 저장한다.
+-- (verify-sweep.ts v1 정직 한계 — "재검수 locale은 ko 고정(런 행에 locale
+--  미저장)" — 를 해소하는 마이그레이션.)
+--
+-- NULL = 레거시 행(locale 미기록) — 코드에서 ko로 취급한다.
+ALTER TABLE workspace_visual_checks ADD COLUMN locale TEXT;

--- a/apps/central-plane/src/routes/workspace-visual-check-runs.ts
+++ b/apps/central-plane/src/routes/workspace-visual-check-runs.ts
@@ -225,7 +225,8 @@ export function createWorkspaceVisualCheckRunRoutes(): Hono<{ Bindings: Env }> {
 
     let run;
     try {
-      run = await insertQueuedVisualCheck(c.env, { projectId, userKey, targetUrl, intent });
+      // 0065: 런 행에 locale 저장 — verify-sweep 자동 재검수가 원 런의 언어를 따른다.
+      run = await insertQueuedVisualCheck(c.env, { projectId, userKey, targetUrl, intent, locale });
     } catch (err) {
       console.error("[visual-check-runs POST run] insert failed:", err);
       return c.json({ ok: false, error: "save_failed" }, 500);

--- a/apps/central-plane/src/routes/workspace-visual-checks.ts
+++ b/apps/central-plane/src/routes/workspace-visual-checks.ts
@@ -85,6 +85,7 @@ export function createWorkspaceVisualChecksRoutes(): Hono<{ Bindings: Env }> {
       executor?: unknown;
       report?: unknown;
       agentPrompt?: unknown;
+      locale?: unknown;
     };
     try {
       body = await c.req.json();
@@ -119,6 +120,10 @@ export function createWorkspaceVisualChecksRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ ok: false, error: "agent_prompt_too_large" }, 400);
     }
 
+    // 0065: 업로드 런에도 locale 기록 (미지정 = 레거시 ko 취급).
+    const locale: "ko" | "en" | undefined =
+      body.locale === "en" ? "en" : body.locale === "ko" ? "ko" : undefined;
+
     const owned = await requireOwnedProject(c.env, projectId, userKey);
     if (!owned.ok) return c.json({ ok: false, error: owned.error }, owned.status);
 
@@ -133,6 +138,7 @@ export function createWorkspaceVisualChecksRoutes(): Hono<{ Bindings: Env }> {
         executor,
         reportJson,
         agentPrompt,
+        locale,
       });
       return c.json(
         {

--- a/apps/central-plane/src/workspace/verify-sweep.ts
+++ b/apps/central-plane/src/workspace/verify-sweep.ts
@@ -16,8 +16,8 @@
  *
  * 정직 한계(v1, 기록):
  *   - App 미설치 repo는 머지 신호가 없다 → 기존 수동 "수리 확인 재검수" CTA 유지.
- *   - 재검수 locale은 ko 고정(런 행에 locale 미저장 — 컬럼 추가는 마이그레이션
- *     배치로 이월). EN 유저 재검수 리포트가 ko로 나올 수 있음.
+ *   - [해소 0065] 재검수 locale: 런 행에 locale이 저장되어 원 런의 언어를
+ *     따른다. locale 미기록 레거시 행만 ko로 폴백.
  */
 import type { Env } from "../env.js";
 import { listRecentUsageEventsByType } from "./usage-events-db.js";
@@ -99,6 +99,7 @@ export async function runVerifySweep(
         userKey: origin.userKey,
         targetUrl: origin.targetUrl,
         intent: origin.intent,
+        locale: origin.locale ?? "ko",
       });
     } catch (err) {
       console.error("[verify-sweep] insert failed:", err);
@@ -111,7 +112,7 @@ export async function runVerifySweep(
       userKey: origin.userKey,
       targetUrl: origin.targetUrl,
       intent: origin.intent,
-      locale: "ko", // v1 한계 — 헤더 주석 참조
+      locale: origin.locale ?? "ko", // 0065: 원 런의 언어 — 레거시 행만 ko 폴백
       publicBaseUrl: opts.publicBaseUrl ?? env.PUBLIC_BASE_URL ?? "https://conclave-ai.seunghunbae.workers.dev",
     });
     if (dispatch.dispatched) {

--- a/apps/central-plane/src/workspace/visual-check-db.ts
+++ b/apps/central-plane/src/workspace/visual-check-db.ts
@@ -26,6 +26,8 @@ export type DbVisualCheck = {
   reportJson: string;
   agentPrompt?: string;
   evidenceKeys: string[];
+  /** 0065: 런을 만든 사용자의 언어. null = 레거시 행(ko 취급). */
+  locale: "ko" | "en" | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -54,6 +56,7 @@ type RawRow = {
   report_json: string;
   agent_prompt: string | null;
   evidence_keys_json: string;
+  locale: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -92,6 +95,7 @@ function fromRow(row: RawRow): DbVisualCheck {
     reportJson: row.report_json,
     agentPrompt: row.agent_prompt ?? undefined,
     evidenceKeys: parseKeys(row.evidence_keys_json),
+    locale: row.locale === "en" ? "en" : row.locale === "ko" ? "ko" : null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -109,6 +113,7 @@ export async function insertVisualCheck(
     executor: VisualCheckExecutor;
     reportJson: string;
     agentPrompt?: string;
+    locale?: "ko" | "en";
     now?: string;
   },
 ): Promise<DbVisualCheck> {
@@ -117,8 +122,8 @@ export async function insertVisualCheck(
   await env.DB.prepare(
     `INSERT INTO workspace_visual_checks
        (id, project_id, user_key, target_url, intent, decision, works,
-        status, executor, report_json, agent_prompt, evidence_keys_json, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, 'uploaded', ?, ?, ?, '[]', ?, ?)`,
+        status, executor, report_json, agent_prompt, evidence_keys_json, locale, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'uploaded', ?, ?, ?, '[]', ?, ?, ?)`,
   )
     .bind(
       id,
@@ -131,6 +136,7 @@ export async function insertVisualCheck(
       input.executor,
       input.reportJson,
       input.agentPrompt ?? null,
+      input.locale ?? null,
       now,
       now,
     )
@@ -148,6 +154,7 @@ export async function insertVisualCheck(
     reportJson: input.reportJson,
     agentPrompt: input.agentPrompt,
     evidenceKeys: [],
+    locale: input.locale ?? null,
     createdAt: now,
     updatedAt: now,
   };
@@ -156,7 +163,7 @@ export async function insertVisualCheck(
 export async function listVisualChecks(env: Env, projectId: string): Promise<VisualCheckListItem[]> {
   const res = await env.DB.prepare(
     `SELECT id, project_id, user_key, target_url, intent, decision, works,
-            status, executor, report_json, agent_prompt, evidence_keys_json, created_at, updated_at
+            status, executor, report_json, agent_prompt, evidence_keys_json, locale, created_at, updated_at
        FROM workspace_visual_checks
       WHERE project_id = ?
       ORDER BY created_at DESC
@@ -179,7 +186,7 @@ export async function listVisualChecks(env: Env, projectId: string): Promise<Vis
 export async function getVisualCheckById(env: Env, id: string): Promise<DbVisualCheck | null> {
   const row = (await env.DB.prepare(
     `SELECT id, project_id, user_key, target_url, intent, decision, works,
-            status, executor, report_json, agent_prompt, evidence_keys_json, created_at, updated_at
+            status, executor, report_json, agent_prompt, evidence_keys_json, locale, created_at, updated_at
        FROM workspace_visual_checks
       WHERE id = ?`,
   )
@@ -201,6 +208,7 @@ export async function insertQueuedVisualCheck(
     userKey: string;
     targetUrl: string;
     intent: string;
+    locale?: "ko" | "en";
     now?: string;
   },
 ): Promise<DbVisualCheck> {
@@ -209,10 +217,10 @@ export async function insertQueuedVisualCheck(
   await env.DB.prepare(
     `INSERT INTO workspace_visual_checks
        (id, project_id, user_key, target_url, intent, decision, works,
-        status, executor, report_json, agent_prompt, evidence_keys_json, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, 'Not Judged', NULL, 'queued', 'container', '{}', NULL, '[]', ?, ?)`,
+        status, executor, report_json, agent_prompt, evidence_keys_json, locale, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, 'Not Judged', NULL, 'queued', 'container', '{}', NULL, '[]', ?, ?, ?)`,
   )
-    .bind(id, input.projectId, input.userKey, input.targetUrl, input.intent, now, now)
+    .bind(id, input.projectId, input.userKey, input.targetUrl, input.intent, input.locale ?? null, now, now)
     .run();
   return {
     id,
@@ -226,6 +234,7 @@ export async function insertQueuedVisualCheck(
     executor: "container",
     reportJson: "{}",
     evidenceKeys: [],
+    locale: input.locale ?? null,
     createdAt: now,
     updatedAt: now,
   };

--- a/apps/central-plane/test/verify-sweep-locale.test.mjs
+++ b/apps/central-plane/test/verify-sweep-locale.test.mjs
@@ -1,0 +1,110 @@
+/**
+ * verify-sweep-locale.test.mjs — 0065: 재검수 locale 영속.
+ *
+ * v1 정직 한계("재검수 locale은 ko 고정")의 해소를 고정한다:
+ *   - 원 런 행에 locale=en → 자동 재검수 디스패치도 en, 새 런 행에도 en 저장
+ *   - locale 미기록 레거시 행 → ko 폴백 (기존 동작 불변)
+ * 이 테스트는 0065 이전 코드(무조건 ko 디스패치)로 되돌리면 실패한다.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runVerifySweep, REPAIR_MERGED_EVENT } from "../dist/workspace/verify-sweep.js";
+
+function makeDb(state) {
+  return {
+    state,
+    prepare(sql) {
+      let bound = [];
+      return {
+        bind(...args) {
+          bound = args;
+          return {
+            first: async () => {
+              if (sql.includes("workspace_visual_checks") && sql.includes("WHERE id = ?")) {
+                return state.runs.find((r) => r.id === bound[0]) ?? null;
+              }
+              if (sql.includes("status IN ('queued', 'running')")) {
+                return state.runs.find((r) => r.project_id === bound[0] && (r.status === "queued" || r.status === "running")) ?? null;
+              }
+              return null;
+            },
+            all: async () => {
+              if (sql.includes("workspace_usage_events")) {
+                return { results: state.events.filter((e) => e.event_type === bound[0] && e.created_at > bound[1]) };
+              }
+              if (sql.includes("workspace_visual_checks") && sql.includes("project_id = ?")) {
+                return { results: state.runs.filter((r) => r.project_id === bound[0]) };
+              }
+              return { results: [] };
+            },
+            run: async () => {
+              state.writes.push({ sql, bound });
+              return { success: true, meta: { changes: 1 } };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+const NOW = Date.parse("2026-08-20T12:00:00Z");
+const iso = (msAgo) => new Date(NOW - msAgo).toISOString();
+
+function runRow(over = {}) {
+  return {
+    id: "wvc_orig", project_id: "p1", user_key: "u1",
+    target_url: "https://app.example.com", intent: "checkout flow",
+    decision: "Needs Fix", works: 0, status: "done",
+    report_json: "{}", agent_prompt: null, executor: "container",
+    evidence_keys_json: "[]", locale: null, error: null,
+    created_at: iso(3600_000), updated_at: iso(3600_000),
+    ...over,
+  };
+}
+
+function eventRow(over = {}) {
+  return {
+    id: "evt1", user_key: "u1", project_id: "p1",
+    event_type: REPAIR_MERGED_EVENT,
+    metadata_json: JSON.stringify({ runId: "wvc_orig" }),
+    created_at: iso(10 * 60_000),
+    ...over,
+  };
+}
+
+function makeEnv(state, calls) {
+  return {
+    DB: makeDb(state),
+    INTERNAL_CALLBACK_TOKEN: "tok",
+    PUBLIC_BASE_URL: "https://base",
+    INSPECTOR: {
+      idFromName: () => "id",
+      get: () => ({
+        fetch: async (_url, init) => {
+          calls.push(JSON.parse(init.body));
+          return { ok: true, text: async () => "" };
+        },
+      }),
+    },
+  };
+}
+
+test("원 런 locale=en → 재검수 디스패치 en + 새 런 행에 en 저장", async () => {
+  const calls = [];
+  const state = { events: [eventRow()], runs: [runRow({ locale: "en" })], writes: [] };
+  const s = await runVerifySweep(makeEnv(state, calls), { nowMs: NOW });
+  assert.equal(s.dispatched, 1);
+  assert.equal(calls[0].locale, "en", "재검수는 원 런의 언어를 따라야 한다");
+  const ins = state.writes.find((w) => /INSERT INTO workspace_visual_checks/.test(w.sql));
+  assert.ok(ins, "재검수 런 행 삽입");
+  assert.ok(ins.bound.includes("en"), "새 런 행에 locale=en 저장");
+});
+
+test("레거시 행(locale 미기록) → ko 폴백 (기존 동작 불변)", async () => {
+  const calls = [];
+  const state = { events: [eventRow()], runs: [runRow({ locale: null })], writes: [] };
+  const s = await runVerifySweep(makeEnv(state, calls), { nowMs: NOW });
+  assert.equal(s.dispatched, 1);
+  assert.equal(calls[0].locale, "ko");
+});


### PR DESCRIPTION
## 무엇
verify-sweep(find→fix→verify 원)의 v1 정직 한계 — "재검수 locale은 ko 고정(런 행에 locale 미저장)" — 를 해소합니다. 갭 #1(EN locale 전면화)의 서버 영속 파트.

- **migration 0065**: `workspace_visual_checks`에 `locale TEXT` 추가 (NULL=레거시, ko 취급)
- **visual-check-db.ts**: insert(큐/업로드) 시 locale 저장, SELECT/fromRow에 locale 포함
- **routes**: 검수 런 생성·업로드 라우트가 body locale을 런 행에 기록
- **verify-sweep.ts**: 자동 재검수를 원 런의 locale로 디스패치 + 새 런 행에도 전파

## ⚠️ 배포 순서 (하드 게이트)
**migration 0065 적용 → 코드 배포** 순서 필수. SELECT 컬럼 목록에 locale이 포함되어, 미적용 D1에 새 코드를 배포하면 검수 조회가 전면 실패합니다. deploy-central-plane workflow의 migrations 스텝과 함께 배포하세요.

## 검증
- 신규 테스트 2케이스: en 원 런 → en 디스패치+저장 / 레거시 NULL → ko 폴백 (0065 이전 코드로 되돌리면 실패)
- central-plane 전체 1,911 pass / 0 fail, typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)