### PR TITLE
fix(inspection): 저장 안 하는 게 정상인 앱을 고장이라 하지 않는다 (F2 오답)

### DIFF
--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -268,8 +268,23 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
     // route), never as an absolute page size — the old `bodyLen > 200` check
     // failed every small app card regardless of actual behavior.
     const bodyTextAt = async () => (await page.locator("body").innerText().catch(() => "")).replace(/\s+/g, " ").trim();
+    /**
+     * ★"추가형 흐름"을 가르는 측정 (2026-08-26).
+     *
+     * 지속성 검사의 원래 의도는 **"추가한 것이 남아 있는가"** 인데, 종전 관문은
+     * "본문에 입력값이 들어 있는가"였다. 그건 너무 약하다 — 단위 변환기에 `5`를
+     * 넣으면 결과가 "5 km = 3.11 miles"라 관문을 통과하고, 새로고침하면 당연히
+     * 사라지므로 **작동하는 앱이 "낙관적 유령"으로 오판**됐다(F2 실측).
+     *
+     * 진짜 구분점은 **모음이 자랐는가**다: 기록장은 목록에 항목이 **추가**되고,
+     * 변환기는 결과 한 칸이 **교체**된다. 저장할 것이 없는 앱에 저장을 요구하지 않는다.
+     */
+    const countCollectionItems = async () =>
+      page.evaluate(() => document.querySelectorAll("li, tbody tr, [role='listitem']").length).catch(() => 0);
     plog(`plan:built steps=${plan.length} bodyBefore:start`);
     const bodyBefore = await bodyTextAt();
+    const itemsBefore = await countCollectionItems();
+    plog(`baseline:items=${itemsBefore}`);
     plog(`bodyBefore:done len=${bodyBefore.length}`);
     // D6: when the plan submits via a CLICK step, Enter after typing would
     // double-submit (or submit an incomplete form) — press Enter only when
