### PR TITLE
fix(entry): AF-6 감사가 잡은 결함 2건 — 폴백 잘림 + 코드 갈래가 앱 주소를 못 봄

### DIFF
--- a/apps/central-plane/src/workspace/anthropic-fetch.ts
+++ b/apps/central-plane/src/workspace/anthropic-fetch.ts
@@ -225,6 +225,27 @@ export type VendorFallback = {
   model?: string;
 };
 
+/**
+ * ★추론 모델은 **같은 예산에서 추론 토큰을 먼저 쓴다** (2026-08-24 실측).
+ *
+ * Anthropic의 `max_tokens`를 그대로 `max_completion_tokens`로 넘겼더니, gpt-5.4가
+ * 그 예산을 추론에 나눠 쓰고 **본문이 중간에서 끊겼다**: 스펙 생성에서 정상
+ * Anthropic 응답이 12,449자인데 폴백은 6,179자에서 잘려 `JSON parse failed`.
+ * 폴백이 "성공"으로 보이는데 결과는 못 쓰는 상태 — 가장 나쁜 실패 모양이다.
+ *
+ * 그래서 폴백에는 **여유 예산**을 준다. 배수는 실측 전까지의 잠정값이고,
+ * `llm_fallback_truncated` 로그의 reasoning_tokens로 조정한다(추측 대신 계측).
+ * OpenAI는 실제로 쓴 만큼만 과금하므로 상한을 넉넉히 잡는 비용은 낮다.
+ */
+const FALLBACK_BUDGET_MULTIPLIER = 3;
+const FALLBACK_BUDGET_MIN = 8000;
+const FALLBACK_BUDGET_MAX = 32000;
+
+export function fallbackOutputBudget(anthropicMaxTokens: number): number {
+  const wanted = Math.max(anthropicMaxTokens * FALLBACK_BUDGET_MULTIPLIER, FALLBACK_BUDGET_MIN);
+  return Math.min(wanted, FALLBACK_BUDGET_MAX);
+}
+
 function openAiUrl(baseUrl?: string): string {
   const base = (baseUrl ?? "").trim().replace(/\/$/, "");
   return base ? `${base}/chat/completions` : "https://api.openai.com/v1/chat/completions";
@@ -246,7 +267,7 @@ async function callOpenAiAsAnthropic(
       headers: { authorization: `Bearer ${fb.openaiApiKey}`, "content-type": "application/json" },
       body: JSON.stringify({
         model: fb.model ?? OPENAI_FALLBACK_MODEL,
-        max_completion_tokens: body.max_tokens,
+        max_completion_tokens: fallbackOutputBudget(body.max_tokens),
         messages: body.messages,
       }),
     });
@@ -255,12 +276,36 @@ async function callOpenAiAsAnthropic(
       throw new Error(`OpenAI ${r.status}: ${tail.slice(0, 200)}`);
     }
     const j = (await r.json()) as {
-      choices?: Array<{ message?: { content?: string } }>;
-      usage?: { prompt_tokens?: number; completion_tokens?: number };
+      choices?: Array<{ message?: { content?: string }; finish_reason?: string }>;
+      usage?: {
+        prompt_tokens?: number;
+        completion_tokens?: number;
+        completion_tokens_details?: { reasoning_tokens?: number };
+      };
     };
