### PR TITLE
feat(obs): /internal/llm-probe — 벤더별 LLM 도달성 관측 도구

### DIFF
--- a/apps/central-plane/src/router.ts
+++ b/apps/central-plane/src/router.ts
@@ -46,6 +46,7 @@ import { createWorkspaceSourcesRoutes } from "./routes/workspace-sources.js";
 import { createWorkspaceDocumentIntakeRoutes } from "./routes/workspace-document-intake.js";
 import { createWorkspaceVisualChecksRoutes } from "./routes/workspace-visual-checks.js";
 import { createWorkspaceVisualCheckRunRoutes } from "./routes/workspace-visual-check-runs.js";
+import { createLlmProbeRoutes } from "./routes/llm-probe.js";
 import { createWorkspaceRepairJobRoutes } from "./routes/workspace-repair-jobs.js";
 import { createWorkspaceExperimentRoutes } from "./routes/workspace-experiment.js";
 import { createWorkspaceAgentWorkflowRoutes } from "./routes/workspace-agent-workflow.js";
@@ -79,6 +80,8 @@ export function createApp(opts: { fetch?: FetchLike } = {}): Hono<{ Bindings: En
   const app = new Hono<{ Bindings: Env }>();
   const fetchImpl: FetchLike = opts.fetch ?? (fetch.bind(globalThis) as FetchLike);
   app.route("/", healthRoutes);
+  // 관측 도구: 벤더별 LLM 도달성(내부 토큰 필요) — 2026-08-22 403 진단에서 신설.
+  app.route("/", createLlmProbeRoutes());
   app.route("/", registerRoutes);
   app.route("/", episodicRoutes);
   app.route("/", federatedBaselinesRoutes);

--- a/apps/central-plane/src/routes/llm-probe.ts
+++ b/apps/central-plane/src/routes/llm-probe.ts
@@ -1,0 +1,137 @@
+/**
+ * llm-probe.ts — 벤더별 LLM 도달성 관측 도구 (2026-08-22).
+ *
+ * 왜 필요한가: `Anthropic 403 "Request not allowed"`를 두고 네 번 가설을 세우고
+ * 네 번 틀렸다(용량 → 경로 → 지터 → 동시성). 매번 "고쳐서 배포하고 프로브"를
+ * 반복했고, 그때마다 원인이 다른 곳에 있었다. 마지막 실측에서 **완전 직렬화도
+ * 0/3 실패** — 동시성조차 아니고 **시간대별 차단**이었다.
+ *
+ * 그래서 추측을 끊고 **사실을 재는 도구**를 먼저 둔다: 벤더별로 Worker egress에서
+ * 실제 도달하는지, 지연은 얼마인지, 동시성에서 달라지는지.
+ *
+ *   POST /internal/llm-probe            — 세 벤더 각 1회
+ *   POST /internal/llm-probe?n=4        — 각 벤더 동시 4회
+ *
+ * 규칙:
+ *   - INTERNAL_CALLBACK_TOKEN 필수(공개 노출 금지)
+ *   - **재시도 없음** — 순수 도달성 측정이므로 anthropic-fetch의 재시도를 타지 않는다
+ *   - 최소 토큰(max 5)만 소비. 프로덕션 예산에 부담을 주지 않는다
+ *   - 어떤 벤더 키도 응답에 담지 않는다
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import { anthropicEndpoint } from "../workspace/anthropic-fetch.js";
+
+type ProbeResult = {
+  vendor: "anthropic" | "openai" | "gemini";
+  path: "gateway" | "direct";
+  status: number | "network_error" | "no_key";
+  ms: number;
+  /** 실패 본문의 앞부분 — 원인 분류에 필요한 최소치만. */
+  detail?: string;
+};
+
+const PROMPT = "Reply with the single word: ok";
+
+async function timed(fn: () => Promise<{ status: number | "network_error"; detail?: string }>): Promise<{ status: number | "network_error"; detail?: string; ms: number }> {
+  const t = Date.now();
+  try {
+    const r = await fn();
+    return { ...r, ms: Date.now() - t };
+  } catch (err) {
+    return { status: "network_error", detail: String(err).slice(0, 120), ms: Date.now() - t };
+  }
+}
+
+async function probeAnthropic(env: Env, useGateway: boolean): Promise<ProbeResult> {
+  const key = env.ANTHROPIC_API_KEY;
+  const path = useGateway ? "gateway" : "direct";
+  if (!key) return { vendor: "anthropic", path, status: "no_key", ms: 0 };
+  const url = useGateway ? anthropicEndpoint(env.CF_AI_GATEWAY_ANTHROPIC_URL) : anthropicEndpoint();
+  const out = await timed(async () => {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { "x-api-key": key, "anthropic-version": "2023-06-01", "content-type": "application/json", "user-agent": "simsa-central-plane/1.0" },
+      body: JSON.stringify({ model: "claude-haiku-4-5-20251001", max_tokens: 5, messages: [{ role: "user", content: PROMPT }] }),
+    });
+    return { status: r.status, detail: r.ok ? undefined : (await r.text().catch(() => "")).slice(0, 120) };
+  });
+  return { vendor: "anthropic", path, ...out };
+}
+
+async function probeOpenAi(env: Env): Promise<ProbeResult> {
+  const key = env.OPENAI_API_KEY;
+  const base = (env.CF_AI_GATEWAY_OPENAI_URL ?? "").trim().replace(/\/$/, "");
+  const path = base ? "gateway" : "direct";
+  if (!key) return { vendor: "openai", path, status: "no_key", ms: 0 };
+  const url = base ? `${base}/chat/completions` : "https://api.openai.com/v1/chat/completions";
+  const out = await timed(async () => {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { authorization: `Bearer ${key}`, "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-5.4", max_completion_tokens: 5, messages: [{ role: "user", content: PROMPT }] }),
+    });
+    return { status: r.status, detail: r.ok ? undefined : (await r.text().catch(() => "")).slice(0, 120) };
+  });
+  return { vendor: "openai", path, ...out };
+}
+
+async function probeGemini(env: Env): Promise<ProbeResult> {
+  const key = env.GEMINI_API_KEY;
+  const base = (env.CF_AI_GATEWAY_GOOGLE_URL ?? "").trim().replace(/\/$/, "");
+  const path = base ? "gateway" : "direct";
+  if (!key) return { vendor: "gemini", path, status: "no_key", ms: 0 };
+  const model = "gemini-2.5-flash";
+  const url = base
+    ? `${base}/v1beta/models/${model}:generateContent`
+    : `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+  const out = await timed(async () => {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { "x-goog-api-key": key, "content-type": "application/json" },
+      body: JSON.stringify({ contents: [{ parts: [{ text: PROMPT }] }] }),
+    });
+    return { status: r.status, detail: r.ok ? undefined : (await r.text().catch(() => "")).slice(0, 120) };
+  });
+  return { vendor: "gemini", path, ...out };
+}
+
+export function createLlmProbeRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+
+  app.post("/internal/llm-probe", async (c) => {
+    const expected = c.env.INTERNAL_CALLBACK_TOKEN;
+    if (!expected) return c.json({ ok: false, error: "probe_disabled" }, 503);
+    const auth = c.req.header("authorization") ?? "";
+    const m = /^Bearer\s+(.+)$/i.exec(auth);
+    if (!m || m[1] !== expected) return c.json({ ok: false, error: "unauthorized" }, 401);
+
+    const n = Math.min(Math.max(parseInt(c.req.query("n") ?? "1", 10) || 1, 1), 4);
+    const one = () => [
+      probeAnthropic(c.env, true),
+      probeAnthropic(c.env, false),
+      probeOpenAi(c.env),
+      probeGemini(c.env),
+    ];
+    const rounds = Array.from({ length: n }, () => one()).flat();
+    const results = await Promise.all(rounds);
+
+    // 벤더·경로별 요약 — 사람이 한눈에 보고 판단하기 위한 집계.
+    const summary: Record<string, { ok: number; total: number; statuses: Record<string, number>; avgMs: number }> = {};
+    for (const r of results) {
+      const k = `${r.vendor}:${r.path}`;
+      const s = (summary[k] ??= { ok: 0, total: 0, statuses: {}, avgMs: 0 });
+      s.total += 1;
+      if (r.status === 200) s.ok += 1;
+      const key = String(r.status);
+      s.statuses[key] = (s.statuses[key] ?? 0) + 1;
+      s.avgMs += r.ms;
+    }
+    for (const s of Object.values(summary)) s.avgMs = Math.round(s.avgMs / Math.max(s.total, 1));
+
+    console.log(JSON.stringify({ event: "llm_probe", concurrency: n, summary }));
+    return c.json({ ok: true, concurrency: n, summary, results });
+  });
+
+  return app;
+}

--- a/apps/central-plane/test/llm-probe.test.mjs
+++ b/apps/central-plane/test/llm-probe.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * llm-probe.test.mjs — 관측 도구의 안전 계약.
+ * 이 엔드포인트는 프로덕션 키로 외부를 때리므로, 보호와 무누출이 계약이다.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { createApp } = await import("../dist/router.js");
+
+const TOKEN = "tok_probe_test";
+const ORIGIN = "https://app.trysimsa.com";
+
+function envWith(overrides = {}) {
+  return {
+    INTERNAL_CALLBACK_TOKEN: TOKEN,
+    ANTHROPIC_API_KEY: "sk-ant-secret-value",
+    OPENAI_API_KEY: "sk-openai-secret-value",
+    GEMINI_API_KEY: "gemini-secret-value",
+    CF_AI_GATEWAY_ANTHROPIC_URL: "https://gateway.example/anthropic",
+    ...overrides,
+  };
+}
+
+async function post(env, { token = TOKEN, query = "" } = {}) {
+  return createApp().request(
+    `/internal/llm-probe${query}`,
+    { method: "POST", headers: { ...(token ? { authorization: `Bearer ${token}` } : {}), origin: ORIGIN } },
+    env,
+  );
+}
+
+describe("/internal/llm-probe — 보호", () => {
+  it("토큰 없으면 401", async () => {
+    const res = await post(envWith(), { token: "" });
+    assert.equal(res.status, 401);
+  });
+
+  it("틀린 토큰이면 401", async () => {
+    const res = await post(envWith(), { token: "wrong" });
+    assert.equal(res.status, 401);
+  });
+
+  it("서버에 토큰이 설정 안 됐으면 503 — 무보호로 열리지 않는다", async () => {
+    const res = await post(envWith({ INTERNAL_CALLBACK_TOKEN: undefined }), { token: "anything" });
+    assert.equal(res.status, 503);
+  });
+});
+
+describe("/internal/llm-probe — 결과 형태와 무누출", () => {
+  it("키가 없는 벤더는 no_key로 표기되고 호출하지 않는다", async () => {
+    const res = await post(envWith({ ANTHROPIC_API_KEY: undefined, OPENAI_API_KEY: undefined, GEMINI_API_KEY: undefined }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.results.every((r) => r.status === "no_key"), "키 없으면 전부 no_key");
+    assert.ok(body.results.every((r) => r.ms === 0), "호출 자체를 하지 않는다");
+  });
+
+  it("★응답에 어떤 벤더 키도 담기지 않는다", async () => {
+    const res = await post(envWith({ ANTHROPIC_API_KEY: undefined, OPENAI_API_KEY: undefined, GEMINI_API_KEY: undefined }));
+    const text = JSON.stringify(await res.json());
+    for (const secret of ["sk-ant-secret-value", "sk-openai-secret-value", "gemini-secret-value"]) {
+      assert.ok(!text.includes(secret), `키가 응답에 노출되면 안 된다: ${secret}`);
+    }
+  });
+
+  it("동시성 n은 1~4로 제한된다 (프로덕션 예산 보호)", async () => {
+    const env = envWith({ ANTHROPIC_API_KEY: undefined, OPENAI_API_KEY: undefined, GEMINI_API_KEY: undefined });
+    const big = await (await post(env, { query: "?n=99" })).json();
+    assert.equal(big.concurrency, 4, "상한 4");
+    const zero = await (await post(env, { query: "?n=0" })).json();
+    assert.equal(zero.concurrency, 1, "하한 1");
+  });
+
+  it("벤더·경로별 요약이 함께 나온다 (사람이 한눈에 판단)", async () => {
+    const env = envWith({ ANTHROPIC_API_KEY: undefined, OPENAI_API_KEY: undefined, GEMINI_API_KEY: undefined });
+    const body = await (await post(env)).json();
+    assert.ok(body.summary["anthropic:gateway"], "게이트웨이 경로 집계");
+    assert.ok(body.summary["anthropic:direct"], "직행 경로 집계");
+    assert.ok(body.summary["openai:direct"] || body.summary["openai:gateway"]);
+    assert.ok(body.summary["gemini:direct"] || body.summary["gemini:gateway"]);
+  });
+});


### PR DESCRIPTION
## 왜
403 `Request not allowed`를 두고 **네 번 가설을 세우고 네 번 틀렸습니다**(용량 → 경로 → 지터 → 동시성). 마지막 실측에서 **완전 직렬화도 0/3 실패** — 동시성조차 아니고 **시간대별 차단**이었습니다. 추측→배포→프로브 반복을 끊기 위해 **재는 도구**를 먼저 둡니다.

## 무엇
- `POST /internal/llm-probe` — anthropic(게이트웨이/직행)·openai·gemini 각 1회
- `?n=4` — 각 벤더 동시 4회(상한 4)
- **재시도 없음**(순수 도달성 측정) · **최소 토큰**(max 5) · 벤더·경로별 요약 집계
- `INTERNAL_CALLBACK_TOKEN` 필수, 미설정 시 503(무보호 개방 금지)

## 다음
이 도구로 **어느 벤더가 Worker egress에서 실제로 되는지**를 재고, 그 데이터 위에서 폴백을 설계합니다(OPENAI·GEMINI 키는 이미 프로덕션에 설정돼 있습니다).

## 검증
7케이스(401/401/503 보호 · no_key 시 미호출 · **키 무누출** · n 상한/하한 · 요약 형태), 전체 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)