### PR TITLE
fix(landing): 루트 / 리다이렉트 명시 규칙 추가

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -3,6 +3,11 @@
   "framework": "nextjs",
   "redirects": [
     {
+      "source": "/",
+      "destination": "https://simsa.dev/",
+      "permanent": true
+    },
+    {
       "source": "/privacy",
       "destination": "https://simsa.dev/privacy",
       "permanent": true


### PR DESCRIPTION
#470 라이브 실측에서 /privacy·/pricing은 308 → simsa.dev 정상, **루트만 200(구 랜딩)** — `/:path*` 매처가 `/`를 매치하지 않는 Vercel 동작. 명시적 `/` 규칙을 맨 앞에 추가(트래픽의 대부분이 루트라 실효 필수). 머지 후 conclave-ai 프로젝트 재배포로 발효.

🤖 Generated with [Claude Code](https://claude.com/claude-code)