-    const text = j.choices?.[0]?.message?.content ?? "";
+    const choice = j.choices?.[0];
+    const text = choice?.message?.content ?? "";
+    const reasoning = j.usage?.completion_tokens_details?.reasoning_tokens ?? 0;
+    // ★잘림을 호출부에 보이게 한다. 종전엔 stop_reason을 안 넘겨서 잘린 JSON이
+    //  그냥 "파싱 실패"로만 보였다 — 원인을 알 수 없는 실패였다(2026-08-24 실측).
+    const stop = choice?.finish_reason === "length" ? "max_tokens" : (choice?.finish_reason ?? undefined);
+    if (choice?.finish_reason === "length") {
+      try {
+        console.log(
+          JSON.stringify({
+            event: "llm_fallback_truncated",
+            model: fb.model ?? OPENAI_FALLBACK_MODEL,
+            requested_max: fallbackOutputBudget(body.max_tokens),
+            completion_tokens: j.usage?.completion_tokens ?? 0,
+            reasoning_tokens: reasoning,
+            text_chars: text.length,
+          }),
+        );
+      } catch { /* logging must not break the call */ }
+    }
     return {
       content: [{ type: "text", text }],
+      ...(stop ? { stop_reason: stop } : {}),
       usage: { input_tokens: j.usage?.prompt_tokens ?? 0, output_tokens: j.usage?.completion_tokens ?? 0 },
     };
   } finally {

--- a/apps/central-plane/test/vendor-fallback.test.mjs
+++ b/apps/central-plane/test/vendor-fallback.test.mjs
@@ -16,7 +16,7 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 
-const { anthropicMessages, OPENAI_FALLBACK_MODEL, __resetAnthropicBreaker } = await import("../dist/workspace/anthropic-fetch.js");
+const { anthropicMessages, OPENAI_FALLBACK_MODEL, __resetAnthropicBreaker, fallbackOutputBudget } = await import("../dist/workspace/anthropic-fetch.js");
 
 // 차단기는 isolate 전역이다 — 테스트 간에 상태가 새면 서로를 오염시킨다.
 beforeEach(() => __resetAnthropicBreaker());
@@ -197,5 +197,73 @@ describe("회로 차단기 — 죽은 벤더를 반복해 두드리지 않는다
     await anthropicMessages("k", BODY, 1000, fetchFail, GATEWAY, "check", { ...recorder(), fallback: FB });
     await anthropicMessages("k", BODY, 1000, async (url) => { urls.push(url); return isOpenAi(url) ? openAiOk() : forbidden(); }, GATEWAY, "check", { ...recorder(), fallback: FB });
     assert.ok(urls.some((u) => !isOpenAi(u)), "리셋 후엔 다시 Anthropic부터 시도한다");
+  });
+});
+
+describe("★추론 모델의 잘림 (2026-08-24 라이브 실측으로 잡힘)", () => {
+  // 실측: Anthropic max_tokens를 그대로 넘겼더니 gpt-5.4가 예산을 추론에 나눠 쓰고
+  // 본문이 6,179자에서 끊겨 JSON 파싱이 실패했다(정상 Anthropic 응답은 12,449자).
+  // 폴백이 "성공"으로 보이는데 결과는 못 쓰는, 가장 나쁜 실패 모양이었다.
+
+  it("폴백 예산은 원래 예산보다 넉넉하다 — 추론 토큰이 같은 주머니에서 나간다", () => {
+    assert.ok(fallbackOutputBudget(4000) > 4000);
+    assert.ok(fallbackOutputBudget(500) >= 8000, "작은 요청도 최소 여유는 준다");
+  });
+
+  it("상한이 있다 — 무한정 키우지 않는다", () => {
+    assert.ok(fallbackOutputBudget(1_000_000) <= 32000);
+  });
+
+  it("실제 요청에 늘어난 예산이 실린다", async () => {
+    let sent = null;
+    const fetchImpl = async (url, init) => {
+      if (isOpenAi(url)) { sent = JSON.parse(init.body); return openAiOk(); }
+      return forbidden();
+    };
+    await anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "generate", { ...recorder(), fallback: FB });
+    assert.equal(sent.max_completion_tokens, fallbackOutputBudget(BODY.max_tokens));
+    assert.ok(sent.max_completion_tokens > BODY.max_tokens);
+  });
+
+  it("★잘리면 stop_reason으로 호출부에 보인다 — 종전엔 원인 모를 파싱 실패였다", async () => {
+    const truncated = () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: '{"partial":' }, finish_reason: "length" }],
+          usage: { prompt_tokens: 10, completion_tokens: 4000, completion_tokens_details: { reasoning_tokens: 3800 } },
+        }),
+        { status: 200 },
+      );
+    const fetchImpl = async (url) => (isOpenAi(url) ? truncated() : forbidden());
+    const data = await anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "generate", { ...recorder(), fallback: FB });
+    assert.equal(data.stop_reason, "max_tokens", "Anthropic 어휘로 옮겨 호출부가 알아본다");
+  });
+
+  it("잘림이 추론 토큰과 함께 로그에 남는다 — 예산을 계측으로 조정하려고", async () => {
+    const fetchImpl = async (url) =>
+      isOpenAi(url)
+        ? new Response(
+            JSON.stringify({
+              choices: [{ message: { content: "x" }, finish_reason: "length" }],
+              usage: { completion_tokens: 4000, completion_tokens_details: { reasoning_tokens: 3800 } },
+            }),
+            { status: 200 },
+          )
+        : forbidden();
+    const { lines } = await captureLogs(() =>
+      anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "generate", { ...recorder(), fallback: FB }),
+    );
+    const ev = parsed(lines).find((j) => j.event === "llm_fallback_truncated");
+    assert.ok(ev, "잘림 이벤트가 있어야 한다");
+    assert.equal(ev.reasoning_tokens, 3800);
+  });
+
+  it("정상 종료면 stop_reason을 지어내지 않는다", async () => {
+    const fetchImpl = async (url) =>
+      isOpenAi(url)
+        ? new Response(JSON.stringify({ choices: [{ message: { content: "ok" }, finish_reason: "stop" }] }), { status: 200 })
+        : forbidden();
+    const data = await anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "generate", { ...recorder(), fallback: FB });
+    assert.notEqual(data.stop_reason, "max_tokens");
   });
 });

