### PR TITLE
fix(llm): A-1 재시도 정책 분리 + A-2 실패 계측

### DIFF
--- a/apps/central-plane/src/workspace/anthropic-fetch.ts
+++ b/apps/central-plane/src/workspace/anthropic-fetch.ts
@@ -8,9 +8,92 @@
  * requests. Every workspace LLM call therefore retries transient statuses.
  */
 
-const RETRYABLE = new Set([403, 429, 500, 502, 503, 504, 529]);
+/**
+ * A-1 (2026-08-21 QA): 재시도 정책을 **오류 종류로 가른다**.
+ *
+ * 종전엔 한 정책(500ms × attempt, 총 ~7.5초)으로 전부 재시도했는데, 그 예산은
+ * 403(공유 egress가 플래그됨 — 다음 시도가 다른 IP라 즉시 재시도가 정답)에
+ * 맞춘 것이다. 반면 **429/503/529는 용량**이고 분 단위로 리셋되므로 7.5초로는
+ * 절대 넘길 수 없다 → 6회를 9초에 다 태우고 llm_unavailable.
+ * 실측(라이브 QA): 동일 페이로드 동시 4건 → 2건 성공 / 2건 503, 항목 수 무관.
+ *
+ * 그래서: FAST는 종전 그대로 촘촘히, CAPACITY는 지수 백오프 + `retry-after`
+ * 준수. 단 사용자가 무한정 기다리면 안 되므로 **총 예산(maxTotalMs)으로 컷**한다
+ * — 예산을 넘길 대기라면 시도하지 않고 정직하게 실패한다.
+ */
+const FAST_RETRY = new Set([403, 500, 502, 504]);
+const CAPACITY_RETRY = new Set([429, 503, 529]);
+const RETRYABLE = new Set([...FAST_RETRY, ...CAPACITY_RETRY]);
 const MAX_ATTEMPTS = 6; // 403 "Request not allowed" hits ~60% of CF egress
 // attempts; more attempts + jitter is the only lever that raises success.
