### PR TITLE
fix(inspector): 컨테이너 상한 5→20 + 평가 장비에 용량 재시도

### DIFF
--- a/apps/central-plane/wrangler.toml
+++ b/apps/central-plane/wrangler.toml
@@ -163,11 +163,21 @@ new_sqlite_classes = ["ConclaveSandbox"]
 # instance_type "basic" (1 GiB memory / 4 GB disk): headless Chromium OOMs on
 # the default "dev" (256 MiB) instance. Image is built in CI by
 # deploy-central-plane.yml — first deploy after this lands builds + pushes it.
+#
+# ★max_instances 5 → 20 (2026-08-25). 정확도 평가를 **순차로** 돌렸는데도 11개 중
+# 6개가 `Maximum number of running container instances exceeded`로 실패했다.
+# 하나씩 돌려도 상한에 닿는다는 것은, 끝난 인스턴스가 곧바로 반환되지 않는다는 뜻이다.
+#
+# 제품 관점의 함의가 더 크다: **여러 사용자가 동시에 검수를 누르면 검수가 아예
+# 시작되지 않는다.** 오픈 전에 반드시 올려야 하는 값이었다.
+#
+# 상한을 올리는 것 자체는 과금되지 않는다(실제로 도는 인스턴스에만 과금).
+# 20은 잠정값 — 동시 검수 실측으로 조정한다.
 [[containers]]
 class_name = "SimsaInspector"
 image = "./inspector-container/Dockerfile"
 image_build_context = "../.."
-max_instances = 5
+max_instances = 20
 instance_type = "basic"
 
 [[durable_objects.bindings]]

--- a/tools/simsa-inspection-fixtures/compare-baseline.mjs
+++ b/tools/simsa-inspection-fixtures/compare-baseline.mjs
@@ -1,0 +1,59 @@
+/**
+ * compare-baseline.mjs — 이번 실행을 7월 기준선과 대조한다.
+ *
+ * 왜: 폴백 이후 **판정하는 모델이 Anthropic Haiku → OpenAI로 바뀌었다.** 검수의
+ * 핵심 가치는 "제대로 판정하는가"인데 그 판정자가 조용히 교체됐고 다시 재지 않았다.
+ * 7월 숫자는 지금 시스템에 대한 증거가 아니다.
+ *
+ * 기준선은 7월 파일들에서 **픽스처별 가장 최근 결과**를 모아 만든다(부분 실행이 많음).
+ * Usage: node compare-baseline.mjs [새결과파일]
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DIR = dirname(fileURLToPath(import.meta.url));
+const files = readdirSync(DIR).filter((f) => f.startsWith("eval-results-") && f.endsWith(".json"));
+const newest = process.argv[2] ?? files.map((f) => join(DIR, f)).sort().pop();
+
+const july = new Map();
+for (const f of files.filter((f) => f.includes("2026-07")).sort()) {
+  const j = JSON.parse(readFileSync(join(DIR, f), "utf8"));
+  for (const r of j.results ?? []) july.set(r.id, { ...r, from: f.replace("eval-results-", "").replace(".json", "") });
+}
+
+const now = JSON.parse(readFileSync(newest, "utf8"));
+const label = (r) => (r ? `${r.works === true ? "작동" : r.works === false ? "고장" : "판단보류"}(${r.score ?? "-"})` : "—");
+/**
+ * ★"못 쟀다"와 "틀렸다"를 절대 뭉뜽그리지 않는다 (증거 규칙 R2·R3).
+ * 첫 판(2026-08-24)에서 이 도구가 컨테이너 상한으로 인한 no-result를 **퇴행**으로
+ * 셌다 — 측정 실패를 품질 저하로 보고할 뻔했다. 도구가 규칙을 어기면 결과가 거짓말이 된다.
+ * @returns {true|false|null} null = 측정 안 됨(판정 불가)
+ */
+const correct = (r) => {
+  if (!r) return null;
+  if (r.score === "no-result" || r.works === undefined) return null;
+  if (r.expected === "working") return r.works === true || (r.nullOk && r.works === null);
+  return r.works === false;
+};
+
+console.log(`기준선: 7월 (판정자 = Anthropic Haiku)\n이번:   ${now.date ?? "?"} (판정자 = OpenAI gpt-5.4 폴백)\n`);
+console.log("픽스처  정답     7월                지금               변화");
+let okNow = 0, okJuly = 0, n = 0;
+for (const r of now.results ?? []) {
+  const j = july.get(r.id);
+  const cN = correct(r), cJ = correct(j);
+  if (cN !== null) { n++; if (cN) okNow++; }
+  if (cJ === true) okJuly++;
+  const change =
+    cN === null || cJ === null ? "— 측정불가" : cJ === cN ? (cN ? "유지 ✅" : "유지 ❌") : cN ? "개선 ⬆" : "★퇴행 ⬇";
+  console.log(
+    `${r.id.padEnd(6)} ${String(r.expected).padEnd(8)} ${label(j).padEnd(18)} ${label(r).padEnd(18)} ${change}`,
+  );
+}
+console.log(`\n정답률: 7월 ${okJuly}/${n} → 지금 ${okNow}/${n}`);
+const regressions = (now.results ?? []).filter((r) => correct(july.get(r.id)) === true && correct(r) === false);
+if (regressions.length) {
+  console.log(`\n★퇴행 ${regressions.length}건 — 모델 교체로 판정 품질이 떨어진 지점:`);
+  for (const r of regressions) console.log(`  ${r.id}: 기대 ${r.expected} / 판정 ${r.verdict ?? r.decision} :: ${(r.oneLine ?? "").slice(0, 80)}`);
+}