--- a/apps/dashboard/src/lib/project-steps.mjs
+++ b/apps/dashboard/src/lib/project-steps.mjs
@@ -134,10 +134,20 @@ export function nextProjectAction(facts) {
     return null;
   }
 
-  // Code (developer) path — connect the repo, then run review.
-  if (f.hasRepo === false) return { action: "connect_code", slug: "settings" };
-  if (f.hasRepo === true && f.hasReviewRun === false) return { action: "run_review", slug: "github" };
-  if (f.hasRepo === true && f.hasReviewRun === true) return { action: "view_results", slug: "checks" };
+  // Code path — 무언가 연결돼 있으면 검수로, 아니면 연결로.
+  //
+  // ★AF-1 이후 이 갈래는 **앱 주소로도 시작한다**(종전엔 항상 저장소였다).
+  // 그때까지 이 분기는 `hasDeployUrl`을 아예 보지 않았고, 그래서 주소를 넣어
+  // **검수까지 이미 끝난 프로젝트에도 "GitHub 저장소를 연결하세요"** 를 계속
+  // 내밀었다(2026-08-24 journey-audit 실측). 사용자가 방금 한 일을 못 본 척하는
+  // 안내는 제품이 자기 상태를 모른다는 뜻이다.
+  //
+  // 저장소가 있으면 코드 리뷰를, 주소만 있으면 화면 검수를 가리킨다.
+  const codeConnected = f.hasRepo === true || f.hasDeployUrl === true;
+  if (f.hasRepo === false && f.hasDeployUrl === false) return { action: "connect_code", slug: "settings" };
+  const codeReviewSlug = f.hasRepo === true ? "github" : "visual-checks";
+  if (codeConnected && f.hasReviewRun === false) return { action: "run_review", slug: codeReviewSlug };
+  if (codeConnected && f.hasReviewRun === true) return { action: "view_results", slug: "checks" };
   return null; // facts still unknown — show nothing rather than mislead
 }
 

--- a/apps/dashboard/test/project-steps.test.mjs
+++ b/apps/dashboard/test/project-steps.test.mjs
@@ -126,7 +126,9 @@ test("activation path (builder): deploy URL connected, no run → run_review via
 test("activation path (code branch): items ready + no repo → connect_code (GitHub stays for devs)", async () => {
   const { nextProjectAction } = await import("../src/lib/project-steps.mjs");
   assert.deepEqual(
-    nextProjectAction({ hasItems: true, hasRepo: false, hasReviewRun: false, entryPath: "code" }),
+    // AF-1 이후 코드 갈래는 앱 주소로도 시작하므로, "연결된 것이 없다"는
+    // 저장소와 주소 **둘 다 없음**이 확인돼야 성립한다.
+    nextProjectAction({ hasItems: true, hasRepo: false, hasDeployUrl: false, hasReviewRun: false, entryPath: "code" }),
     { action: "connect_code", slug: "settings" },
   );
 });
@@ -135,7 +137,7 @@ test("activation path: CODE branch with no items skips create_items entirely", a
   const { nextProjectAction } = await import("../src/lib/project-steps.mjs");
   // Missing items must NOT interpose on the code branch — connect → run is the whole path.
   assert.deepEqual(
-    nextProjectAction({ hasItems: false, hasRepo: false, hasReviewRun: false, entryPath: "code" }),
+    nextProjectAction({ hasItems: false, hasRepo: false, hasDeployUrl: false, hasReviewRun: false, entryPath: "code" }),
     { action: "connect_code", slug: "settings" },
   );
 });
