### PR TITLE
fix(llm): 폴백이 assistant prefill을 못 다뤄 generate가 통째로 깨져 있었다

### DIFF
--- a/apps/central-plane/src/workspace/anthropic-fetch.ts
+++ b/apps/central-plane/src/workspace/anthropic-fetch.ts
@@ -241,6 +241,32 @@ const FALLBACK_BUDGET_MULTIPLIER = 3;
 const FALLBACK_BUDGET_MIN = 8000;
 const FALLBACK_BUDGET_MAX = 32000;
 
+/**
+ * ★assistant prefill을 벤더 간에 번역한다 (2026-08-24, 라이브 실측으로 잡힘).
+ *
+ * Anthropic은 마지막 메시지가 assistant면 **그 뒤를 이어서** 쓴다. 그래서
+ * `generate.ts`는 `{ role:"assistant", content:"{" }`를 붙여 "반드시 JSON으로
+ * 시작"을 강제하고, 응답 앞에 `"{"`를 **되붙인다**.
+ *
+ * OpenAI는 이어쓰기를 하지 않는다 — **완전한 JSON**을 돌려준다. 그래서 되붙이면
+ * `{{...}`가 되어 파싱이 깨졌다. 실제 로그가 정확히 `head: {{` 였다.
+ *
+ * 즉 **폴백은 prefill을 쓰는 모든 호출부에서 조용히 망가져 있었다.** prefill을
+ * 안 쓰는 검수(check)는 멀쩡했기에 더 늦게 드러났다.
+ *
+ * 폴백의 계약은 "호출부는 폴백을 모른다"이므로, 여기서 **Anthropic의 이어쓰기
+ * 모양으로 맞춰서** 돌려준다: 응답이 prefill로 시작하면 그만큼 떼어낸다.
+ * 떼어낼 것이 없으면 그대로 둔다(이미 이어쓰기 모양).
+ */
+export function stripAssistantPrefill(text: string, messages: AnthropicMessagesBody["messages"]): string {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== "assistant") return text;
+  const prefill = (last.content ?? "").trim();
+  if (!prefill) return text;
+  const lead = text.replace(/^\s+/, "");
+  return lead.startsWith(prefill) ? lead.slice(prefill.length) : text;
+}
+
 export function fallbackOutputBudget(anthropicMaxTokens: number): number {
   const wanted = Math.max(anthropicMaxTokens * FALLBACK_BUDGET_MULTIPLIER, FALLBACK_BUDGET_MIN);
   return Math.min(wanted, FALLBACK_BUDGET_MAX);
@@ -284,7 +310,8 @@ async function callOpenAiAsAnthropic(
       };
     };
     const choice = j.choices?.[0];
-    const text = choice?.message?.content ?? "";
+    // prefill을 쓴 호출부는 응답 앞에 그 조각을 되붙인다 — 벤더 차이를 여기서 흡수한다.
+    const text = stripAssistantPrefill(choice?.message?.content ?? "", body.messages);
     const reasoning = j.usage?.completion_tokens_details?.reasoning_tokens ?? 0;
     // ★잘림을 호출부에 보이게 한다. 종전엔 stop_reason을 안 넘겨서 잘린 JSON이
     //  그냥 "파싱 실패"로만 보였다 — 원인을 알 수 없는 실패였다(2026-08-24 실측).

--- a/apps/central-plane/test/vendor-fallback.test.mjs
+++ b/apps/central-plane/test/vendor-fallback.test.mjs
@@ -16,7 +16,7 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 
-const { anthropicMessages, OPENAI_FALLBACK_MODEL, __resetAnthropicBreaker, fallbackOutputBudget } = await import("../dist/workspace/anthropic-fetch.js");
+const { anthropicMessages, OPENAI_FALLBACK_MODEL, __resetAnthropicBreaker, fallbackOutputBudget, stripAssistantPrefill } = await import("../dist/workspace/anthropic-fetch.js");
 
 // 차단기는 isolate 전역이다 — 테스트 간에 상태가 새면 서로를 오염시킨다.
 beforeEach(() => __resetAnthropicBreaker());