--- a/tools/simsa-inspection-fixtures/eval-results-2026-07-19-F8-F1.json
+++ b/tools/simsa-inspection-fixtures/eval-results-2026-07-19-F8-F1.json
@@ -1,0 +1,32 @@
+{
+  "base": "https://conclave-ai.seunghunbae.workers.dev",
+  "fixtures": "https://simsa-inspection-fixtures.seunghunbae.workers.dev",
+  "date": "2026-07-19",
+  "results": [
+    {
+      "id": "F1",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/working-todo",
+      "expected": "working",
+      "intent": "할 일을 입력하고 추가 버튼을 누르면 목록에 나타나야 한다",
+      "works": null,
+      "decision": "User Acceptance Required",
+      "verdict": "직접 눈으로 확인이 필요해요",
+      "oneLine": "아직 '작동한다'고 확정하기엔 확인이 더 필요해요.",
+      "runStatus": "done",
+      "score": "partial(null)"
+    },
+    {
+      "id": "F8",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/geo-gated",
+      "expected": "working",
+      "nullOk": true,
+      "intent": "산책 기록을 입력하고 추가를 누르면 목록에 저장되어 나타나야 한다",
+      "works": null,
+      "decision": "User Acceptance Required",
+      "verdict": "직접 눈으로 확인이 필요해요",
+      "oneLine": "아직 '작동한다'고 확정하기엔 확인이 더 필요해요.",
+      "runStatus": "done",
+      "score": "correct"
+    }
+  ]
+}