+
+/**
+ * 재시도 대기 총합의 상한. 호출자 쪽 타임아웃(대시보드 check-draft 25s)보다
+ * 짧게 잡아, 서버가 붙들고 있다가 클라이언트가 먼저 끊는 상황을 만들지 않는다.
+ */
+const DEFAULT_MAX_TOTAL_MS = 12_000;
+
+/** `retry-after`(초 또는 HTTP date) → ms. 파싱 불가/과대값은 무시한다. */
+export function parseRetryAfterMs(header: string | null, nowMs: number): number | null {
+  if (!header) return null;
+  const secs = Number(header.trim());
+  if (Number.isFinite(secs)) return secs >= 0 && secs <= 60 ? Math.round(secs * 1000) : null;
+  const at = Date.parse(header);
+  if (!Number.isFinite(at)) return null;
+  const delta = at - nowMs;
+  return delta > 0 && delta <= 60_000 ? delta : null;
+}
+
+/**
+ * 다음 시도까지의 대기. FAST는 종전 공식 유지(회귀 없음), CAPACITY는 지수
+ * 백오프(1s·2s·4s…, 상한 6s)에 `retry-after`가 있으면 그것을 우선한다.
+ */
+export function retryDelayMs(status: number | null, attempt: number, retryAfterMs: number | null): number {
+  const jitter = (attempt * 137) % 400;
+  if (status !== null && CAPACITY_RETRY.has(status)) {
+    if (retryAfterMs !== null) return retryAfterMs + jitter;
+    return Math.min(1000 * 2 ** (attempt - 1), 6000) + jitter;
+  }
+  // 403 등 egress성 오류 + 네트워크 예외: 종전 그대로 촘촘하게.
+  return 500 * attempt + jitter;
+}
+
+/**
+ * A-2 (2026-08-21 QA): 실패도 한 줄로 남긴다. 종전엔 모든 실패가 클라이언트에
+ * `llm_unavailable` 하나로만 보여 **무엇이 문제인지 집계할 수 없었다**(용량인지
+ * egress인지 타임아웃인지). 성공 로그(anthropic_usage)와 짝을 이루는 실패 로그로,
+ * Workers 로그에서 `event:"llm_failure"`를 집계하면 원인 분포가 나온다.
+ */
+export function logAnthropicFailure(
+  callSite: string,
+  model: string,
+  info: { finalStatus: number | null; attempts: number; latencyMs: number; reason: string },
+): void {
+  try {
+    console.log(
+      JSON.stringify({
+        event: "llm_failure",
+        vendor: "anthropic",
+        call_site: callSite,
+        model,
+        final_status: info.finalStatus,
+        failure_class:
+          info.finalStatus === null
+            ? "network"
+            : CAPACITY_RETRY.has(info.finalStatus)
+              ? "capacity"
+              : FAST_RETRY.has(info.finalStatus)
+                ? "egress"
+                : "other",
+        attempts: info.attempts,
+        latency_ms: info.latencyMs,
+        reason: info.reason,
+      }),
+    );
+  } catch {
+    // never let logging break the call
+  }
+}
 
 export type AnthropicMessagesBody = {
   model: string;
@@ -82,10 +165,26 @@ export async function anthropicMessages(
   endpoint: string = anthropicEndpoint(),
   /** Which workspace feature made this call (generate·check·fix·pr-review·recommend). */
   callSite = "unknown",
+  /** A-1: 재시도 예산·시계 주입(테스트에서 실제로 자지 않고 예산 계약을 검증). */
+  opts: {
+    maxTotalMs?: number;
+    sleepImpl?: (ms: number) => Promise<void>;
+    nowImpl?: () => number;
+  } = {},
 ): Promise<AnthropicMessagesData> {
   let lastErr: unknown = null;
-  const startedAt = Date.now();
+  let lastStatus: number | null = null;
+  let attemptsMade = 0;
+  /** 예산은 **재시도 대기의 총합**만 센다. 요청 자체의 소요는 포함하지 않는다 —
+   *  포함하면 generate(성공도 ~45초)처럼 느린 호출이 재시도를 한 번도 못 받는다. */
+  let sleptTotalMs = 0;
+  const maxTotalMs = opts.maxTotalMs ?? DEFAULT_MAX_TOTAL_MS;
+  const sleep = opts.sleepImpl ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  // 예산은 **사용자가 기다린 실제 시간** 기준 — 대기뿐 아니라 요청 지연도 포함한다.
+  const now = opts.nowImpl ?? (() => Date.now());
+  const startedAt = now();
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    attemptsMade = attempt;
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
     let resp: Response | null = null;
@@ -104,27 +203,54 @@ export async function anthropicMessages(
       });
     } catch (err) {
       lastErr = err; // network/abort — retryable
+      lastStatus = null;
     } finally {
       clearTimeout(timer);
     }
+    let retryAfterMs: number | null = null;
     if (resp) {
       if (resp.ok) {
         const data = (await resp.json()) as AnthropicMessagesData;
         // latency_ms is wall time including retries — what the user waited.
-        logAnthropicUsage(callSite, body.model, data.usage, Date.now() - startedAt);
+        logAnthropicUsage(callSite, body.model, data.usage, now() - startedAt);
         return data;
       }
       const tail = await resp.text().catch(() => "");
+      lastStatus = resp.status;
       lastErr = new Error(`Anthropic ${resp.status}: ${tail.slice(0, 200)}`);
-      if (!RETRYABLE.has(resp.status)) throw lastErr;
+      if (!RETRYABLE.has(resp.status)) {
+        logAnthropicFailure(callSite, body.model, {
+          finalStatus: resp.status,
+          attempts: attempt,
+          latencyMs: now() - startedAt,
+          reason: "non_retryable",
+        });
+        throw lastErr;
+      }
+      retryAfterMs = parseRetryAfterMs(resp.headers.get("retry-after"), now());
       console.warn(`[anthropic-fetch] attempt ${attempt} got ${resp.status} — retrying`);
     }
-    if (attempt < MAX_ATTEMPTS) {
-      // Jittered backoff — a longer, varied gap gives CF a chance to re-route
-      // egress before the next attempt (retries otherwise reuse a hot IP).
-      const base = 500 * attempt;
-      await new Promise((r) => setTimeout(r, base + Math.floor((attempt * 137) % 400)));
+    if (attempt >= MAX_ATTEMPTS) break;
+    // A-1: 오류 종류별 대기. 남은 예산을 넘길 대기라면 더 시도하지 않고
+    // 정직하게 실패한다 — 클라이언트 타임아웃까지 붙들고 있는 것이 더 나쁘다.
+    const delay = retryDelayMs(lastStatus, attempt, retryAfterMs);
+    if (sleptTotalMs + delay > maxTotalMs) {
+      logAnthropicFailure(callSite, body.model, {
+        finalStatus: lastStatus,
+        attempts: attempt,
+        latencyMs: now() - startedAt,
+        reason: "budget_exhausted",
+      });
+      throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
     }
+    sleptTotalMs += delay;
+    await sleep(delay);
   }