@@ -242,4 +244,37 @@ test("packReadiness: every failed item has a fix plan → fixes_ready", async ()
   assert.equal(r.state, "fixes_ready");
   assert.equal(r.failedCount, 1);
   assert.equal(r.missingCount, 0);
+});
+
+test("★AF-1: 코드 갈래에 앱 주소만 있어도 연결된 것으로 본다", async () => {
+  const { nextProjectAction } = await import("../src/lib/project-steps.mjs");
+  // 2026-08-24 journey-audit 실측: 주소를 넣어 **검수까지 끝난 프로젝트**에도
+  // "GitHub 저장소를 연결하세요"가 계속 떴다. 제품이 자기 상태를 모르는 안내다.
+  assert.deepEqual(
+    nextProjectAction({ hasItems: false, hasRepo: false, hasDeployUrl: true, hasReviewRun: false, entryPath: "code" }),
+    { action: "run_review", slug: "visual-checks" },
+    "주소만 있으면 화면 검수를 가리킨다",
+  );
+  assert.deepEqual(
+    nextProjectAction({ hasItems: false, hasRepo: false, hasDeployUrl: true, hasReviewRun: true, entryPath: "code" }),
+    { action: "view_results", slug: "checks" },
+    "검수가 끝났으면 결과로 보낸다 — 연결을 다시 요구하지 않는다",
+  );
+});
+
+test("저장소가 있으면 코드 갈래는 여전히 코드 리뷰를 가리킨다 (무회귀)", async () => {
+  const { nextProjectAction } = await import("../src/lib/project-steps.mjs");
+  assert.deepEqual(
+    nextProjectAction({ hasItems: true, hasRepo: true, hasDeployUrl: true, hasReviewRun: false, entryPath: "code" }),
+    { action: "run_review", slug: "github" },
+  );
+});
+
+test("사실을 모르면 CTA를 내지 않는다 (기존 원칙)", async () => {
+  const { nextProjectAction } = await import("../src/lib/project-steps.mjs");
+  assert.equal(
+    nextProjectAction({ hasItems: true, hasRepo: false, hasDeployUrl: null, hasReviewRun: false, entryPath: "code" }),
+    null,
+    "주소 여부가 미확인이면 잘못된 안내보다 침묵이 낫다",
+  );
 });

--- a/tools/simsa-completion-loop-spike/af-verify.mjs
+++ b/tools/simsa-completion-loop-spike/af-verify.mjs
@@ -1,0 +1,48 @@
+/** AF 트레인 라이브 실증 — 특정 문구의 존재를 직접 확인한다(잘린 스냅샷 말고). */
+import { chromium } from "playwright";
+
+const BASE = "https://app.trysimsa.com";
+const MARKERS = {
+  "AF-1 첫 화면": "만드신 앱을 보여주세요",
+  "AF-1 감지 표시": "읽었어요",
+  "AF-4 확인 카드": "저희가 읽은 이 앱은",
+  "AF-4 로딩": "앱을 읽어서",
+  "AF-4 빈 상태": "이 앱이 무엇을 하는지 알려주세요",
+  "AF-4 오류": "지금은 앱을 읽지 못했어요",
+  "AF-5 깊이(공개화면)": "공개 화면",
+  "AF-5 못본것": "로그인 뒤 화면은 확인하지 않았습니다",
+  "AF-1 need_url": "코드는 연결됐어요",
+  "옛 GitHub 강요": "GitHub 저장소를 연결하세요",
+};
+
+async function report(page, title) {
+  const body = await page.evaluate(() => (document.body.innerText || "").replace(/\s+/g, " "));
+  console.log(`\n=== ${title} (${page.url()}) len=${body.length}`);
+  for (const [name, needle] of Object.entries(MARKERS)) {
+    if (body.includes(needle)) console.log(`   ✔ ${name}`);
+  }
+  return body;
+}
+
+const browser = await chromium.launch();
+async function run(submission, label) {
+  const ctx = await browser.newContext({ locale: "ko-KR" });
+  const page = await ctx.newPage();
+  await page.addInitScript(() => localStorage.setItem("conclave:locale", "ko"));
+  await page.goto(`${BASE}/projects/new?path=code`, { waitUntil: "networkidle", timeout: 60000 });
+  await report(page, `${label} — 첫 화면`);
+  await page.locator("main input[type='text']").first().fill(submission);
+  await page.waitForTimeout(500);
+  await report(page, `${label} — 입력 후`);
+  await page.locator("main .btn-primary, main button[class*='primary']").last().click();
+  await page.waitForURL(/projects\/(?!new)/, { timeout: 120000 }).catch(() => {});
+  for (const wait of [5000, 15000, 20000]) {
+    await page.waitForTimeout(wait);
+    await report(page, `${label} — 랜딩 +${wait}ms 누적`);
+  }
+  await ctx.close();
+}
+
+await run("https://app.trysimsa.com/", "A) 앱 주소");
+await run("https://github.com/3SVS/simsa", "B) 저장소만");
+await browser.close();

