### PR TITLE
fix(stack): P2 결함 — export 라우트가 hosting/data 축을 버려 조합이 팩에 미반영

### DIFF
--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -47,6 +47,7 @@ import {
 import {
   generateBuilderPack,
   type WorkspaceExportBuilderPackRequest,
+  type ExportUserProfile,
 } from "../workspace/export.js";
 import { BRAND } from "../workspace/brand.js";
 import {
@@ -852,13 +853,28 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
     const appBaseUrl = c.env.DASHBOARD_BASE_URL ?? BRAND.appUrl;
     // #296 Phase 3: interview profile — enum-whitelisted, anything else dropped.
     const rawProfile = (body as Record<string, unknown>)["userProfile"];
-    const userProfile = (() => {
+    const userProfile = ((): ExportUserProfile | undefined => {
       if (typeof rawProfile !== "object" || rawProfile === null) return undefined;
       const p = rawProfile as Record<string, unknown>;
-      const out: { platform?: "web" | "mobile" | "unknown"; githubLevel?: "fluent" | "heard" | "new"; aiToolLevel?: "yes" | "some" | "no" } = {};
+      const out: ExportUserProfile = {};
       if (p.platform === "web" || p.platform === "mobile" || p.platform === "unknown") out.platform = p.platform;
       if (p.githubLevel === "fluent" || p.githubLevel === "heard" || p.githubLevel === "new") out.githubLevel = p.githubLevel;
       if (p.aiToolLevel === "yes" || p.aiToolLevel === "some" || p.aiToolLevel === "no") out.aiToolLevel = p.aiToolLevel;
+      // 스택 불가지 P2 (D-1): hosting/data 축. 위 3개와 달리 **닫힌 enum이 아니다** —
+      // 카탈로그 확장과 "기타" 자유입력을 서버가 막지 않아야 하므로(D-3) 문자열
+      // 길이만 캡하고 값은 그대로 통과시킨다. 미지 id는 소비자에서 중립 처리(D-2).
+      // (2026-08-21 라이브 QA: 이 화이트리스트가 두 축을 조용히 버려서 유저가
+      //  답한 조합이 팩에 전혀 반영되지 않았다 — 라우트 경유 회귀 가드 필수.)
+      const str = (v: unknown, cap: number): string | undefined =>
+        typeof v === "string" && v.trim() ? v.trim().slice(0, cap) : undefined;
+      const hosting = str(p.hosting, 40);
+      const hostingOther = str(p.hostingOther, 80);
+      const data = str(p.data, 40);
+      const dataOther = str(p.dataOther, 80);
+      if (hosting) out.hosting = hosting;
+      if (hostingOther) out.hostingOther = hostingOther;
+      if (data) out.data = data;
+      if (dataOther) out.dataOther = dataOther;
       return Object.keys(out).length > 0 ? out : undefined;
     })();
     const result = generateBuilderPack({

--- a/apps/central-plane/test/export-route-stack-profile.test.mjs
+++ b/apps/central-plane/test/export-route-stack-profile.test.mjs
@@ -1,0 +1,126 @@
+/**
+ * export-route-stack-profile.test.mjs — 스택 불가지 P2의 **라우트 경유** 계약.
+ *
+ * 2026-08-21 라이브 QA에서 잡힌 결함: 유저가 호스팅/데이터를 답했는데 빌더팩이
+ * 중립 안내로 나왔다. 진범은 `/workspace/export-builder-pack` 라우트의
+ * userProfile 정규화가 **닫힌 enum 화이트리스트**(platform/githubLevel/aiToolLevel)라
+ * hosting·data 축을 조용히 버린 것.
+ *
+ * P2의 기존 테스트(workspace-export-stack.test.mjs)는 generateBuilderPack을 직접
+ * 호출해 라우트를 우회했기 때문에 이 갭을 못 봤다. 이 파일은 **HTTP 요청부터**
+ * 검증한다 — 수정 이전 코드에서 실패한다.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { createApp } = await import("../dist/router.js");
+
+const ORIGIN = "https://app.trysimsa.com";
+
+const SPEC = {
+  productName: "사내 회의실 예약",
+  oneLine: "직원이 회의실을 예약하고 관리자가 현황을 봅니다",
+  targetUsers: ["직원"],
+  problem: "예약이 메신저로 흩어져 중복됩니다.",
+  included: ["회의실 예약 만들기", "직원 로그인"],
+  excluded: ["결제"],
+  userFlow: ["로그인", "예약"],
+  decisions: [],
+  openQuestions: [],
+};
+const ITEMS = [
+  { id: "r1", title: "직원이 회의실 예약을 만들 수 있다", status: "not_started", criteria: ["시간 선택", "중복 방지"] },
+];
+
+/** D1/R2가 필요 없는 결정론 라우트 — 사용량 기록만 best-effort로 흘려보낸다. */
+function makeEnv() {
+  return {
+    DB: {
+      prepare() {
+        return {
+          bind() { return this; },
+          async run() { return { success: true, meta: { changes: 1 } }; },
+          async first() { return null; },
+          async all() { return { results: [] }; },
+        };
+      },
+    },
+  };
+}
+
+async function packViaRoute(userProfile) {
+  const res = await createApp().request(
+    "/workspace/export-builder-pack",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: ORIGIN },
+      body: JSON.stringify({
+        project: { title: SPEC.productName, productSpec: SPEC, items: ITEMS },
+        target: "claude_code",
+        format: "json",
+        locale: "ko",
+        ...(userProfile ? { userProfile } : {}),
+      }),
+    },
+    makeEnv(),
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  const prompt = (body.bundle?.files ?? []).find((f) => f.path.endsWith("CLAUDE_CODE_PROMPT.md"))?.content ?? "";
+  assert.ok(prompt.length > 0, "CLAUDE_CODE_PROMPT.md must exist");
+  return prompt;
+}
+
+const NEUTRAL_DATA = "먼저 사용자에게 이미 쓰는 데이터 서비스가 있는지 물어라";
+
+describe("export 라우트 — 답한 조합이 팩까지 도달한다 (P2 라우트 계약)", () => {
+  it("userProfile 없음 → 중립(물음-먼저), 특정 벤더 단정 없음 (D-2)", async () => {
+    const p = await packViaRoute(undefined);
+    assert.match(p, new RegExp(NEUTRAL_DATA));
+    assert.doesNotMatch(p, /https:\/\/supabase\.com/);
+  });
+
+  it("data=supabase → Supabase 워크스루가 라우트를 통과해 팩에 실린다", async () => {
+    const p = await packViaRoute({ data: "supabase" });
+    assert.match(p, /https:\/\/supabase\.com/);
+    assert.doesNotMatch(p, new RegExp(NEUTRAL_DATA));
+  });
+
+  it("data=firebase → Firebase 안내, Supabase 기본값 없음", async () => {
+    const p = await packViaRoute({ data: "firebase" });
+    assert.match(p, /console\.firebase\.google\.com/);
+    assert.doesNotMatch(p, /https:\/\/supabase\.com/);
+  });
+
+  it("hosting=netlify → Netlify 기준 배포 안내 (Vercel 경로 아님)", async () => {
+    const p = await packViaRoute({ hosting: "netlify" });
+    assert.match(p, /Netlify를 쓴다/);
+    assert.doesNotMatch(p, /https:\/\/vercel\.com/);
+  });
+
+  it("hosting=builder_hosted → Publish 버튼 안내로 대체", async () => {
+    const p = await packViaRoute({ hosting: "builder_hosted" });
+    assert.match(p, /Publish\/Deploy 버튼/);
+  });
+
+  it('기타 자유입력(한글)이 이름 그대로 전달된다 — 치환 금지 (D-3, Rule 6)', async () => {
+    const p = await packViaRoute({ data: "other", dataOther: "우리회사 사내 포스그레스" });
+    assert.match(p, /우리회사 사내 포스그레스/);
+    assert.match(p, /다른 서비스로 바꾸지 말고/);
+  });
+
+  it("hosting=other 자유입력도 그대로 전달된다", async () => {
+    const p = await packViaRoute({ hosting: "other", hostingOther: "회사 자체 서버" });
+    assert.match(p, /회사 자체 서버/);
+  });
+
+  it("구 필드(githubLevel)는 종전대로 동작한다 — 무회귀", async () => {
+    const p = await packViaRoute({ githubLevel: "new" });
+    assert.match(p, /GitHub이 처음이거나 계정이 없다/);
+  });
+
+  it("빈 문자열·비문자열 축은 무시된다 (정규화 유지)", async () => {
+    const p = await packViaRoute({ hosting: "   ", data: 42, dataOther: null });
+    assert.match(p, new RegExp(NEUTRAL_DATA));
+  });
+});

--- a/tools/simsa-completion-loop-spike/journey-audit-result.json
+++ b/tools/simsa-completion-loop-spike/journey-audit-result.json
@@ -1,5 +1,5 @@
 {
-  "startedAt": "2026-08-20T01:41:31.516Z",
+  "startedAt": "2026-08-20T15:56:04.157Z",
   "version": 2,
   "journeys": [
     {
@@ -63,7 +63,12 @@
             "네",
             "조금",
             "아뇨",
-            "제품 설명서 만들기 →"
+            "Vercel",
+            "Netlify",
+            "만든 도구가 알아서 해줘요",
+            "아직 없어요",
+            "잘 모르겠어요",
+            "다른 곳이에요"
           ],
           "primaryCta": [
             "제품 설명서 만들기 →"
@@ -75,10 +80,10 @@
           "disabledLabels": [
             "제품 설명서 만들기 →"
           ],
-          "bodyLen": 500,
+          "bodyLen": 652,
           "errorish": 0,
           "guidanceish": 0,
-          "koLeakChars": 307,
+          "koLeakChars": 392,
           "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 1 아이디어 → 2 이해 → 3 질문 → 4 완성 ← 처음 선택으로 돌아가기 어떤 제품을 만들고 싶으신가요? 완성된 문장이 아니어도 괜찮습니다. 아이디어를 자유롭게 적어주세요. 예시로 시작하기 회의 녹음을 요약해서 할 일을 Linear로 보내주는 앱 사진을 올리면 쇼핑몰 상품 설명을 자동으로 써주는 도구 고객 문의를 분석해서 FAQ를 자동으로 정리해주는 서비스 심사에게 더 알려줄 내용이 있나요? (선택) 몇 가지만 알려주세요 (선택) — 안내를 맞춰 드려요 어디서 돌아가는 앱인가요? 웹사이트·웹앱 휴대폰 앱 잘"
         },
         {
@@ -108,7 +113,12 @@
             "네",
             "조금",
             "아뇨",
-            "Simsa가 이해하는 중…"
+            "Vercel",
+            "Netlify",
+            "만든 도구가 알아서 해줘요",
+            "아직 없어요",
+            "잘 모르겠어요",
+            "다른 곳이에요"
           ],
           "primaryCta": [
             "Simsa가 이해하는 중…"
@@ -120,10 +130,10 @@
           "disabledLabels": [
             "Simsa가 이해하는 중…"
           ],
-          "bodyLen": 518,
+          "bodyLen": 670,
           "errorish": 0,
           "guidanceish": 0,
-          "koLeakChars": 316,
+          "koLeakChars": 401,
           "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 1 아이디어 → 2 이해 → 3 질문 → 4 완성 ← 처음 선택으로 돌아가기 어떤 제품을 만들고 싶으신가요? 완성된 문장이 아니어도 괜찮습니다. 아이디어를 자유롭게 적어주세요. 예시로 시작하기 회의 녹음을 요약해서 할 일을 Linear로 보내주는 앱 사진을 올리면 쇼핑몰 상품 설명을 자동으로 써주는 도구 고객 문의를 분석해서 FAQ를 자동으로 정리해주는 서비스 심사에게 더 알려줄 내용이 있나요? (선택) 몇 가지만 알려주세요 (선택) — 안내를 맞춰 드려요 어디서 돌아가는 앱인가요? 웹사이트·웹앱 휴대폰 앱 잘"
         }
       ],
@@ -157,7 +167,15 @@
             "Windsurf",
             "Codex",
             "직접 코딩",
-            "프로젝트 만들고 코드 연결하기 →"
+            "Vercel",
+            "Netlify",
+            "만든 도구가 알아서 해줘요",
+            "아직 없어요",
+            "잘 모르겠어요",
+            "다른 곳이에요",
+            "Supabase",
+            "Firebase",
+            "만든 도구 안에 있어요"
           ],
           "primaryCta": [
             "프로젝트 만들고 코드 연결하기 →"
@@ -169,11 +187,11 @@
           "disabledLabels": [
             "프로젝트 만들고 코드 연결하기 →"
           ],
-          "bodyLen": 407,
+          "bodyLen": 588,
           "errorish": 0,
           "guidanceish": 0,
-          "koLeakChars": 219,
-          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO ← 처음 선택으로 돌아가기 앱에 대해 알려주세요 기본 정보만 적으면 — 바로 코드를 연결하고 검수할 수 있어요. 앱 이름 이 앱을 어떤 도구로 만들었나요? 해당하는 것 모두 골라주세요. 각 도구의 방식에 맞춰 확인 품질을 높이는 데 써요. v0 Lovable Bolt Cursor Claude Code Replit Windsurf Codex 직접 코딩 무엇을 하는 앱인가요? (선택) 꼭 작동해야 하는 건 뭔가요? (선택) 2~3개면 충분해요. 적어주시면 확인 항목이 내 앱에 맞게 만들어져요. 프로젝트 만들고 코드"
+          "koLeakChars": 323,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO ← 처음 선택으로 돌아가기 앱에 대해 알려주세요 기본 정보만 적으면 — 바로 코드를 연결하고 검수할 수 있어요. 앱 이름 이 앱을 어떤 도구로 만들었나요? 해당하는 것 모두 골라주세요. 각 도구의 방식에 맞춰 확인 품질을 높이는 데 써요. v0 Lovable Bolt Cursor Claude Code Replit Windsurf Codex 직접 코딩 몇 가지만 알려주세요 (선택) — 안내를 맞춰 드려요 앱이 인터넷 어디에 올라가 있나요? Vercel Netlify 만든 도구가 알아서 해줘요 아직 없어요 잘 모르"
         },
         {
           "label": "code 스텝1 입력 후",
@@ -199,7 +217,15 @@
             "Windsurf",
             "Codex",
             "직접 코딩",
-            "프로젝트 만들고 코드 연결하기 →"
+            "Vercel",
+            "Netlify",
+            "만든 도구가 알아서 해줘요",
+            "아직 없어요",
+            "잘 모르겠어요",
+            "다른 곳이에요",
+            "Supabase",
+            "Firebase",
+            "만든 도구 안에 있어요"
           ],
           "primaryCta": [
             "프로젝트 만들고 코드 연결하기 →"
@@ -209,17 +235,17 @@
           "deadEnd": false,
           "disabledCount": 0,
           "disabledLabels": [],
-          "bodyLen": 407,
+          "bodyLen": 588,
           "errorish": 0,
           "guidanceish": 0,
-          "koLeakChars": 219,
-          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO ← 처음 선택으로 돌아가기 앱에 대해 알려주세요 기본 정보만 적으면 — 바로 코드를 연결하고 검수할 수 있어요. 앱 이름 이 앱을 어떤 도구로 만들었나요? 해당하는 것 모두 골라주세요. 각 도구의 방식에 맞춰 확인 품질을 높이는 데 써요. v0 Lovable Bolt Cursor Claude Code Replit Windsurf Codex 직접 코딩 무엇을 하는 앱인가요? (선택) 꼭 작동해야 하는 건 뭔가요? (선택) 2~3개면 충분해요. 적어주시면 확인 항목이 내 앱에 맞게 만들어져요. 프로젝트 만들고 코드"
+          "koLeakChars": 323,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO ← 처음 선택으로 돌아가기 앱에 대해 알려주세요 기본 정보만 적으면 — 바로 코드를 연결하고 검수할 수 있어요. 앱 이름 이 앱을 어떤 도구로 만들었나요? 해당하는 것 모두 골라주세요. 각 도구의 방식에 맞춰 확인 품질을 높이는 데 써요. v0 Lovable Bolt Cursor Claude Code Replit Windsurf Codex 직접 코딩 몇 가지만 알려주세요 (선택) — 안내를 맞춰 드려요 앱이 인터넷 어디에 올라가 있나요? Vercel Netlify 만든 도구가 알아서 해줘요 아직 없어요 잘 모르"
         },
         {
           "label": "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가",
           "note": "",
           "locale": "ko",
-          "url": "https://app.trysimsa.com/projects/proj_uuk5e3iq/settings",
+          "url": "https://app.trysimsa.com/projects/proj_pe8vd4xq/settings",
           "h1": [
             "준비와 연결"
           ],
@@ -235,17 +261,19 @@
             "✕",
             "키 찾는 방법",
             "✕",
-            "+ Resend (이메일 보내기)",
+            "키 찾는 방법",
+            "✕",
+            "+ Firebase (데이터 저장·로그인)",
             "+ Sentry (오류 추적)",
+            "+ 추가",
             "Claude Code",
             "Codex",
+            "Cursor",
+            "Windsurf",
+            "Gemini CLI",
             "복사",
             "복사",
-            "작성하고 저장하기",
-            "저장",
-            "저장",
-            "새로고침",
-            "다음: 코드 변경 →"
+            "작성하고 저장하기"
           ],
           "primaryCta": [
             "GitHub 연결",
@@ -254,22 +282,23 @@
           "primaryCtaCount": 2,
           "hasExit": true,
           "deadEnd": false,
-          "disabledCount": 2,
+          "disabledCount": 3,
           "disabledLabels": [
+            "+ 추가",
             "저장",
             "저장"
           ],
-          "bodyLen": 3315,
+          "bodyLen": 3506,
           "errorish": 0,
           "guidanceish": 2,
-          "koLeakChars": 1745,
-          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 1 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 준비와 연결 앱에 필요한 서비스와 키를 준비하고, 알림을 설정하고, 코드가 있는 곳을 연결하는 — 이 프로젝트를 위해 한 번 해두는 것들이에요. GitHub 연결 GitHub 계정을 연결하면 이 프로젝트에 쓸 저장소를 고를 수 있어요. GitHub 연결 현재 브라우저에 로그인된 GitHub 계정으로 연결됩니다. github.com에서 로그아웃 GitHu"
+          "koLeakChars": 1824,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 ✓ 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 준비와 연결 앱에 필요한 서비스와 키를 준비하고, 알림을 설정하고, 코드가 있는 곳을 연결하는 — 이 프로젝트를 위해 한 번 해두는 것들이에요. GitHub 연결 GitHub 계정을 연결하면 이 프로젝트에 쓸 저장소를 고를 수 있어요. GitHub 연결 현재 브라우저에 로그인된 GitHub 계정으로 연결됩니다. github.com에서 로그아웃 GitHu"
         },
         {
           "label": "개요 — 지금 할 일이 이 갈래에 맞는가",
           "note": "",
           "locale": "ko",
-          "url": "https://app.trysimsa.com/projects/proj_uuk5e3iq",
+          "url": "https://app.trysimsa.com/projects/proj_pe8vd4xq",
           "h1": [
             "동네 빵집 예약 테스트앱"
           ],
@@ -292,17 +321,17 @@
           "disabledLabels": [
             "도움받기"
           ],
-          "bodyLen": 588,
+          "bodyLen": 1126,
           "errorish": 0,
           "guidanceish": 1,
-          "koLeakChars": 349,
-          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 1 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 동네 빵집 예약 테스트앱 빵을 예약하고 픽업 시간을 고르는 앱 지금 할 일 1 준비 2 만들기·검수 3 결과·수정 1. 제품 설명서 확인 — 만들고 싶은 제품을 Simsa가 제대로 이해했는지 봐주세요. 2. 코드 저장소 연결 — AI가 만든 코드가 있는 GitHub 저장소를 연결하세요. 3. 확인 실행 — 코드 변경을 골라 검수 항목 기준으로 확인하세요"
+          "koLeakChars": 724,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 ✓ 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 동네 빵집 예약 테스트앱 원하는 시간에 빵을 픽업하기 위해 미리 예약하는 웹앱 지금 할 일 ✓ 준비 2 만들기·검수 3 결과·수정 1. 제품 설명서 확인 — 만들고 싶은 제품을 Simsa가 제대로 이해했는지 봐주세요. 2. 코드 저장소 연결 — AI가 만든 코드가 있는 GitHub 저장소를 연결하세요. 3. 확인 실행 — 코드 변경을 골라 검수 항목 기"
         },
         {
           "label": "checks 첫 화면 — 모드 선택/소스 없이 안내",
           "note": "",
           "locale": "ko",
-          "url": "https://app.trysimsa.com/projects/proj_uuk5e3iq/checks",
+          "url": "https://app.trysimsa.com/projects/proj_pe8vd4xq/checks",
           "h1": [
             "확인 결과"
           ],
@@ -330,13 +359,13 @@
           "errorish": 0,
           "guidanceish": 0,
           "koLeakChars": 391,
-          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 1 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 확인 결과 확인 항목을 기준으로 제품을 확인한 결과예요. 제품 설명서 기준 사전 확인 코드를 연결하기 전에 제품 설명서와 검수 항목을 확인합니다. 어떻게 검수할까요? 기본 검수 선택됨 AI가 검수하고, 문제로 판정된 항목은 다른 AI가 한 번 더 교차 확인해요 — 모든 플랜에 포함. 협의체 검수 유료 플랜 AI 3개가 각자 검토하고, 의견이 갈리면 토론"
+          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 ✓ 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 확인 결과 확인 항목을 기준으로 제품을 확인한 결과예요. 제품 설명서 기준 사전 확인 코드를 연결하기 전에 제품 설명서와 검수 항목을 확인합니다. 어떻게 검수할까요? 기본 검수 선택됨 AI가 검수하고, 문제로 판정된 항목은 다른 AI가 한 번 더 교차 확인해요 — 모든 플랜에 포함. 협의체 검수 유료 플랜 AI 3개가 각자 검토하고, 의견이 갈리면 토론"
         },
         {
           "label": "소스 없이 검수 시도 — 막힘 안내",
           "note": "",
           "locale": "ko",
-          "url": "https://app.trysimsa.com/projects/proj_uuk5e3iq/checks",
+          "url": "https://app.trysimsa.com/projects/proj_pe8vd4xq/checks",
           "h1": [
             "확인 결과"
           ],
@@ -364,7 +393,7 @@
           "errorish": 0,
           "guidanceish": 2,
           "koLeakChars": 393,
-          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 1 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 코드를 먼저 연결하세요. 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 확인 결과 확인 항목을 기준으로 제품을 확인한 결과예요. 제품 설명서 기준 사전 확인 코드를 연결하기 전에 제품 설명서와 검수 항목을 확인합니다. 어떻게 검수할까요? 기본 검수 선택됨 AI가 검수하고, 문제로 판정된 항목은 다른 AI가 한 번 더 교차 확인해요 — 모든 플랜에 포함. 협의체 검수 유료 플랜 AI 3개가 각자 검토하고, 의견이 갈리면 "
+          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 동네 빵집 예약 테스트앱 개요 ✓ 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 코드를 먼저 연결하세요. 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 확인 결과 확인 항목을 기준으로 제품을 확인한 결과예요. 제품 설명서 기준 사전 확인 코드를 연결하기 전에 제품 설명서와 검수 항목을 확인합니다. 어떻게 검수할까요? 기본 검수 선택됨 AI가 검수하고, 문제로 판정된 항목은 다른 AI가 한 번 더 교차 확인해요 — 모든 플랜에 포함. 협의체 검수 유료 플랜 AI 3개가 각자 검토하고, 의견이 갈리면 "
         }
       ],
       "failure": null
@@ -471,17 +500,17 @@
           "deadEnd": false,
           "disabledCount": 0,
           "disabledLabels": [],
-          "bodyLen": 2854,
+          "bodyLen": 2193,
           "errorish": 0,
           "guidanceish": 0,
-          "koLeakChars": 1815,
-          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 이 앱을 어떤 도구로 만들었나요? 해당하는 것 모두 골라주세요. 각 도구의 방식에 맞춰 확인 품질을 높이는 데 써요. v0 Lovable Bolt Cursor Claude Code Replit Windsurf Codex 직접 코딩 ✓ 제품 설명서 초안이 완성됐습니다 저장하면 프로젝트 페이지에서 언제든 확인할 수 있습니다. 반려견 산책 기록 앱 반려견의 산책 거리와 시간을 자동으로 기록하고 주간 통계로 보며 다른 보호자와 공유하는 웹앱 누가 쓰는 제품 20~50대 반려견 보호자, 반려견의 일일 운동량 관리에 관심"
+          "koLeakChars": 1364,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 전체 프로젝트 회의록 자동 요약 앱예시 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 이 앱을 어떤 도구로 만들었나요? 해당하는 것 모두 골라주세요. 각 도구의 방식에 맞춰 확인 품질을 높이는 데 써요. v0 Lovable Bolt Cursor Claude Code Replit Windsurf Codex 직접 코딩 ✓ 제품 설명서 초안이 완성됐습니다 저장하면 프로젝트 페이지에서 언제든 확인할 수 있습니다. 반려견 산책 기록 앱 반려견의 산책을 기록하고 주간 통계를 확인하며 가족·친구와 공유할 수 있는 웹앱 누가 쓰는 제품 반려견 1마리 이상을 키우는 보호자, 반려견의 건강 관리와 운동량을 추적하"
         },
         {
           "label": "저장 후 랜딩 — 다음 행동",
           "note": "",
           "locale": "ko",
-          "url": "https://app.trysimsa.com/projects/proj_uvxcw1dt",
+          "url": "https://app.trysimsa.com/projects/proj_pffglck3",
           "h1": [
             "반려견 산책 기록 앱"
           ],
@@ -505,11 +534,11 @@
           "disabledLabels": [
             "도움받기"
           ],
-          "bodyLen": 1323,
+          "bodyLen": 1089,
           "errorish": 0,
           "guidanceish": 1,
-          "koLeakChars": 857,
-          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 반려견 산책 기록 앱 개요 ✓ 준비 아이디어 제품 설명서 확인 항목 2 만들기·검수 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 반려견 산책 기록 앱 반려견의 산책 거리와 시간을 자동으로 기록하고 주간 통계로 보며 다른 보호자와 공유하는 웹앱 지금 할 일 ✓ 준비 2 만들기·검수 3 결과·수정 1. 제품 설명서 확인 — 만들고 싶은 제품을 Simsa가 제대로 이해했는지 봐주세요. 2. 코드 저장소 연결 — AI가 만든 코드가 있는 GitHub 저장소를 연결하세요. 3. 확인 실행 — 코드 변경을 골"
+          "koLeakChars": 688,
+          "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 반려견 산책 기록 앱 개요 ✓ 준비 아이디어 제품 설명서 확인 항목 2 만들기·검수 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 반려견 산책 기록 앱 반려견의 산책을 기록하고 주간 통계를 확인하며 가족·친구와 공유할 수 있는 웹앱 지금 할 일 ✓ 준비 2 만들기·검수 3 결과·수정 1. 제품 설명서 확인 — 만들고 싶은 제품을 Simsa가 제대로 이해했는지 봐주세요. 2. 코드 저장소 연결 — AI가 만든 코드가 있는 GitHub 저장소를 연결하세요. 3. 확인 실행 — 코드 변경을 골라 검수 항목"
         }
       ],
       "failure": null
@@ -522,7 +551,7 @@
           "label": "settings/연결 화면 — 미연결 유저가 보는 것",
           "note": "",
           "locale": "ko",
-          "url": "https://app.trysimsa.com/projects/proj_uw0sz1e9/settings",
+          "url": "https://app.trysimsa.com/projects/proj_pfj9lk7g/settings",
           "h1": [
             "준비와 연결"
           ],
@@ -537,17 +566,20 @@
             "키 찾는 방법",
             "✕",
             "+ Supabase (데이터 저장·로그인)",
+            "+ Firebase (데이터 저장·로그인)",
             "+ Resend (이메일 보내기)",
             "+ Sentry (오류 추적)",
+            "+ 추가",
             "Claude Code",
             "Codex",
+            "Cursor",
+            "Windsurf",
+            "Gemini CLI",
             "복사",
             "복사",
             "작성하고 저장하기",
             "저장",
-            "저장",
-            "새로고침",
-            "다음: 코드 변경 →"
+            "저장"
           ],
           "primaryCta": [
             "GitHub 연결",
@@ -556,15 +588,16 @@
           "primaryCtaCount": 2,
           "hasExit": true,
           "deadEnd": false,
-          "disabledCount": 2,
+          "disabledCount": 3,
           "disabledLabels": [
+            "+ 추가",
             "저장",
             "저장"
           ],
-          "bodyLen": 2960,
+          "bodyLen": 2986,
           "errorish": 0,
           "guidanceish": 2,
-          "koLeakChars": 1605,
+          "koLeakChars": 1591,
           "bodyHead": "Simsa « ＋ 새 프로젝트 ← 전체 프로젝트 연결 여정 테스트 개요 1 준비 선택 아이디어 제품 설명서 확인 항목 2 만들기·검수 코드 변경 빌더 팩 3 결과·수정 확인 결과 시각 검수 고급 + 언제든지 준비·설정 연결 도움말 · 피드백 GitHub에서 별 주기 요금 안내 이용약관 개인정보처리방침 환불 정책 M 워크스페이스 로그인 → ⌃ EN KO 준비와 연결 앱에 필요한 서비스와 키를 준비하고, 알림을 설정하고, 코드가 있는 곳을 연결하는 — 이 프로젝트를 위해 한 번 해두는 것들이에요. GitHub 연결 GitHub 계정을 연결하면 이 프로젝트에 쓸 저장소를 고를 수 있어요. GitHub 연결 현재 브라우저에 로그인된 GitHub 계정으로 연결됩니다. github.com에서 로그아웃 GitHub이 처"
         }
       ],