+  logAnthropicFailure(callSite, body.model, {
+    finalStatus: lastStatus,
+    attempts: attemptsMade,
+    latencyMs: now() - startedAt,
+    reason: "attempts_exhausted",
+  });
   throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
 }

--- a/apps/central-plane/test/anthropic-retry-policy.test.mjs
+++ b/apps/central-plane/test/anthropic-retry-policy.test.mjs
@@ -1,0 +1,178 @@
+/**
+ * anthropic-retry-policy.test.mjs — A-1/A-2 (2026-08-21 라이브 QA 대응).
+ *
+ * 배경: 동일 페이로드 동시 4건 중 2건이 503으로 실패했다. 원인은 재시도 예산이
+ * `500ms × attempt`(총 ~7.5초)뿐이라 **분 단위로 리셋되는 용량 오류(429/503/529)를
+ * 넘지 못한 것**. 그 예산은 403(공유 egress) 전용으로 튜닝된 값이었다.
+ *
+ * 여기서 고정하는 계약:
+ *   A-1 ① 용량 오류는 지수 백오프 + `retry-after` 우선
+ *        ② egress성 오류(403 등)는 종전 공식 유지(무회귀)
+ *        ③ 총 예산을 넘길 대기는 하지 않고 정직하게 실패
+ *   A-2 ④ 실패도 한 줄 구조화 로그(`llm_failure`)로 원인 분류가 남는다
+ */
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+const { anthropicMessages, retryDelayMs, parseRetryAfterMs } = await import("../dist/workspace/anthropic-fetch.js");
+
+const BODY = { model: "claude-haiku-4-5-20251001", max_tokens: 100, messages: [{ role: "user", content: "hi" }] };
+
+const okResponse = () =>
+  new Response(JSON.stringify({ content: [{ type: "text", text: "ok" }], usage: { input_tokens: 1, output_tokens: 1 } }), { status: 200 });
+const errResponse = (status, headers = {}) => new Response("upstream said no", { status, headers });
+
+/**
+ * 실제로 자지 않고 **가상 시계를 전진**시킨다 — 대기 값과 총 예산 계약을
+ * 실시간 없이 검증하기 위함(mock at the seam).
+ */
+function recorder() {
+  const slept = [];
+  let clock = 1_000_000;
+  return {
+    slept,
+    sleepImpl: async (ms) => { slept.push(ms); clock += ms; },
+    nowImpl: () => clock,
+    advance: (ms) => { clock += ms; },
+  };
+}
+
+describe("retryDelayMs — 오류 종류별 대기 (A-1)", () => {
+  it("용량 오류(429/503/529)는 지수 백오프 — 1s·2s·4s… 상한 6s", () => {
+    for (const status of [429, 503, 529]) {
+      const d1 = retryDelayMs(status, 1, null);
+      const d2 = retryDelayMs(status, 2, null);
+      const d3 = retryDelayMs(status, 3, null);
+      assert.ok(d1 >= 1000 && d1 < 1500, `${status} attempt1=${d1}`);
+      assert.ok(d2 >= 2000 && d2 < 2500, `${status} attempt2=${d2}`);
+      assert.ok(d3 >= 4000 && d3 < 4500, `${status} attempt3=${d3}`);
+      assert.ok(retryDelayMs(status, 6, null) <= 6400, "상한 6s + 지터");
+      assert.ok(d2 > d1 && d3 > d2, "단조 증가");
+    }
+  });
+
+  it("egress성 오류(403)와 네트워크 예외(null)는 종전 공식 유지 — 무회귀", () => {
+    // 종전: 500 * attempt + 지터. 용량 오류보다 촘촘해야 한다.
+    for (const status of [403, null]) {
+      assert.ok(retryDelayMs(status, 1, null) < 1000, `${status} attempt1`);
+      assert.ok(retryDelayMs(status, 3, null) < 2000, `${status} attempt3`);
+    }
+    assert.ok(retryDelayMs(403, 2, null) < retryDelayMs(429, 2, null), "403이 429보다 짧다");
+  });
+
+  it("retry-after가 있으면 용량 백오프보다 우선한다", () => {
+    assert.ok(retryDelayMs(429, 3, 800) < 1300, "서버가 0.8s라면 4s를 기다리지 않는다");
+    assert.ok(retryDelayMs(429, 1, 5000) >= 5000, "서버가 5s라면 그만큼 기다린다");
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  it("초 단위 숫자를 ms로", () => assert.equal(parseRetryAfterMs("2", Date.now()), 2000));
+  it("HTTP date를 남은 시간으로", () => {
+    const ms = parseRetryAfterMs(new Date(Date.now() + 3000).toUTCString(), Date.now());
+    assert.ok(ms !== null && ms > 1000 && ms <= 3000);
+  });
+  it("없음·파싱불가·과대값은 무시", () => {
+    assert.equal(parseRetryAfterMs(null, Date.now()), null);
+    assert.equal(parseRetryAfterMs("soon", Date.now()), null);
+    assert.equal(parseRetryAfterMs("9999", Date.now()), null);
+  });
+});
+
+describe("anthropicMessages — 예산과 실패 로그 (A-1·A-2)", () => {
+  it("용량 오류가 계속되면 총 예산에서 끊고 실패한다 (클라 타임아웃 전에)", async () => {
+    const { slept, sleepImpl, nowImpl } = recorder();
+    const fetchImpl = async () => errResponse(529);
+    await assert.rejects(
+      anthropicMessages("k", BODY, 1000, fetchImpl, "https://x/v1/messages", "check", { maxTotalMs: 5000, sleepImpl, nowImpl }),
+      /Anthropic 529/,
+    );
+    const total = slept.reduce((a, b) => a + b, 0);
+    assert.ok(total <= 5000, `누적 대기 ${total}ms 는 예산 이내여야 한다`);
+    assert.ok(slept.length >= 1 && slept.length < 6, "예산에서 잘려 6회를 다 쓰지 않는다");
+  });
+
+  it("예산은 **대기 총합**만 센다 — 느린 호출(generate)도 재시도를 받는다", async () => {
+    // 각 시도가 8초씩 걸리고 실패하는 상황: 요청 시간을 예산에 넣으면 첫 실패
+    // 직후 예산이 소진돼 재시도가 0회가 된다. 대기만 세면 정상적으로 재시도한다.
+    const { slept, sleepImpl, nowImpl, advance } = recorder();
+    let n = 0;
+    const fetchImpl = async () => {
+      advance(8000); // 느린 요청
+      return ++n < 3 ? errResponse(429) : okResponse();
+    };
+    const data = await anthropicMessages("k", BODY, 30_000, fetchImpl, "https://x/v1/messages", "generate", {
+      maxTotalMs: 12_000,
+      sleepImpl,
+      nowImpl,
+    });
+    assert.equal(data.content[0].text, "ok");
+    assert.equal(n, 3, "요청이 느려도 재시도가 이뤄져야 한다");
+    assert.ok(slept.length === 2);
+  });
+
+  it("예산이 넉넉하면 재시도 후 성공한다", async () => {
+    const { sleepImpl, nowImpl } = recorder();
+    let n = 0;
+    const fetchImpl = async () => (++n < 3 ? errResponse(429) : okResponse());
+    const data = await anthropicMessages("k", BODY, 1000, fetchImpl, "https://x/v1/messages", "check", { maxTotalMs: 60_000, sleepImpl, nowImpl });
+    assert.equal(data.content[0].text, "ok");
+    assert.equal(n, 3);
+  });
+
+  it("403은 종전처럼 촘촘히 재시도해 회복한다 (무회귀)", async () => {
+    const { slept, sleepImpl, nowImpl } = recorder();
+    let n = 0;
+    const fetchImpl = async () => (++n < 4 ? errResponse(403) : okResponse());
+    const data = await anthropicMessages("k", BODY, 1000, fetchImpl, "https://x/v1/messages", "generate", { sleepImpl, nowImpl });
+    assert.equal(data.content[0].text, "ok");
+    assert.ok(slept.every((ms) => ms < 2000), "403 재시도는 촘촘하다");
+  });
+
+  it("재시도 불가 오류(400)는 즉시 던진다", async () => {
+    const { slept, sleepImpl, nowImpl } = recorder();
+    const fetchImpl = async () => errResponse(400);
+    await assert.rejects(anthropicMessages("k", BODY, 1000, fetchImpl, "https://x/v1/messages", "check", { sleepImpl, nowImpl }), /Anthropic 400/);
+    assert.equal(slept.length, 0, "재시도 없음");
+  });
+
+  it("A-2: 실패는 llm_failure 한 줄로 원인 분류와 함께 남는다", async () => {
+    const logged = [];
+    const orig = console.log;
+    console.log = (...a) => { logged.push(String(a[0])); };
+    try {
+      const { sleepImpl, nowImpl } = recorder();
+      const fetchImpl = async () => errResponse(529);
+      await assert.rejects(
+        anthropicMessages("k", BODY, 1000, fetchImpl, "https://x/v1/messages", "check", { maxTotalMs: 3000, sleepImpl, nowImpl }),
+      );
+    } finally {
+      console.log = orig;
+    }
+    const line = logged.map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .find((j) => j && j.event === "llm_failure");
+    assert.ok(line, "llm_failure 로그가 있어야 한다");
+    assert.equal(line.call_site, "check");
+    assert.equal(line.final_status, 529);
+    assert.equal(line.failure_class, "capacity", "용량 오류로 분류되어 집계 가능해야 한다");
+    assert.ok(line.attempts >= 1);
+    assert.equal(typeof line.latency_ms, "number");
+  });
+
+  it("A-2: egress성 실패는 capacity와 구분되어 분류된다", async () => {
+    const logged = [];
+    const orig = console.log;
+    console.log = (...a) => { logged.push(String(a[0])); };
+    try {
+      const { sleepImpl, nowImpl } = recorder();
+      const fetchImpl = async () => errResponse(403);
+      await assert.rejects(anthropicMessages("k", BODY, 1000, fetchImpl, "https://x/v1/messages", "fix", { sleepImpl, nowImpl }));
+    } finally {
+      console.log = orig;
+    }
+    const line = logged.map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .find((j) => j && j.event === "llm_failure");
+    assert.ok(line);
+    assert.equal(line.failure_class, "egress");
+  });
+});


### PR DESCRIPTION
라이브 QA에서 확정한 P1-2(동시 요청 시 검수 실패)에 대한 수정입니다. 승인하신 순서대로 **A-2(계측) → A-1(정책)** 두 커밋으로 나눴습니다.

## A-2 — 실패 계측
모든 실패가 `llm_unavailable` 하나로만 보여 **원인 집계가 불가능**했습니다. 성공 로그(`anthropic_usage`)와 짝을 이루는 실패 로그를 추가합니다:
`{event:"llm_failure", call_site, model, final_status, failure_class, attempts, latency_ms, reason}`
- `failure_class`: capacity(429/503/529) · egress(403/500/502/504) · network · other
- `reason`: non_retryable · budget_exhausted · attempts_exhausted

## A-1 — 오류 종류별 백오프
- **FAST**(403 등): 종전 공식 유지 — egress는 즉시 재시도가 정답이므로 **무회귀**
- **CAPACITY**(429/503/529): 지수 백오프 1s·2s·4s(상한 6s), **`retry-after` 우선**
- **총 예산 12초로 컷** — 예산은 *재시도 대기 총합만* 셉니다. 요청 소요까지 넣으면 generate(성공도 ~45초)가 재시도를 한 번도 못 받습니다. 예산 초과 시 붙들지 않고 정직하게 실패(클라 타임아웃 25초 안쪽).

## 검증
- 신규 13케이스 — `sleepImpl`/`nowImpl` 주입 seam으로 **실시간 없이 예산 계약을 검증**
- 재현 시나리오: retry-after=2s → 1회 재시도로 회복(호출 2회) · 5초 용량 장애 → 7.4초에 회복(구 정책 예산으론 실패하던 구간)
- central-plane 1,982 pass / 0 fail, typecheck green

⚠️ 배포 후에야 발효됩니다. 배포 뒤 동시 4건 프로브로 재확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)