### PR TITLE
docs: HANDOFF 추가 2 — 3면 배포 완결

### DIFF
--- a/docs/HANDOFF-2026-08-20.md
+++ b/docs/HANDOFF-2026-08-20.md
@@ -70,3 +70,17 @@
 - 이로써 인벤토리 위반 B1~B10 중 B1~B10 전부 해소 또는 정정(§6 표).
 - **미배포 누적 주의**: #474·#475·#477~#479가 central-plane 미배포분,
   dashboard도 오늘 전 변경 미배포. 다음 배포 승인 시 한 번에 반영 권장.
+
+## [추가 2] 3면 배포 완결 (같은 날 마감)
+
+- `deploy central-plane approved.` / `deploy dashboard approved.` / `deploy landing
+  approved.` 전부 집행·검증:
+  - **central-plane**: deployedSha = main(#480) 일치, db up, 카나리 green.
+  - **dashboard**: repo 루트 `--archive=tgz` → `vercel ls` Ready 확인(메모리 절차).
+  - **landing(conclave-ai)**: ★실측 버그 — `/:path*` 리다이렉트가 **루트 `/`를
+    매치하지 않음**(경로들은 308 정상, 루트만 구 랜딩 200). 명시적 `/` 규칙
+    핫픽스 **#481** → 재배포 → 루트 308 → simsa.dev 라이브 확인.
+    apps/landing은 Vercel 프로젝트 `conclave-ai`(root dir=apps/landing)라
+    **repo 루트에서 VERCEL_ORG_ID/PROJECT_ID env 오버라이드 + --archive=tgz**로
+    배포해야 한다(앱 폴더 실행은 경로 중복 에러 — 실측).
+- 미배포 잔여 **0**. 오늘 세션 총 **16 PR 머지**(#467~#471, #473~#481).


### PR DESCRIPTION
central/dashboard/landing 배포 집행·검증 기록 + landing 루트 리다이렉트 실측 버그(#481)와 conclave-ai 프로젝트 배포 절차 교훈.

🤖 Generated with [Claude Code](https://claude.com/claude-code)