### PR TITLE
fix(probe): 200 ≠ 쓸 만하다 — 프로브가 실제 텍스트 수신까지 확인

### DIFF
--- a/apps/central-plane/src/routes/llm-probe.ts
+++ b/apps/central-plane/src/routes/llm-probe.ts
@@ -20,7 +20,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
-import { anthropicEndpoint } from "../workspace/anthropic-fetch.js";
+import { anthropicEndpoint, OPENAI_FALLBACK_MODEL } from "../workspace/anthropic-fetch.js";
 
 type ProbeResult = {
   vendor: "anthropic" | "openai" | "gemini";
@@ -29,11 +29,26 @@ type ProbeResult = {
   ms: number;
   /** 실패 본문의 앞부분 — 원인 분류에 필요한 최소치만. */
   detail?: string;
+  /**
+   * ★200이 곧 "쓸 만하다"가 아니다 (2026-08-22 교훈).
+   *
+   * 종전 프로브는 **HTTP 상태만** 봤다. 그 결과 "openai 4/4 200"을 근거로 폴백을
+   * 그 모델에 걸었는데, 그건 **도달 가능**의 증거일 뿐 **텍스트를 돌려준다**는
+   * 증거가 아니었다. 추론형 모델은 토큰 예산을 추론에 다 쓰고 본문을 비워 보내도
+   * 200이다. 폴백이 이 모델에 의존하므로, 프로브가 그 질문에 직접 답해야 한다.
+   */
+  usable?: boolean;
+  /** 실제로 받은 텍스트 길이 — usable의 근거를 숫자로 남긴다. */
+  textChars?: number;
 };
 
 const PROMPT = "Reply with the single word: ok";
+/** 추론형 모델이 예산을 추론에 다 써서 본문을 비우지 않도록 넉넉히. 그래도 응답은 한 단어다. */
+const MAX_OUT = 512;
 
-async function timed(fn: () => Promise<{ status: number | "network_error"; detail?: string }>): Promise<{ status: number | "network_error"; detail?: string; ms: number }> {
+type Probed = { status: number | "network_error"; detail?: string; usable?: boolean; textChars?: number };
+
+async function timed(fn: () => Promise<Probed>): Promise<Probed & { ms: number }> {
   const t = Date.now();
   try {
     const r = await fn();
@@ -52,9 +67,12 @@ async function probeAnthropic(env: Env, useGateway: boolean): Promise<ProbeResul
     const r = await fetch(url, {
       method: "POST",
       headers: { "x-api-key": key, "anthropic-version": "2023-06-01", "content-type": "application/json", "user-agent": "simsa-central-plane/1.0" },
-      body: JSON.stringify({ model: "claude-haiku-4-5-20251001", max_tokens: 5, messages: [{ role: "user", content: PROMPT }] }),
+      body: JSON.stringify({ model: "claude-haiku-4-5-20251001", max_tokens: MAX_OUT, messages: [{ role: "user", content: PROMPT }] }),
     });
-    return { status: r.status, detail: r.ok ? undefined : (await r.text().catch(() => "")).slice(0, 120) };
+    if (!r.ok) return { status: r.status, detail: (await r.text().catch(() => "")).slice(0, 120) };
+    const j = (await r.json().catch(() => null)) as { content?: Array<{ type: string; text?: string }> } | null;
+    const text = (j?.content ?? []).find((b) => b.type === "text")?.text ?? "";
+    return { status: r.status, usable: text.trim().length > 0, textChars: text.length };
   });
   return { vendor: "anthropic", path, ...out };
 }
@@ -69,9 +87,12 @@ async function probeOpenAi(env: Env): Promise<ProbeResult> {
     const r = await fetch(url, {
       method: "POST",
       headers: { authorization: `Bearer ${key}`, "content-type": "application/json" },
-      body: JSON.stringify({ model: "gpt-5.4", max_completion_tokens: 5, messages: [{ role: "user", content: PROMPT }] }),
+      body: JSON.stringify({ model: OPENAI_FALLBACK_MODEL, max_completion_tokens: MAX_OUT, messages: [{ role: "user", content: PROMPT }] }),
     });
-    return { status: r.status, detail: r.ok ? undefined : (await r.text().catch(() => "")).slice(0, 120) };
+    if (!r.ok) return { status: r.status, detail: (await r.text().catch(() => "")).slice(0, 120) };
+    const j = (await r.json().catch(() => null)) as { choices?: Array<{ message?: { content?: string } }> } | null;
+    const text = j?.choices?.[0]?.message?.content ?? "";
+    return { status: r.status, usable: text.trim().length > 0, textChars: text.length };
   });
   return { vendor: "openai", path, ...out };
 }
@@ -91,7 +112,10 @@ async function probeGemini(env: Env): Promise<ProbeResult> {
       headers: { "x-goog-api-key": key, "content-type": "application/json" },
       body: JSON.stringify({ contents: [{ parts: [{ text: PROMPT }] }] }),
     });
-    return { status: r.status, detail: r.ok ? undefined : (await r.text().catch(() => "")).slice(0, 120) };
+    if (!r.ok) return { status: r.status, detail: (await r.text().catch(() => "")).slice(0, 120) };
+    const j = (await r.json().catch(() => null)) as { candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> } | null;
+    const text = (j?.candidates?.[0]?.content?.parts ?? []).map((p) => p.text ?? "").join("");
+    return { status: r.status, usable: text.trim().length > 0, textChars: text.length };
   });
   return { vendor: "gemini", path, ...out };
 }