--- a/tools/simsa-inspection-fixtures/eval-results-2026-08-24.json
+++ b/tools/simsa-inspection-fixtures/eval-results-2026-08-24.json
@@ -1,0 +1,120 @@
+{
+  "base": "https://conclave-ai.seunghunbae.workers.dev",
+  "fixtures": "https://simsa-inspection-fixtures.seunghunbae.workers.dev",
+  "date": "2026-08-24",
+  "results": [
+    {
+      "id": "F1",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/working-todo",
+      "expected": "working",
+      "intent": "할 일을 입력하고 추가 버튼을 누르면 목록에 나타나야 한다",
+      "works": null,
+      "decision": "User Acceptance Required",
+      "verdict": "직접 눈으로 확인이 필요해요",
+      "oneLine": "아직 '작동한다'고 확정하기엔 확인이 더 필요해요.",
+      "runStatus": "done",
+      "score": "partial(null)"
+    },
+    {
+      "id": "F2",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/noisy-working",
+      "expected": "working",
+      "intent": "숫자를 입력하고 변환하기를 누르면 마일 결과가 보여야 한다",
+      "works": false,
+      "decision": "Needs Fix",
+      "verdict": "작동 안 해요 — 고쳐야 해요",
+      "oneLine": "핵심 흐름이 지금은 작동하지 않아요. 화면에서 코드 오류가 났어요.",
+      "runStatus": "done",
+      "score": "FALSE-NEGATIVE"
+    },
+    {
+      "id": "F3",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/potemkin-crm",
+      "expected": "broken",
+      "intent": "고객 메모를 입력하고 저장을 누르면 저장된 메모가 목록에 나타나야 한다",
+      "works": false,
+      "decision": "Needs Fix",
+      "verdict": "작동 안 해요 — 고쳐야 해요",
+      "oneLine": "핵심 흐름이 지금은 작동하지 않아요. 앱이 데이터를 가져오는 서버 주소를 찾지 못했어요.",
+      "runStatus": "done",
+      "score": "correct"
+    },
+    {
+      "id": "F4",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/js-crash",
+      "expected": "broken",
+      "intent": "원화 금액을 입력하고 계산하기를 누르면 달러 금액이 보여야 한다",
+      "works": false,
+      "decision": "Needs Fix",
+      "verdict": "작동 안 해요 — 고쳐야 해요",
+      "oneLine": "핵심 흐름이 지금은 작동하지 않아요. 화면에서 코드 오류가 났어요.",
+      "runStatus": "done",
+      "score": "correct"
+    },
+    {
+      "id": "F5",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/blank",
+      "expected": "broken",
+      "intent": "방문자가 이 서비스가 무엇인지 화면에서 알 수 있어야 한다",
+      "works": null,
+      "decision": "Needs Clarification",
+      "verdict": "무엇을 확인해야 할지 애매해요",
+      "oneLine": "아직 '작동한다'고 확정하기엔 확인이 더 필요해요. 처음 화면에서 무엇을 눌러 시작해야 할지 못 찾았어요.",
+      "runStatus": "done",
+      "score": "partial(null)"
+    },
+    {
+      "id": "F6",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/optimistic-ghost",
+      "expected": "broken",
+      "intent": "기록을 입력하고 추가를 누르면 목록에 저장되어 나타나야 한다",
+      "runStatus": "dispatch_failed(202 container returned 500: Failed to start container: Maximum number of running container instances exceeded. Try again later, or try configuring a higher value for max_instances)",
+      "score": "no-result"
+    },
+    {
+      "id": "F7",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/heavy-site",
+      "expected": "working",
+      "nullOk": true,
+      "intent": "기록을 입력하고 추가를 누르면 목록에 저장되어 나타나야 한다",
+      "runStatus": "dispatch_failed(202 container returned 500: Failed to start container: Maximum number of running container instances exceeded. Try again later, or try configuring a higher value for max_instances)",
+      "score": "no-result"
+    },
+    {
+      "id": "F8",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/geo-gated",
+      "expected": "working",
+      "nullOk": true,
+      "intent": "산책 기록을 입력하고 추가를 누르면 목록에 저장되어 나타나야 한다",
+      "runStatus": "dispatch_failed(202 container returned 500: Failed to start container: Maximum number of running container instances exceeded. Try again later, or try configuring a higher value for max_instances)",
+      "score": "no-result"
+    },
+    {
+      "id": "R1",
+      "url": "https://app.trysimsa.com",
+      "expected": "working",
+      "nullOk": true,
+      "intent": "방문자가 이 제품이 무엇인지 이해하고 시작할 수 있어야 한다",
+      "runStatus": "dispatch_failed(202 container returned 500: Failed to start container: Maximum number of running container instances exceeded. Try again later, or try configuring a higher value for max_instances)",
+      "score": "no-result"
+    },
+    {
+      "id": "R2",
+      "url": "https://golf-now.vercel.app",
+      "expected": "working",
+      "nullOk": true,
+      "intent": "골퍼가 지금 코스가 플레이 가능한지 확인하는 흐름을 시작할 수 있어야 한다",
+      "runStatus": "dispatch_failed(202 container returned 500: Failed to start container: Maximum number of running container instances exceeded. Try again later, or try configuring a higher value for max_instances)",
+      "score": "no-result"
+    },
+    {
+      "id": "R3",
+      "url": "https://trysimsa.com",
+      "expected": "working",
+      "nullOk": true,
+      "intent": "방문자가 이 서비스가 무엇인지 이해하고 시작 버튼을 찾을 수 있어야 한다",
+      "runStatus": "dispatch_failed(202 container returned 500: Failed to start container: Maximum number of running container instances exceeded. Try again later, or try configuring a higher value for max_instances)",
+      "score": "no-result"
+    }
+  ]
+}