--- a/tools/simsa-completion-loop-spike/af4-net.mjs
+++ b/tools/simsa-completion-loop-spike/af4-net.mjs
@@ -1,0 +1,35 @@
+/** AF-4 카드의 infer-intent 요청을 브라우저에서 직접 관측한다. */
+import { chromium } from "playwright";
+const BASE = "https://app.trysimsa.com";
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ locale: "ko-KR" });
+const page = await ctx.newPage();
+
+page.on("console", (m) => { if (m.type() === "error") console.log("  [console.error]", m.text().slice(0, 200)); });
+page.on("requestfailed", (r) => {
+  if (r.url().includes("infer-intent")) console.log("  [requestfailed]", r.url(), "→", r.failure()?.errorText);
+});
+page.on("response", async (r) => {
+  if (r.url().includes("infer-intent")) {
+    console.log("  [response]", r.status(), r.url());
+    console.log("            body:", (await r.text().catch(() => "<no body>")).slice(0, 300));
+  }
+});
+
+await page.addInitScript(() => localStorage.setItem("conclave:locale", "ko"));
+await page.goto(`${BASE}/projects/new?path=code`, { waitUntil: "networkidle", timeout: 60000 });
+await page.locator("main input[type='text']").first().fill("https://app.trysimsa.com/");
+await page.locator("main .btn-primary, main button[class*='primary']").last().click();
+await page.waitForURL(/projects\/(?!new)/, { timeout: 120000 }).catch(() => {});
+console.log("landed:", page.url());
+for (let i = 1; i <= 9; i++) {
+  await page.waitForTimeout(5000);
+  const body = await page.evaluate(() => (document.body.innerText || "").replace(/\s+/g, " "));
+  const state = body.includes("저희가 읽은 이 앱은") ? "READY(초안)"
+    : body.includes("이 앱이 무엇을 하는지 알려주세요") ? "EMPTY(정직하게 빈칸)"
+    : body.includes("지금은 앱을 읽지 못했어요") ? "ERROR"
+    : body.includes("앱을 읽어서") ? "LOADING" : "카드없음";
+  console.log(`  +${i * 5}s → ${state}`);
+  if (state !== "LOADING") break;
+}
+await browser.close();

