### PR TITLE
fix(llm): A'-4 지터 랜덤화 — 동시 요청 재시도 동기화 해소

### DIFF
--- a/apps/central-plane/src/workspace/anthropic-fetch.ts
+++ b/apps/central-plane/src/workspace/anthropic-fetch.ts
@@ -73,14 +73,27 @@ export function parseRetryAfterMs(header: string | null, nowMs: number): number 
  * 다음 시도까지의 대기. FAST는 종전 공식 유지(회귀 없음), CAPACITY는 지수
  * 백오프(1s·2s·4s…, 상한 6s)에 `retry-after`가 있으면 그것을 우선한다.
  */
-export function retryDelayMs(status: number | null, attempt: number, retryAfterMs: number | null): number {
-  const jitter = (attempt * 137) % 400;
-  if (status !== null && CAPACITY_RETRY.has(status)) {
-    if (retryAfterMs !== null) return retryAfterMs + jitter;
-    return Math.min(1000 * 2 ** (attempt - 1), 6000) + jitter;
+export function retryDelayMs(
+  status: number | null,
+  attempt: number,
+  retryAfterMs: number | null,
+  /** A′-4: 지터 난수(테스트 주입). */
+  rand: () => number = Math.random,
+): number {
+  // A′-4 (2026-08-21 라이브 로그): 종전 지터는 `(attempt*137)%400` — **결정론적**이라
+  // 같은 순간 실패한 요청들이 **정확히 같은 시각에 함께 재시도**했다. 그래서 동시
+  // 4건이 6회 내내 뭉쳐 다니며 매번 같이 거절당했다(성공한 건은 전부 attempt 1에서
+  // 성공, 첫 시도에 실패한 건은 6회 전부 실패 — 재시도가 무력했던 정확한 이유).
+  // equal jitter(base/2 + rand*base)로 재시도 시각을 흩어 동시성을 스스로 낮춘다.
+  if (status !== null && CAPACITY_RETRY.has(status) && retryAfterMs !== null) {
+    // 서버가 명시한 대기는 **하한**으로 존중하고, 그 위에만 흩뿌린다.
+    return retryAfterMs + Math.round(rand() * 500);
   }
-  // 403 등 egress성 오류 + 네트워크 예외: 종전 그대로 촘촘하게.
-  return 500 * attempt + jitter;
+  const base =
+    status !== null && CAPACITY_RETRY.has(status)
+      ? Math.min(1000 * 2 ** (attempt - 1), 6000)
+      : 500 * attempt; // 403 등 egress성 오류 + 네트워크 예외
+  return Math.round(base / 2 + rand() * base);
 }
 
 /**
@@ -209,6 +222,8 @@ export async function anthropicMessages(
     maxTotalMs?: number;
     sleepImpl?: (ms: number) => Promise<void>;
     nowImpl?: () => number;
+    /** A′-4: 지터 난수 주입(테스트 결정론화). */
+    randomImpl?: () => number;
   } = {},
 ): Promise<AnthropicMessagesData> {
   let lastErr: unknown = null;
@@ -283,7 +298,7 @@ export async function anthropicMessages(
     if (attempt >= MAX_ATTEMPTS) break;
     // A-1: 오류 종류별 대기. 남은 예산을 넘길 대기라면 더 시도하지 않고
     // 정직하게 실패한다 — 클라이언트 타임아웃까지 붙들고 있는 것이 더 나쁘다.
-    const delay = retryDelayMs(lastStatus, attempt, retryAfterMs);
+    const delay = retryDelayMs(lastStatus, attempt, retryAfterMs, opts.randomImpl);
     if (sleptTotalMs + delay > maxTotalMs) {
       logAnthropicFailure(callSite, body.model, {
         finalStatus: lastStatus,

--- a/apps/central-plane/src/workspace/anthropic-fetch.ts
+++ b/apps/central-plane/src/workspace/anthropic-fetch.ts
@@ -33,6 +33,31 @@ const MAX_ATTEMPTS = 6; // 403 "Request not allowed" hits ~60% of CF egress
  */
 const DEFAULT_MAX_TOTAL_MS = 12_000;
 
+/**
+ * A′-1 (2026-08-21 실측): 재시도할 때 **경로를 번갈아 쓴다**.
+ *
+ * A-2 계측이 밝힌 진범은 용량이 아니라 **403 egress**였다 — Anthropic이 Cloudflare
+ * egress IP에 "Request not allowed"를 준다. 종전엔 6회 재시도가 **모두 같은 경로**로
+ * 나갔고, 그 경로가 막히면 6회가 통째로 막혔다(라이브: 동시 4건 중 2~4건 실패,
+ * 로그상 attempt 1~6 전부 403).
+ *
+ * 게이트웨이와 직행은 서로 다른 출구다. 둘이 완전히 상관되지 않는 한 번갈아 쓰는
+ * 편이 한 경로로 6번 두드리는 것보다 낫다. 어느 쪽이 실제로 잘 되는지는 추측하지
+ * 않고 **로그로 집계**한다(성공·실패 양쪽에 endpoint_kind를 남긴다).
+ */
+export const DIRECT_ANTHROPIC_ENDPOINT = "https://api.anthropic.com/v1/messages";
+export type EndpointKind = "gateway" | "direct";
+
+export function endpointRotation(primary: string): Array<{ url: string; kind: EndpointKind }> {
+  if (!primary || primary === DIRECT_ANTHROPIC_ENDPOINT) {
+    return [{ url: DIRECT_ANTHROPIC_ENDPOINT, kind: "direct" }];
+  }
+  return [
+    { url: primary, kind: "gateway" },
+    { url: DIRECT_ANTHROPIC_ENDPOINT, kind: "direct" },
+  ];
+}
+
 /** `retry-after`(초 또는 HTTP date) → ms. 파싱 불가/과대값은 무시한다. */
 export function parseRetryAfterMs(header: string | null, nowMs: number): number | null {
   if (!header) return null;
@@ -67,7 +92,15 @@ export function retryDelayMs(status: number | null, attempt: number, retryAfterM
 export function logAnthropicFailure(
   callSite: string,
   model: string,
-  info: { finalStatus: number | null; attempts: number; latencyMs: number; reason: string },
+  info: {
+    finalStatus: number | null;
+    attempts: number;
+    latencyMs: number;
+    reason: string;
+    /** A′-1: 마지막으로 시도한 경로와 경로별 시도 횟수 — 어느 출구가 막히는지 집계용. */
+    endpointKind?: EndpointKind;
+    triedByEndpoint?: Record<string, number>;
+  },
 ): void {
   try {
     console.log(
@@ -88,6 +121,8 @@ export function logAnthropicFailure(
         attempts: info.attempts,
         latency_ms: info.latencyMs,
         reason: info.reason,
+        ...(info.endpointKind ? { endpoint_kind: info.endpointKind } : {}),
+        ...(info.triedByEndpoint ? { tried_by_endpoint: info.triedByEndpoint } : {}),
       }),
     );
   } catch {
@@ -124,6 +159,8 @@ export function logAnthropicUsage(
   model: string,
   usage: AnthropicMessagesData["usage"],
   latencyMs: number,
+  /** A′-1: 성공한 경로와 몇 번째 시도였는지 — 경로별 성공률 집계의 반쪽. */
+  meta?: { endpointKind?: EndpointKind; attempt?: number },
 ): void {
   try {
     console.log(
@@ -136,6 +173,8 @@ export function logAnthropicUsage(
         cache_creation_input_tokens: usage?.cache_creation_input_tokens ?? 0,
         cache_read_input_tokens: usage?.cache_read_input_tokens ?? 0,
         latency_ms: latencyMs,
+        ...(meta?.endpointKind ? { endpoint_kind: meta.endpointKind } : {}),
+        ...(meta?.attempt ? { attempt: meta.attempt } : {}),
       }),
     );
   } catch {
@@ -180,16 +219,22 @@ export async function anthropicMessages(
   let sleptTotalMs = 0;
   const maxTotalMs = opts.maxTotalMs ?? DEFAULT_MAX_TOTAL_MS;
   const sleep = opts.sleepImpl ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
-  // 예산은 **사용자가 기다린 실제 시간** 기준 — 대기뿐 아니라 요청 지연도 포함한다.
   const now = opts.nowImpl ?? (() => Date.now());
   const startedAt = now();
+  // A′-1: 시도마다 경로를 번갈아 쓴다(게이트웨이 → 직행 → 게이트웨이 …).
+  const rotation = endpointRotation(endpoint);
+  const triedByEndpoint: Record<string, number> = {};
+  let lastKind: EndpointKind = rotation[0]!.kind;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     attemptsMade = attempt;
+    const target = rotation[(attempt - 1) % rotation.length]!;
+    lastKind = target.kind;
+    triedByEndpoint[target.kind] = (triedByEndpoint[target.kind] ?? 0) + 1;
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
     let resp: Response | null = null;
     try {
-      resp = await fetchImpl(endpoint, {
+      resp = await fetchImpl(target.url, {
         method: "POST",
         signal: ctrl.signal,
         headers: {
@@ -212,7 +257,10 @@ export async function anthropicMessages(
       if (resp.ok) {
         const data = (await resp.json()) as AnthropicMessagesData;
         // latency_ms is wall time including retries — what the user waited.
-        logAnthropicUsage(callSite, body.model, data.usage, now() - startedAt);
+        logAnthropicUsage(callSite, body.model, data.usage, now() - startedAt, {
+          endpointKind: target.kind,
+          attempt,
+        });
         return data;
       }
       const tail = await resp.text().catch(() => "");
@@ -224,11 +272,13 @@ export async function anthropicMessages(
           attempts: attempt,
           latencyMs: now() - startedAt,
           reason: "non_retryable",
+          endpointKind: target.kind,
+          triedByEndpoint,
         });
         throw lastErr;
       }
       retryAfterMs = parseRetryAfterMs(resp.headers.get("retry-after"), now());
-      console.warn(`[anthropic-fetch] attempt ${attempt} got ${resp.status} — retrying`);
+      console.warn(`[anthropic-fetch] attempt ${attempt} via ${target.kind} got ${resp.status} — retrying`);
     }
     if (attempt >= MAX_ATTEMPTS) break;
     // A-1: 오류 종류별 대기. 남은 예산을 넘길 대기라면 더 시도하지 않고
@@ -240,6 +290,8 @@ export async function anthropicMessages(
         attempts: attempt,
         latencyMs: now() - startedAt,
         reason: "budget_exhausted",
+        endpointKind: lastKind,
+        triedByEndpoint,
       });
       throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
     }
@@ -251,6 +303,8 @@ export async function anthropicMessages(
     attempts: attemptsMade,
     latencyMs: now() - startedAt,
     reason: "attempts_exhausted",
+    endpointKind: lastKind,
+    triedByEndpoint,
   });
   throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
 }

--- a/apps/central-plane/test/anthropic-endpoint-rotation.test.mjs
+++ b/apps/central-plane/test/anthropic-endpoint-rotation.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * anthropic-endpoint-rotation.test.mjs — A′-1 (2026-08-21 실측 대응).
+ *
+ * A-2 계측이 밝힌 진범: 용량(429/529)이 아니라 **403 egress**. 라이브 로그상
+ * `attempt 1~6 got 403` — 재시도 6회가 **모두 같은 경로**로 나가 통째로 막혔다.
+ *
+ * 여기서 고정하는 계약:
+ *   ① 게이트웨이가 설정돼 있으면 시도마다 경로를 번갈아 쓴다(gateway↔direct)
+ *   ② 한 경로가 403으로 막혀도 다른 경로가 열려 있으면 회복한다
+ *   ③ 게이트웨이 미설정이면 직행만 — 종전 동작 무회귀
+ *   ④ 성공·실패 로그 모두 endpoint_kind를 남겨 **경로별 성공률 집계**가 가능하다
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { anthropicMessages, endpointRotation, DIRECT_ANTHROPIC_ENDPOINT } =
+  await import("../dist/workspace/anthropic-fetch.js");
+
+const GATEWAY = "https://gateway.ai.cloudflare.com/v1/acct/simsa/anthropic/v1/messages";
+const BODY = { model: "claude-haiku-4-5-20251001", max_tokens: 100, messages: [{ role: "user", content: "hi" }] };
+
+const ok = () => new Response(JSON.stringify({ content: [{ type: "text", text: "ok" }], usage: { input_tokens: 1, output_tokens: 1 } }), { status: 200 });
+const forbidden = () => new Response('{"type":"forbidden","message":"Request not allowed"}', { status: 403 });
+
+function recorder() {
+  const slept = [];
+  let clock = 1_000_000;
+  return { slept, sleepImpl: async (ms) => { slept.push(ms); clock += ms; }, nowImpl: () => clock };
+}
+
+/** console.log을 가로채 구조화 로그만 걷어온다. */
+async function captureLogs(fn) {
+  const lines = [];
+  const orig = console.log;
+  console.log = (...a) => { lines.push(String(a[0])); };
+  try { return { result: await fn(), lines }; }
+  catch (err) { return { error: err, lines }; }
+  finally { console.log = orig; }
+}
+const jsonLines = (lines) => lines.map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+
+describe("endpointRotation (A′-1 ①③)", () => {
+  it("게이트웨이가 있으면 gateway → direct 두 경로", () => {
+    assert.deepEqual(endpointRotation(GATEWAY), [
+      { url: GATEWAY, kind: "gateway" },
+      { url: DIRECT_ANTHROPIC_ENDPOINT, kind: "direct" },
+    ]);
+  });
+
+  it("게이트웨이 미설정(직행 URL)이면 직행 하나 — 무회귀", () => {
+    assert.deepEqual(endpointRotation(DIRECT_ANTHROPIC_ENDPOINT), [
+      { url: DIRECT_ANTHROPIC_ENDPOINT, kind: "direct" },
+    ]);
+    assert.equal(endpointRotation("").length, 1);
+  });
+});
+
+describe("anthropicMessages — 경로 교대 (A′-1 ②)", () => {
+  it("시도마다 경로가 번갈아 나간다", async () => {
+    const { sleepImpl, nowImpl } = recorder();
+    const urls = [];
+    const fetchImpl = async (url) => { urls.push(url); return forbidden(); };
+    await assert.rejects(
+      anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "check", { maxTotalMs: 60_000, sleepImpl, nowImpl }),
+      /Anthropic 403/,
+    );
+    assert.equal(urls.length, 6, "6회 시도");
+    assert.equal(urls[0], GATEWAY);
+    assert.equal(urls[1], DIRECT_ANTHROPIC_ENDPOINT);
+    assert.equal(urls[2], GATEWAY);
+    assert.equal(urls[3], DIRECT_ANTHROPIC_ENDPOINT);
+    const gw = urls.filter((u) => u === GATEWAY).length;
+    assert.equal(gw, 3, "두 경로가 균등하게 3회씩");
+  });
+
+  it("★게이트웨이가 403으로 막혀도 직행이 열려 있으면 회복한다 (라이브 결함의 형태)", async () => {
+    const { sleepImpl, nowImpl } = recorder();
+    let gwCalls = 0;
+    const fetchImpl = async (url) => {
+      if (url === GATEWAY) { gwCalls++; return forbidden(); }
+      return ok();
+    };
+    const data = await anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "check", { sleepImpl, nowImpl });
+    assert.equal(data.content[0].text, "ok");
+    assert.equal(gwCalls, 1, "게이트웨이 1회 실패 후 직행에서 바로 성공");
+  });
+
+  it("반대 방향도 성립한다 — 직행이 막히고 게이트웨이가 열린 경우", async () => {
+    const { sleepImpl, nowImpl } = recorder();
+    let n = 0;
+    const fetchImpl = async (url) => {
+      n++;
+      if (url === DIRECT_ANTHROPIC_ENDPOINT) return forbidden();
+      return n === 1 ? forbidden() : ok(); // 첫 게이트웨이는 실패, 세 번째 시도(게이트웨이)에서 성공
+    };
+    const data = await anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "generate", { sleepImpl, nowImpl });
+    assert.equal(data.content[0].text, "ok");
+    assert.equal(n, 3);
+  });
+
+  it("게이트웨이 미설정이면 직행만 6회 — 종전 동작 무회귀", async () => {
+    const { sleepImpl, nowImpl } = recorder();
+    const urls = [];
+    const fetchImpl = async (url) => { urls.push(url); return forbidden(); };
+    await assert.rejects(
+      anthropicMessages("k", BODY, 1000, fetchImpl, DIRECT_ANTHROPIC_ENDPOINT, "check", { maxTotalMs: 60_000, sleepImpl, nowImpl }),
+    );
+    assert.ok(urls.every((u) => u === DIRECT_ANTHROPIC_ENDPOINT));
+  });
+});
+
+describe("경로별 계측 (A′-1 ④)", () => {
+  it("성공 로그에 endpoint_kind와 몇 번째 시도였는지가 남는다", async () => {
+    const { sleepImpl, nowImpl } = recorder();
+    const fetchImpl = async (url) => (url === GATEWAY ? forbidden() : ok());
+    const { lines } = await captureLogs(() =>
+      anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "check", { sleepImpl, nowImpl }),
+    );
+    const usage = jsonLines(lines).find((j) => j.event === "anthropic_usage");
+    assert.ok(usage, "성공 로그가 있어야 한다");
+    assert.equal(usage.endpoint_kind, "direct", "성공한 경로가 기록된다");
+    assert.equal(usage.attempt, 2);
+  });
+
+  it("실패 로그에 경로별 시도 횟수가 남는다 — 어느 출구가 막히는지 집계 가능", async () => {
+    const { sleepImpl, nowImpl } = recorder();
+    const fetchImpl = async () => forbidden();
+    const { lines } = await captureLogs(() =>
+      anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "check", { maxTotalMs: 60_000, sleepImpl, nowImpl }),
+    );
+    const fail = jsonLines(lines).find((j) => j.event === "llm_failure");
+    assert.ok(fail);
+    assert.equal(fail.failure_class, "egress");
+    assert.deepEqual(fail.tried_by_endpoint, { gateway: 3, direct: 3 });
+  });
+});

--- a/apps/central-plane/test/anthropic-retry-policy.test.mjs
+++ b/apps/central-plane/test/anthropic-retry-policy.test.mjs
@@ -43,26 +43,28 @@ describe("retryDelayMs — 오류 종류별 대기 (A-1)", () => {
       const d1 = retryDelayMs(status, 1, null);
       const d2 = retryDelayMs(status, 2, null);
       const d3 = retryDelayMs(status, 3, null);
-      assert.ok(d1 >= 1000 && d1 < 1500, `${status} attempt1=${d1}`);
-      assert.ok(d2 >= 2000 && d2 < 2500, `${status} attempt2=${d2}`);
-      assert.ok(d3 >= 4000 && d3 < 4500, `${status} attempt3=${d3}`);
-      assert.ok(retryDelayMs(status, 6, null) <= 6400, "상한 6s + 지터");
-      assert.ok(d2 > d1 && d3 > d2, "단조 증가");
+      // A′-4 equal jitter: [base/2, base*1.5]. rand를 고정해 결정론 검증.
+      const mid = (a, n) => retryDelayMs(status, a, null, () => 0.5);
+      assert.equal(mid(1), 1000, `${status} attempt1 중앙값`);
+      assert.equal(mid(2), 2000, `${status} attempt2 중앙값`);
+      assert.equal(mid(3), 4000, `${status} attempt3 중앙값`);
+      assert.equal(retryDelayMs(status, 6, null, () => 1), 9000, "상한 6s의 최대 지터");
+      assert.ok(retryDelayMs(status, 1, null, () => 0) === 500, "최소는 base/2");
     }
   });
 
   it("egress성 오류(403)와 네트워크 예외(null)는 종전 공식 유지 — 무회귀", () => {
     // 종전: 500 * attempt + 지터. 용량 오류보다 촘촘해야 한다.
     for (const status of [403, null]) {
-      assert.ok(retryDelayMs(status, 1, null) < 1000, `${status} attempt1`);
-      assert.ok(retryDelayMs(status, 3, null) < 2000, `${status} attempt3`);
+      assert.ok(retryDelayMs(status, 1, null, () => 0.5) <= 500, `${status} attempt1`);
+      assert.ok(retryDelayMs(status, 3, null, () => 0.5) <= 1500, `${status} attempt3`);
     }
-    assert.ok(retryDelayMs(403, 2, null) < retryDelayMs(429, 2, null), "403이 429보다 짧다");
+    assert.ok(retryDelayMs(403, 2, null, () => 0.5) < retryDelayMs(429, 2, null, () => 0.5), "403이 429보다 짧다");
   });
 
   it("retry-after가 있으면 용량 백오프보다 우선한다", () => {
-    assert.ok(retryDelayMs(429, 3, 800) < 1300, "서버가 0.8s라면 4s를 기다리지 않는다");
-    assert.ok(retryDelayMs(429, 1, 5000) >= 5000, "서버가 5s라면 그만큼 기다린다");
+    assert.ok(retryDelayMs(429, 3, 800, () => 0.5) < 1300, "서버가 0.8s라면 4s를 기다리지 않는다");
+    assert.ok(retryDelayMs(429, 1, 5000, () => 0) >= 5000, "서버가 5s라면 그만큼 기다린다(하한 준수)");
   });
 });
 
@@ -174,5 +176,34 @@ describe("anthropicMessages — 예산과 실패 로그 (A-1·A-2)", () => {
       .find((j) => j && j.event === "llm_failure");
     assert.ok(line);
     assert.equal(line.failure_class, "egress");
+  });
+});
+
+describe("A′-4 — 지터가 동시 요청의 재시도를 흩는다", () => {
+  it("★같은 순간 실패한 요청들의 재시도 시각이 서로 달라진다 (종전엔 완전 동기화)", () => {
+    // 동시에 실패한 8건이 각자 다른 난수를 받으면 재시도 시각이 흩어져야 한다.
+    // 종전 결정론 지터에서는 8건 모두 같은 값이 나와 재시도가 뭉쳐 다녔다.
+    const delays = Array.from({ length: 8 }, (_, i) => retryDelayMs(403, 1, null, () => i / 8));
+    const unique = new Set(delays);
+    assert.ok(unique.size >= 6, `재시도 시각이 흩어져야 한다 — 서로 다른 값 ${unique.size}/8`);
+    const spread = Math.max(...delays) - Math.min(...delays);
+    assert.ok(spread >= 300, `분산이 충분해야 한다 — 폭 ${spread}ms`);
+  });
+
+  it("흩뿌려도 하한이 있어 폭주하지 않는다 (base/2 이상, base*1.5 이하)", () => {
+    for (const attempt of [1, 2, 3]) {
+      const lo = retryDelayMs(403, attempt, null, () => 0);
+      const hi = retryDelayMs(403, attempt, null, () => 1);
+      const base = 500 * attempt;
+      assert.equal(lo, base / 2);
+      assert.equal(hi, Math.round(base * 1.5));
+    }
+  });
+
+  it("retry-after는 하한으로 존중하고 그 위에만 흩뿌린다", () => {
+    const lo = retryDelayMs(429, 2, 2000, () => 0);
+    const hi = retryDelayMs(429, 2, 2000, () => 1);
+    assert.equal(lo, 2000, "서버 지시보다 일찍 가지 않는다");
+    assert.ok(hi > 2000 && hi <= 2500, "그 위에서만 흩어진다");
   });
 });


