### PR TITLE
fix(sources): 레이트리밋이면 github.com 웹으로 폴백 — "모르겠어요"를 줄인다

### DIFF
--- a/apps/central-plane/src/workspace/source-reachability.ts
+++ b/apps/central-plane/src/workspace/source-reachability.ts
@@ -32,6 +32,7 @@ import { getGitHubConnectionByUserKey } from "./github-db.js";
 import { decryptToken } from "../crypto.js";
 
 const GITHUB_API = "https://api.github.com";
+const GITHUB_WEB = "https://github.com";
 const PROBE_TIMEOUT_MS = 6000;
 
 export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
@@ -104,14 +105,42 @@ export async function probeGithubRepo(
   }
   // 레이트리밋을 "안 보임"으로 셈하면 멀쩡한 공개 저장소를 비공개로 오진한다.
   // 비인증 GitHub API는 IP당 60회/시간이고 Worker는 egress IP를 공유한다.
-  if (resp.status === 429) return { state: "unknown", reason: "rate_limited" };
-  if (resp.status === 403) {
-    const remaining = resp.headers.get("x-ratelimit-remaining");
-    if (remaining === "0") return { state: "unknown", reason: "rate_limited" };
-    return { state: "needs_access", via };
-  }
-  if (resp.status === 404) return { state: "needs_access", via };
+  const rateLimited =
+    resp.status === 429 ||
+    (resp.status === 403 && resp.headers.get("x-ratelimit-remaining") === "0");
+  if (rateLimited) return webFallback(repoFullName, fetchImpl);
+  if (resp.status === 403 || resp.status === 404) return { state: "needs_access", via };
   return { state: "unknown", reason: "network" };