@@ -702,7 +735,12 @@
             "Yes",
             "A little",
             "No",
-            "Create product brief →"
+            "Vercel",
+            "Netlify",
+            "My building tool handles it",
+            "Nowhere yet",
+            "Not sure",
+            "Somewhere else"
           ],
           "primaryCta": [
             "Create product brief →"
@@ -714,7 +752,7 @@
           "disabledLabels": [
             "Create product brief →"
           ],
-          "bodyLen": 873,
+          "bodyLen": 1115,
           "errorish": 0,
           "guidanceish": 1,
           "koLeakChars": 8,
@@ -747,7 +785,12 @@
             "Yes",
             "A little",
             "No",
-            "Simsa is reading…"
+            "Vercel",
+            "Netlify",
+            "My building tool handles it",
+            "Nowhere yet",
+            "Not sure",
+            "Somewhere else"
           ],
           "primaryCta": [
             "Simsa is reading…"
@@ -759,7 +802,7 @@
           "disabledLabels": [
             "Simsa is reading…"
           ],
-          "bodyLen": 895,
+          "bodyLen": 1137,
           "errorish": 0,
           "guidanceish": 1,
           "koLeakChars": 8,
@@ -796,7 +839,15 @@
             "Windsurf",
             "Codex",
             "Hand-coded",
-            "Create project & connect code →"
+            "Vercel",
+            "Netlify",
+            "My building tool handles it",
+            "Nowhere yet",
+            "Not sure",
+            "Somewhere else",
+            "Supabase",
+            "Firebase",
+            "Inside my building tool"
           ],
           "primaryCta": [
             "Create project & connect code →"
@@ -808,7 +859,7 @@
           "disabledLabels": [
             "Create project & connect code →"
           ],
-          "bodyLen": 618,
+          "bodyLen": 921,
           "errorish": 0,
           "guidanceish": 2,
           "koLeakChars": 8,
@@ -838,7 +889,15 @@
             "Windsurf",
             "Codex",
             "Hand-coded",
-            "Create project & connect code →"
+            "Vercel",
+            "Netlify",
+            "My building tool handles it",
+            "Nowhere yet",
+            "Not sure",
+            "Somewhere else",
+            "Supabase",
+            "Firebase",
+            "Inside my building tool"
           ],
           "primaryCta": [
             "Create project & connect code →"
@@ -848,7 +907,7 @@
           "deadEnd": false,
           "disabledCount": 0,
           "disabledLabels": [],
-          "bodyLen": 618,
+          "bodyLen": 921,
           "errorish": 0,
           "guidanceish": 2,
           "koLeakChars": 8,
@@ -858,7 +917,7 @@
           "label": "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가",
           "note": "",
           "locale": "en",
-          "url": "https://app.trysimsa.com/projects/proj_uwxezfev/settings",
+          "url": "https://app.trysimsa.com/projects/proj_ph0q436r/settings",
           "h1": [
             "Prep & connections"
           ],
@@ -872,18 +931,21 @@
             "Connect GitHub",
             "How to get the keys",
             "✕",
-            "+ Supabase (data & sign-in)",
-            "+ Resend (sending email)",
+            "How to get the keys",
+            "✕",
+            "How to get the keys",
+            "✕",
+            "+ Firebase (data & sign-in)",
             "+ Sentry (error tracking)",
+            "+ Add",
             "Claude Code",
             "Codex",
+            "Cursor",
+            "Windsurf",
+            "Gemini CLI",
             "Copy",
             "Copy",
-            "Save setup",
-            "Save",
-            "Save",
-            "Refresh",
-            "Next: Code changes →"
+            "Save setup"
           ],
           "primaryCta": [
             "Connect GitHub",
@@ -892,22 +954,23 @@
           "primaryCtaCount": 2,
           "hasExit": true,
           "deadEnd": false,
-          "disabledCount": 2,
+          "disabledCount": 3,
           "disabledLabels": [
+            "+ Add",
             "Save",
             "Save"
           ],
-          "bodyLen": 4951,
+          "bodyLen": 5683,
           "errorish": 0,
           "guidanceish": 15,
           "koLeakChars": 0,
-          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview 1 Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Review results Visual checks ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Prep & connections Get the app's service"
+          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview ✓ Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Review results Visual checks ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Prep & connections Get the app's service"
         },
         {
           "label": "개요 — 지금 할 일이 이 갈래에 맞는가",
           "note": "",
           "locale": "en",
-          "url": "https://app.trysimsa.com/projects/proj_uwxezfev",
+          "url": "https://app.trysimsa.com/projects/proj_ph0q436r",
           "h1": [
             "Bakery reservation test app"
           ],
@@ -930,17 +993,17 @@
           "disabledLabels": [
             "Get help"
           ],
-          "bodyLen": 1092,
+          "bodyLen": 1944,
           "errorish": 0,
           "guidanceish": 2,
           "koLeakChars": 0,
-          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview 1 Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Review results Visual checks ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Bakery reservation test app Reserve brea"
+          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview ✓ Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Review results Visual checks ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Bakery reservation test app A web app wh"
         },
         {
           "label": "checks 첫 화면 — 모드 선택/소스 없이 안내",
           "note": "",
           "locale": "en",
-          "url": "https://app.trysimsa.com/projects/proj_uwxezfev/checks",
+          "url": "https://app.trysimsa.com/projects/proj_ph0q436r/checks",
           "h1": [
             "Review results"
           ],
@@ -968,13 +1031,13 @@
           "errorish": 0,
           "guidanceish": 4,
           "koLeakChars": 0,
-          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview 1 Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Review results Visual checks ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Review results The results of checking y"
+          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview ✓ Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Review results Visual checks ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Review results The results of checking y"
         },
         {
           "label": "소스 없이 검수 시도 — 막힘 안내",
           "note": "",
           "locale": "en",
-          "url": "https://app.trysimsa.com/projects/proj_uwxezfev/checks",
+          "url": "https://app.trysimsa.com/projects/proj_ph0q436r/checks",
           "h1": [
             "Review results"
           ],
@@ -1002,7 +1065,7 @@
           "errorish": 0,
           "guidanceish": 6,
           "koLeakChars": 0,
-          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview 1 Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Connect your code first. ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Review results The results of checking your "
+          "bodyHead": "Simsa « ＋ New project ← All projects Bakery reservation test app Overview ✓ Prepare optional Idea Product brief Acceptance items 2 Build & review Code changes Builder pack 3 Results & fixes Connect your code first. ADVANCED + ANYTIME Prep & connections Sources Help & feedback Star on GitHub See pricing Terms Privacy Refunds M Workspace Sign in → ⌃ EN KO Review results The results of checking your "
         }
       ],
       "failure": null