### PR DESCRIPTION
## 라이브 로그가 알려준 것
A′-1(경로 교대) 배포 후 실측에서 **재시도가 왜 무력한지**가 드러났습니다:

- 성공한 건은 **전부 attempt 1**에서 성공
- 첫 시도에 실패한 건은 **6회 전부 실패** (경로 교대에도 gateway 9회·direct 9회 모두 403)

원인은 지터였습니다. 종전 `(attempt*137)%400`은 **결정론적**이라, 같은 순간 실패한 요청들이 **정확히 같은 시각에 함께 재시도**합니다. 동시 4건이 6회 내내 뭉쳐 다니며 매번 같이 거절당했습니다 — 재시도가 동시성을 전혀 낮추지 못한 것입니다.

## 수정
- **equal jitter**: `base/2 + rand()*base` (범위 [base/2, base×1.5], 평균 base). 재시도 시각이 흩어져 **동시성이 스스로 내려갑니다**.
- `retry-after`는 **하한으로 존중**하고 그 위에만 흩뿌립니다.
- `randomImpl` 주입으로 테스트 결정론화.

## 검증
- 핵심 계약 테스트: 동시 8건의 재시도 시각이 서로 달라짐(≥6/8 고유, 폭 ≥300ms)
- 하한/상한 고정 · retry-after 하한 준수
- 전체 1,993 pass / 0 fail

배포 후 동일 프로브로 즉시 실측합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)