### PR TITLE
feat(llm): Anthropic 킬스위치 — egress 차단이 실측 확정되어 건너뛴다

### DIFF
--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -180,6 +180,13 @@ export interface Env {
    */
   GH_APP_INSTALL_URL?: string;
   /**
+   * 킬스위치 — "off"면 Anthropic을 건너뛰고 곧장 OpenAI 폴백으로 간다.
+   * 2026-08-25 실측: 같은 키가 노트북에서 200, Worker에서 403 → egress 차단 확정.
+   * 복구 확인은 `/internal/llm-probe`, 되돌리기는 wrangler.toml에서 "on" + 배포.
+   * 설정 해석은 workspace/vendor-routing.ts 단일 출처.
+   */
+  ANTHROPIC_ENABLED?: string;
+  /**
    * Stage 17 — base URL of the dashboard. Used when building Telegram notification
    * message links. Defaults to https://app.trysimsa.com when unset (Stage 92).
    * Set via wrangler.toml [vars] or `wrangler secret put DASHBOARD_BASE_URL`.

--- a/apps/central-plane/src/routes/workspace-document-intake.ts
+++ b/apps/central-plane/src/routes/workspace-document-intake.ts
@@ -25,6 +25,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
+import { vendorFallback } from "../workspace/vendor-routing.js";
 import { corsMiddleware } from "./cors.js";
 import { getProject } from "../workspace/db.js";
 import { getProjectSourceById } from "../workspace/project-sources-db.js";
@@ -177,7 +178,7 @@ export function createWorkspaceDocumentIntakeRoutes(): Hono<{ Bindings: Env }> {
 
     let result;
     try {
-      result = await generateIdeaToSpecDraft({ idea: input, locale }, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL, c.env.OPENAI_API_KEY ? { openaiApiKey: c.env.OPENAI_API_KEY, openaiBaseUrl: c.env.CF_AI_GATEWAY_OPENAI_URL } : undefined);
+      result = await generateIdeaToSpecDraft({ idea: input, locale }, c.env.ANTHROPIC_API_KEY, c.env.CF_AI_GATEWAY_ANTHROPIC_URL, vendorFallback(c.env));
     } catch (err) {
       console.error("[workspace/document-intake] unexpected generate error:", err);
       return c.json({ ok: false, error: "internal_error" }, 500);

--- a/apps/central-plane/src/routes/workspace-github.ts
+++ b/apps/central-plane/src/routes/workspace-github.ts
@@ -21,6 +21,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
+import { vendorFallback } from "../workspace/vendor-routing.js";
 import { ALLOWED_ORIGINS, CORS_ALLOW_METHODS } from "./cors.js";
 import { BRAND } from "../workspace/brand.js";
 import type { FetchLike } from "../github.js";
@@ -977,9 +978,7 @@ export function createWorkspaceGitHubRoutes(
         fetchImpl,
         c.env.CF_AI_GATEWAY_ANTHROPIC_URL,
         // 벤더 폴백: Anthropic이 Worker egress에서 차단될 때 OpenAI로.
-        c.env.OPENAI_API_KEY
-          ? { openaiApiKey: c.env.OPENAI_API_KEY, openaiBaseUrl: c.env.CF_AI_GATEWAY_OPENAI_URL }
-          : undefined,
+        vendorFallback(c.env),
       );
       if (reviewResult.warnings?.length) warnings.push(...reviewResult.warnings);
     } catch (err) {

--- a/apps/central-plane/src/routes/workspace-sources.ts
+++ b/apps/central-plane/src/routes/workspace-sources.ts
@@ -16,6 +16,7 @@
 import { Hono } from "hono";
 import { corsMiddleware } from "./cors.js";
 import type { Env } from "../env.js";
+import { vendorFallback } from "../workspace/vendor-routing.js";
 import { getProject } from "../workspace/db.js";
 import { normalizeGithubRepoRef } from "../workspace/github-repo-ref.js";
 import { probeGithubRepo, probeWebsite, type Reachability } from "../workspace/source-reachability.js";
@@ -223,9 +224,7 @@ export function createWorkspaceSourcesRoutes(): Hono<{ Bindings: Env }> {
       { idea, locale },
       c.env.ANTHROPIC_API_KEY,
       c.env.CF_AI_GATEWAY_ANTHROPIC_URL,
-      c.env.OPENAI_API_KEY
-        ? { openaiApiKey: c.env.OPENAI_API_KEY, openaiBaseUrl: c.env.CF_AI_GATEWAY_OPENAI_URL }
-        : undefined,
+      vendorFallback(c.env),
     );
     if ("ok" in draft && draft.ok === false) {
       return c.json({ ok: true, inferred: null, reason: "llm_unavailable", readSources: evidence.readSources, stack: evidence.stack });

--- a/apps/central-plane/src/routes/workspace.ts
+++ b/apps/central-plane/src/routes/workspace.ts
@@ -12,6 +12,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../env.js";
+import { vendorFallback } from "../workspace/vendor-routing.js";
 import { ALLOWED_ORIGINS, CORS_ALLOW_METHODS } from "./cors.js";
 import { generateIdeaToSpecDraft, toClientDraft, type IdeaToSpecDraftRequest } from "../workspace/generate.js";
 import { sendLangfuseGeneration } from "../workspace/langfuse.js";
@@ -62,16 +63,6 @@ import {
   betaProjectCreateDailyLimit,
   BETA_PROJECT_CREATE_DAILY_BUCKET,
 } from "../workspace/beta-limits.js";
-
-/**
- * 벤더 폴백 설정 — Anthropic이 Worker egress에서 차단될 때(실측 403 100%)
- * 같은 프롬프트를 OpenAI로 넘긴다. 키가 없으면 undefined라 종전과 동일하게 동작.
- * `/internal/llm-probe` 실측: anthropic 0/4 · **openai 4/4**(2.9초) · gemini 지역 제한.
- */
-function vendorFallback(env: Env): { openaiApiKey?: string; openaiBaseUrl?: string } | undefined {
-  if (!env.OPENAI_API_KEY) return undefined;
-  return { openaiApiKey: env.OPENAI_API_KEY, openaiBaseUrl: env.CF_AI_GATEWAY_OPENAI_URL };
-}
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 

--- a/apps/central-plane/src/workspace/anthropic-fetch.ts
+++ b/apps/central-plane/src/workspace/anthropic-fetch.ts
@@ -220,6 +220,12 @@ export const OPENAI_FALLBACK_MODEL = "gpt-5.4";
 
 export type VendorFallback = {
   openaiApiKey?: string;
+  /**
+   * 킬스위치(ANTHROPIC_ENABLED="off"). 참이면 Anthropic을 **아예 시도하지 않고**
+   * 곧장 이 폴백으로 간다. 실측으로 egress가 막힌 것이 확정됐을 때, 요청마다
+   * 6회 재시도로 태우는 ~7초를 없앤다. 설정은 workspace/vendor-routing.ts 단일 출처.
+   */
+  preferFallback?: boolean;
   /** CF AI Gateway의 OpenAI 베이스(없으면 직행). */
   openaiBaseUrl?: string;
   model?: string;
@@ -468,6 +474,18 @@ export async function anthropicMessages(
   // A′-1: 시도마다 경로를 번갈아 쓴다(게이트웨이 → 직행 → 게이트웨이 …).
   const rotation = endpointRotation(endpoint);
   const triedByEndpoint: Record<string, number> = {};
+  // ★킬스위치: 사람이 실측으로 "Anthropic은 지금 막혔다"를 확정하고 끈 상태.
+  //  차단기(자동·isolate 단위)와 달리 이건 **전역·명시적**이라 첫 요청부터 적용된다.
+  if (opts.fallback?.openaiApiKey && opts.fallback.preferFallback) {
+    try {
+      console.log(JSON.stringify({ event: "llm_primary_skipped", call_site: callSite, reason: "anthropic_disabled" }));
+    } catch { /* logging must not break the call */ }
+    return fallbackOrThrow(
+      opts.fallback, body, timeoutMs, fetchImpl, callSite, now, startedAt,
+      null, new Error("Anthropic skipped: disabled by configuration"),
+    );
+  }
+
   // 차단기가 열려 있고 갈 곳이 있으면 12초를 태우지 않고 곧장 폴백으로.
   if (opts.fallback?.openaiApiKey && breakerIsOpen(startedAt)) {
     try {

--- a/apps/central-plane/src/workspace/vendor-routing.ts
+++ b/apps/central-plane/src/workspace/vendor-routing.ts
@@ -1,0 +1,40 @@
+/**
+ * vendor-routing.ts — 어느 벤더로 갈지 정하는 **단일 출처** (2026-08-25).
+ *
+ * ## 왜 한 곳으로 모았나
+ *
+ * 폴백 설정이 라우트 네 곳에 각각 인라인으로 복제돼 있었다. 그 상태에서 킬스위치를
+ * 넣으면 **일부 경로만 바뀐다** — 스위치를 켰는데 절반은 여전히 막힌 문을 두드리는,
+ * 알아채기 어려운 반쪽 상태가 된다. (같은 종류의 결함을 이미 두 번 겪었다:
+ * GitHub 저장소 정규화가 입력구와 소비처에서 갈렸던 것, 클라이언트 검증이 서버보다
+ * 엄격했던 것.)
+ *
+ * ## 킬스위치 (ANTHROPIC_ENABLED)
+ *
+ * 실측(2026-08-25): 같은 API 키가 **노트북에서는 200**, Cloudflare Worker에서는
+ * **403 "Request not allowed"**. 키·계정·지역 문제가 아니라 **egress 차단**이 확정됐다.
+ *
+ * 그렇다면 요청마다 6회 재시도로 태우는 ~7초는 **순손실**이다. `"off"`로 두면
+ * Anthropic을 아예 건너뛰고 곧장 폴백으로 간다.
+ *
+ * **되돌리기는 한 줄이다** — `wrangler.toml`의 값을 `"on"`으로 바꾸고 배포.
+ * 복구 여부는 `POST /internal/llm-probe`의 `anthropic:*` 항목으로 확인한다
+ * (`usable`이 살아나면 되돌릴 때다). 회로 차단기와 달리 이 스위치는 **스스로
+ * 복구하지 않는다** — 사람이 실측하고 켜는 것이 의도된 설계다.
+ */
+import type { Env } from "../env.js";
+import type { VendorFallback } from "./anthropic-fetch.js";
+
+/**
+ * 이 요청이 쓸 벤더 폴백 설정. OpenAI 키가 없으면 undefined —
+ * 그러면 종전과 완전히 동일하게 Anthropic만 쓴다.
+ */
+export function vendorFallback(env: Env): VendorFallback | undefined {
+  if (!env.OPENAI_API_KEY) return undefined;
+  return {
+    openaiApiKey: env.OPENAI_API_KEY,
+    openaiBaseUrl: env.CF_AI_GATEWAY_OPENAI_URL,
+    // 명시적으로 "off"일 때만 건너뛴다 — 값이 없으면 종전 동작(Anthropic 먼저).
+    ...(env.ANTHROPIC_ENABLED === "off" ? { preferFallback: true } : {}),
+  };
+}

--- a/apps/central-plane/test/vendor-routing.test.mjs
+++ b/apps/central-plane/test/vendor-routing.test.mjs
@@ -1,0 +1,102 @@
+/**
+ * vendor-routing.test.mjs — 벤더 라우팅 단일 출처 (2026-08-25).
+ *
+ * 고정하는 계약:
+ *   ① OpenAI 키가 없으면 폴백 자체가 없다 — 종전과 완전히 동일하게 동작
+ *   ② 킬스위치는 **명시적으로 "off"** 일 때만 켜진다(값 없음 = 종전 동작)
+ *   ③ 켜지면 Anthropic을 **한 번도** 두드리지 않는다 — 그게 이 스위치의 목적
+ *   ④ 폴백이 없으면 스위치가 켜져 있어도 Anthropic을 쓴다 — 유일한 경로를 끊지 않는다
+ */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+const { vendorFallback } = await import("../dist/workspace/vendor-routing.js");
+const { anthropicMessages, __resetAnthropicBreaker } = await import("../dist/workspace/anthropic-fetch.js");
+
+beforeEach(() => __resetAnthropicBreaker());
+
+const BODY = { model: "claude-haiku-4-5-20251001", max_tokens: 500, messages: [{ role: "user", content: "hi" }] };
+const GATEWAY = "https://gateway.example/anthropic/v1/messages";
+const isOpenAi = (u) => String(u).includes("/chat/completions");
+const clock = () => {
+  let t = 1_000_000;
+  return { sleepImpl: async (ms) => { t += ms; }, nowImpl: () => t, randomImpl: () => 0.5 };
+};
+
+describe("설정 해석 (①②)", () => {
+  it("OpenAI 키가 없으면 undefined — 종전 동작 유지", () => {
+    assert.equal(vendorFallback({}), undefined);
+    assert.equal(vendorFallback({ ANTHROPIC_ENABLED: "off" }), undefined, "키 없이 스위치만 켜도 폴백은 없다");
+  });
+
+  it('명시적 "off"일 때만 preferFallback', () => {
+    assert.equal(vendorFallback({ OPENAI_API_KEY: "k" }).preferFallback, undefined);
+    assert.equal(vendorFallback({ OPENAI_API_KEY: "k", ANTHROPIC_ENABLED: "on" }).preferFallback, undefined);
+    assert.equal(vendorFallback({ OPENAI_API_KEY: "k", ANTHROPIC_ENABLED: "" }).preferFallback, undefined);
+    assert.equal(vendorFallback({ OPENAI_API_KEY: "k", ANTHROPIC_ENABLED: "off" }).preferFallback, true);
+  });
+
+  it("게이트웨이 주소를 그대로 전달한다", () => {
+    const fb = vendorFallback({ OPENAI_API_KEY: "k", CF_AI_GATEWAY_OPENAI_URL: "https://gw/openai" });
+    assert.equal(fb.openaiBaseUrl, "https://gw/openai");
+  });
+});
+
+describe("★스위치가 켜지면 Anthropic을 한 번도 안 두드린다 (③)", () => {
+  it("첫 요청부터 곧장 폴백 — 차단기와 달리 학습이 필요 없다", async () => {
+    const urls = [];
+    const fetchImpl = async (u) => {
+      urls.push(u);
+      return isOpenAi(u)
+        ? new Response(JSON.stringify({ choices: [{ message: { content: "ok" }, finish_reason: "stop" }] }), { status: 200 })
+        : new Response("{}", { status: 403 });
+    };
+    const fb = vendorFallback({ OPENAI_API_KEY: "k", ANTHROPIC_ENABLED: "off" });
+    const data = await anthropicMessages("ant", BODY, 1000, fetchImpl, GATEWAY, "check", { ...clock(), fallback: fb });
+    assert.equal(data.content[0].text, "ok");
+    assert.equal(urls.filter((u) => !isOpenAi(u)).length, 0, "★Anthropic 호출 0회 — 7초 낭비 제거");
+  });
+
+  it("건너뛴 사실이 로그에 남는다 — 조용히 벤더가 바뀌지 않는다", async () => {
+    const lines = [];
+    const orig = console.log;
+    console.log = (...a) => lines.push(String(a[0]));
+    try {
+      await anthropicMessages(
+        "ant", BODY, 1000,
+        async (u) => (isOpenAi(u)
+          ? new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 })
+          : new Response("{}", { status: 403 })),
+        GATEWAY, "generate",
+        { ...clock(), fallback: vendorFallback({ OPENAI_API_KEY: "k", ANTHROPIC_ENABLED: "off" }) },
+      );
+    } finally { console.log = orig; }
+    const ev = lines.map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .filter(Boolean).find((j) => j.event === "llm_primary_skipped");
+    assert.ok(ev, "건너뛴 이벤트가 있어야 한다");
+    assert.equal(ev.reason, "anthropic_disabled");
+  });
+
+  it("★폴백이 없으면 스위치가 켜져 있어도 Anthropic을 쓴다 (④)", async () => {
+    const urls = [];
+    await assert.rejects(
+      anthropicMessages("ant", BODY, 1000, async (u) => { urls.push(u); return new Response("{}", { status: 403 }); },
+        GATEWAY, "check", { ...clock(), fallback: vendorFallback({ ANTHROPIC_ENABLED: "off" }) }),
+      /Anthropic 403/,
+    );
+    assert.equal(urls.length, 6, "유일한 경로를 스스로 끊지 않는다");
+  });
+
+  it("스위치가 꺼져 있으면 종전대로 Anthropic부터 (무회귀)", async () => {
+    const urls = [];
+    const fetchImpl = async (u) => {
+      urls.push(u);
+      return new Response(JSON.stringify({ content: [{ type: "text", text: "from-anthropic" }], usage: {} }), { status: 200 });
+    };
+    const data = await anthropicMessages("ant", BODY, 1000, fetchImpl, GATEWAY, "check", {
+      ...clock(), fallback: vendorFallback({ OPENAI_API_KEY: "k" }),
+    });
+    assert.equal(data.content[0].text, "from-anthropic");
+    assert.ok(!urls.some(isOpenAi));
+  });
+});

--- a/apps/central-plane/wrangler.toml
+++ b/apps/central-plane/wrangler.toml
@@ -55,6 +55,19 @@ WORKSPACE_GH_SCOPES = "read:user public_repo"
 # 2026-07-05: dashboard.conclave-ai.dev is a DEAD domain (DNS gone) — post-connect
 # OAuth redirects were pointing at it. Live dashboard is app.trysimsa.com (Stage 92).
 WORKSPACE_GH_DASHBOARD_URL = "https://app.trysimsa.com"
+# ★킬스위치 — Anthropic egress 차단 대응 (2026-08-25).
+#
+# 실측: **같은 API 키가 노트북에서는 200, 이 Worker에서는 403** "Request not allowed".
+# 키·계정·지역 문제가 아니라 Cloudflare egress가 막힌 것이 확정됐다. 그렇다면
+# 요청마다 6회 재시도로 태우는 ~7초는 순손실이므로, Anthropic을 건너뛰고 곧장
+# OpenAI 폴백으로 간다(지연 16~21초 → 9~14초).
+#
+# 되돌리기: 이 값을 "on"으로 바꾸고 배포하면 끝. 복구 여부는
+# `POST /internal/llm-probe`의 anthropic 항목 usable로 확인한다.
+# 회로 차단기와 달리 이 스위치는 **스스로 복구하지 않는다** — 사람이 실측하고
+# 켜는 것이 의도된 설계다. 해석은 workspace/vendor-routing.ts 단일 출처.
+ANTHROPIC_ENABLED = "off"
+
 # Private-repo support — public install URL of the existing GitHub App
 # (e.g. "https://github.com/apps/<slug>/installations/new"). Shown to users
 # whose private repo needs the App installed. Empty = no install link surfaced.


### PR DESCRIPTION
## 결정적 실측

Bae가 노트북에서 **같은 API 키**로 직접 호출한 결과:

| 어디서 | 결과 |
|---|---|
| **Bae 노트북** → api.anthropic.com | **STATUS 200** ✅ |
| **Cloudflare Worker** → 같은 주소 | **403 "Request not allowed"** ❌ |

키·계정·크레딧·지역 문제가 **전부 배제**됐습니다. **Cloudflare egress만 막혀 있습니다.**
지난 며칠 다섯 번의 가설을 이 한 번의 대조가 끝냈습니다 — 코드를 바꾸는 대신 **재는 쪽을
바꿔서** 가른 것입니다.

## 그래서

100% 막힌 게 확정된 이상, 요청마다 6회 재시도로 태우는 ~7초는 **순손실**입니다.
`ANTHROPIC_ENABLED = "off"`면 건너뛰고 곧장 폴백으로 갑니다. 지연 **16~21초 → 9~14초**.

## ★스위치를 넣기 전에 설정을 한 곳으로 모았습니다

폴백 설정이 라우트 **네 곳에 인라인 복제**돼 있었습니다. 그 상태로 스위치를 넣으면
**일부 경로만 바뀝니다** — 켰는데 절반은 여전히 막힌 문을 두드리는, 알아채기 어려운
반쪽 상태가 됩니다. 같은 종류의 결함을 이미 두 번 겪었습니다(#498 저장소 정규화가
입력구와 소비처에서 갈림, #499 클라이언트 검증이 서버보다 엄격).

→ `workspace/vendor-routing.ts` **단일 출처**. 네 곳이 이걸 씁니다.

## 설계

- **명시적 `"off"`일 때만** 켜집니다. 값 없음/다른 값 = 종전 동작.
- **폴백이 없으면 스위치가 켜져 있어도 Anthropic을 씁니다** — 유일한 경로를 스스로
  끊지 않습니다(회로 차단기와 같은 원칙).
- 건너뛴 사실을 `llm_primary_skipped`로 남깁니다 — 조용히 벤더가 바뀌지 않습니다.
- **스스로 복구하지 않습니다.** 되돌리기는 `"on"` + 배포 한 번이고, 복구 확인은
  `/internal/llm-probe`의 anthropic `usable`. 사람이 실측하고 켜는 것이 의도된 설계입니다.

## 검증

- `vendor-routing.test.mjs` **7건** — 설정 해석 3 · **Anthropic 호출 0회 실증** ·
  건너뜀 로그 · **폴백 없으면 종전대로 6회** · 스위치 꺼짐 시 무회귀.
- central-plane **2120/2120** · typecheck · lint green.

## 배포 후 확인

`concurrency-verify.mjs`로 지연이 실제로 줄었는지 실측합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