@@ -349,14 +364,23 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
     ) {
       try {
         plog("persist:check start");
-        const bodyAfterAction = await bodyTextAt();
-        if (bodyAfterAction.includes(typedStep.value)) {
+        const itemsAfter = await countCollectionItems();
+        const collectionGrew = itemsAfter > itemsBefore;
+        plog(`persist:gate itemsBefore=${itemsBefore} itemsAfter=${itemsAfter} grew=${collectionGrew}`);
+        // ★관문: **모음이 자란 흐름에서만** 지속성을 묻는다. 자라지 않았다면 이 앱은
+        //  애초에 "추가"를 하는 앱이 아니므로(계산기·변환기·조회 화면) 저장을
+        //  요구하는 것 자체가 틀렸다 — null 유지로 판정에 영향을 주지 않는다.
+        if (collectionGrew) {
           plog("persist:reload start");
           await page.reload({ waitUntil: "domcontentloaded", timeout: 15000 });
           await page.waitForTimeout(1800);
           await snap(`step-${String(stepIdx + 1).padStart(2, "0")}-reload.png`);
           const bodyReload = await bodyTextAt();
-          evidence.persistedAfterReload = bodyReload.includes(typedStep.value);
+          const itemsReload = await countCollectionItems();
+          // 추가된 항목이 살아남았는가. 개수가 먼저이고(정렬·페이지네이션에 강함),
+          // 텍스트 잔존은 보조 신호다.
+          evidence.persistedAfterReload = itemsReload > itemsBefore || bodyReload.includes(typedStep.value);
+          plog(`persist:result itemsReload=${itemsReload} persisted=${evidence.persistedAfterReload}`);
           stepOutcomes.push({
             label: N.reloadCheck,
             ok: evidence.persistedAfterReload,

--- a/apps/central-plane/test/persistence-gate.test.mjs
+++ b/apps/central-plane/test/persistence-gate.test.mjs
@@ -1,0 +1,71 @@
+/**
+ * persistence-gate.test.mjs — 지속성 검사의 **관문** (2026-08-26).
+ *
+ * ## 왜 바뀌었나
+ *
+ * 종전 관문은 `본문에 입력값이 들어 있는가`였다. 너무 약하다 — 단위 변환기에 `5`를
+ * 넣으면 결과가 "5 km = 3.11 miles"라 관문을 통과하고, 새로고침하면 당연히 사라지므로
+ * **작동하는 앱이 "낙관적 유령"으로 오판**됐다(F2 라이브 실측, FALSE-NEGATIVE).
+ *
+ * 멀쩡한 앱을 고장이라 하는 것은 이 제품에서 **가장 비싼 오답**이다. 사용자가 자기
+ * 앱이 되는 걸 아는 상태에서 그 말을 들으면 그때부터 우리 판정을 믿지 않는다.
+ *
+ * ## 진짜 구분점
+ *
+ * **모음이 자랐는가.** 기록장은 목록에 항목이 **추가**되고, 변환기는 결과 한 칸이
+ * **교체**된다. 저장할 것이 없는 앱에 저장을 요구하지 않는다.
+ *
+ * 아래는 라이브 픽스처에서 실측한 값을 계약으로 고정한 것이다:
+ *   F2 변환기(정상)     항목 0→0  관문 미통과 → 지속성 null (판정 무영향)
+ *   F6 기록장(진짜 결함) 항목 1→2  관문 통과   → 지속성 false → Needs Fix
+ *   F1 할일앱(정상)     항목 0→1  관문 통과   → 지속성 true
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { decideFromEvidence } = await import("../dist/nondev-report.js");
+
+/** 컨테이너의 관문 로직과 같은 형태(inspector-run.mjs). */
+const gatePasses = (itemsBefore, itemsAfter) => itemsAfter > itemsBefore;
+
+describe("관문 — 모음이 자란 흐름에서만 지속성을 묻는다", () => {
+  it("★변환기: 항목이 늘지 않으면 관문을 통과하지 않는다 (F2 오답의 원인)", () => {
+    assert.equal(gatePasses(0, 0), false);
+  });
+
+  it("기록장·할일앱: 항목이 늘면 관문을 통과한다", () => {
+    assert.equal(gatePasses(1, 2), true, "F6");
+    assert.equal(gatePasses(0, 1), true, "F1");
+  });
+});
+
+describe("판정 — 관문을 통과하지 않으면 지속성이 판정에 영향을 주지 않는다", () => {
+  const base = {
+    consoleErrors: [],
+    networkFailures: [],
+    primaryActionFound: true,
+    interacted: true,
+    visibleChangeAfterAction: true,
+  };
+
+  it("★F2 재현: 화면은 바뀌었고 저장은 안 했지만 **측정하지 않았으므로** 고장이 아니다", () => {
+    const d = decideFromEvidence({ ...base, persistedAfterReload: null }, [{ ok: true }]);
+    assert.equal(d, "Conditionally Ready", "작동하는 변환기를 고장이라 하면 안 된다");
+  });
+
+  it("★F6 재현: 측정했고 저장이 안 됐으면 고장이다 — 진짜 결함은 계속 잡는다", () => {
+    const d = decideFromEvidence({ ...base, persistedAfterReload: false }, [{ ok: true }]);
+    assert.equal(d, "Needs Fix");
+  });
+
+  it("F1 재현: 측정했고 저장됐으면 문제를 찾지 못한 것", () => {
+    const d = decideFromEvidence({ ...base, persistedAfterReload: true }, [{ ok: true }]);
+    assert.equal(d, "Conditionally Ready");
+  });
+
+  it("측정 안 됨(null)과 저장 안 됨(false)은 절대 같지 않다", () => {
+    const unmeasured = decideFromEvidence({ ...base, persistedAfterReload: null }, [{ ok: true }]);
+    const measured = decideFromEvidence({ ...base, persistedAfterReload: false }, [{ ok: true }]);
+    assert.notEqual(unmeasured, measured, "뭉뜽그리면 멀쩡한 앱이 고장이 된다");
+  });
+});

--- a/tools/simsa-completion-loop-spike/f2-plan.mjs
+++ b/tools/simsa-completion-loop-spike/f2-plan.mjs
@@ -1,0 +1,47 @@
+/** F2에서 planVisualFlow가 실제로 무슨 계획을 세우는지 로컬 재현. */
+import { chromium } from "playwright";
+import { planVisualFlow } from "../../apps/central-plane/dist/visual-flow-plan.js";
+
+const URL = "https://simsa-inspection-fixtures.seunghunbae.workers.dev/noisy-working";
+const b = await chromium.launch();
+const p = await b.newPage();
+const consoleErrors = [];
+p.on("console", (m) => m.type() === "error" && consoleErrors.push(m.text().slice(0, 120)));
+await p.goto(URL, { waitUntil: "networkidle" });
+
+const ctas = await p.$$eval("button, a, [role=button], input[type=submit]", (els) =>
+  els.filter((e) => e.offsetParent !== null).map((e) => ({
+    text: (e.innerText || e.value || "").trim().slice(0, 60),
+    tag: e.tagName.toLowerCase(),
+  })).filter((c) => c.text));
+const inputs = await p.$$eval("input, textarea", (els) =>
+  els.filter((e) => e.offsetParent !== null).map((i) => ({
+    placeholder: i.placeholder || "", type: i.type || "text",
+    selector: i.placeholder ? `[placeholder="${i.placeholder}"]` : "input",
+  })));
+
+console.log("CTA:", JSON.stringify(ctas));
+console.log("입력칸:", JSON.stringify(inputs));
+
+const plan = planVisualFlow({ intent: "숫자를 입력하고 변환하기를 누르면 마일 결과가 보여야 한다", ctas, inputs });
+console.log("계획:", JSON.stringify(plan, null, 1));
+
+// 계획대로 실행하며 본문 변화를 관찰
+const bodyText = () => p.evaluate(() => (document.body.innerText || "").replace(/\s+/g, " "));
+let before = await bodyText();
+for (const step of plan) {
+  if (step.action === "type") {
+    const f = step.placeholder ? p.getByPlaceholder(step.placeholder).first() : p.locator("input").first();
+    await f.fill(step.value, { timeout: 8000 }).catch((e) => console.log("  type 실패:", e.message.slice(0, 60)));
+  } else if (step.action === "click") {
+    await p.getByText(step.targetText, { exact: false }).first().click({ timeout: 8000 })
+      .catch((e) => console.log("  click 실패:", e.message.slice(0, 80)));
+  }
+  await p.waitForTimeout(800);
+  const now = await bodyText();
+  console.log(`  [${step.action}] "${step.targetText ?? step.value ?? ""}" → 본문변화=${now !== before}`);
+  before = now;
+}
+console.log("콘솔오류:", consoleErrors.length, JSON.stringify(consoleErrors));
+console.log("최종 본문:", (await bodyText()).slice(0, 160));
+await b.close();

--- a/tools/simsa-completion-loop-spike/gate-check.mjs
+++ b/tools/simsa-completion-loop-spike/gate-check.mjs
@@ -1,0 +1,40 @@
+/** 새 관문(모음이 자랐는가)이 F2(정상)와 F6(진짜 결함)을 가르는지 로컬 검증. */
+import { chromium } from "playwright";
+import { planVisualFlow } from "../../apps/central-plane/dist/visual-flow-plan.js";
+const F = "https://simsa-inspection-fixtures.seunghunbae.workers.dev";
+const b = await chromium.launch();
+
+for (const [id, path, intent, expect] of [
+  ["F2 변환기(정상)", "/noisy-working", "숫자를 입력하고 변환하기를 누르면 마일 결과가 보여야 한다", "관문 통과 안 함"],
+  ["F6 기록장(결함)", "/optimistic-ghost", "기록을 입력하고 추가를 누르면 목록에 저장되어 나타나야 한다", "관문 통과 + 저장 안 됨"],
+  ["F1 할일앱(정상,저장함)", "/working-todo", "할 일을 입력하고 추가 버튼을 누르면 목록에 나타나야 한다", "관문 통과 + 저장됨"],
+]) {
+  const p = await b.newPage();
+  await p.goto(F + path, { waitUntil: "networkidle" });
+  const count = () => p.evaluate(() => document.querySelectorAll("li, tbody tr, [role='listitem']").length);
+  const ctas = await p.$$eval("button, a, [role=button], input[type=submit]", (els) =>
+    els.filter((e) => e.offsetParent !== null).map((e) => ({ text: (e.innerText || e.value || "").trim().slice(0, 60), tag: e.tagName.toLowerCase() })).filter((c) => c.text));
+  const inputs = await p.$$eval("input, textarea", (els) =>
+    els.filter((e) => e.offsetParent !== null).map((i) => ({ placeholder: i.placeholder || "", type: i.type || "text", selector: i.placeholder ? `[placeholder="${i.placeholder}"]` : "input" })));
+  const plan = planVisualFlow({ intent, ctas, inputs });
+  const before = await count();
+  let typed = null;
+  for (const s of plan) {
+    if (s.action === "type") { typed = s.value; await (s.placeholder ? p.getByPlaceholder(s.placeholder).first() : p.locator("input").first()).fill(s.value).catch(() => {}); }
+    else if (s.action === "click") await p.getByText(s.targetText, { exact: true }).first().click({ timeout: 8000 }).catch(() => {});
+    await p.waitForTimeout(600);
+  }
+  const after = await count();
+  const grew = after > before;
+  let persisted = null;
+  if (grew) {
+    await p.reload({ waitUntil: "domcontentloaded" });
+    await p.waitForTimeout(1200);
+    const rc = await count();
+    const body = await p.evaluate(() => document.body.innerText);
+    persisted = rc > before || (typed && body.includes(typed));
+  }
+  console.log(`${id}\n  항목 ${before}→${after} · 관문통과=${grew} · 지속성=${persisted === null ? "측정안함(null)" : persisted}\n  기대: ${expect}`);
+  await p.close();
+}
+await b.close();

--- a/tools/simsa-inspection-fixtures/eval-results-2026-08-26-F1-F2-F7.json
+++ b/tools/simsa-inspection-fixtures/eval-results-2026-08-26-F1-F2-F7.json
@@ -1,0 +1,44 @@
+{
+  "base": "https://conclave-ai.seunghunbae.workers.dev",
+  "fixtures": "https://simsa-inspection-fixtures.seunghunbae.workers.dev",
+  "date": "2026-08-26",
+  "results": [
+    {
+      "id": "F1",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/working-todo",
+      "expected": "working",
+      "intent": "할 일을 입력하고 추가 버튼을 누르면 목록에 나타나야 한다",
+      "works": null,
+      "decision": "User Acceptance Required",
+      "verdict": "직접 눈으로 확인이 필요해요",
+      "oneLine": "아직 '작동한다'고 확정하기엔 확인이 더 필요해요.",
+      "runStatus": "done",
+      "score": "partial(null)"
+    },
+    {
+      "id": "F2",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/noisy-working",
+      "expected": "working",
+      "intent": "숫자를 입력하고 변환하기를 누르면 마일 결과가 보여야 한다",
+      "works": false,
+      "decision": "Needs Fix",
+      "verdict": "작동 안 해요 — 고쳐야 해요",
+      "oneLine": "핵심 흐름이 지금은 작동하지 않아요. 화면에서 코드 오류가 났어요.",
+      "runStatus": "done",
+      "score": "FALSE-NEGATIVE"
+    },
+    {
+      "id": "F7",
+      "url": "https://simsa-inspection-fixtures.seunghunbae.workers.dev/heavy-site",
+      "expected": "working",
+      "nullOk": true,
+      "intent": "기록을 입력하고 추가를 누르면 목록에 저장되어 나타나야 한다",
+      "works": null,
+      "decision": "User Acceptance Required",
+      "verdict": "직접 눈으로 확인이 필요해요",
+      "oneLine": "아직 '작동한다'고 확정하기엔 확인이 더 필요해요. '핵심 버튼 '추가' 누르기' 단계가 끝까지 되지 않았어요.",
+      "runStatus": "done",
+      "score": "correct"
+    }
+  ]
+}

--- a/tools/simsa-inspection-fixtures/f2-detail.mjs
+++ b/tools/simsa-inspection-fixtures/f2-detail.mjs
@@ -1,0 +1,36 @@
+/** 성공 분기에 왜 도달 못 하는지 — 리포트 전문과 스텝 결과를 본다. */
+const B = "https://conclave-ai.seunghunbae.workers.dev";
+const F = "https://simsa-inspection-fixtures.seunghunbae.workers.dev";
+const H = { "content-type": "application/json", origin: "https://app.trysimsa.com" };
+const api = async (m, p, b) => {
+  const r = await fetch(B + p, { method: m, headers: H, ...(b ? { body: JSON.stringify(b) } : {}) });
+  return { status: r.status, json: await r.json().catch(() => null) };
+};
+const uk = "uk_sd_" + Math.random().toString(36).slice(2);
+const pid = "proj_sd_" + Math.random().toString(36).slice(2);
+await api("POST", "/workspace/projects", { userKey: uk, id: pid, title: "step detail", entryPath: "code" });
+await api("POST", `/workspace/projects/${pid}/sources`, { userKey: uk, type: "website", reference: F + "/noisy-working" });
+const run = await api("POST", `/workspace/projects/${pid}/visual-checks/run`, {
+  userKey: uk, locale: "ko", targetUrl: F + "/noisy-working",
+  intent: "숫자를 입력하고 변환하기를 누르면 마일 결과가 보여야 한다",
+});
+const runId = run.json?.check?.id;
+for (let i = 0; i < 30; i++) {
+  await new Promise((r) => setTimeout(r, 10000));
+  const g = await api("GET", `/workspace/projects/${pid}/visual-checks/${runId}?userKey=${encodeURIComponent(uk)}`);
+  const c = g.json?.check;
+  if (c?.status === "done" || c?.status === "failed") {
+    console.log("decision:", c.decision, "| works:", c.works);
+    const rep = typeof c.report === "string" ? JSON.parse(c.report) : c.report;
+    console.log("verdict:", rep?.verdict);
+    console.log("oneLine:", rep?.oneLine);
+    console.log("findings:", JSON.stringify(rep?.findings ?? []).slice(0, 300));
+    console.log("전체 리포트 키:", Object.keys(rep ?? {}).join(", "));
+    console.log("nextSteps:", JSON.stringify(rep?.nextSteps ?? []).slice(0, 300));
+    console.log("agentPrompt(앞 600):", String(c.agentPrompt ?? "").slice(0, 600));
+    for (const k of ["steps", "stepOutcomes", "flow", "plan", "evidence"]) {
+      if (rep?.[k]) console.log(`${k}:`, JSON.stringify(rep[k]).slice(0, 600));
+    }
+    break;
+  }
+}

--- a/tools/simsa-inspection-fixtures/step-detail.mjs
+++ b/tools/simsa-inspection-fixtures/step-detail.mjs
@@ -1,0 +1,34 @@
+/** 성공 분기에 왜 도달 못 하는지 — 리포트 전문과 스텝 결과를 본다. */
+const B = "https://conclave-ai.seunghunbae.workers.dev";
+const F = "https://simsa-inspection-fixtures.seunghunbae.workers.dev";
+const H = { "content-type": "application/json", origin: "https://app.trysimsa.com" };
+const api = async (m, p, b) => {
+  const r = await fetch(B + p, { method: m, headers: H, ...(b ? { body: JSON.stringify(b) } : {}) });
+  return { status: r.status, json: await r.json().catch(() => null) };
+};
+const uk = "uk_sd_" + Math.random().toString(36).slice(2);
+const pid = "proj_sd_" + Math.random().toString(36).slice(2);
+await api("POST", "/workspace/projects", { userKey: uk, id: pid, title: "step detail", entryPath: "code" });
+await api("POST", `/workspace/projects/${pid}/sources`, { userKey: uk, type: "website", reference: F + "/working-todo" });
+const run = await api("POST", `/workspace/projects/${pid}/visual-checks/run`, {
+  userKey: uk, locale: "ko", targetUrl: F + "/working-todo",
+  intent: "할 일을 입력하고 추가 버튼을 누르면 목록에 나타나야 한다",
+});
+const runId = run.json?.check?.id;
+for (let i = 0; i < 30; i++) {
+  await new Promise((r) => setTimeout(r, 10000));
+  const g = await api("GET", `/workspace/projects/${pid}/visual-checks/${runId}?userKey=${encodeURIComponent(uk)}`);
+  const c = g.json?.check;
+  if (c?.status === "done" || c?.status === "failed") {
+    console.log("decision:", c.decision, "| works:", c.works);
+    const rep = typeof c.report === "string" ? JSON.parse(c.report) : c.report;
+    console.log("verdict:", rep?.verdict);
+    console.log("oneLine:", rep?.oneLine);
+    console.log("findings:", JSON.stringify(rep?.findings ?? []).slice(0, 300));
+    console.log("전체 리포트 키:", Object.keys(rep ?? {}).join(", "));
+    for (const k of ["steps", "stepOutcomes", "flow", "plan", "evidence"]) {
+      if (rep?.[k]) console.log(`${k}:`, JSON.stringify(rep[k]).slice(0, 600));
+    }
+    break;
+  }
+}


### PR DESCRIPTION
## 무엇이 문제였나

지속성 검사의 관문이 **"본문에 입력값이 들어 있는가"** 였습니다. 너무 약합니다:

```
단위 변환기에 5 입력 → 결과 "5 km = 3.11 miles" → 관문 통과
새로고침 → 당연히 사라짐 → "저장 안 됨" → Needs Fix
```

**작동하는 앱을 고장이라 단정**했습니다. 이 제품에서 **가장 비싼 오답**입니다 —
사용자가 자기 앱이 되는 걸 아는 상태에서 그 말을 들으면 그때부터 우리 판정을 믿지 않습니다.

## 진짜 구분점 — 모음이 자랐는가

기록장은 목록에 항목이 **추가**되고, 변환기는 결과 한 칸이 **교체**됩니다.
지속성 검사의 원래 의도가 "추가한 것이 남아 있는가"였으니 관문도 그렇게 물어야 합니다.
**저장할 것이 없는 앱에 저장을 요구하지 않습니다.**

## 라이브 픽스처로 배포 전 실측

| | 항목 | 관문 | 지속성 | |
|---|---|---|---|---|
| F2 변환기(정상) | 0→0 | 미통과 | null | **오답 해소** |
| F6 기록장(진짜 결함) | 1→2 | 통과 | **false** | **결함 계속 잡음** |
| F1 할일앱(정상) | 0→1 | 통과 | **true** | 정상 확인 |

**양방향으로 쟀습니다** — 오탐이 사라지면서 진짜 결함이 그대로 잡히는지 함께 확인했습니다.
한쪽만 보면 관대하게 만들어 Potemkin을 놓치기 쉽습니다.

## 검증

- **6건 추가** — 관문 판정 2 · F2/F6/F1 재현 3 ·
  **"측정 안 됨(null)"과 "저장 안 됨(false)"은 절대 같지 않다**.
- central-plane **2130/2130** · typecheck · lint green.

## 배포 후

F2를 다시 재서 FALSE-NEGATIVE가 사라졌는지, F6이 여전히 잡히는지 확인하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