--- a/tools/simsa-completion-loop-spike/infer-probe.mjs
+++ b/tools/simsa-completion-loop-spike/infer-probe.mjs
@@ -1,0 +1,28 @@
+/** infer-intent 라이브 응답을 직접 본다 — 브라우저 오류의 원인 확인. */
+const B = "https://conclave-ai.seunghunbae.workers.dev";
+const H = { "content-type": "application/json", origin: "https://app.trysimsa.com" };
+const userKey = "uk_infer_" + Math.floor(Math.random() * 1e9).toString(36);
+const projectId = "proj_infer_" + Math.floor(Math.random() * 1e9).toString(36);
+
+async function j(method, path, body) {
+  const r = await fetch(B + path, { method, headers: H, ...(body ? { body: JSON.stringify(body) } : {}) });
+  const text = await r.text();
+  let parsed = null;
+  try { parsed = JSON.parse(text); } catch {}
+  return { status: r.status, cors: r.headers.get("access-control-allow-origin"), body: parsed ?? text.slice(0, 300) };
+}
+
+console.log("생성:", (await j("POST", "/workspace/projects", { userKey, id: projectId, title: "infer probe", entryPath: "code" })).status);
+console.log("소스:", (await j("POST", `/workspace/projects/${projectId}/sources`, { userKey, type: "website", reference: "https://app.trysimsa.com/" })).status);
+
+// 프리플라이트도 확인 — 새 경로가 CORS에서 막히는지.
+const pre = await fetch(`${B}/workspace/projects/${projectId}/infer-intent`, {
+  method: "OPTIONS",
+  headers: { origin: "https://app.trysimsa.com", "access-control-request-method": "POST", "access-control-request-headers": "content-type" },
+});
+console.log("preflight:", pre.status, "allow-origin:", pre.headers.get("access-control-allow-origin"), "allow-methods:", pre.headers.get("access-control-allow-methods"));
+
+const t = Date.now();
+const res = await j("POST", `/workspace/projects/${projectId}/infer-intent`, { userKey, locale: "ko" });
+console.log(`infer-intent: ${res.status} (${Date.now() - t}ms) cors=${res.cors}`);
+console.log(JSON.stringify(res.body, null, 2).slice(0, 1200));

--- a/tools/simsa-completion-loop-spike/journey-audit.mjs
+++ b/tools/simsa-completion-loop-spike/journey-audit.mjs
@@ -25,6 +25,15 @@ import { mkdirSync, writeFileSync } from "node:fs";
 
 const BASE = "https://app.trysimsa.com";
 const KO_ONLY = process.argv.includes("--ko-only");
+
+/**
+ * AF 트레인 이후 코드 갈래가 받는 것은 **주소 또는 저장소** 하나다.
+ * 리얼 데이터로 잰다(Rule 6): 실제로 살아 있는 주소와 실제 공개 저장소.
+ */
+const CODE_SUBMISSION = {
+  website: "https://app.trysimsa.com/",
+  repo: "https://github.com/3SVS/simsa",
+};
 const SHOTS = new URL("./journey-audit-shots", import.meta.url).pathname.replace(/^\/(\w):/, "$1:");
 mkdirSync(SHOTS, { recursive: true });
 