+}
+
+/**
+ * API가 레이트리밋에 걸렸을 때의 폴백 — **github.com 웹 페이지**를 찍는다.
+ *
+ * 왜 필요한가(2026-08-24 라이브 실측): 배포 직후 익명으로 4건을 연결해 봤더니
+ * **2건이 rate_limited**로 나왔다. `unknown`으로 분류한 것 자체는 옳았지만(오진을
+ * 막았다), 실사용에서 절반이 "모르겠어요"면 계측이 값을 못 낸다.
+ *
+ * 실측으로 확인한 대안: `github.com/owner/repo`에 HEAD를 던지면 **API 레이트리밋과
+ * 별개**로 동작하고(연속 20회 전부 200), 존재·공개 여부가 200/404로 갈린다.
+ *
+ * **성공한 API 답을 대체하지 않는다** — 오직 API가 막혔을 때만 부른다. 그래서 이
+ * 폴백이 실패해도 결과는 종전과 같은 `unknown`이고, 회귀가 없다.
+ * 비공개 저장소도 익명에겐 404이므로 `needs_access`가 맞다(우리 눈엔 안 보인다).
+ */
+async function webFallback(repoFullName: string, fetchImpl: FetchLike): Promise<Reachability> {
+  const resp = await withTimeout((signal) =>
+    fetchImpl(`${GITHUB_WEB}/${repoFullName}`, {
+      method: "HEAD",
+      redirect: "follow",
+      headers: { "user-agent": "simsa-central-plane/1.0" },
+      signal,
+    }),
+  );
+  if (!resp) return { state: "unknown", reason: "rate_limited" };
+  if (resp.ok) return { state: "readable", visibility: "public", via: "anonymous" };
+  if (resp.status === 404) return { state: "needs_access", via: "anonymous" };
+  // 웹까지 이상하면 종전대로 정직하게 "모름".
+  return { state: "unknown", reason: "rate_limited" };
 }
 
 /**

--- a/apps/central-plane/test/source-reachability.test.mjs
+++ b/apps/central-plane/test/source-reachability.test.mjs
@@ -59,18 +59,56 @@ describe("안 보이는 저장소 (②)", () => {
   });
 });
 
-describe("★모름과 못 읽음을 구분한다 (③)", () => {
-  it("429 → unknown/rate_limited (needs_access가 아니다)", async () => {
-    const r = await probeGithubRepo(anonEnv, "uk_none", "3SVS/simsa", async () => json({}, 429));
+describe("★레이트리밋이면 웹 페이지로 폴백한다 (2026-08-24 라이브 실측)", () => {
+  // 배포 직후 익명 4건 중 2건이 rate_limited였다. unknown 분류는 옳았지만
+  // 실사용에서 절반이 "모르겠어요"면 계측이 값을 못 낸다.
+  // github.com HEAD는 API 레이트리밋과 별개다(연속 20회 200 실측).
+  const rateLimitedApi = (webStatus) => async (url, init) => {
+    if (url.startsWith("https://api.github.com")) return json({}, 429);
+    assert.equal(init?.method, "HEAD", "웹 폴백은 본문을 받지 않는다");
+    assert.equal(url, "https://github.com/3SVS/simsa");
+    return new Response("", { status: webStatus });
+  };
+
+  it("API 429 → 웹 200이면 readable/public — 공개 저장소를 되살린다", async () => {
+    const r = await probeGithubRepo(anonEnv, "uk_none", "3SVS/simsa", rateLimitedApi(200));
+    assert.deepEqual(r, { state: "readable", visibility: "public", via: "anonymous" });
+  });
+
+  it("API 429 → 웹 404면 needs_access — 익명에겐 비공개도 404다", async () => {
+    const r = await probeGithubRepo(anonEnv, "uk_none", "3SVS/simsa", rateLimitedApi(404));
+    assert.equal(r.state, "needs_access");
+  });
+
+  it("403 + remaining:0도 같은 폴백을 탄다", async () => {
+    const r = await probeGithubRepo(anonEnv, "uk_none", "3SVS/simsa", async (url) =>
+      url.startsWith("https://api.github.com")
+        ? json({}, 403, { "x-ratelimit-remaining": "0" })
+        : new Response("", { status: 200 }),
+    );
+    assert.equal(r.state, "readable");
+  });
+
+  it("★웹까지 실패하면 종전대로 unknown — 폴백이 회귀를 만들지 않는다", async () => {
+    const r = await probeGithubRepo(anonEnv, "uk_none", "3SVS/simsa", async (url) => {
+      if (url.startsWith("https://api.github.com")) return json({}, 429);
+      throw new Error("web down");
+    });
     assert.deepEqual(r, { state: "unknown", reason: "rate_limited" });
   });
 
-  it("403 + x-ratelimit-remaining:0 → unknown — 공개 저장소 오진 방지", async () => {
-    const r = await probeGithubRepo(anonEnv, "uk_none", "3SVS/simsa", async () =>
-      json({}, 403, { "x-ratelimit-remaining": "0" }),
-    );
-    assert.deepEqual(r, { state: "unknown", reason: "rate_limited" });
+  it("★성공한 API 답은 폴백이 건드리지 않는다", async () => {
+    let webCalled = false;
+    const r = await probeGithubRepo(anonEnv, "uk_none", "3SVS/simsa", async (url) => {
+      if (!url.startsWith("https://api.github.com")) { webCalled = true; }
+      return json({ private: true });
+    });
+    assert.equal(r.visibility, "private");
+    assert.equal(webCalled, false, "API가 답했으면 웹은 부르지 않는다");
   });
+});
+
+describe("★모름과 못 읽음을 구분한다 (③)", () => {
 
   it("네트워크 예외 → unknown (던지지 않는다, ④)", async () => {
     const r = await probeGithubRepo(anonEnv, "uk_none", "3SVS/simsa", async () => {


### PR DESCRIPTION
## 라이브 실측이 문제를 보여줬습니다

#499 배포 직후 **익명으로 실제 프로덕션에 4건**을 연결해 봤습니다:

| 입력 | 결과 |
|---|---|
| 공개 저장소 주소 | `unknown/rate_limited` ← **실제로는 읽히는 저장소** |
| 저장소 안쪽 경로 | `readable/public` ✅ |
| 존재하지 않는 저장소 | `unknown/rate_limited` ← 판정 못 함 |
| 앱 주소 | `readable` ✅ |

**4건 중 2건이 레이트리밋.** `unknown`으로 분류한 설계 자체는 옳았습니다 — 공개 저장소를
"비공개인가 봐요"로 오진하지 않았으니까요. 하지만 실사용에서 절반이 "모르겠어요"면
연결 시점 계측이 값을 못 냅니다.

원인은 예측대로입니다: 비인증 GitHub API는 **IP당 60회/시간**이고 Worker는 egress IP를
공유하므로 남의 호출과 한도를 나눠 씁니다.

## 추측 대신 대안을 쟀습니다

```
GET  github.com/{owner}/{repo}   공개 200 · 존재하지 않음 404
HEAD × 20회 연속                  {"200": 20}   ← API 레이트리밋과 별개
```

## 변경

API가 레이트리밋일 때**만** 웹 페이지로 폴백합니다.

- **성공한 API 답은 절대 대체하지 않습니다** — 막혔을 때만 부릅니다.
- 웹 200 → `readable/public` · 웹 404 → `needs_access`(익명에겐 비공개도 404이고,
  "우리 눈엔 안 보인다"가 정확히 `needs_access`의 뜻입니다).
- **웹까지 실패하면 종전과 같은 `unknown`** — 그래서 이 폴백은 회귀를 만들 수 없습니다.
- HEAD만 씁니다(본문 미수신).

## 검증

- **5건 추가** — 429→웹200=readable · 429→웹404=needs_access · 403+remaining:0 동일 폴백 ·
  **웹까지 실패하면 unknown**(무회귀) · **API 성공 시 웹 미호출**.
- central-plane **2068/2068** · typecheck · lint green.

배포 후 같은 라이브 스크립트로 재측정해서 `unknown` 비율이 실제로 줄었는지 확인하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
