### PR TITLE
feat(journey): journey-store 복원 — 미머지 브랜치 유실분 재상륙

### DIFF
--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -53,6 +53,7 @@ import { reviewPRAgainstItems, deriveRunStatus } from "../workspace/pr-review.js
 import { applyVerifyPanelWithContext } from "../workspace/verify-panel.js";
 import { buildDiffSummary } from "../workspace/github-pr.js";
 import { captureTrainingRecord, computeRecheckOutcome, updateTrainingRecordOutcome } from "../workspace/training-store.js";
+import { captureJourneyEvent } from "../workspace/journey-store.js";
 import type { TopicTags, AcquisitionTag } from "../workspace/training-store.js";
 import { normalizeBuiltWith } from "../workspace/built-with.js";
 import { detectContentLang } from "../workspace/topic-tags.js";
@@ -1084,6 +1085,26 @@ export function createWorkspaceGitHubRoutes(
       }
     }
 
+    // 9e. Journey event (e1f9f9f 복원, 2026-08-20): pr_reviewed(첫 리뷰) vs
+    // pr_rechecked(재실행). rerunOfReviewRunId가 둘을 구분한다 — recheck은
+    // fix_brief → next-PR 라운드트립의 후반부(per-agent 크라운 주얼).
+    // 코드 기반 이벤트라 전체 payload 캡처(시크릿 스크럽), 동의 게이트 동일.
+    await captureJourneyEvent(c.env, {
+      userKey,
+      projectId,
+      eventType: rerunOfReviewRunId ? "pr_rechecked" : "pr_reviewed",
+      builtWith: normalizeBuiltWith(projForTag?.builtWith),
+      eventId: run.id,
+      payload: {
+        reviewRunId: run.id,
+        rerunOfReviewRunId: rerunOfReviewRunId ?? null,
+        prNumber,
+        finalStatus,
+        summary: reviewResult.summary,
+        source: reviewResult.source,
+      },
+    }).catch(() => {});
+
     // 10. Telegram notification (non-blocking: failure must not fail the review response)
     await (async () => {
       try {
@@ -1398,6 +1419,22 @@ export function createWorkspaceGitHubRoutes(
       runId: runId,
       target,
     });
+
+    // Journey event (e1f9f9f 복원): fix_brief_generated — 라운드트립의 전반부
+    // (이 지시서 → 유저의 다음 PR → pr_rechecked, per agent). dbProj 재사용.
+    await captureJourneyEvent(c.env, {
+      userKey,
+      projectId,
+      eventType: "fix_brief_generated",
+      builtWith: normalizeBuiltWith(dbProj?.builtWith),
+      eventId: `${runId}_fixbrief`,
+      payload: {
+        sourceReviewRunId: runId,
+        prNumber,
+        target,
+        itemCount: selectedItemIds.length,
+      },
+    }).catch(() => {});
 
     return json({
       ...result,

--- a/apps/central-plane/src/workspace/journey-store.ts
+++ b/apps/central-plane/src/workspace/journey-store.ts
@@ -1,0 +1,182 @@
+/**
+ * journey-store.ts
+ *
+ * Captures the non-developer JOURNEY (not just the final review triplet): what
+ * they built with, how they shaped the idea, where the draft got corrected, and
+ * — the crown jewel — the fix-brief → next-PR round-trip per agent. Only Simsa
+ * sees this cross-agent behavioral trace, and it can only be captured in the
+ * moment (golden-time; no backfill). Every event carries the builtWith tag so
+ * the data resolves per agent.
+ *
+ * Same guarantees as training-store: opt-in (default OFF), version-gated
+ * consent, secret-scrubbed, keyed by sha256(userKey) with no raw handle/email,
+ * never throws, no-op without consent or an R2 bucket. Events land as JSON under
+ * `journey/YYYY/MM/DD/<projectId>/<eventId>.json`.
+ */
+import type { Env } from "../env.js";
+import { redactSecrets } from "@simsa/secret-guard";
+import { sha256Hex } from "../util.js";
+import { TRAINING_CONSENT_VERSION, hasActiveTrainingConsent } from "./training-consent-db.js";
+import type { BuiltWith } from "./built-with.js";
+
+export const JOURNEY_SCHEMA_VERSION = 1;
+
+/**
+ * Event taxonomy. Extensible — add a new value and one captureJourneyEvent call
+ * at the relevant handler; existing data stays valid. Kept as a plain string
+ * union so unknown future events don't break old readers.
+ */
+export type JourneyEventType =
+  | "idea_submitted"
+  | "spec_generated"
+  | "spec_edited"
+  | "items_finalized"
+  | "repo_connected"
+  | "pr_reviewed"
+  | "fix_brief_generated"
+  | "pr_rechecked"
+  | "outcome_recorded";
+
+/**
+ * NATURAL-LANGUAGE events. Their raw payload is free-form prose a non-developer
+ * types (idea descriptions, spec edits) and routinely contains PII / business
+ * secrets — customer names, phone numbers, revenue figures — that our
+ * code-oriented secret scrubber (redactSecrets: API-key/token PATTERNS) cannot
+ * detect, because there is no pattern. Until a dedicated PII scrubber lands,
+ * callers for these event types MUST pass METADATA ONLY (lengths, counts, edit
+ * deltas) — never the raw text. Code-based events (the fix_brief → pr_rechecked
+ * round-trip, PR reviews) are safe to capture in full via the existing scrub.
+ * `assertNoRawProseForNlEvent` enforces this at capture time.
+ */
+export const NATURAL_LANGUAGE_EVENTS: ReadonlySet<JourneyEventType> = new Set([
+  "idea_submitted",
+  "spec_generated",
+  "spec_edited",
+  "items_finalized",
+]);
+
+/** Fields that, on an NL event, would carry raw prose — refuse to store them. */
+const RAW_PROSE_FIELDS = new Set(["idea", "text", "raw", "content", "spec", "productSpec", "items", "reason"]);
+
+/**
+ * Drop any raw-prose field from an NL event's payload (defense in depth). This
+ * makes it structurally impossible to persist un-PII-scrubbed prose even if a
+ * caller passes it by mistake. Non-NL events pass through untouched.
+ */
+function enforceNlMetadataOnly(eventType: JourneyEventType, payload: unknown): unknown {
+  if (!NATURAL_LANGUAGE_EVENTS.has(eventType)) return payload;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    // A bare string/array on an NL event is almost certainly raw prose — drop it.
+    return { note: "metadata_only_pending_pii_scrub" };
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(payload as Record<string, unknown>)) {
+    if (RAW_PROSE_FIELDS.has(k)) continue;
+    // Also drop any long free-text string that slipped through.
+    if (typeof v === "string" && v.length > 120) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+export type CaptureJourneyInput = {
+  userKey: string;
+  projectId: string;
+  eventType: JourneyEventType;
+  /** Event-specific data. Deep secret-scrubbed before storage. */
+  payload: unknown;
+  /** The agent tag for this project, if known. Copied onto every event. */
+  builtWith?: BuiltWith | null;
+  /** Stable per-event id (e.g. review run id). Falls back to a hash of the payload+type. */
+  eventId?: string;
+  /** Injected clock for tests. */
+  now?: string;
+  /** Injected subject hash for tests. */
+  subjectHash?: string;
+};
+
+export type JourneyRecord = {
+  schema_version: number;
+  captured_at: string;
+  subject_hash: string;
+  consent_version: string;
+  project_id: string;
+  event_type: JourneyEventType;
+  built_with: BuiltWith | null;
+  payload: unknown;
+};
+
+/** Deep-scrub a JSON-serializable value. Returns a marker rather than leak on error. */
+function scrubJson(value: unknown): unknown {
+  try {
+    const s = JSON.stringify(value);
+    if (s === undefined) return null;
+    return JSON.parse(redactSecrets(s).text);
+  } catch {
+    return "[redacted-unserializable]";
+  }
+}
+
+/** Pure, deterministic assembler. Safe to unit-test for shape + no-PII. */
+export function buildJourneyRecord(
+  input: CaptureJourneyInput,
+  subjectHash: string,
+  capturedAt: string,
+): JourneyRecord {
+  // NL events: strip raw prose FIRST (PII the code scrubber can't catch), then
+  // secret-scrub the remaining metadata. Code events: secret-scrub in full.
+  const safePayload = enforceNlMetadataOnly(input.eventType, input.payload);
+  return {
+    schema_version: JOURNEY_SCHEMA_VERSION,
+    captured_at: capturedAt,
+    subject_hash: subjectHash,
+    consent_version: TRAINING_CONSENT_VERSION,
+    project_id: input.projectId,
+    event_type: input.eventType,
+    built_with: input.builtWith ?? null,
+    payload: scrubJson(safePayload),
+  };
+}
+
+/** R2 object key: day-bucketed, grouped by project so a full journey is browsable. */
+export function journeyRecordKey(capturedAt: string, projectId: string, eventId: string): string {
+  const [y, m, d] = capturedAt.slice(0, 10).split("-");
+  // Sanitize ids for a safe key (no slashes/spaces).
+  const safeProject = projectId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 80);
+  const safeEvent = eventId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 80);
+  return `journey/${y}/${m}/${d}/${safeProject}/${safeEvent}.json`;
+}
+
+export type JourneyCaptureResult =
+  | { stored: true; key: string }
+  | { stored: false; reason: "no_consent" | "no_bucket" | "error" };
+
+/**
+ * Consent-gated, best-effort capture. Never throws. No consent → no bucket read.
+ */
+export async function captureJourneyEvent(
+  env: Env,
+  input: CaptureJourneyInput,
+): Promise<JourneyCaptureResult> {
+  try {
+    if (!(await hasActiveTrainingConsent(env, input.userKey))) {
+      return { stored: false, reason: "no_consent" };
+    }
+    if (!env.EVIDENCE) {
+      return { stored: false, reason: "no_bucket" };
+    }
+    const capturedAt = input.now ?? new Date().toISOString();
+    const subjectHash = input.subjectHash ?? (await sha256Hex(input.userKey));
+    const eventId =
+      input.eventId ?? (await sha256Hex(`${input.eventType}:${JSON.stringify(input.payload)}`)).slice(0, 24);
+    const record = buildJourneyRecord(input, subjectHash, capturedAt);
+    const key = journeyRecordKey(capturedAt, input.projectId, eventId);
+    await env.EVIDENCE.put(key, JSON.stringify(record), {
+      httpMetadata: { contentType: "application/json" },
+    });
+    return { stored: true, key };
+  } catch (err) {
+    console.warn("[journey-store] capture failed (non-fatal):", err instanceof Error ? err.message : err);
+    return { stored: false, reason: "error" };
+  }
+}

--- a/apps/central-plane/test/journey-store.test.mjs
+++ b/apps/central-plane/test/journey-store.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * journey-store.test.mjs — consent-gated journey capture. Asserts the real path
+ * (captureJourneyEvent → r2 payload), the NL metadata-only guard (no raw prose
+ * for natural-language events, since the code scrubber can't catch PII), the
+ * builtWith tag, no raw identity, and never-throws.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildJourneyRecord,
+  journeyRecordKey,
+  captureJourneyEvent,
+  NATURAL_LANGUAGE_EVENTS,
+} from "../dist/workspace/journey-store.js";
+import { TRAINING_CONSENT_VERSION } from "../dist/workspace/training-consent-db.js";
+
+function dbWithConsent({ consented, version }) {
+  return {
+    prepare() {
+      return {
+        bind() { return this; },
+        async first() {
+          return consented === null ? null : {
+            user_key: "uk_secret", consented: consented ? 1 : 0,
+            consent_version: version, created_at: "t", updated_at: "t",
+          };
+        },
+      };
+    },
+  };
+}
+
+class FakeR2 {
+  constructor() { this.puts = []; this.throwOnPut = false; }
+  async put(key, value, opts) {
+    if (this.throwOnPut) throw new Error("r2 down");
+    this.puts.push({ key, value, opts });
+  }
+}
+
+const base = (over = {}) => ({
+  userKey: "uk_secret",
+  projectId: "proj_1",
+  eventType: "pr_reviewed",
+  builtWith: { tools: ["cursor"] },
+  eventId: "run_1",
+  payload: { reviewRunId: "run_1", finalStatus: "passed" },
+  now: "2026-07-04T09:00:00.000Z",
+  subjectHash: "deadbeef",
+  ...over,
+});
+
+test("buildJourneyRecord: shape + builtWith tag + consent version", () => {
+  const rec = buildJourneyRecord(base(), "hash_x", "2026-07-04T00:00:00.000Z");
+  assert.equal(rec.event_type, "pr_reviewed");
+  assert.deepEqual(rec.built_with, { tools: ["cursor"] });
+  assert.equal(rec.consent_version, TRAINING_CONSENT_VERSION);
+  assert.equal(rec.subject_hash, "hash_x");
+});
+
+test("journeyRecordKey day-buckets + groups by project", () => {
+  assert.equal(
+    journeyRecordKey("2026-07-04T09:00:00.000Z", "proj_1", "run_1"),
+    "journey/2026/07/04/proj_1/run_1.json",
+  );
+});
+
+test("no consent → no-op", async () => {
+  const r2 = new FakeR2();
+  const res = await captureJourneyEvent({ DB: dbWithConsent({ consented: null }), EVIDENCE: r2 }, base());
+  assert.deepEqual(res, { stored: false, reason: "no_consent" });
+  assert.equal(r2.puts.length, 0);
+});
+
+test("consent + bucket → stored at journey key", async () => {
+  const r2 = new FakeR2();
+  const env = { DB: dbWithConsent({ consented: true, version: TRAINING_CONSENT_VERSION }), EVIDENCE: r2 };
+  const res = await captureJourneyEvent(env, base());
+  assert.equal(res.stored, true);
+  assert.equal(res.key, "journey/2026/07/04/proj_1/run_1.json");
+});
+
+test("NATURAL-LANGUAGE event drops raw prose (PII the code scrubber can't catch)", async () => {
+  const r2 = new FakeR2();
+  const env = { DB: dbWithConsent({ consented: true, version: TRAINING_CONSENT_VERSION }), EVIDENCE: r2 };
+  assert.ok(NATURAL_LANGUAGE_EVENTS.has("idea_submitted"));
+  await captureJourneyEvent(env, base({
+    eventType: "idea_submitted",
+    payload: {
+      idea: "고객 김철수(010-1234-5678)에게 매출 리포트 메일 보내기",  // raw PII prose
+      ideaLength: 42,
+    },
+  }));
+  const payload = r2.puts[0].value;
+  assert.ok(!payload.includes("김철수"), "raw name must not be stored");
+  assert.ok(!payload.includes("010-1234-5678"), "raw phone must not be stored");
+  const parsed = JSON.parse(payload);
+  assert.equal(parsed.payload.idea, undefined, "the raw idea field must be dropped");
+  assert.equal(parsed.payload.ideaLength, 42, "metadata is kept");
+});
+
+test("code-based event keeps full payload", async () => {
+  const r2 = new FakeR2();
+  const env = { DB: dbWithConsent({ consented: true, version: TRAINING_CONSENT_VERSION }), EVIDENCE: r2 };
+  await captureJourneyEvent(env, base({ eventType: "pr_rechecked", payload: { reviewRunId: "r2", finalStatus: "failed" } }));
+  const parsed = JSON.parse(r2.puts[0].value);
+  assert.equal(parsed.payload.finalStatus, "failed");
+  assert.equal(parsed.event_type, "pr_rechecked");
+});
+
+test("payload carries no raw userKey", async () => {
+  const r2 = new FakeR2();
+  const env = { DB: dbWithConsent({ consented: true, version: TRAINING_CONSENT_VERSION }), EVIDENCE: r2 };
+  await captureJourneyEvent(env, base({ userKey: "uk_super_secret" }));
+  assert.ok(!r2.puts[0].value.includes("uk_super_secret"));
+});
+
+test("never throws on R2 failure", async () => {
+  const r2 = new FakeR2();
+  r2.throwOnPut = true;
+  const env = { DB: dbWithConsent({ consented: true, version: TRAINING_CONSENT_VERSION }), EVIDENCE: r2 };
+  assert.deepEqual(await captureJourneyEvent(env, base()), { stored: false, reason: "error" });
+});


### PR DESCRIPTION
## 배경 (갭 #2 조사 결과)
journey-store는 **삭제된 게 아니라 2026-07-04 `beta-data-capture` 브랜치(e1f9f9f)가 main에 머지되지 않은 채 유실**된 것입니다. 같은 커밋의 builtWith 절반만 별도 PR로 재상륙했고, journey-store 본체(182줄)+테스트(123줄)+배선은 `dist/`의 stale `.d.ts`로만 남아 있었습니다.

## 무엇
- **journey-store.ts 원본 그대로 복원**: 9-이벤트 계보(idea_submitted→outcome_recorded), NATURAL_LANGUAGE_EVENTS metadata-only PII 가드(원문 프로즈 구조적 저장 불가), R2 `journey/YYYY/MM/DD/{project}/{event}.json`, training-consent 동의 게이트(기본 OFF), sha256(userKey), never-throws
- **배선을 현재 main에 이식**: 리뷰 핸들러에 `pr_reviewed`/`pr_rechecked`(rerunOfReviewRunId로 구분 — fix_brief→다음 PR 라운드트립의 후반부), fix-brief 핸들러에 `fix_brief_generated`(전반부). 둘 다 builtWith 태그 동반 → per-agent 수리 성공률이 측정 가능해짐
- 원본과 달리 현재 main에 이미 있는 projForTag/dbProj 로드를 재사용 (중복 getProject 없음)

## 검증
- 원본 테스트 8케이스(NL 가드·no-PII·never-throws 포함) 복원 통과
- central-plane 전체 1,917 pass / 0 fail, typecheck green
- 소비자 없는 신규 캡처만 추가 — 기존 경로 동작 불변(전부 .catch(()=>{}) best-effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)