### PR TITLE
feat(landing): conclave-ai.dev → simsa.dev 전면 리다이렉트 (랜딩 Simsa 통일)

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,4 +1,21 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "redirects": [
+    {
+      "source": "/privacy",
+      "destination": "https://simsa.dev/privacy",
+      "permanent": true
+    },
+    {
+      "source": "/terms",
+      "destination": "https://simsa.dev/terms",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "destination": "https://simsa.dev/",
+      "permanent": true
+    }
+  ]
 }


### PR DESCRIPTION
## 무엇 (갭 #5 — Bae 결정 "다 simsa로")
Conclave 브랜드 랜딩(`apps/landing`, conclave-ai.dev)을 simsa.dev로 전면 리다이렉트합니다. trysimsa.com→simsa.dev와 동일한 vercel.json permanent redirect 패턴.

- `/privacy`, `/terms` → 경로 보존 리다이렉트 (simsa-landing에 동일 문서 존재 확인)
- 그 외 전 경로 → simsa.dev 루트
- 앱 코드는 삭제하지 않음 — redirect가 앱 앞단에서 실행되므로 빌드 불변, 노출만 종료

## 참고
- 과금 무료 유지 결정(같은 날)과 정합 — Conclave GHM 유료 랜딩의 존치 이유 소멸
- GHM 리스팅의 홈페이지 URL은 추후 리스팅 편집에서 simsa.dev로 갱신 권장(리다이렉트라 당장 깨지지 않음)
- 반영은 landing Vercel 재배포 시점부터 (merge≠deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)