@@ -1075,7 +1138,7 @@
       "journey": "J1 기존-앱 갈래: 만든 앱 검수받기 완주",
       "locale": "ko",
       "step": "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가",
-      "what": "비활성 버튼 2개(저장/저장) — 이유 표시 스크린샷 확인"
+      "what": "비활성 버튼 3개(+ 추가/저장/저장) — 이유 표시 스크린샷 확인"
     },
     {
       "sev": "P2",
@@ -1110,7 +1173,7 @@
       "journey": "J3 repo 연결 여정: GitHub 미연결 신규 유저",
       "locale": "ko",
       "step": "settings/연결 화면 — 미연결 유저가 보는 것",
-      "what": "비활성 버튼 2개(저장/저장) — 이유 표시 스크린샷 확인"
+      "what": "비활성 버튼 3개(+ 추가/저장/저장) — 이유 표시 스크린샷 확인"
     },
     {
       "sev": "P2",
@@ -1138,7 +1201,7 @@
       "journey": "J1 기존-앱 갈래: 만든 앱 검수받기 완주",
       "locale": "en",
       "step": "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가",
-      "what": "비활성 버튼 2개(Save/Save) — 이유 표시 스크린샷 확인"
+      "what": "비활성 버튼 3개(+ Add/Save/Save) — 이유 표시 스크린샷 확인"
     },
     {
       "sev": "P2",


### PR DESCRIPTION
## 무엇 (라이브 QA에서 발견)
브라우저로 실제 완주하다 잡은 결함입니다. 유저가 **호스팅=Netlify · 데이터=기타("우리회사 사내 포스그레스")**를 답했는데도 빌더팩이 **중립 안내**로 생성됐습니다.

진범: `/workspace/export-builder-pack` 라우트의 `userProfile` 정규화가 **닫힌 enum 화이트리스트**(platform/githubLevel/aiToolLevel)라, P2(#477)에서 추가한 `hosting·hostingOther·data·dataOther`를 **조용히 버렸습니다**. 서버 어댑터는 정상인데 입력이 도달하지 못한 상태 → Phase 2 서버 절반이 실사용자에게 발효되지 않고 있었습니다.

- 4개 축을 정규화에 추가. **닫힌 enum이 아니라 문자열 캡(40/80자)만** — 카탈로그 확장과 "기타" 자유입력을 서버가 막으면 안 되므로(D-3), 미지 id는 소비자 쪽 중립 처리(D-2)에 맡깁니다.
- 라우트가 `ExportUserProfile` 타입을 직접 참조하도록 변경 — 로컬 형상 복제를 없애 같은 종류의 필드 누락 재발을 막습니다.

## 근본 원인 회고 (중요)
P2 테스트가 `generateBuilderPack`을 **직접 호출**해 라우트를 우회했습니다. 그래서 유닛 1,956개가 green인데 실제 유저 경로는 전혀 동작하지 않았습니다. 신규 `export-route-stack-profile.test.mjs`는 **HTTP 요청부터** 검증하며, 수정 전 코드에서 **6 fail / 3 pass**(중립 케이스만 통과)로 결함 재현을 확인했습니다.

## 검증
- 신규 9케이스(supabase/firebase/netlify/builder_hosted/기타 한글 자유입력/구필드 무회귀/정규화 유지)
- central-plane 1,969 pass / 0 fail, typecheck green
- journey-audit 2026-08-21 KO+EN 풀런 결과 동봉(P0=0 · P1=0 · P2=15)

⚠️ 배포 필요: 머지만으로는 발효되지 않습니다(central-plane 재배포 대상).

🤖 Generated with [Claude Code](https://claude.com/claude-code)