@@ -265,5 +265,56 @@ describe("★추론 모델의 잘림 (2026-08-24 라이브 실측으로 잡힘)"
         : forbidden();
     const data = await anthropicMessages("k", BODY, 1000, fetchImpl, GATEWAY, "generate", { ...recorder(), fallback: FB });
     assert.notEqual(data.stop_reason, "max_tokens");
+  });
+});
+
+describe("★assistant prefill의 벤더 간 번역 (2026-08-24 실측)", () => {
+  // Anthropic은 마지막 assistant 메시지 **뒤를 이어서** 쓴다. generate.ts는 그걸
+  // 이용해 `{`를 prefill로 주고 응답 앞에 `{`를 되붙인다. OpenAI는 이어쓰기를
+  // 하지 않고 완전한 JSON을 준다 — 되붙이면 `{{...}`가 되어 파싱이 깨졌다.
+  // 실제 라이브 로그가 정확히 `head: {{` 였고, **폴백은 prefill을 쓰는 모든
+  // 호출부에서 조용히 망가져 있었다.**
+  const PREFILLED = [
+    { role: "user", content: "make json" },
+    { role: "assistant", content: "{" },
+  ];
+
+  it("완전한 JSON이 오면 prefill 조각을 떼어낸다 — 호출부가 되붙여도 정상", () => {
+    const out = stripAssistantPrefill('{"a":1}', PREFILLED);
+    assert.equal(out, '"a":1}');
+    assert.equal("{" + out, '{"a":1}', "호출부의 되붙이기와 합쳐 유효한 JSON");
+  });
+
+  it("앞 공백이 있어도 떼어낸다", () => {
+    const leading = String.fromCharCode(10) + '  {"a":1}';
+    assert.equal("{" + stripAssistantPrefill(leading, PREFILLED), '{"a":1}');
+  });
+
+  it("이미 이어쓰기 모양이면 손대지 않는다", () => {
+    assert.equal(stripAssistantPrefill('"a":1}', PREFILLED), '"a":1}');
+  });
+
+  it("prefill이 없는 호출부는 영향받지 않는다 (검수·수정 등 — 이들은 멀쩡했다)", () => {
+    const plain = [{ role: "user", content: "hi" }];
+    assert.equal(stripAssistantPrefill('{"a":1}', plain), '{"a":1}');
+  });
+
+  it("빈 prefill·빈 메시지에도 던지지 않는다", () => {
+    assert.equal(stripAssistantPrefill("x", [{ role: "assistant", content: "" }]), "x");
+    assert.equal(stripAssistantPrefill("x", []), "x");
+  });
+
+  it("★폴백 전체 경로에서 실증 — prefill 호출부가 유효한 JSON을 얻는다", async () => {
+    const body = { model: "m", max_tokens: 500, messages: PREFILLED };
+    const fetchImpl = async (url) =>
+      isOpenAi(url)
+        ? new Response(
+            JSON.stringify({ choices: [{ message: { content: '{"productName":"내 앱"}' }, finish_reason: "stop" }], usage: {} }),
+            { status: 200 },
+          )
+        : forbidden();
+    const data = await anthropicMessages("k", body, 1000, fetchImpl, GATEWAY, "generate", { ...recorder(), fallback: FB });
+    const reassembled = "{" + data.content[0].text;
+    assert.deepEqual(JSON.parse(reassembled), { productName: "내 앱" }, "한글 값도 온전하다 (Rule 6)");
   });
 });


### PR DESCRIPTION
## 근본 원인 — 코드에서 확정했습니다 (추측 아님)

Anthropic은 마지막 메시지가 assistant면 **그 뒤를 이어서** 씁니다. `generate.ts`는
이걸 이용해 `{ role:"assistant", content:"{" }`를 prefill로 주고, 받은 텍스트 앞에
`"{"`를 **되붙입니다**(`generate.ts:595`).

OpenAI는 이어쓰기를 하지 않습니다 — **완전한 JSON**을 돌려줍니다. 되붙이면 `{{...}`가
되어 파싱이 깨집니다. 라이브 로그가 정확히 `head: {{` 였습니다.

즉 **벤더 폴백은 prefill을 쓰는 호출부에서 조용히 망가져 있었습니다.** prefill을 안 쓰는
검수(check)는 멀쩡했기에(동시 4건 8/8 성공) 더 늦게 드러났습니다. AF-4 확인 카드가
계속 빈칸이던 이유가 이것입니다.

## 앞선 두 가설이 틀렸던 기록

| # | 가설 | 결과 |
|---|---|---|
| 1 | 응답이 잘렸다 | **틀림** — 배포 후 로그가 `stop=stop`(정상 종료). #502의 예산 확대·`finish_reason` 매핑 자체는 유효한 개선이라 유지 |
| 2 | (오진의 원인) 진단이 두 글자에서 잘려 있었다 | #503에서 수정 |
| 3 | **prefill 벤더 차이** | ✅ 코드로 확정 |

세 번째에야 **코드를 읽어** 확정했습니다. 계측이 읽히지 않으면 가설만 쌓입니다.

## 변경

`stripAssistantPrefill()` — 폴백이 **Anthropic의 이어쓰기 모양으로 맞춰서** 돌려줍니다.
응답이 prefill 조각으로 시작하면 그만큼 떼어내고, 이미 이어쓰기 모양이면 손대지 않습니다.
폴백의 설계 계약이 *"호출부는 폴백을 모른다"* 이므로 벤더 차이는 이 층에서 흡수합니다.

## 회귀 전수 검색

`rg 'role: "assistant"'` → prefill을 쓰는 곳은 `generate.ts` **한 곳뿐**입니다.
나머지 호출부(check·fix·recommend·unstick·pr-review)는 영향 없음을 확인했습니다.

## 검증

- **6건 추가** — 완전 JSON에서 조각 제거 · 앞 공백 · 이미 이어쓰기면 무변경 ·
  **prefill 없는 호출부 무영향** · 빈 값 안전 · **폴백 전체 경로에서 유효한 JSON
  재조립**(한글 값 포함, Rule 6).
- central-plane **2113/2113** · typecheck · lint green.

## 배포 후 확인

`infer-intent`가 `inferred`를 실제로 돌려주는지, 그리고 AF-4 카드에
"저희가 읽은 이 앱은 이렇습니다"가 뜨는지 감사로 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