--- a/tools/simsa-inspection-fixtures/eval-run.mjs
+++ b/tools/simsa-inspection-fixtures/eval-run.mjs
@@ -83,12 +83,27 @@ async function evalTarget(t) {
     });
     if (src.status >= 300) { row.runStatus = `source_failed(${src.status})`; return row; }
 
-    const run = await api("POST", `/workspace/projects/${projectId}/visual-checks/run`, {
-      userKey, locale: "ko", targetUrl: t.url, intent: t.intent,
-    });
-    const runId = run.json?.check?.id;
-    if (!runId || run.json?.dispatched !== true) {
-      row.runStatus = `dispatch_failed(${run.status} ${run.json?.note ?? ""})`; return row;
+    // ★용량 부족은 **측정 실패**이지 결과가 아니다 (2026-08-25).
+    // 첫 판에서 11개 중 6개가 `Maximum number of running container instances exceeded`로
+    // no-result가 됐다. 그걸 그대로 기록하면 표본이 조용히 절반으로 줄고, 대조 도구가
+    // 그걸 "퇴행"으로 오독할 뻔했다. 용량이면 **기다렸다 다시 시도**한다.
+    let run, runId;
+    for (let attempt = 1; attempt <= 4; attempt++) {
+      run = await api("POST", `/workspace/projects/${projectId}/visual-checks/run`, {
+        userKey, locale: "ko", targetUrl: t.url, intent: t.intent,
+      });
+      runId = run.json?.check?.id;
+      if (runId && run.json?.dispatched === true) break;
+      const note = String(run.json?.note ?? "");
+      const capacity = /Maximum number of running container instances|instances exceeded/i.test(note);
+      if (!capacity || attempt === 4) {
+        row.runStatus = `dispatch_failed(${run.status} ${note})`;
+        return row;
+      }
+      const waitMs = 45_000 * attempt;
+      process.stdout.write(`    용량 부족 — ${waitMs / 1000}초 후 재시도 (${attempt}/3)
+`);
+      await new Promise((r) => setTimeout(r, waitMs));
     }
 
     const started = Date.now();


### PR DESCRIPTION
## 정확도를 재려다 더 큰 걸 발견했습니다

평가를 **순차로** 돌렸는데도 11개 중 **6개가 실패**했습니다:

```
Failed to start container: Maximum number of running container instances exceeded
```

하나씩 돌려도 상한(5)에 닿는다는 건 끝난 인스턴스가 곧바로 반환되지 않는다는 뜻입니다.

**제품 관점의 함의가 더 큽니다 — 여러 사용자가 동시에 검수를 누르면 검수가 아예
시작되지 않습니다.** 오픈 전에 반드시 올려야 하는 값이었습니다.

## 변경

| | 전 | 후 |
|---|---|---|
| `SimsaInspector.max_instances` | 5 | **20** |
| 평가 장비 용량 실패 | no-result로 기록 | **45·90·135초 재시도** |

상한을 올리는 것 자체는 과금되지 않습니다(실제로 도는 인스턴스에만 과금).
20은 잠정값이고 동시 검수 실측으로 조정합니다.

## ★대조 도구가 규칙을 어겼던 것도 고쳤습니다

`compare-baseline.mjs` 첫 판이 컨테이너 상한으로 인한 no-result를 **"모델 교체로 인한
퇴행"으로** 셌습니다. 측정 실패를 품질 저하로 보고할 뻔했고, 이건 방금 제정한
증거 규칙(R2·R3)을 도구가 어긴 것입니다. **도구가 규칙을 어기면 결과가 거짓말이 됩니다.**

## 참고 — 첫 판에서 측정된 5건

| 픽스처 | 정답 | 7월(Haiku) | 지금(OpenAI) |
|---|---|---|---|
| F1 작동 할일앱 | 작동 | 판단보류 | 판단보류 |
| F2 노이즈 변환기 | 작동 | 판단보류 | **고장이라 단정(오답)** |
| F3 겉만 번지르르 CRM | 고장 | 판단보류 | 고장 ✅ |
| F4 JS 크래시 | 고장 | 고장 ✅ | 고장 ✅ |
| F5 빈 화면 | 고장 | 판단보류 | 판단보류 |

판정자가 **더 가혹해졌습니다.** 고장은 더 잘 잡지만 **작동하는 앱을 고장이라 단정**합니다 —
이 제품에서 가장 해로운 실패 유형입니다. 배포 후 전체 재측정으로 확인하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