@@ -119,12 +143,15 @@ export function createLlmProbeRoutes(): Hono<{ Bindings: Env }> {
     const results = await Promise.all(rounds);
 
     // 벤더·경로별 요약 — 사람이 한눈에 보고 판단하기 위한 집계.
-    const summary: Record<string, { ok: number; total: number; statuses: Record<string, number>; avgMs: number }> = {};
+    // ok(=200 도달)와 usable(=실제 텍스트를 받음)을 **따로** 센다. 둘이 갈리는
+    // 경우가 정확히 폴백이 조용히 망가지는 지점이다.
+    const summary: Record<string, { ok: number; usable: number; total: number; statuses: Record<string, number>; avgMs: number }> = {};
     for (const r of results) {
       const k = `${r.vendor}:${r.path}`;
-      const s = (summary[k] ??= { ok: 0, total: 0, statuses: {}, avgMs: 0 });
+      const s = (summary[k] ??= { ok: 0, usable: 0, total: 0, statuses: {}, avgMs: 0 });
       s.total += 1;
       if (r.status === 200) s.ok += 1;
+      if (r.usable) s.usable += 1;
       const key = String(r.status);
       s.statuses[key] = (s.statuses[key] ?? 0) + 1;
       s.avgMs += r.ms;

--- a/apps/central-plane/test/llm-probe.test.mjs
+++ b/apps/central-plane/test/llm-probe.test.mjs
@@ -81,6 +81,23 @@ describe("/internal/llm-probe — 결과 형태와 무누출", () => {
   });
 });
 
+describe("/internal/llm-probe — usable (200 ≠ 쓸 만하다)", () => {
+  it("★요약이 ok와 usable을 따로 센다", async () => {
+    const env = envWith({ ANTHROPIC_API_KEY: undefined, OPENAI_API_KEY: undefined, GEMINI_API_KEY: undefined });
+    const body = await (await post(env)).json();
+    for (const [key, s] of Object.entries(body.summary)) {
+      assert.equal(typeof s.usable, "number", `${key}에 usable 집계가 있어야 한다`);
+      assert.equal(typeof s.ok, "number");
+    }
+  });
+
+  it("키가 없으면 usable은 0이다 — 호출하지 않았으니 쓸 만함도 증명 못 한다", async () => {
+    const env = envWith({ ANTHROPIC_API_KEY: undefined, OPENAI_API_KEY: undefined, GEMINI_API_KEY: undefined });
+    const body = await (await post(env)).json();
+    assert.ok(Object.values(body.summary).every((s) => s.usable === 0));
+  });
+});
+
 describe("/internal/llm-probe — 전용 토큰 (관측/콜백 분리)", () => {
   it("LLM_PROBE_TOKEN이 있으면 그것으로 연다", async () => {
     const env = envWith({ LLM_PROBE_TOKEN: "probe_only", ANTHROPIC_API_KEY: undefined, OPENAI_API_KEY: undefined, GEMINI_API_KEY: undefined });


### PR DESCRIPTION
## 요약

#496에서 벤더 폴백을 `gpt-5.4`에 걸었고 근거는 프로브의 "openai 4/4 200"이었다.
그런데 **프로브는 HTTP 상태만 봤다** — 200은 도달 가능의 증거일 뿐, 모델이 텍스트를
돌려준다는 증거가 아니다. 추론형 모델은 토큰 예산을 추론에 다 쓰고 본문을 비워 보내도
200이다. 폴백 경로 전체가 이 모델에 의존하므로 측정 도구가 그 질문에 직접 답해야 한다.

그렇지 않으면 라이브에서 빈 응답 → `llm_unavailable`로 떨어지는데, 로그상으론
"폴백 성공"처럼 보인다.

## 변경

| 항목 | 전 | 후 |
|---|---|---|
| 판정 기준 | HTTP 200 | 200 **+ 텍스트 비어있지 않음** |
| 요약 필드 | `ok` | `ok` · **`usable`** (따로 집계) |
| 결과 필드 | `status`·`ms` | + `usable`·`textChars` |
| 출력 예산 | 5 토큰 | 512 (측정 도구가 빈 응답을 스스로 유발하지 않도록) |
| 폴백 모델명 | 하드코딩 | `OPENAI_FALLBACK_MODEL` 참조 (재는 모델 = 쓰는 모델) |

## 검증

- `llm-probe.test.mjs` 2건 추가 — 요약의 ok/usable 분리, 키 없으면 usable 0.
- central-plane **2018/2018** · typecheck · lint green.
- 정직한 관측: 전체 스위트 최초 1회에서 1건 실패가 있었으나 이후 **5회 연속 clean**,
  재현되지 않음(테스트 파일 수정 직후 실행이라 stale dist 읽기가 유력). 재현 시 별건 추적.

## 배포 후 첫 확인

`POST /internal/llm-probe?n=4` → `openai:gateway`의 **usable이 4/4인지**. 여기가
0이면 #496의 폴백은 형태만 작동하고 실제로는 못 쓴다는 뜻이므로 모델을 바꿔야 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
