### PR TITLE
feat(verdict): 긍정 판정을 만든다 — "문제를 찾지 못했어요" (Bae 결정 ②)

### DIFF
--- a/apps/central-plane/src/nondev-report.ts
+++ b/apps/central-plane/src/nondev-report.ts
@@ -70,7 +70,7 @@ export interface NonDevReport {
 const DECISION_LABEL: Record<ReportLocale, Record<string, string>> = {
   ko: {
     Ready: "정상 작동해요",
-    "Conditionally Ready": "대체로 되지만 확인이 필요해요",
+    "Conditionally Ready": "문제를 찾지 못했어요",
     "Needs Fix": "작동 안 해요 — 고쳐야 해요",
     "Not Verified": "확인 못 했어요",
     "Needs Clarification": "무엇을 확인해야 할지 애매해요",
@@ -83,7 +83,7 @@ const DECISION_LABEL: Record<ReportLocale, Record<string, string>> = {
   },
   en: {
     Ready: "It works",
-    "Conditionally Ready": "Mostly works, but needs a check",
+    "Conditionally Ready": "We could not find a problem",
     "Needs Fix": "It doesn't work — needs a fix",
     "Not Verified": "Couldn't verify",
     "Needs Clarification": "Unclear what to verify",
@@ -310,7 +310,23 @@ export function decideFromEvidence(
   if (e.interacted && e.visibleChangeAfterAction === true && e.persistedAfterReload === false) return "Needs Fix";
   if (steps.some((s) => !s.ok)) return e.interacted ? "User Acceptance Required" : "Needs Clarification";
   if (!e.primaryActionFound) return "Needs Clarification";
-  if (e.interacted) return "User Acceptance Required";
+  // ★2026-08-26 (Bae 결정 ②) — 여기가 **성공 경로**다: 모든 스텝이 끝까지 갔고,
+  //  주요 동작을 찾았고, 실제로 눌러봤고, 위의 어떤 결함 신호에도 걸리지 않았다.
+  //
+  //  그런데 종전엔 이 자리도 "직접 눈으로 확인이 필요해요"(UAR)였다. 즉 **이 시스템은
+  //  구조적으로 어떤 긍정 판정도 내리지 못했다** — `"Ready"`를 반환하는 코드가 최초
+  //  버전(#347)부터 아예 없었고, `works=true`의 유일한 조건이 그것이었다. 7월 정확도
+  //  평가에서 작동 픽스처가 계속 "판단보류"로 나온 원인이 이것인데, 그동안 모델과
+  //  프롬프트를 의심했다.
+  //
+  //  근거를 다 모아놓고 아무 말도 하지 않는 것은 정직이 아니라 회피에 가깝다.
+  //  그렇다고 "작동해요"를 확언할 수는 없다 — 우리는 **로그인 뒤를 보지 못하고**,
+  //  본 것도 한 흐름뿐이다. 그래서 확언과 침묵 사이의 정직한 자리를 쓴다:
+  //  **"문제를 찾지 못했어요"**(Conditionally Ready). `works`는 여전히 null이다
+  //  — 우리가 확인한 범위를 넘어서는 주장을 하지 않는다.
+  //
+  //  더 강한 판정("작동해요")은 로그인 뒤 왕복까지 확인할 수 있을 때의 몫이다.
+  if (e.interacted) return "Conditionally Ready";
   return "Not Verified";
 }
 
@@ -380,6 +396,8 @@ function firstMatch(arr: string[], re: RegExp): string | null {
 const REPORT_STR: Record<ReportLocale, {
   title: string;
   oneLineWorks: string;
+  /** ② 성공 경로 — 확언하지도, 침묵하지도 않는 자리. */
+  oneLineNoProblems: string;
   oneLineBroken: (firstWhat: string) => string;
   oneLineUnverified: (firstWhat: string) => string;
   nextTop: (how: string) => string;
@@ -390,6 +408,8 @@ const REPORT_STR: Record<ReportLocale, {
   ko: {
     title: "Simsa 검수 리포트",
     oneLineWorks: "핵심 흐름이 눈으로 확인한 범위에서 정상 동작했어요.",
+    oneLineNoProblems:
+      "핵심 흐름을 따라가 봤는데 문제를 찾지 못했어요. 다만 로그인 뒤 화면은 확인하지 않았습니다.",
     oneLineBroken: (w) => `핵심 흐름이 지금은 작동하지 않아요. ${w}`.trim(),
     oneLineUnverified: (w) => `아직 '작동한다'고 확정하기엔 확인이 더 필요해요. ${w}`.trim(),
     nextTop: (how) => `가장 급한 것부터: ${how}`,
@@ -404,6 +424,8 @@ const REPORT_STR: Record<ReportLocale, {
   en: {
     title: "Simsa Review Report",
     oneLineWorks: "The core flow worked correctly within what we could observe.",
+    oneLineNoProblems:
+      "We followed the core flow and could not find a problem. Anything behind a login was not checked.",
     oneLineBroken: (w) => `The core flow doesn't work right now. ${w}`.trim(),
     oneLineUnverified: (w) => `More checking is needed before we can confirm it "works". ${w}`.trim(),
     nextTop: (how) => `Most urgent first: ${how}`,
@@ -426,12 +448,21 @@ export function buildNonDevReport(input: VisualCheckInput, locale: ReportLocale 
   const verdict = decisionLabel(input.decision, L);
 
   const firstWhat = findings[0]?.what ?? "";
+  // ② "문제를 찾지 못했어요"는 실패가 아니다 — 종전 문구("확인이 더 필요해요")를
+  //    그대로 쓰면 성공 경로가 실패처럼 읽힌다. 판정과 문구를 같이 옮긴다.
+  const noProblems = input.decision === "Conditionally Ready";
   const oneLine =
-    works === true ? s.oneLineWorks : works === false ? s.oneLineBroken(firstWhat) : s.oneLineUnverified(firstWhat);
+    works === true
+      ? s.oneLineWorks
+      : works === false
+        ? s.oneLineBroken(firstWhat)
+        : noProblems
+          ? s.oneLineNoProblems
+          : s.oneLineUnverified(firstWhat);
 
   const nextSteps: string[] = [];
   if (findings[0]) nextSteps.push(s.nextTop(findings[0].how));
-  if (works === null && input.primaryActionFound === false) nextSteps.push(s.nextNoPrimary);
+  if (works === null && !noProblems && input.primaryActionFound === false) nextSteps.push(s.nextNoPrimary);
   nextSteps.push(s.nextRerun);
 
   return {

--- a/apps/central-plane/test/inspection-accuracy.test.mjs
+++ b/apps/central-plane/test/inspection-accuracy.test.mjs
@@ -1,6 +1,16 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
+// ★2026-08-26 판정 ② (Bae 결정): 깨끗하게 완주한 검수의 판정이
+// "User Acceptance Required"(직접 눈으로 확인이 필요해요) → **"Conditionally Ready"
+// (문제를 찾지 못했어요)** 로 바뀌었다.
+//
+// 왜: 종전엔 `decideFromEvidence`의 **어떤 분기도 긍정 판정을 내지 못했다**
+// (`"Ready"` 반환이 최초 버전부터 코드에 없었고 works=true의 유일한 조건이 그것).
+// 근거를 다 모아놓고 아무 말도 안 하는 것은 정직이 아니라 회피에 가깝다.
+// `works`는 여전히 null이다 — 확인한 범위를 넘어서는 주장은 하지 않는다.
+// UAR은 **부분 완주**(스텝 일부 실패 + 상호작용함) 자리로 남는다.
+
 // P0-B inspection accuracy (2026-07-16). Live: vercel.com (a working site) was
 // called "작동 안 해요 — 고쳐야 해요" because a third-party analytics 403 + console
 // noise + a CTA click timeout were all counted as defects. The fix: the verdict
@@ -68,8 +78,8 @@ describe("decideFromEvidence — the vercel.com false-negative is fixed", () => 
     assert.equal(d, "Needs Clarification"); // couldn't drive it → ask, don't fail
   });
 
-  it("a clean interactive journey is User Acceptance Required, not a fail", () => {
-    assert.equal(decideFromEvidence({ ...base, interacted: true }, [{ ok: true }]), "User Acceptance Required");
+  it("★깨끗한 완주는 문제를 찾지 못했어요 판정이다 (2026-08-26 ②)", () => {
+    assert.equal(decideFromEvidence({ ...base, interacted: true }, [{ ok: true }]), "Conditionally Ready");
   });
 });
 
@@ -104,12 +114,12 @@ describe("decideFromEvidence — D9: dead-button crash is the CONJUNCTION, never
     );
     assert.equal(d, "Needs Fix");
   });
-  it("console error alone (screen DID change) stays a clean acceptance ask", () => {
+  it("console error alone (screen DID change) stays a clean pass", () => {
     const d = decideFromEvidence(
       { ...base, interacted: true, visibleChangeAfterAction: true, consoleErrorCount: 3 },
       [{ ok: true }],
     );
-    assert.equal(d, "User Acceptance Required");
+    assert.equal(d, "Conditionally Ready");
   });
   it("no visible change alone (no console error) is 'couldn't confirm', not broken", () => {
     const d = decideFromEvidence(
@@ -119,7 +129,7 @@ describe("decideFromEvidence — D9: dead-button crash is the CONJUNCTION, never
     assert.notEqual(d, "Needs Fix");
   });
   it("older callers without the D9 fields keep their existing verdicts (fields optional)", () => {
-    assert.equal(decideFromEvidence({ ...base, interacted: true }, [{ ok: true }]), "User Acceptance Required");
+    assert.equal(decideFromEvidence({ ...base, interacted: true }, [{ ok: true }]), "Conditionally Ready");
   });
 });
 
@@ -133,19 +143,19 @@ describe("decideFromEvidence — G4-①: persistence is the FINAL Potemkin test"
     );
     assert.equal(d, "Needs Fix");
   });
-  it("persisted (localStorage app survives reload) → clean acceptance ask", () => {
+  it("persisted (localStorage app survives reload) → clean pass", () => {
     const d = decideFromEvidence(
       { ...base, interacted: true, visibleChangeAfterAction: true, persistedAfterReload: true },
       [{ ok: true }],
     );
-    assert.equal(d, "User Acceptance Required");
+    assert.equal(d, "Conditionally Ready");
   });
   it("not measured (null — search flow / route change / no marker) never drives the verdict", () => {
     const d = decideFromEvidence(
       { ...base, interacted: true, visibleChangeAfterAction: true, persistedAfterReload: null },
       [{ ok: true }],
     );
-    assert.equal(d, "User Acceptance Required");
+    assert.equal(d, "Conditionally Ready");
   });
   it("persisted=false WITHOUT a visible change is not this rung (nothing was 'added')", () => {
     const d = decideFromEvidence(
@@ -160,7 +170,7 @@ describe("classifyFindings — noise is info, real failures are high, console is
   const input = (over) => ({
     targetUrl: "https://myapp.vercel.app/", intentAnchor: "x", loadStatus: 200,
     primaryActionFound: true, interacted: true, routeAfterClick: null, routeChanged: false,
-    consoleErrors: [], networkFailures: [], noiseFailures: [], decision: "User Acceptance Required", steps: [],
+    consoleErrors: [], networkFailures: [], noiseFailures: [], decision: "Conditionally Ready", steps: [],
     ...over,
   });
 
@@ -182,5 +192,54 @@ describe("classifyFindings — noise is info, real failures are high, console is
     const con = f.find((x) => /코드 오류/.test(x.what));
     assert.ok(con, "console finding still listed");
     assert.equal(con.severity, "low", "console errors must be low, not medium");
+  });
+});
+
+describe("★긍정 판정이 실제로 존재한다 (2026-08-26 ②)", () => {
+  it("깨끗한 완주는 '문제를 찾지 못했어요'로 읽힌다 — 실패처럼 읽히면 안 된다", async () => {
+    const { buildNonDevReport } = await import("../dist/nondev-report.js");
+    const r = buildNonDevReport(
+      {
+        targetUrl: "https://x.dev",
+        intentAnchor: "버튼을 누르면 목록에 나타난다",
+        decision: "Conditionally Ready",
+        consoleErrors: [],
+        networkFailures: [],
+        primaryActionFound: true,
+        interacted: true,
+      },
+      "ko",
+    );
+    assert.equal(r.verdict, "문제를 찾지 못했어요");
+    assert.match(r.oneLine, /문제를 찾지 못했어요/);
+    assert.doesNotMatch(r.oneLine, /확정하기엔 확인이 더 필요/, "성공 경로가 실패 문구를 쓰면 안 된다");
+  });
+
+  it("★그래도 works는 null이다 — 확인한 범위를 넘어서는 주장을 하지 않는다", async () => {
+    const { decisionToWorks } = await import("../dist/nondev-report.js");
+    assert.equal(decisionToWorks("Conditionally Ready"), null);
+  });
+
+  it("로그인 뒤를 못 봤다는 한계를 문구가 계속 말한다", async () => {
+    const { buildNonDevReport } = await import("../dist/nondev-report.js");
+    for (const [locale, re] of [["ko", /로그인 뒤/], ["en", /behind a login/i]]) {
+      const r = buildNonDevReport(
+        { targetUrl: "https://x.dev", intentAnchor: "x", decision: "Conditionally Ready",
+          consoleErrors: [], networkFailures: [], primaryActionFound: true, interacted: true },
+        locale,
+      );
+      assert.match(r.oneLine, re, locale);
+    }
+  });
+
+  it("부분 완주는 여전히 '직접 확인'이다 — 두 자리를 뭉뜽그리지 않는다", async () => {
+    const { decideFromEvidence } = await import("../dist/nondev-report.js");
+    assert.equal(
+      decideFromEvidence(
+        { consoleErrors: [], networkFailures: [], primaryActionFound: true, interacted: true },
+        [{ ok: true }, { ok: false }],
+      ),
+      "User Acceptance Required",
+    );
   });
 });


### PR DESCRIPTION
## 무엇이 없었나

`decideFromEvidence`의 **어떤 분기도 긍정 판정을 내지 못했습니다.** `"Ready"`를 반환하는
코드가 최초 버전(#347, 7월)부터 존재하지 않았고, `works=true`의 유일한 조건이 그것입니다.
깨끗하게 완주한 검수조차 "직접 눈으로 확인이 필요해요"에서 끝났습니다.

즉 이 제품은 **고장은 찾아주지만 "괜찮다"고는 말하지 못하는 상태**였습니다. 비개발자가
"내가 만든 게 제대로 된 건가?"를 물으러 오는데 답이 "모르겠어요"뿐이었습니다.

7월 정확도 평가에서 작동 픽스처가 계속 "판단보류"로 나온 원인이 이것인데, 그동안
모델과 프롬프트를 의심했습니다.

## 변경

성공 경로 — 모든 스텝 완주 · 주요 동작 발견 · 실제 상호작용 · 5xx/4xx/네트워크 실패/
잘못된 라우트/죽은 버튼/낙관적 유령 **어디에도 안 걸림** — 를
**`"Conditionally Ready"` = "문제를 찾지 못했어요"** 로 옮겼습니다.

| | 전 | 후 |
|---|---|---|
| 깨끗한 완주 | "직접 눈으로 확인이 필요해요" | **"문제를 찾지 못했어요"** |
| 한 줄 요약 | "아직 '작동한다'고 확정하기엔…" | "문제를 찾지 못했어요. 다만 로그인 뒤 화면은 확인하지 않았습니다." |
| `works` | null | **null (그대로)** |
| 부분 완주 | UAR | UAR (그대로) |

라벨도 "대체로 되지만 확인이 필요해요" → **"문제를 찾지 못했어요"** 로 바꿨습니다.
전자는 모아놓은 근거보다 약하게 들립니다.

## 왜 "작동해요"가 아닌가

우리는 **로그인 뒤를 보지 못하고**, 본 것도 한 흐름뿐입니다. 확언은 그 범위를 넘습니다.
더 강한 판정은 로그인 뒤 왕복까지 확인할 수 있을 때의 몫입니다(다음 작업).

근거를 다 모아놓고 아무 말도 하지 않는 것은 정직이 아니라 회피에 가깝습니다 —
확언과 침묵 사이의 정직한 자리를 씁니다.

## 검증

- **4건 추가** — 성공 경로 문구 · **works는 여전히 null** · 로그인 한계 문구 유지(KO/EN) ·
  부분 완주는 UAR 유지(두 자리를 뭉뜽그리지 않음).
- 기존 5건은 옛 판정을 고정하던 것이라 사유와 함께 갱신(의도한 동작 변경).
- central-plane **2124/2124** · typecheck · lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