@@ -122,35 +131,59 @@ async function runIdeaEntry(locale) {
 
 async function runCodeJourney(locale) {
   try {
-    journey("J1 기존-앱 갈래: 만든 앱 검수받기 완주", locale);
+    journey("J1 기존-앱 갈래: 주소 하나로 검수까지 완주 (AF 트레인)", locale);
     const page = await newUserPage(locale);
     await page.goto(`${BASE}/projects/new?path=code`, { waitUntil: "networkidle", timeout: 45000 });
     await facts(page, "code 갈래 스텝1 — 무엇을 묻는가");
-    // ★사이드바 검색 input이 first("input")에 걸린다 — 본문 필드는 placeholder로.
-    const nameInput = page.locator("main input[type='text']").first();
-    await nameInput.fill(locale === "en" ? "Bakery reservation test app" : "동네 빵집 예약 테스트앱");
-    const descBox = page.locator("main textarea").first();
-    if (await descBox.count()) await descBox.fill(locale === "en" ? "Reserve bread and pick a pickup time" : "빵을 예약하고 픽업 시간을 고르는 앱");
-    await facts(page, "code 스텝1 입력 후");
+
+    // ★AF-1 이후 이 화면은 **칸 하나**다(종전: 이름+빌더칩+호스팅+데이터+설명+필수동작).
+    // 옛 스크립트는 이름 칸에 "동네 빵집 예약 테스트앱"을 넣었는데, 그건 주소가
+    // 아니므로 이제 거절된다 — 측정 장비부터 새 여정에 맞춰야 한다.
+    const submitField = page.locator("main input[type='text']").first();
+    await submitField.fill(CODE_SUBMISSION.website);
+    await page.waitForTimeout(400);
+    await facts(page, "주소 입력 후 — 무엇으로 읽었는지 보이는가");
+
     await page.locator("main .btn-primary, main button[class*='primary']").last().click();
-    await page.waitForURL(/projects\/(?!new)/, { timeout: 90000 }).catch(() => {});
-    await page.waitForTimeout(2500);
-    await facts(page, "생성 직후 랜딩 — 여기가 어디고 다음 행동이 보이는가");
+    // AF-2: 제출 즉시 1차 검수가 걸리므로 생성이 종전보다 오래 걸릴 수 있다.
+    await page.waitForURL(/projects\/(?!new)/, { timeout: 120000 }).catch(() => {});
+    await page.waitForTimeout(3000);
+    await facts(page, "생성 직후 랜딩 — 검수가 돌고 확인 카드가 보이는가");
+
     const pid = (page.url().match(/projects\/([^/?#]+)/) ?? [])[1];
     if (pid) {
+      // AF-3/AF-4: 의도 추론은 LLM을 타므로 시간이 걸린다. 카드가 자리를 잡을 때까지.
+      await page.waitForTimeout(20000);
+      await facts(page, "AF-4 의도 확인 카드 — 초안이 왔는가 / 정직하게 비었는가");
       await page.goto(`${BASE}/projects/${pid}`, { waitUntil: "networkidle", timeout: 45000 });
       await facts(page, "개요 — 지금 할 일이 이 갈래에 맞는가");
-      await page.goto(`${BASE}/projects/${pid}/checks`, { waitUntil: "networkidle", timeout: 45000 });
-      await facts(page, "checks 첫 화면 — 모드 선택/소스 없이 안내");
-      const runBtn = page.getByRole("button", { name: /검수|확인|run|check/i }).first();
-      if (await runBtn.count()) {
-        await runBtn.click().catch(() => {});
-        await page.waitForTimeout(2500);
-        await facts(page, "소스 없이 검수 시도 — 막힘 안내");
-      }
+      await page.goto(`${BASE}/projects/${pid}/visual-checks`, { waitUntil: "networkidle", timeout: 45000 });
+      await facts(page, "AF-5 검수 화면 — 깊이와 '못 본 것'이 표기되는가");
     } else {
       audit.journeys.at(-1).failure = "프로젝트 생성 후 URL에서 id를 못 얻음";
     }
+    await page.context().close();
+  } catch (err) {
+    audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
+  }
+}
+
+/**
+ * J1b — 저장소만 넣은 경우. AF-1에서 새로 판 `need_url` 문이 실제로 뜨는지 본다.
+ * 종전엔 이 상태에서 "첫 검수 돌려보기"로 보냈다가 **비활성 버튼**을 만나게 했다.
+ */
+async function runRepoOnlyJourney(locale) {
+  try {
+    journey("J1b 저장소만 연결: 막다른 골목이 없는가 (need_url)", locale);
+    const page = await newUserPage(locale);
+    await page.goto(`${BASE}/projects/new?path=code`, { waitUntil: "networkidle", timeout: 45000 });
+    await page.locator("main input[type='text']").first().fill(CODE_SUBMISSION.repo);
+    await page.waitForTimeout(400);
+    await facts(page, "저장소 주소 입력 후 — 저장소로 읽었는가");
+    await page.locator("main .btn-primary, main button[class*='primary']").last().click();
+    await page.waitForURL(/projects\/(?!new)/, { timeout: 120000 }).catch(() => {});
+    await page.waitForTimeout(4000);
+    await facts(page, "★저장소만 있을 때 개요 — 비활성 버튼으로 보내지 않는가");
     await page.context().close();
   } catch (err) {
     audit.journeys.at(-1).failure = String(err?.message ?? err).slice(0, 200);
@@ -262,6 +295,7 @@ async function runSeededResultJourney(locale) {
 
 await runIdeaEntry("ko");
 await runCodeJourney("ko");
+await runRepoOnlyJourney("ko");
 await runSpecJourney("ko");
 await runConnectJourney("ko");
 await runSeededResultJourney("ko");
@@ -269,6 +303,7 @@ await runSeededResultJourney("ko");
 if (!KO_ONLY) {
   await runIdeaEntry("en");
   await runCodeJourney("en");
+  await runRepoOnlyJourney("en");
   // spec/connect의 EN은 code 여정이 셸·생성·랜딩을 이미 커버 — 입구만 본다.
   try {
     journey("J2e 기획서 갈래 입구(EN)", "en");


### PR DESCRIPTION
## AF-6 실브라우저 감사 결과

배포 후 journey-audit을 새 여정에 맞춰 고쳐 돌렸습니다. **P0=0이지만 진짜 결함 2건**이
나왔고, 둘 다 **API 프로브로는 안 보이고 실제 여정을 걸어야** 보이는 것들입니다.

### ① 폴백이 "성공"인데 결과를 못 씁니다 — 가장 나쁜 실패 모양

라이브 로그:
```
llm_failure  anthropic 403 (generate) → llm_fallback → openai gpt-5.4 응답
[workspace/generate] blocks=text textLen=6179 → JSON parse failed
```
정상 Anthropic 응답은 **12,449자**인데 폴백은 **6,179자에서 끊겼습니다.**

원인은 **추론 모델이 같은 예산에서 추론 토큰을 먼저 쓰기** 때문입니다. Anthropic의
`max_tokens`를 그대로 `max_completion_tokens`로 넘긴 것이 잘못이었습니다. 게다가
`finish_reason`을 매핑하지 않아 **잘림이 호출부에 보이지도 않았습니다** — 원인 모를
파싱 실패로만 보였습니다.

이 때문에 AF-4 확인 카드가 항상 빈칸으로 끝났습니다. 정직성 계약은 지켜졌지만
(지어내지 않음) **초안을 한 번도 못 줍니다.**

| | 전 | 후 |
|---|---|---|
| 폴백 출력 예산 | Anthropic과 동일 | ×3, 최소 8k, 상한 32k |
| 잘림 가시성 | 없음 | `stop_reason: "max_tokens"` + `llm_fallback_truncated` 로그 |

배수는 **잠정값**이고 로그의 `reasoning_tokens`로 조정합니다 — 추측 대신 계측.
OpenAI는 쓴 만큼만 과금하므로 상한을 넉넉히 잡는 비용은 낮습니다.

### ② 코드 갈래가 앱 주소를 못 봅니다

`nextProjectAction`의 코드 갈래 분기가 `hasDeployUrl`을 **아예 보지 않았습니다.**
AF-1 이전엔 이 갈래가 항상 저장소로 시작했으니 맞는 로직이었지만, 이제 주소로도
시작합니다. 그래서 주소를 넣어 **검수까지 끝난 프로젝트에도** "GitHub 저장소를
연결하세요"가 계속 떴습니다 — 사용자가 방금 한 일을 못 본 척하는 안내입니다.

저장소가 있으면 코드 리뷰를, 주소만 있으면 화면 검수를 가리킵니다. 둘 다 **확인된
false**일 때만 연결을 요구하고, 미확인이면 종전 원칙대로 침묵합니다.

## 감사 장비도 고쳤습니다

journey-audit의 J1이 **옛 화면**(이름+설명 두 칸)을 전제로 짜여 있어 새 화면에
주소가 아닌 문자열을 넣고 있었습니다. 측정 장비부터 새 여정에 맞춰야 합니다.
J1b(저장소만 연결 → `need_url` 확인)도 추가했습니다.

## 라이브로 확인된 것

AF-1 첫 화면("만드신 앱을 보여주세요") · 입력 즉시 감지 표시 · 이름 도출(주소→
`trysimsa`, 저장소→`simsa`) · **AF-5 깊이 배지와 "로그인 뒤 화면은 확인하지
않았습니다"** — 전부 라이브에서 확인.

## 검증

- `vendor-fallback.test.mjs` **6건 추가** — 예산 여유·상한·실제 요청 반영·**잘림이
  stop_reason으로 보임**·추론 토큰 로그·정상 종료 시 지어내지 않음.
- `project-steps.test.mjs` **3건 추가 + 기존 2건 갱신**(사실을 빠뜨린 케이스였음).
- central-plane **2105/2105** · dashboard **679/679** · typecheck · lint · build green.

## 배포 후 확인 예정

같은 감사를 재실행해 **AF-4 카드가 초안을 실제로 주는지**, 그리고 "GitHub 연결하세요"
오안내가 사라졌는지 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
