### PR TITLE
feat(llm): 벤더 폴백 + 회로 차단기 — Anthropic egress 차단 실측 대응

### DIFF
--- a/apps/central-plane/src/routes/workspace-document-intake.ts
+++ b/apps/central-plane/src/routes/workspace-document-intake.ts
@@ -177,7 +177,7 @@ export function createWorkspaceDocumentIntakeRoutes(): Hono<{ Bindings: Env }> {
 
     let result;
     try {
-      result = await generateIdeaToSpecDraft({ idea: input, locale }, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL);
+      result = await generateIdeaToSpecDraft({ idea: input, locale }, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL, c.env.OPENAI_API_KEY ? { openaiApiKey: c.env.OPENAI_API_KEY, openaiBaseUrl: c.env.CF_AI_GATEWAY_OPENAI_URL } : undefined);
     } catch (err) {
       console.error("[workspace/document-intake] unexpected generate error:", err);
       return c.json({ ok: false, error: "internal_error" }, 500);

--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -969,6 +969,10 @@ export function createWorkspaceGitHubRoutes(
         c.env.ANTHROPIC_API_KEY,
         fetchImpl,
         c.env.CF_AI_GATEWAY_ANTHROPIC_URL,
+        // 벤더 폴백: Anthropic이 Worker egress에서 차단될 때 OpenAI로.
+        c.env.OPENAI_API_KEY
+          ? { openaiApiKey: c.env.OPENAI_API_KEY, openaiBaseUrl: c.env.CF_AI_GATEWAY_OPENAI_URL }
+          : undefined,
       );
       if (reviewResult.warnings?.length) warnings.push(...reviewResult.warnings);
     } catch (err) {

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -63,6 +63,16 @@ import {
   BETA_PROJECT_CREATE_DAILY_BUCKET,
 } from "../workspace/beta-limits.js";
 
+/**
+ * 벤더 폴백 설정 — Anthropic이 Worker egress에서 차단될 때(실측 403 100%)
+ * 같은 프롬프트를 OpenAI로 넘긴다. 키가 없으면 undefined라 종전과 동일하게 동작.
+ * `/internal/llm-probe` 실측: anthropic 0/4 · **openai 4/4**(2.9초) · gemini 지역 제한.
+ */
+function vendorFallback(env: Env): { openaiApiKey?: string; openaiBaseUrl?: string } | undefined {
+  if (!env.OPENAI_API_KEY) return undefined;
+  return { openaiApiKey: env.OPENAI_API_KEY, openaiBaseUrl: env.CF_AI_GATEWAY_OPENAI_URL };
+}
+
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const DEFAULT_LIMIT_PER_HOUR = 20;
@@ -259,7 +269,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
 
     let result;
     try {
-      result = await generateIdeaToSpecDraft(input, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL);
+      result = await generateIdeaToSpecDraft(input, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL, vendorFallback(c.env));
     } catch (err) {
       console.error("[workspace] unexpected generate error:", err);
       return new Response(JSON.stringify({ ok: false, error: "internal_error" }), {
@@ -565,7 +575,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
       // direct Worker→Anthropic egress ~90% 403s, which surfaced as the
       // recurring "확인 중 오류가 발생했습니다". This was the ONE LLM route that
       // omitted the gateway URL.
-      result = await generateCheckDraft({ productSpec: req.productSpec, items: req.items, projectId: req.projectId, locale: req.locale ?? "ko" }, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL);
+      result = await generateCheckDraft({ productSpec: req.productSpec, items: req.items, projectId: req.projectId, locale: req.locale ?? "ko" }, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL, vendorFallback(c.env));
     } catch (err) {
       console.error("[workspace/check-draft] error:", err);
       return new Response(JSON.stringify({ ok: false, error: "internal_error" }), { status: 500, headers: { "content-type": "application/json", ...headers } });
@@ -642,6 +652,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
         },
         c.env.ANTHROPIC_API_KEY,
         c.env.CF_AI_GATEWAY_ANTHROPIC_URL,
+        vendorFallback(c.env),
       );
     } catch (err) {
       console.error("[workspace/recommend-answer] error:", err);
@@ -704,6 +715,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
         },
         c.env.ANTHROPIC_API_KEY,
         c.env.CF_AI_GATEWAY_ANTHROPIC_URL,
+        vendorFallback(c.env),
       );
     } catch (err) {
       console.error("[workspace/unstick] error:", err);
@@ -769,7 +781,7 @@ export function createWorkspaceRoutes(): Hono<{ Bindings: Env }> {
 
     let result;
     try {
-      result = await generateFixSuggestion(req as WorkspaceFixSuggestionRequest, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL);
+      result = await generateFixSuggestion(req as WorkspaceFixSuggestionRequest, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL, vendorFallback(c.env));
     } catch (err) {
       console.error("[workspace/fix-suggestion] error:", err);
       return new Response(JSON.stringify({ ok: false, error: "internal_error" }), { status: 500, headers: { "content-type": "application/json", ...headers } });

--- a/apps/central-plane/src/workspace/anthropic-fetch.ts
+++ b/apps/central-plane/src/workspace/anthropic-fetch.ts
@@ -172,8 +172,9 @@ export function logAnthropicUsage(
   model: string,
   usage: AnthropicMessagesData["usage"],
   latencyMs: number,
-  /** A′-1: 성공한 경로와 몇 번째 시도였는지 — 경로별 성공률 집계의 반쪽. */
-  meta?: { endpointKind?: EndpointKind; attempt?: number },
+  /** A′-1: 성공한 경로와 몇 번째 시도였는지 — 경로별 성공률 집계의 반쪽.
+   *  vendor: 실제로 응답한 벤더(폴백 시 openai). 정직성상 반드시 남긴다. */
+  meta?: { endpointKind?: EndpointKind; attempt?: number; vendor?: string },
 ): void {
   try {
     console.log(
@@ -186,6 +187,7 @@ export function logAnthropicUsage(
         cache_creation_input_tokens: usage?.cache_creation_input_tokens ?? 0,
         cache_read_input_tokens: usage?.cache_read_input_tokens ?? 0,
         latency_ms: latencyMs,
+        vendor: meta?.vendor ?? "anthropic",
         ...(meta?.endpointKind ? { endpoint_kind: meta.endpointKind } : {}),
         ...(meta?.attempt ? { attempt: meta.attempt } : {}),
       }),
@@ -199,6 +201,74 @@ export function logAnthropicUsage(
 export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
 
 /**
+ * ★벤더 폴백 (2026-08-22) — 이 파일의 가장 중요한 장치.
+ *
+ * `/internal/llm-probe` 실측(동시성 1·4 각각):
+ *   anthropic:gateway 0/1·0/4 (403 forbidden)   anthropic:direct 0/1·0/4 (403)
+ *   **openai:gateway 1/1·4/4 (200, 평균 2.9초)**  gemini:gateway 0/1·0/4
+ *     (400 "User location is not supported" — 지역 제한)
+ *
+ * 즉 Worker egress에서 **Anthropic은 완전 차단**이고 **OpenAI만 열려 있다**.
+ * 재시도·백오프·경로 교대·지터로는 절대 못 넘는다(네 번 시도해 네 번 실패했다).
+ * 그래서 마지막 수단으로 **다른 벤더로 같은 프롬프트를 던진다**.
+ *
+ * 정직성: 조용한 품질 저하가 아니다 — 같은 프롬프트·같은 출력 계약이고,
+ * **어느 벤더가 응답했는지 로그에 남긴다**(anthropic_usage.vendor / llm_fallback).
+ * 폴백이 없으면(키 없음·폴백도 실패) 종전처럼 정직하게 실패한다.
+ */
+export const OPENAI_FALLBACK_MODEL = "gpt-5.4";
+
+export type VendorFallback = {
+  openaiApiKey?: string;
+  /** CF AI Gateway의 OpenAI 베이스(없으면 직행). */
+  openaiBaseUrl?: string;
+  model?: string;
+};
+
+function openAiUrl(baseUrl?: string): string {
+  const base = (baseUrl ?? "").trim().replace(/\/$/, "");
+  return base ? `${base}/chat/completions` : "https://api.openai.com/v1/chat/completions";
+}
+
+/** OpenAI 응답을 Anthropic 응답 형태로 옮긴다 — 호출부는 폴백을 몰라도 된다. */
+async function callOpenAiAsAnthropic(
+  fb: VendorFallback,
+  body: AnthropicMessagesBody,
+  timeoutMs: number,
+  fetchImpl: FetchLike,
+): Promise<AnthropicMessagesData> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const r = await fetchImpl(openAiUrl(fb.openaiBaseUrl), {
+      method: "POST",
+      signal: ctrl.signal,
+      headers: { authorization: `Bearer ${fb.openaiApiKey}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        model: fb.model ?? OPENAI_FALLBACK_MODEL,
+        max_completion_tokens: body.max_tokens,
+        messages: body.messages,
+      }),
+    });
+    if (!r.ok) {
+      const tail = await r.text().catch(() => "");
+      throw new Error(`OpenAI ${r.status}: ${tail.slice(0, 200)}`);
+    }
+    const j = (await r.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    const text = j.choices?.[0]?.message?.content ?? "";
+    return {
+      content: [{ type: "text", text }],
+      usage: { input_tokens: j.usage?.prompt_tokens ?? 0, output_tokens: j.usage?.completion_tokens ?? 0 },
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Base URL for the Anthropic Messages API. When CF_AI_GATEWAY_ANTHROPIC_URL is
  * set (e.g. https://gateway.ai.cloudflare.com/v1/{acct}/{gw}/anthropic) the
  * call routes through Cloudflare AI Gateway, which sidesteps the direct
@@ -207,6 +277,91 @@ export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>
 export function anthropicEndpoint(baseUrl?: string): string {
   const base = (baseUrl ?? "").trim().replace(/\/$/, "");
   return base ? `${base}/v1/messages` : "https://api.anthropic.com/v1/messages";
+}
+
+/**
+ * Anthropic이 끝내 실패했을 때의 마지막 수단. 폴백이 없거나 그마저 실패하면
+ * **원래 에러를 그대로 던진다** — 조용히 성공한 척하지 않는다.
+ */
+async function fallbackOrThrow(
+  fb: VendorFallback | undefined,
+  body: AnthropicMessagesBody,
+  timeoutMs: number,
+  fetchImpl: FetchLike,
+  callSite: string,
+  now: () => number,
+  startedAt: number,
+  lastStatus: number | null,
+  lastErr: unknown,
+): Promise<AnthropicMessagesData> {
+  const primaryErr = lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+  if (!fb?.openaiApiKey) throw primaryErr;
+  try {
+    const data = await callOpenAiAsAnthropic(fb, body, timeoutMs, fetchImpl);
+    logAnthropicUsage(callSite, fb.model ?? OPENAI_FALLBACK_MODEL, data.usage, now() - startedAt, {
+      vendor: "openai",
+    });
+    try {
+      console.log(
+        JSON.stringify({
+          event: "llm_fallback",
+          call_site: callSite,
+          from: "anthropic",
+          to: "openai",
+          primary_status: lastStatus,
+          latency_ms: now() - startedAt,
+        }),
+      );
+    } catch { /* logging must not break the call */ }
+    return data;
+  } catch (fbErr) {
+    try {
+      console.log(
+        JSON.stringify({
+          event: "llm_fallback_failed",
+          call_site: callSite,
+          primary_status: lastStatus,
+          fallback_error: String(fbErr).slice(0, 200),
+        }),
+      );
+    } catch { /* ignore */ }
+    // 폴백도 실패 — 사용자에겐 원래 원인이 더 유용하다.
+    throw primaryErr;
+  }
+}
+
+/**
+ * ★회로 차단기 (2026-08-22) — 폴백의 짝.
+ *
+ * Anthropic이 100% 403인 지금, 호출마다 6회 재시도로 ~12초를 태우고 나서야
+ * 폴백에 들어간다. 그 12초는 실측상 **순손실**이다(네 번 시도해 네 번 실패한
+ * 경로를 다시 여섯 번 두드리는 것). 그래서 연속 실패가 임계에 닿으면 이후
+ * 호출은 Anthropic을 건너뛰고 바로 폴백으로 간다.
+ *
+ * 영구적으로 포기하진 않는다 — 쿨다운이 지나면 딱 한 번 다시 통과시켜
+ * (half-open) 살아났는지 실측한다. 살아나면 즉시 원복, 또 죽으면 재차단.
+ * 상태는 isolate 단위 메모리이므로 정확한 전역 합의가 아니라 **최적화**다.
+ * 폴백이 없으면 차단하지 않는다 — 유일한 경로를 스스로 끊으면 안 된다.
+ */
+const BREAKER_THRESHOLD = 2;
+const BREAKER_COOLDOWN_MS = 60_000;
+let breakerFailures = 0;
+let breakerOpenedAt = 0;
+
+function breakerIsOpen(t: number): boolean {
+  return breakerFailures >= BREAKER_THRESHOLD && t - breakerOpenedAt < BREAKER_COOLDOWN_MS;
+}
+function breakerRecordFailure(t: number): void {
+  breakerFailures += 1;
+  breakerOpenedAt = t;
+}
+function breakerRecordSuccess(): void {
+  breakerFailures = 0;
+  breakerOpenedAt = 0;
+}
+/** 테스트 전용 — isolate 전역 상태가 테스트 간에 새지 않도록. */
+export function __resetAnthropicBreaker(): void {
+  breakerRecordSuccess();
 }
 
 export async function anthropicMessages(
@@ -224,6 +379,8 @@ export async function anthropicMessages(
     nowImpl?: () => number;
     /** A′-4: 지터 난수 주입(테스트 결정론화). */
     randomImpl?: () => number;
+    /** ★벤더 폴백: Anthropic이 끝내 실패하면 여기로 같은 프롬프트를 던진다. */
+    fallback?: VendorFallback;
   } = {},
 ): Promise<AnthropicMessagesData> {
   let lastErr: unknown = null;
@@ -239,6 +396,18 @@ export async function anthropicMessages(
   // A′-1: 시도마다 경로를 번갈아 쓴다(게이트웨이 → 직행 → 게이트웨이 …).
   const rotation = endpointRotation(endpoint);
   const triedByEndpoint: Record<string, number> = {};
+  // 차단기가 열려 있고 갈 곳이 있으면 12초를 태우지 않고 곧장 폴백으로.
+  if (opts.fallback?.openaiApiKey && breakerIsOpen(startedAt)) {
+    try {
+      console.log(
+        JSON.stringify({ event: "llm_breaker_open", call_site: callSite, skipped: "anthropic", failures: breakerFailures }),
+      );
+    } catch { /* logging must not break the call */ }
+    return fallbackOrThrow(
+      opts.fallback, body, timeoutMs, fetchImpl, callSite, now, startedAt,
+      null, new Error("Anthropic skipped: circuit breaker open"),
+    );
+  }
   let lastKind: EndpointKind = rotation[0]!.kind;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     attemptsMade = attempt;
@@ -271,10 +440,12 @@ export async function anthropicMessages(
     if (resp) {
       if (resp.ok) {
         const data = (await resp.json()) as AnthropicMessagesData;
+        breakerRecordSuccess(); // Anthropic이 살아 있다 — 차단 해제.
         // latency_ms is wall time including retries — what the user waited.
         logAnthropicUsage(callSite, body.model, data.usage, now() - startedAt, {
           endpointKind: target.kind,
           attempt,
+          vendor: "anthropic",
         });
         return data;
       }
@@ -308,7 +479,8 @@ export async function anthropicMessages(
         endpointKind: lastKind,
         triedByEndpoint,
       });
-      throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+      breakerRecordFailure(now());
+      return fallbackOrThrow(opts.fallback, body, timeoutMs, fetchImpl, callSite, now, startedAt, lastStatus, lastErr);
     }
     sleptTotalMs += delay;
     await sleep(delay);
@@ -321,5 +493,6 @@ export async function anthropicMessages(
     endpointKind: lastKind,
     triedByEndpoint,
   });
-  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+  breakerRecordFailure(now());
+  return fallbackOrThrow(opts.fallback, body, timeoutMs, fetchImpl, callSite, now, startedAt, lastStatus, lastErr);
 }

--- a/apps/central-plane/src/workspace/check.ts
+++ b/apps/central-plane/src/workspace/check.ts
@@ -5,7 +5,7 @@
  * This is NOT a code review — it checks the spec document only.
  * LLM failure → deterministic mock fallback via heuristics.
  */
-import { anthropicMessages, anthropicEndpoint } from "./anthropic-fetch.js";
+import { anthropicMessages, anthropicEndpoint, type VendorFallback } from "./anthropic-fetch.js";
 
 export type CheckableItem = {
   id: string;
@@ -202,7 +202,7 @@ ${itemsText}
 
 // ─── Anthropic call ───────────────────────────────────────────────────────────
 
-async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | undefined, timeoutMs = 20000): Promise<string> {
+async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | undefined, timeoutMs = 20000, fallback?: VendorFallback): Promise<string> {
   const data = (await anthropicMessages(
     apiKey,
     { model: "claude-haiku-4-5-20251001", max_tokens: 4000, messages: [{ role: "user", content: prompt }] },
@@ -210,6 +210,7 @@ async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | u
     undefined,
     anthropicEndpoint(baseUrl),
     "check",
+    { fallback },
   )) as { content?: Array<{ type: string; text?: string }> };
   return (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
 }
@@ -402,6 +403,8 @@ export async function generateCheckDraft(
   req: WorkspaceCheckDraftRequest,
   anthropicApiKey: string | undefined,
   anthropicBaseUrl?: string,
+  /** 벤더 폴백(Anthropic 차단 시 OpenAI) — 라우트가 env에서 전달. */
+  fallback?: VendorFallback,
 ): Promise<WorkspaceCheckDraftResponse | { ok: false; error: "llm_unavailable" }> {
   if (!req.items?.length) {
     return {
@@ -421,7 +424,7 @@ export async function generateCheckDraft(
   const prompt = buildCheckPrompt(req);
   let rawText = "";
   try {
-    rawText = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl);
+    rawText = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl, undefined, fallback);
   } catch (err) {
     console.error("[workspace/check] LLM call failed:", err);
     return { ok: false as const, error: "llm_unavailable" as const };

--- a/apps/central-plane/src/workspace/fix.ts
+++ b/apps/central-plane/src/workspace/fix.ts
@@ -5,7 +5,7 @@
  * Produces: plain summary + spec patch + builder brief (개발 AI에게 줄 지시서).
  * LLM failure → deterministic mock fallback.
  */
-import { anthropicMessages, anthropicEndpoint } from "./anthropic-fetch.js";
+import { anthropicMessages, anthropicEndpoint, type VendorFallback } from "./anthropic-fetch.js";
 
 export type WorkspaceFixSuggestionRequest = {
   projectId?: string;
@@ -147,7 +147,7 @@ ${JSON.stringify(req.productSpec, null, 2).slice(0, 800)}
 
 // ─── Anthropic call ───────────────────────────────────────────────────────────
 
-async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | undefined, timeoutMs = 20000): Promise<string> {
+async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | undefined, timeoutMs = 20000, fallback?: VendorFallback): Promise<string> {
   const data = (await anthropicMessages(
     apiKey,
     { model: "claude-haiku-4-5-20251001", max_tokens: 3000, messages: [{ role: "user", content: prompt }] },
@@ -155,6 +155,7 @@ async function callAnthropic(apiKey: string, prompt: string, baseUrl: string | u
     undefined,
     anthropicEndpoint(baseUrl),
     "fix",
+    { fallback },
   )) as { content?: Array<{ type: string; text?: string }> };
   return (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
 }
@@ -360,6 +361,8 @@ export async function generateFixSuggestion(
   req: WorkspaceFixSuggestionRequest,
   anthropicApiKey: string | undefined,
   anthropicBaseUrl?: string,
+  /** 벤더 폴백(Anthropic 차단 시 OpenAI) — 라우트가 env에서 전달. */
+  fallback?: VendorFallback,
 ): Promise<WorkspaceFixSuggestionResponse | { ok: false; error: "llm_unavailable" }> {
   if (!anthropicApiKey) {
     console.warn("[workspace/fix] no API key — using mock fallback");
@@ -369,7 +372,7 @@ export async function generateFixSuggestion(
   const prompt = buildFixPrompt(req);
   let rawText = "";
   try {
-    rawText = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl);
+    rawText = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl, undefined, fallback);
   } catch (err) {
     console.error("[workspace/fix] LLM call failed:", err);
     return { ok: false as const, error: "llm_unavailable" as const };

--- a/apps/central-plane/src/workspace/generate.ts
+++ b/apps/central-plane/src/workspace/generate.ts
@@ -3,7 +3,7 @@
  * idea-to-spec draft. Falls back to inline mock data on any failure
  * so the user-facing flow never breaks.
  */
-import { anthropicMessages, anthropicEndpoint } from "./anthropic-fetch.js";
+import { anthropicMessages, anthropicEndpoint, type VendorFallback } from "./anthropic-fetch.js";
 import { verifySpecAgainstUserWords, type SpecVerification } from "./verify-spec.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -548,6 +548,7 @@ async function callAnthropic(
   prompt: string,
   baseUrl: string | undefined,
   timeoutMs = 120000, // document-scale prompts (up to 80k chars) need generous time
+  fallback?: VendorFallback,
 ): Promise<{ text: string; usage: LlmCallUsage }> {
   const startedAt = Date.now();
   const data = (await anthropicMessages(
@@ -572,6 +573,7 @@ async function callAnthropic(
     undefined,
     anthropicEndpoint(baseUrl),
     "generate",
+    { fallback },
   )) as {
     content?: Array<{ type: string; text?: string }>;
     stop_reason?: string;
@@ -992,6 +994,8 @@ export async function generateIdeaToSpecDraft(
   req: IdeaToSpecDraftRequest,
   anthropicApiKey: string | undefined,
   anthropicBaseUrl?: string,
+  /** 벤더 폴백(Anthropic 차단 시 OpenAI) — 라우트가 env에서 전달. */
+  fallback?: VendorFallback,
 ): Promise<IdeaToSpecDraftResponse | { ok: false; error: "llm_unavailable" }> {
   if (!req.idea?.trim()) {
     return { ...buildMockFallback(req), warnings: ["아이디어를 입력해주세요."] };
@@ -1005,7 +1009,7 @@ export async function generateIdeaToSpecDraft(
   let rawText = "";
   let llmUsage: LlmCallUsage | undefined;
   try {
-    const call = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl);
+    const call = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl, undefined, fallback);
     rawText = call.text;
     llmUsage = call.usage;
   } catch (err) {

--- a/apps/central-plane/src/workspace/pr-review.ts
+++ b/apps/central-plane/src/workspace/pr-review.ts
@@ -6,7 +6,7 @@
  * LLM failure → heuristic fallback (diff-aware: matching filenames lean toward "통과").
  */
 import type { CheckableItem, ProductSpecForCheck, CheckResultItem } from "./check.js";
-import { anthropicMessages, anthropicEndpoint } from "./anthropic-fetch.js";
+import { anthropicMessages, anthropicEndpoint, type VendorFallback } from "./anthropic-fetch.js";
 import type { PullRequestMeta, PullRequestFile } from "./github-pr.js";
 import { buildDiffSummary } from "./github-pr.js";
 import type { FetchLike } from "../github.js";
@@ -106,6 +106,7 @@ async function callAnthropic(
   timeoutMs = 25000,
   fetchImpl: FetchLike = fetch.bind(globalThis) as FetchLike,
   baseUrl?: string,
+  fallback?: VendorFallback,
 ): Promise<{ text: string; tokens: number | null }> {
   const data = (await anthropicMessages(
     apiKey,
@@ -114,6 +115,7 @@ async function callAnthropic(
     fetchImpl,
     anthropicEndpoint(baseUrl),
     "pr-review",
+    { fallback },
   )) as {
     content?: Array<{ type: string; text?: string }>;
     usage?: { input_tokens?: number; output_tokens?: number };
@@ -294,6 +296,8 @@ export async function reviewPRAgainstItems(
   anthropicApiKey: string | undefined,
   fetchImpl: FetchLike = fetch.bind(globalThis) as FetchLike,
   anthropicBaseUrl?: string,
+  /** 벤더 폴백(Anthropic 차단 시 OpenAI) — 라우트가 env에서 전달. */
+  fallback?: VendorFallback,
 ): Promise<PRReviewResponse> {
   if (!req.items?.length) {
     return {
@@ -314,7 +318,7 @@ export async function reviewPRAgainstItems(
   let rawText = "";
   let tokensConsumed: number | null = null;
   try {
-    const out = await callAnthropic(anthropicApiKey, prompt, 25000, fetchImpl, anthropicBaseUrl);
+    const out = await callAnthropic(anthropicApiKey, prompt, 25000, fetchImpl, anthropicBaseUrl, fallback);
     rawText = out.text;
     tokensConsumed = out.tokens;
   } catch (err) {

--- a/apps/central-plane/src/workspace/recommend.ts
+++ b/apps/central-plane/src/workspace/recommend.ts
@@ -13,7 +13,7 @@
  *      product decision would be worse than saying "추천을 못 가져왔어요".
  */
 
-import { anthropicMessages, anthropicEndpoint } from "./anthropic-fetch.js";
+import { anthropicMessages, anthropicEndpoint, type VendorFallback } from "./anthropic-fetch.js";
 
 export type WorkspaceRecommendAnswerRequest = {
   /** The open decision to resolve, verbatim from productSpec.openQuestions. */
@@ -92,6 +92,7 @@ async function callAnthropic(
   prompt: string,
   baseUrl: string | undefined,
   timeoutMs = 15000,
+  fallback?: VendorFallback,
 ): Promise<string> {
   const data = (await anthropicMessages(
     apiKey,
@@ -100,6 +101,7 @@ async function callAnthropic(
     undefined,
     anthropicEndpoint(baseUrl),
     "recommend",
+    { fallback },
   )) as { content?: Array<{ type: string; text?: string }> };
   return (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
 }
@@ -125,6 +127,8 @@ export async function generateRecommendedAnswer(
   req: WorkspaceRecommendAnswerRequest,
   anthropicApiKey: string | undefined,
   anthropicBaseUrl?: string,
+  /** 벤더 폴백(Anthropic 차단 시 OpenAI) — 라우트가 env에서 전달. */
+  fallback?: VendorFallback,
 ): Promise<WorkspaceRecommendAnswerResponse> {
   if (!anthropicApiKey) {
     console.warn("[workspace/recommend] no API key — honest failure (no silent default)");
@@ -134,7 +138,7 @@ export async function generateRecommendedAnswer(
   const prompt = buildRecommendPrompt(req);
   let rawText = "";
   try {
-    rawText = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl);
+    rawText = await callAnthropic(anthropicApiKey, prompt, anthropicBaseUrl, undefined, fallback);
   } catch (err) {
     console.error("[workspace/recommend] LLM call failed:", err);
     return { ok: false as const, error: "llm_unavailable" as const };

--- a/apps/central-plane/src/workspace/unstick.ts
+++ b/apps/central-plane/src/workspace/unstick.ts
@@ -11,7 +11,7 @@
  *      지어낸 해결책은 막힌 비개발자를 더 깊이 막는다.
  *   ③ 영문 스캐폴드 + 한국어 출력 (recommend.ts의 검증된 기법, 2026-07-07 결정)
  */
-import { anthropicMessages, anthropicEndpoint } from "./anthropic-fetch.js";
+import { anthropicMessages, anthropicEndpoint, type VendorFallback } from "./anthropic-fetch.js";
 
 export type WorkspaceUnstickRequest = {
   /** 붙여넣은 에러 메시지 또는 상황 설명 (서버에서 8000자 컷). */
@@ -71,6 +71,7 @@ async function callAnthropic(
   prompt: string,
   baseUrl: string | undefined,
   timeoutMs = 20000,
+  fallback?: VendorFallback,
 ): Promise<string> {
   const data = (await anthropicMessages(
     apiKey,
@@ -79,6 +80,7 @@ async function callAnthropic(
     undefined,
     anthropicEndpoint(baseUrl),
     "unstick",
+    { fallback },
   )) as { content?: Array<{ type: string; text?: string }> };
   return (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
 }
@@ -99,6 +101,8 @@ export async function generateUnstickAdvice(
   req: WorkspaceUnstickRequest,
   anthropicApiKey: string | undefined,
   anthropicBaseUrl?: string,
+  /** 벤더 폴백(Anthropic 차단 시 OpenAI) — 라우트가 env에서 전달. */
+  fallback?: VendorFallback,
 ): Promise<WorkspaceUnstickResponse> {
   if (!anthropicApiKey) {
     console.warn("[workspace/unstick] no API key — honest failure");
@@ -107,7 +111,7 @@ export async function generateUnstickAdvice(
 
   let rawText = "";
   try {
-    rawText = await callAnthropic(anthropicApiKey, buildUnstickPrompt(req), anthropicBaseUrl);
+    rawText = await callAnthropic(anthropicApiKey, buildUnstickPrompt(req), anthropicBaseUrl, undefined, fallback);
   } catch (err) {
     console.error("[workspace/unstick] LLM call failed:", err);
     return { ok: false as const, error: "llm_unavailable" as const };

--- a/apps/central-plane/test/vendor-fallback.test.mjs
+++ b/apps/central-plane/test/vendor-fallback.test.mjs
@@ -1,0 +1,201 @@
+/**
+ * vendor-fallback.test.mjs — Anthropic 차단 시 OpenAI 폴백 (2026-08-22).
+ *
+ * 실측 근거(/internal/llm-probe, 동시성 1·4):
+ *   anthropic gateway 0/1·0/4 · direct 0/1·0/4 (403 forbidden)
+ *   **openai 1/1·4/4 (200)** · gemini 400 "User location is not supported"
+ * 재시도·백오프·경로 교대·지터로 네 번 시도해 네 번 실패한 뒤의 마지막 수단.
+ *
+ * 고정하는 계약:
+ *   ① Anthropic이 끝내 실패하면 OpenAI로 같은 프롬프트를 던진다
+ *   ② 응답은 **Anthropic 형태로 변환**되어 호출부는 폴백을 모른다
+ *   ③ 폴백이 없거나(키 없음) 폴백도 실패하면 **원래 에러로 정직하게 실패**
+ *   ④ 어느 벤더가 응답했는지 로그에 남는다(조용한 대체 금지)
+ *   ⑤ Anthropic이 성공하면 폴백을 호출하지 않는다(무회귀)
+ */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+const { anthropicMessages, OPENAI_FALLBACK_MODEL, __resetAnthropicBreaker } = await import("../dist/workspace/anthropic-fetch.js");
+
+// 차단기는 isolate 전역이다 — 테스트 간에 상태가 새면 서로를 오염시킨다.
+beforeEach(() => __resetAnthropicBreaker());
+
+const GATEWAY = "https://gateway.example/anthropic/v1/messages";
+const BODY = { model: "claude-haiku-4-5-20251001", max_tokens: 500, messages: [{ role: "user", content: "hi" }] };
+const FB = { openaiApiKey: "sk-openai", openaiBaseUrl: "https://gateway.example/openai" };
+
+const forbidden = () => new Response('{"error":{"type":"forbidden","message":"Request not allowed"}}', { status: 403 });
+const anthropicOk = () => new Response(JSON.stringify({ content: [{ type: "text", text: "from-anthropic" }], usage: { input_tokens: 1, output_tokens: 2 } }), { status: 200 });
+const openAiOk = () => new Response(JSON.stringify({ choices: [{ message: { content: "from-openai" } }], usage: { prompt_tokens: 11, completion_tokens: 22 } }), { status: 200 });
+
+const isOpenAi = (url) => String(url).includes("/chat/completions");
+function recorder() {
+  let clock = 1_000_000;
+  return { sleepImpl: async (ms) => { clock += ms; }, nowImpl: () => clock, randomImpl: () => 0.5 };
+}
+async function captureLogs(fn) {
+  const lines = [];
+  const orig = console.log;
+  console.log = (...a) => { lines.push(String(a[0])); };
+  try { return { result: await fn(), lines }; }
+  catch (error) { return { error, lines }; }
+  finally { console.log = orig; }
+}
+const parsed = (lines) => lines.map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+
+describe("벤더 폴백 — Anthropic 차단 시 OpenAI (①②④)", () => {
+  it("★Anthropic이 403으로 전멸해도 OpenAI로 응답을 받아온다", async () => {
+    const opts = { ...recorder(), fallback: FB };
+    const urls = [];
+    const fetchImpl = async (url) => { urls.push(url); return isOpenAi(url) ? openAiOk() : forbidden(); };
+    const data = await anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "check", opts);
+    assert.equal(data.content[0].text, "from-openai", "OpenAI 응답이 반환된다");
+    assert.equal(data.content[0].type, "text", "Anthropic 형태로 변환된다(②)");
+    assert.ok(urls.some(isOpenAi), "OpenAI가 호출됐다");
+    assert.equal(urls.filter((u) => !isOpenAi(u)).length, 6, "Anthropic은 6회 다 시도한 뒤 폴백");
+  });
+
+  it("usage가 OpenAI 필드에서 옮겨진다", async () => {
+    const opts = { ...recorder(), fallback: FB };
+    const fetchImpl = async (url) => (isOpenAi(url) ? openAiOk() : forbidden());
+    const data = await anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "check", opts);
+    assert.equal(data.usage.input_tokens, 11);
+    assert.equal(data.usage.output_tokens, 22);
+  });
+
+  it("④ 어느 벤더가 응답했는지 로그에 남는다 — 조용한 대체 금지", async () => {
+    const opts = { ...recorder(), fallback: FB };
+    const fetchImpl = async (url) => (isOpenAi(url) ? openAiOk() : forbidden());
+    const { lines } = await captureLogs(() => anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "check", opts));
+    const logs = parsed(lines);
+    const usage = logs.find((j) => j.event === "anthropic_usage");
+    assert.equal(usage.vendor, "openai", "실제 응답 벤더가 기록된다");
+    assert.equal(usage.model, OPENAI_FALLBACK_MODEL);
+    const fb = logs.find((j) => j.event === "llm_fallback");
+    assert.ok(fb, "폴백 사실이 별도 이벤트로 남는다");
+    assert.equal(fb.from, "anthropic");
+    assert.equal(fb.to, "openai");
+    assert.equal(fb.primary_status, 403);
+  });
+});
+
+describe("벤더 폴백 — 정직한 실패 (③)", () => {
+  it("OpenAI 키가 없으면 종전처럼 원래 에러로 실패한다", async () => {
+    const opts = { ...recorder() }; // fallback 없음
+    const fetchImpl = async () => forbidden();
+    await assert.rejects(
+      anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "check", opts),
+      /Anthropic 403/,
+    );
+  });
+
+  it("폴백도 실패하면 **원래 Anthropic 에러**를 던진다 (원인이 더 유용)", async () => {
+    const opts = { ...recorder(), fallback: FB };
+    const fetchImpl = async (url) => (isOpenAi(url) ? new Response("nope", { status: 500 }) : forbidden());
+    await assert.rejects(
+      anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "check", opts),
+      /Anthropic 403/,
+    );
+  });
+
+  it("폴백 실패도 로그에 남는다", async () => {
+    const opts = { ...recorder(), fallback: FB };
+    const fetchImpl = async (url) => (isOpenAi(url) ? new Response("nope", { status: 500 }) : forbidden());
+    const { lines } = await captureLogs(() => anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "check", opts));
+    assert.ok(parsed(lines).some((j) => j.event === "llm_fallback_failed"));
+  });
+});
+
+describe("벤더 폴백 — 무회귀 (⑤)", () => {
+  it("Anthropic이 성공하면 OpenAI를 호출하지 않는다", async () => {
+    const opts = { ...recorder(), fallback: FB };
+    const urls = [];
+    const fetchImpl = async (url) => { urls.push(url); return anthropicOk(); };
+    const data = await anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "check", opts);
+    assert.equal(data.content[0].text, "from-anthropic");
+    assert.ok(!urls.some(isOpenAi), "폴백 미호출");
+  });
+
+  it("성공 로그의 vendor는 anthropic으로 남는다", async () => {
+    const opts = { ...recorder(), fallback: FB };
+    const fetchImpl = async () => anthropicOk();
+    const { lines } = await captureLogs(() => anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "generate", opts));
+    const usage = parsed(lines).find((j) => j.event === "anthropic_usage");
+    assert.equal(usage.vendor, "anthropic");
+  });
+});
+
+describe("회로 차단기 — 죽은 벤더를 반복해 두드리지 않는다", () => {
+  it("연속 실패 후 다음 호출은 Anthropic을 아예 건너뛰고 폴백으로 간다", async () => {
+    const fetchFail = async (url) => (isOpenAi(url) ? openAiOk() : forbidden());
+    // 임계(2회)까지 실패시킨다.
+    await anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", { ...recorder(), fallback: FB });
+    await anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", { ...recorder(), fallback: FB });
+
+    const urls = [];
+    const data = await anthropicMessages(
+      "k", BODY, 1000,
+      async (url) => { urls.push(url); return isOpenAi(url) ? openAiOk() : forbidden(); },
+      GATEWAY, "check", { ...recorder(), fallback: FB },
+    );
+    assert.equal(data.content[0].text, "from-openai");
+    assert.ok(!urls.some((u) => !isOpenAi(u)), "★Anthropic을 한 번도 두드리지 않는다 — 12초 낭비 제거");
+  });
+
+  it("차단 사실이 로그에 남는다", async () => {
+    const fetchFail = async (url) => (isOpenAi(url) ? openAiOk() : forbidden());
+    const opts = () => ({ ...recorder(), fallback: FB });
+    await anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", opts());
+    await anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", opts());
+    const { lines } = await captureLogs(() => anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", opts()));
+    const ev = parsed(lines).find((j) => j.event === "llm_breaker_open");
+    assert.ok(ev, "무엇을 건너뛰었는지 남는다");
+    assert.equal(ev.skipped, "anthropic");
+  });
+
+  it("★폴백이 없으면 차단하지 않는다 — 유일한 경로를 스스로 끊지 않는다", async () => {
+    const fetchFail = async (url) => (isOpenAi(url) ? openAiOk() : forbidden());
+    await anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", { ...recorder(), fallback: FB });
+    await anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", { ...recorder(), fallback: FB });
+
+    const urls = [];
+    await assert.rejects(
+      anthropicMessages("k", BODY, 1000, async (url) => { urls.push(url); return forbidden(); }, GATEWAY, "check", recorder()),
+      /Anthropic 403/,
+    );
+    assert.equal(urls.length, 6, "폴백 없으면 종전대로 6회 다 시도한다");
+  });
+
+  it("쿨다운이 지나면 한 번 다시 통과시켜 살아났는지 확인한다 (half-open)", async () => {
+    const fetchFail = async (url) => (isOpenAi(url) ? openAiOk() : forbidden());
+    await anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", { ...recorder(), fallback: FB });
+    await anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", { ...recorder(), fallback: FB });
+
+    // 60초 뒤의 시계로 호출 — 차단이 풀려 Anthropic을 다시 시도해야 한다.
+    let clock = Date.now() + 120_000;
+    const urls = [];
+    const data = await anthropicMessages(
+      "k", BODY, 1000,
+      async (url) => { urls.push(url); return anthropicOk(); },
+      GATEWAY, "check",
+      { sleepImpl: async (ms) => { clock += ms; }, nowImpl: () => clock, randomImpl: () => 0.5, fallback: FB },
+    );
+    assert.equal(data.content[0].text, "from-anthropic", "살아났으면 원래 벤더로 돌아온다");
+    assert.ok(urls.some((u) => !isOpenAi(u)), "Anthropic을 다시 시도했다");
+  });
+
+  it("Anthropic이 한 번 성공하면 차단기가 즉시 리셋된다", async () => {
+    const fetchFail = async (url) => (isOpenAi(url) ? openAiOk() : forbidden());
+    await anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", { ...recorder(), fallback: FB });
+    let clock = Date.now() + 120_000;
+    const late = { sleepImpl: async (ms) => { clock += ms; }, nowImpl: () => clock, randomImpl: () => 0.5, fallback: FB };
+    await anthropicMessages("k", BODY, 1000, async () => anthropicOk(), GATEWAY, "check", late);
+
+    // 실패 카운트가 0이므로, 다음 실패 1회로는 차단되지 않는다.
+    const urls = [];
+    await anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", { ...recorder(), fallback: FB });
+    await anthropicMessages("k", BODY, 1000, async (url) => { urls.push(url); return isOpenAi(url) ? openAiOk() : forbidden(); }, GATEWAY, "check", { ...recorder(), fallback: FB });
+    assert.ok(urls.some((u) => !isOpenAi(u)), "리셋 후엔 다시 Anthropic부터 시도한다");
+  });
+});


### PR DESCRIPTION
## 요약

`/internal/llm-probe` 실측으로 **Anthropic이 Worker egress에서 완전 차단**(간헐 아님)이고
**OpenAI만 열려 있다**는 것이 확인됐다. 재시도로는 넘을 수 없는 벽이라, Anthropic이 끝내
실패하면 같은 프롬프트를 OpenAI로 넘기고 응답을 Anthropic 형태로 옮겨 돌려준다.
덧붙여 100% 막힌 경로를 매 호출마다 6회 두드리는 ~12초를 회로 차단기로 없앤다.

## 측정 (추측 아님)

| 벤더·경로 | 동시성 1 | 동시성 4 | 비고 |
|---|---|---|---|
| anthropic:gateway | 0/1 | 0/4 | 403 "Request not allowed" |
| anthropic:direct | 0/1 | 0/4 | 403 |
| **openai:gateway** | **1/1** | **4/4** | 200, 평균 2.9초 |
| gemini:gateway | 0/1 | 0/4 | 400 "User location is not supported" (지역 제한) |

이 403은 그동안 용량 → 경로 → 지터 → 동시성 네 가지로 가정해 네 번 고쳤고 **네 번 다
틀렸다**(각각 배포 후 실측으로 반증). 이번엔 가정 대신 프로브를 먼저 만들어 쟀다.

## 변경

1. **벤더 폴백** (`anthropic-fetch.ts`) — 실패 시 OpenAI(`gpt-5.4`)로 재시도, 응답을
   `{content:[{type:"text"}], usage}` 형태로 변환. 호출부 6곳(check·fix·recommend·
   unstick·generate·pr-review)은 폴백의 존재를 모른다.
2. **회로 차단기** — 연속 2회 실패 시 이후 호출은 Anthropic을 건너뛰고 곧장 폴백으로.
   쿨다운 60초마다 한 번 통과시켜 살아났는지 확인(half-open), 성공하면 즉시 원복.
3. **라우트 배선** — `OPENAI_API_KEY`가 있을 때만 폴백을 전달. 키가 없으면 동작이
   종전과 완전히 동일하다.

## 정직성 — 조용한 대체가 아니다

- 어느 벤더가 응답했는지 항상 로그에 남는다: `anthropic_usage.vendor`,
  `llm_fallback`, `llm_fallback_failed`, `llm_breaker_open`.
- 폴백이 없거나 폴백마저 실패하면 **원래 Anthropic 에러를 그대로 던진다**.
- **폴백이 없으면 차단기를 열지 않는다** — 유일한 경로를 스스로 끊으면 안 된다.

## 검증

- `vendor-fallback.test.mjs` **13건 신규** — 폴백 동작·형태 변환·usage 이관·로그 4종·
  정직한 실패 2종·무회귀 2종·차단기 5종.
- central-plane **2016/2016** · typecheck · lint green.

## 배포 후 확인 예정

`concurrency-verify.mjs` 재실행 — 동시 4건 실패가 사라지는지 실측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
