### PR TITLE
feat(login-depth): 로그인 뒤 검수의 토대 — 일회용 메일함 + 계정 만들기 계획

### DIFF
--- a/apps/central-plane/migrations/0066_probe_mailbox.sql
+++ b/apps/central-plane/migrations/0066_probe_mailbox.sql
@@ -1,0 +1,28 @@
+-- 0066 — 검수용 일회용 메일함 (2026-08-26).
+--
+-- 왜: 로그인 뒤 화면을 검수하려면 계정이 필요한데, **남의 비밀번호를 받아 보관하는
+-- 것은 하지 않는다**(유출 시 그 앱뿐 아니라 비밀번호를 재사용한 다른 계정까지
+-- 열리고, 비개발자에게 "검수 도구에 비밀번호를 주는 습관"을 가르치게 된다).
+--
+-- 대신 **우리가 일회용 계정을 만든다.** 그러려면 앱이 보내는 확인 메일을 받아야 하고,
+-- 그게 이 표다. `probe-<runId>@<수신도메인>` 앞으로 온 메일을 Email Worker가 여기에
+-- 넣고, 컨테이너가 링크를 꺼내 가입을 완주한다.
+--
+-- 보존: 본문은 저장하지 않는다. **링크와 제목만** 남긴다 — 남의 앱이 보낸 메일에는
+-- 그 앱 사용자의 정보가 담길 수 있으므로 필요한 최소치만 갖는다.
+CREATE TABLE IF NOT EXISTS probe_emails (
+  id TEXT PRIMARY KEY,
+  -- 어느 검수 실행의 메일함인가. probe-<run_id>@... 의 그 run_id.
+  run_id TEXT NOT NULL,
+  to_addr TEXT NOT NULL,
+  from_addr TEXT,
+  subject TEXT,
+  -- 본문에서 뽑아낸 링크 목록(JSON 배열). 본문 자체는 저장하지 않는다.
+  links TEXT NOT NULL DEFAULT '[]',
+  received_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS probe_emails_run_idx ON probe_emails(run_id, received_at);
+
+-- 오래된 메일은 남겨둘 이유가 없다. 정리는 기존 GC 크론이 이 인덱스로 훑는다.
+CREATE INDEX IF NOT EXISTS probe_emails_received_idx ON probe_emails(received_at);

--- a/apps/central-plane/src/env.ts
+++ b/apps/central-plane/src/env.ts
@@ -187,6 +187,14 @@ export interface Env {
    */
   ANTHROPIC_ENABLED?: string;
   /**
+   * 검수용 일회용 메일 수신 도메인 (2026-08-26). 예: "probe.trysimsa.com".
+   * 로그인 뒤 검수를 하려면 우리가 일회용 계정을 만들어야 하고, 앱이 보내는 확인
+   * 메일을 `probe-<runId>@<이 도메인>` 으로 받는다. **비어 있으면 계정 준비 기능
+   * 자체가 꺼진다** — 받을 곳이 없는데 가입을 시도하면 중간에 멈춘 계정만 남는다.
+   * 라우팅 규칙은 Cloudflare 대시보드에서 이 워커로 연결한다.
+   */
+  PROBE_MAIL_DOMAIN?: string;
+  /**
    * Stage 17 — base URL of the dashboard. Used when building Telegram notification
    * message links. Defaults to https://app.trysimsa.com when unset (Stage 92).
    * Set via wrangler.toml [vars] or `wrangler secret put DASHBOARD_BASE_URL`.

--- a/apps/central-plane/src/index.ts
+++ b/apps/central-plane/src/index.ts
@@ -1,5 +1,6 @@
 import { createApp } from "./router.js";
 import type { Env } from "./env.js";
+import { handleProbeEmail, type IncomingEmail } from "./probe-mailbox.js";
 import { assertPreflight } from "./preflight.js";
 import { selfHealWebhook } from "./webhook-heal.js";
 import { cleanupStuckJobs, cleanupStuckVisualChecks, cleanupStuckRepairJobs } from "./stuck-cleanup.js";
@@ -37,6 +38,24 @@ export default {
     }
     return app.fetch(request, env, ctx);
   },
+
+  /**
+   * ★Email Workers 진입점 (2026-08-26) — 검수용 일회용 메일함.
+   *
+   * 로그인 뒤 화면을 검수하려면 계정이 필요한데, **남의 비밀번호를 받아 보관하지
+   * 않는다.** 대신 우리가 일회용 계정을 만들고, 앱이 보내는 확인 메일을 여기서 받는다.
+   * `probe-<runId>@<수신도메인>` 앞으로 온 것만 처리하고 나머지는 조용히 버린다.
+   *
+   * 본문은 저장하지 않는다 — 제목과 링크만 남긴다(남의 앱 메일에는 그 앱 사용자의
+   * 정보가 담길 수 있다). 자세한 근거는 src/probe-mailbox.ts 헤더.
+   *
+   * 라우팅 규칙(어느 주소를 이 워커로 보낼지)은 Cloudflare 대시보드에서 연결한다.
+   * 연결 전에는 이 핸들러가 아무 일도 하지 않으므로 배포해도 무해하다.
+   */
+  async email(message: IncomingEmail, env: Env, _ctx: ExecutionContext): Promise<void> {
+    await handleProbeEmail(env, message);
+  },
+
   // Scheduled handler for cron triggers.
   //
   // Multiple crons are wired to the same handler; we branch on

--- a/apps/central-plane/src/probe-mailbox.ts
+++ b/apps/central-plane/src/probe-mailbox.ts
@@ -1,0 +1,167 @@
+/**
+ * probe-mailbox.ts — 검수용 일회용 메일함 (2026-08-26).
+ *
+ * ## 왜 이게 있나
+ *
+ * 로그인 뒤 화면을 검수하려면 계정이 필요하다. 두 가지 길이 있는데:
+ *
+ *   ① 사용자에게 아이디·비밀번호를 받는다 — **하지 않는다.** 유출되면 그 앱뿐 아니라
+ *      비밀번호를 재사용한 다른 계정까지 열리고, 무엇보다 비개발자에게 "검수 도구에
+ *      비밀번호를 주는 습관"을 가르치게 된다. 우리가 안전하게 다뤄도 그 습관이
+ *      다음번에 다른 곳에서 그 사람을 다치게 한다. 소셜 로그인 앱에는 애초에 못 쓴다.
+ *
+ *   ② **우리가 일회용 계정을 만든다** — 이쪽. 남의 자격증명을 보관하지 않는다.
+ *      그러려면 앱이 보내는 확인 메일을 받아야 하고, 그 수신구가 이 모듈이다.
+ *
+ * 역할 계정(관리자·기업)처럼 자가 가입이 막힌 경우도 같은 구조로 푼다 — 사용자가
+ * **자기 앱에서 우리 주소로 초대를 보내면** 우리가 받아서 가입을 완주한다.
+ * **초대는 자격증명이 아니다**: 사용자가 통제권을 계속 쥐고, 언제든 그 계정을 지울 수 있다.
+ *
+ * ## 정직성·최소수집
+ *
+ * 남의 앱이 보낸 메일에는 그 앱 사용자의 정보가 담길 수 있다. 그래서 **본문을
+ * 저장하지 않는다.** 제목과 **링크만** 남기고, 그것도 검수가 끝나면 지운다.
+ */
+import type { Env } from "./env.js";
+
+/** Email Workers가 넘겨주는 메시지의 우리가 쓰는 부분만. */
+export type IncomingEmail = {
+  from: string;
+  to: string;
+  headers: { get(name: string): string | null };
+  raw: ReadableStream<Uint8Array>;
+  rawSize: number;
+};
+
+/** 주소에서 검수 실행 id를 꺼낸다. `probe-<runId>@…` 형태만 받는다. */
+export function runIdFromAddress(addr: string): string | null {
+  const local = String(addr ?? "").trim().toLowerCase().split("@")[0] ?? "";
+  const m = /^probe-([a-z0-9_-]{6,64})$/.exec(local);
+  return m?.[1] ?? null;
+}
+
+/**
+ * 메일 본문에서 링크를 뽑는다. HTML과 평문 둘 다 훑는다.
+ *
+ * 확인·초대 링크는 보통 하나가 아니다(푸터의 도움말·수신거부까지 섞인다).
+ * 그래서 **거르지 않고 다 넘긴다** — 어느 것이 확인 링크인지는 실제로 열어보는
+ * 쪽(컨테이너)이 판단한다. 여기서 똑똑한 척 고르면 앱마다 다른 문구에 걸려 넘어진다.
+ * 다만 수신거부·구독취소는 누르면 되돌리기 어려우므로 **여기서 뺀다.**
+ */
+export function extractLinks(body: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (raw: string) => {
+    const url = raw.replace(/[)\]>"'.,;]+$/, "").replace(/&amp;/g, "&");
+    if (!/^https?:\/\//i.test(url) || url.length > 2000) return;
+    // 누르면 되돌리기 어려운 것은 아예 넘기지 않는다.
+    if (/unsubscribe|수신거부|opt[-_]?out|구독\s*취소/i.test(url)) return;
+    if (seen.has(url)) return;
+    seen.add(url);
+    out.push(url);
+  };
+  for (const m of body.matchAll(/href\s*=\s*["']([^"']+)["']/gi)) push(m[1] ?? "");
+  for (const m of body.matchAll(/https?:\/\/[^\s<>"']+/gi)) push(m[0]);
+  return out.slice(0, 25);
+}
+
+/**
+ * 메일 원문에서 사람이 읽는 본문만 성기게 뽑는다.
+ *
+ * 완전한 MIME 파서를 들이지 않는 이유: 우리는 **링크만** 필요하고, 링크는 인코딩을
+ * 거의 타지 않는다. quoted-printable의 줄바꿈(`=\r\n`)만 풀어주면 대부분 잡힌다.
+ */
+export function decodeBodyForLinks(raw: string): string {
+  return raw.replace(/=\r?\n/g, "").replace(/=3D/gi, "=");
+}
+
+export type StoredProbeEmail = {
+  id: string;
+  runId: string;
+  toAddr: string;
+  fromAddr: string;
+  subject: string;
+  links: string[];
+  receivedAt: string;
+};
+
+/** 받은 메일을 저장한다. 본문은 넣지 않는다(최소수집). */
+export async function storeProbeEmail(
+  env: Env,
+  mail: { runId: string; toAddr: string; fromAddr: string; subject: string; links: string[] },
+): Promise<void> {
+  const id = `pm_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
+  await env.DB.prepare(
+    `INSERT INTO probe_emails (id, run_id, to_addr, from_addr, subject, links, received_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      id,
+      mail.runId,
+      mail.toAddr.slice(0, 200),
+      mail.fromAddr.slice(0, 200),
+      mail.subject.slice(0, 300),
+      JSON.stringify(mail.links),
+      new Date().toISOString(),
+    )
+    .run();
+}
+
+/** 한 검수 실행의 메일함을 읽는다(오래된 것부터). */
+export async function listProbeEmails(env: Env, runId: string): Promise<StoredProbeEmail[]> {
+  const res = await env.DB.prepare(
+    `SELECT id, run_id, to_addr, from_addr, subject, links, received_at
+       FROM probe_emails WHERE run_id = ? ORDER BY received_at ASC LIMIT 50`,
+  )
+    .bind(runId)
+    .all<{ id: string; run_id: string; to_addr: string; from_addr: string; subject: string; links: string; received_at: string }>();
+  return (res.results ?? []).map((r) => ({
+    id: r.id,
+    runId: r.run_id,
+    toAddr: r.to_addr,
+    fromAddr: r.from_addr ?? "",
+    subject: r.subject ?? "",
+    links: safeParseLinks(r.links),
+    receivedAt: r.received_at,
+  }));
+}
+
+function safeParseLinks(raw: string): string[] {
+  try {
+    const v = JSON.parse(raw);
+    return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/** 검수가 끝나면 지운다 — 남의 앱 메일을 오래 들고 있을 이유가 없다. */
+export async function deleteProbeEmails(env: Env, runId: string): Promise<void> {
+  await env.DB.prepare(`DELETE FROM probe_emails WHERE run_id = ?`).bind(runId).run();
+}
+
+/**
+ * Email Workers 진입점이 부르는 처리기.
+ *
+ * **모르는 주소는 조용히 버린다.** 우리 수신 도메인으로 오는 스팸을 D1에 쌓지 않는다.
+ * 던지지 않는다 — 메일 처리 실패가 워커를 깨뜨리면 안 된다.
+ */
+export async function handleProbeEmail(env: Env, message: IncomingEmail): Promise<"stored" | "ignored"> {
+  const runId = runIdFromAddress(message.to);
+  if (!runId) return "ignored";
+  try {
+    const raw = await new Response(message.raw).text();
+    const links = extractLinks(decodeBodyForLinks(raw.slice(0, 500_000)));
+    await storeProbeEmail(env, {
+      runId,
+      toAddr: message.to,
+      fromAddr: message.from,
+      subject: message.headers.get("subject") ?? "",
+      links,
+    });
+    return "stored";
+  } catch (err) {
+    console.error("[probe-mailbox] store failed:", err);
+    return "ignored";
+  }
+}

--- a/apps/central-plane/src/router.ts
+++ b/apps/central-plane/src/router.ts
@@ -47,6 +47,7 @@ import { createWorkspaceDocumentIntakeRoutes } from "./routes/workspace-document
 import { createWorkspaceVisualChecksRoutes } from "./routes/workspace-visual-checks.js";
 import { createWorkspaceVisualCheckRunRoutes } from "./routes/workspace-visual-check-runs.js";
 import { createLlmProbeRoutes } from "./routes/llm-probe.js";
+import { createProbeMailRoutes } from "./routes/probe-mail.js";
 import { createWorkspaceRepairJobRoutes } from "./routes/workspace-repair-jobs.js";
 import { createWorkspaceExperimentRoutes } from "./routes/workspace-experiment.js";
 import { createWorkspaceAgentWorkflowRoutes } from "./routes/workspace-agent-workflow.js";
@@ -82,6 +83,7 @@ export function createApp(opts: { fetch?: FetchLike } = {}): Hono<{ Bindings: En
   app.route("/", healthRoutes);
   // 관측 도구: 벤더별 LLM 도달성(내부 토큰 필요) — 2026-08-22 403 진단에서 신설.
   app.route("/", createLlmProbeRoutes());
+  app.route("/", createProbeMailRoutes());
   app.route("/", registerRoutes);
   app.route("/", episodicRoutes);
   app.route("/", federatedBaselinesRoutes);

--- a/apps/central-plane/src/routes/probe-mail.ts
+++ b/apps/central-plane/src/routes/probe-mail.ts
@@ -1,0 +1,58 @@
+/**
+ * probe-mail.ts — 검수 컨테이너가 일회용 메일함을 읽는 내부 경로 (2026-08-26).
+ *
+ *   GET    /internal/probe-mail?runId=…   — 그 검수 실행 앞으로 온 메일(제목·링크)
+ *   DELETE /internal/probe-mail?runId=…   — 검수가 끝나면 비운다
+ *
+ * 보호: `INTERNAL_CALLBACK_TOKEN`. 이 경로는 **남의 앱이 보낸 메일의 링크**를 담고
+ * 있으므로 공개되면 안 된다 — 확인 링크는 그 자체가 계정 접근권이다.
+ * 토큰이 설정돼 있지 않으면 503으로 닫는다(무보호로 열리지 않는다).
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import { deleteProbeEmails, listProbeEmails } from "../probe-mailbox.js";
+
+function requireInternalToken(c: {
+  env: Env;
+  req: { header: (name: string) => string | undefined };
+}): { ok: true } | { ok: false; status: 401 | 503; error: string } {
+  const expected = c.env.INTERNAL_CALLBACK_TOKEN;
+  if (!expected) return { ok: false, status: 503, error: "probe_mail_disabled" };
+  const m = /^Bearer\s+(.+)$/i.exec(c.req.header("authorization") ?? "");
+  if (!m || m[1] !== expected) return { ok: false, status: 401, error: "unauthorized" };
+  return { ok: true };
+}
+
+export function createProbeMailRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+
+  app.get("/internal/probe-mail", async (c) => {
+    const auth = requireInternalToken(c);
+    if (!auth.ok) return c.json({ ok: false, error: auth.error }, auth.status);
+    const runId = c.req.query("runId") ?? "";
+    if (!runId) return c.json({ ok: false, error: "runId_required" }, 400);
+    try {
+      const emails = await listProbeEmails(c.env, runId);
+      return c.json({ ok: true, emails });
+    } catch (err) {
+      console.error("[internal/probe-mail] list failed:", err);
+      return c.json({ ok: false, error: "db_error" }, 500);
+    }
+  });
+
+  app.delete("/internal/probe-mail", async (c) => {
+    const auth = requireInternalToken(c);
+    if (!auth.ok) return c.json({ ok: false, error: auth.error }, auth.status);
+    const runId = c.req.query("runId") ?? "";
+    if (!runId) return c.json({ ok: false, error: "runId_required" }, 400);
+    try {
+      await deleteProbeEmails(c.env, runId);
+      return c.json({ ok: true });
+    } catch (err) {
+      console.error("[internal/probe-mail] delete failed:", err);
+      return c.json({ ok: false, error: "db_error" }, 500);
+    }
+  });
+
+  return app;
+}

--- a/apps/central-plane/src/signup-plan.ts
+++ b/apps/central-plane/src/signup-plan.ts
@@ -1,0 +1,217 @@
+/**
+ * signup-plan.ts — 일회용 계정 만들기 계획 (2026-08-26).
+ *
+ * 순수 함수만 둔다(네트워크·브라우저 없음). 실행은 컨테이너가 하고, 여기서는
+ * **무엇을 할지와 무엇을 하지 않을지**를 정한다. `visual-flow-plan.ts`와 같은 구조다.
+ *
+ * ## 왜 계정을 만드는가
+ *
+ * 로그인 뒤를 보지 못하면 검수가 절반에서 멈춘다. 그런데 남의 비밀번호를 받아
+ * 보관하는 길은 쓰지 않기로 했다(probe-mailbox.ts 헤더 참조). 그래서 우리가
+ * **일회용 계정을 만든다.**
+ *
+ * ## 안전 원칙 — 여기서 멈추는 것들
+ *
+ * 로그인 뒤는 공개 화면보다 **위험하다**. 관리자 권한이면 더욱 그렇다. 그래서
+ * 계정 준비 단계는 공개 화면보다 **더 보수적으로** 움직인다:
+ *
+ *   - **캡차가 보이면 멈춘다.** 우회하지 않는다.
+ *   - **결제 정보를 요구하면 멈춘다.** 무료 가입이 아니면 우리 일이 아니다.
+ *   - **파괴적 문구가 붙은 버튼은 누르지 않는다**(기존 금지 목록과 같은 원칙).
+ *   - 멈추면 **정직하게 남긴다** — "로그인 뒤는 못 봤습니다"는 지금도 하는 말이고,
+ *     그 자리로 돌아가는 것뿐이라 나빠지지 않는다.
+ */
+
+/** 계정 준비가 멈춘 이유 — 사용자에게 그대로 설명할 수 있어야 한다. */
+export type SignupBlocker =
+  | "captcha"
+  | "payment_required"
+  | "no_signup_form"
+  | "no_mail_domain"
+  | "verification_timeout"
+  | "unsafe_action";
+
+export type SignupField = {
+  /** 화면에서 찾은 입력칸. placeholder/label/name 중 있는 것. */
+  selectorHint: string;
+  type: string;
+  label: string;
+};
+
+export type SignupStep =
+  | { action: "fill"; selectorHint: string; value: string; label: string }
+  | { action: "submit"; targetText: string; label: string }
+  | { action: "await_mail"; label: string }
+  | { action: "open_link"; label: string };
+
+export type SignupPlan =
+  | { ok: true; email: string; password: string; displayName: string; steps: SignupStep[] }
+  | { ok: false; blocker: SignupBlocker };
+
+/** 캡차의 흔한 흔적. 하나라도 보이면 멈춘다. */
+const CAPTCHA_MARKERS = [
+  "recaptcha",
+  "g-recaptcha",
+  "hcaptcha",
+  "cf-turnstile",
+  "turnstile",
+  "captcha",
+  "로봇이 아닙니다",
+  "i'm not a robot",
+];
+
+/** 결제 정보를 요구하는 가입은 우리 일이 아니다. */
+const PAYMENT_MARKERS = [
+  "card number",
+  "카드 번호",
+  "카드번호",
+  "cvc",
+  "cvv",
+  "expiry",
+  "유효기간",
+  "billing",
+  "결제 정보",
+];
+
+export function hasCaptcha(pageMarkup: string): boolean {
+  const t = (pageMarkup ?? "").toLowerCase();
+  return CAPTCHA_MARKERS.some((m) => t.includes(m.toLowerCase()));
+}
+
+export function requiresPayment(pageText: string): boolean {
+  const t = (pageText ?? "").toLowerCase();
+  return PAYMENT_MARKERS.some((m) => t.includes(m.toLowerCase()));
+}
+
+/**
+ * 이 검수 실행 전용 주소. `probe-<runId>@<도메인>`.
+ * 메일함(probe-mailbox.ts)이 같은 규칙으로 되읽으므로 형식을 바꾸면 양쪽을 함께 바꾼다.
+ */
+export function probeEmailFor(runId: string, mailDomain: string): string {
+  return `probe-${runId}@${mailDomain}`;
+}
+
+/**
+ * 비밀번호를 만든다. 앱마다 규칙이 다르므로 **흔한 요구를 모두 만족**시킨다
+ * (대문자·소문자·숫자·기호·12자 이상). 짧거나 단순하면 가입이 규칙 위반으로
+ * 튕기는데, 그건 앱의 결함이 아니라 우리 실수다.
+ */
+export function probePassword(runId: string): string {
+  const tail = runId.replace(/[^A-Za-z0-9]/g, "").slice(-6).padEnd(6, "x");
+  return `Simsa!${tail}A9`;
+}
+
+/**
+ * 우리가 만든 계정임을 **앱 안에서 알아볼 수 있어야 한다.** 앱 주인이 사용자 목록에서
+ * 이게 뭔지 몰라 당황하면 안 되고, 나중에 골라 지울 수 있어야 한다.
+ */
+export function probeDisplayName(locale: "ko" | "en" = "ko"): string {
+  return locale === "en" ? "Simsa review test" : "Simsa 검수 테스트";
+}
+
+const EMAIL_HINT = /e-?mail|이메일|메일|아이디/i;
+const PASSWORD_HINT = /password|비밀번호|암호/i;
+const NAME_HINT = /name|이름|닉네임|nickname|company|회사|상호/i;
+
+/**
+ * 가입 화면에서 할 일을 정한다.
+ *
+ * 확인 링크를 여는 단계까지 계획에 넣는다 — 메일이 안 오는 앱도 많으므로
+ * 실행 쪽에서 기다리다 없으면 그대로 진행한다(그것 자체는 실패가 아니다).
+ */
+export function planSignup(input: {
+  runId: string;
+  mailDomain?: string;
+  fields: SignupField[];
+  submitTexts: string[];
+  pageMarkup?: string;
+  pageText?: string;
+  locale?: "ko" | "en";
+}): SignupPlan {
+  if (!input.mailDomain) return { ok: false, blocker: "no_mail_domain" };
+  if (hasCaptcha(input.pageMarkup ?? "")) return { ok: false, blocker: "captcha" };
+  if (requiresPayment(input.pageText ?? "")) return { ok: false, blocker: "payment_required" };
+
+  const email = probeEmailFor(input.runId, input.mailDomain);
+  const password = probePassword(input.runId);
+  const displayName = probeDisplayName(input.locale ?? "ko");
+
+  const steps: SignupStep[] = [];
+  let sawEmail = false;
+  let sawPassword = false;
+
+  for (const f of input.fields) {
+    const hay = `${f.label} ${f.selectorHint} ${f.type}`;
+    if (!sawEmail && (f.type === "email" || EMAIL_HINT.test(hay))) {
+      steps.push({ action: "fill", selectorHint: f.selectorHint, value: email, label: "이메일 입력" });
+      sawEmail = true;
+      continue;
+    }
+    if (f.type === "password" || PASSWORD_HINT.test(hay)) {
+      // 비밀번호 확인칸이 따로 있는 앱이 많다 — 같은 값을 그대로 넣는다.
+      steps.push({ action: "fill", selectorHint: f.selectorHint, value: password, label: "비밀번호 입력" });
+      sawPassword = true;
+      continue;
+    }
+    if (NAME_HINT.test(hay)) {
+      steps.push({ action: "fill", selectorHint: f.selectorHint, value: displayName, label: "이름 입력" });
+    }
+  }
+
+  // 이메일 칸이 없으면 가입 화면이 아니다(로그인 화면이거나 다른 폼).
+  if (!sawEmail || !sawPassword) return { ok: false, blocker: "no_signup_form" };
+
+  const submit = input.submitTexts.find((t) => t.trim().length > 0);
+  if (!submit) return { ok: false, blocker: "no_signup_form" };
+  steps.push({ action: "submit", targetText: submit.trim(), label: "가입 버튼 누르기" });
+  steps.push({ action: "await_mail", label: "확인 메일 기다리기" });
+  steps.push({ action: "open_link", label: "확인 링크 열기" });
+
+  return { ok: true, email, password, displayName, steps };
+}
+
+/**
+ * 받은 메일들에서 **열어볼 링크 후보**를 우선순위대로 고른다.
+ *
+ * 메일함은 후보를 거르지 않고 다 넘긴다(앱마다 문구가 달라서). 고르는 일은 여기서
+ * 하되, **확신하지 않는다** — 확인/인증처럼 보이는 것을 앞에 두고 나머지도 남긴다.
+ * 실행 쪽이 앞에서부터 열어보고 로그인 상태가 되면 멈춘다.
+ */
+export function rankVerificationLinks(emails: Array<{ subject: string; links: string[] }>): string[] {
+  const scored: Array<{ url: string; score: number }> = [];
+  const seen = new Set<string>();
+  for (const mail of emails) {
+    const subjectBoost = /verify|confirm|activate|인증|확인|가입|초대|invite/i.test(mail.subject) ? 2 : 0;
+    for (const url of mail.links) {
+      if (seen.has(url)) continue;
+      seen.add(url);
+      let score = subjectBoost;
+      if (/verify|confirm|activate|validation|auth|token|invite|accept/i.test(url)) score += 3;
+      if (/login|signin/i.test(url)) score += 1;
+      if (/help|docs|support|privacy|terms|blog/i.test(url)) score -= 3;
+      scored.push({ url, score });
+    }
+  }
+  return scored.sort((a, b) => b.score - a.score).map((s) => s.url);
+}
+
+/** 멈춘 이유를 사용자 말로. 실패가 아니라 **한계 보고**다. */
+export function blockerMessage(b: SignupBlocker, locale: "ko" | "en" = "ko"): string {
+  const ko: Record<SignupBlocker, string> = {
+    captcha: "가입 화면에 로봇 확인(캡차)이 있어서 로그인 뒤 화면은 확인하지 못했어요.",
+    payment_required: "가입에 결제 정보가 필요해서 로그인 뒤 화면은 확인하지 못했어요.",
+    no_signup_form: "가입 화면을 찾지 못해서 로그인 뒤 화면은 확인하지 못했어요.",
+    no_mail_domain: "확인 메일을 받을 준비가 되어 있지 않아 로그인 뒤 화면은 확인하지 못했어요.",
+    verification_timeout: "가입은 했지만 확인 메일이 오지 않아 로그인 뒤 화면은 확인하지 못했어요.",
+    unsafe_action: "가입 과정에 되돌리기 어려운 동작이 있어서 거기서 멈췄어요.",
+  };
+  const en: Record<SignupBlocker, string> = {
+    captcha: "The sign-up screen has a robot check (CAPTCHA), so we could not check what is behind the login.",
+    payment_required: "Sign-up requires payment details, so we could not check what is behind the login.",
+    no_signup_form: "We could not find a sign-up screen, so we could not check what is behind the login.",
+    no_mail_domain: "We are not set up to receive the confirmation email, so we could not check behind the login.",
+    verification_timeout: "We signed up but the confirmation email never arrived, so we could not check behind the login.",
+    unsafe_action: "Sign-up involved an action that is hard to undo, so we stopped there.",
+  };
+  return (locale === "en" ? en : ko)[b];
+}

--- a/apps/central-plane/test/probe-mailbox.test.mjs
+++ b/apps/central-plane/test/probe-mailbox.test.mjs
@@ -1,0 +1,143 @@
+/**
+ * probe-mailbox.test.mjs — 검수용 일회용 메일함 (2026-08-26).
+ *
+ * 고정하는 계약:
+ *   ① 우리 앞으로 온 것만 처리한다 — 모르는 주소는 조용히 버린다(스팸을 쌓지 않는다)
+ *   ② **본문을 저장하지 않는다** — 남의 앱 메일에는 그 앱 사용자의 정보가 담긴다
+ *   ③ 수신거부 링크는 넘기지 않는다 — 누르면 되돌리기 어렵다
+ *   ④ 메일함 경로는 **무보호로 열리지 않는다** — 확인 링크는 그 자체가 계정 접근권
+ *   ⑤ 메일 처리 실패가 워커를 깨뜨리지 않는다
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { runIdFromAddress, extractLinks, decodeBodyForLinks, handleProbeEmail } = await import(
+  "../dist/probe-mailbox.js"
+);
+const { createApp } = await import("../dist/router.js");
+
+describe("① 우리 앞으로 온 것만 (주소 파싱)", () => {
+  it("probe-<runId>@… 를 받는다", () => {
+    assert.equal(runIdFromAddress("probe-wvc_9am2yegj19@probe.trysimsa.com"), "wvc_9am2yegj19");
+    assert.equal(runIdFromAddress("PROBE-ABC123XYZ@Probe.TrySimsa.com"), "abc123xyz", "대소문자 무관");
+  });
+
+  it("★모르는 주소는 버린다 — 스팸을 D1에 쌓지 않는다", () => {
+    for (const addr of ["hello@probe.trysimsa.com", "probe@x.com", "probe-@x.com", "probe-ab@x.com", "", "그냥문자열"]) {
+      assert.equal(runIdFromAddress(addr), null, addr);
+    }
+  });
+
+  it("주소를 지어내 다른 실행의 메일함을 노리지 못한다", () => {
+    // 경로 구분자·공백 등이 섞이면 형식 자체가 안 맞는다.
+    assert.equal(runIdFromAddress("probe-abc/../def@x.com"), null);
+    assert.equal(runIdFromAddress("probe-abc def@x.com"), null);
+  });
+});
+
+describe("②③ 링크만 뽑는다", () => {
+  const HTML = `<html><body>
+    <p>가입을 완료하려면 아래를 눌러주세요</p>
+    <a href="https://myapp.com/verify?token=abc123">이메일 인증하기</a>
+    <a href="https://myapp.com/help">도움말</a>
+    <a href="https://myapp.com/unsubscribe?u=9">수신거부</a>
+  </body></html>`;
+
+  it("확인 링크를 뽑는다", () => {
+    const links = extractLinks(HTML);
+    assert.ok(links.includes("https://myapp.com/verify?token=abc123"));
+  });
+
+  it("★어느 게 확인 링크인지 여기서 고르지 않는다 — 도움말도 함께 넘긴다", () => {
+    // 앱마다 문구가 달라서 여기서 똑똑한 척 고르면 넘어진다. 판단은 실제로
+    // 열어보는 쪽(컨테이너)의 몫이다.
+    assert.ok(extractLinks(HTML).includes("https://myapp.com/help"));
+  });
+
+  it("★수신거부는 넘기지 않는다 — 누르면 되돌리기 어렵다", () => {
+    const links = extractLinks(HTML);
+    assert.ok(!links.some((l) => /unsubscribe/.test(l)));
+    assert.ok(!extractLinks('<a href="https://x.com/수신거부">x</a>').length);
+  });
+
+  it("평문 메일에서도 뽑는다", () => {
+    assert.deepEqual(extractLinks("확인: https://myapp.com/v/1 감사합니다"), ["https://myapp.com/v/1"]);
+  });
+
+  it("문장부호가 붙어 와도 잘라낸다", () => {
+    assert.deepEqual(extractLinks("여기를 누르세요 (https://myapp.com/v/2)."), ["https://myapp.com/v/2"]);
+  });
+
+  it("quoted-printable 줄바꿈으로 끊긴 링크를 잇는다", () => {
+    const raw = "https://myapp.com/verify?token=3D=\r\nabcdef";
+    assert.ok(extractLinks(decodeBodyForLinks(raw))[0].includes("abcdef"));
+  });
+
+  it("중복은 한 번만, 개수는 제한된다", () => {
+    const many = Array.from({ length: 60 }, (_, i) => `https://x.com/${i}`).join(" ");
+    assert.ok(extractLinks(many + " " + many).length <= 25);
+  });
+});
+
+describe("⑤ 메일 처리 실패가 워커를 깨뜨리지 않는다", () => {
+  const env = { DB: { prepare: () => ({ bind: () => ({ run: async () => ({}) }) }) } };
+  const msg = (to, raw) => ({
+    from: "noreply@myapp.com",
+    to,
+    headers: { get: () => "가입을 완료해주세요" },
+    raw: new Response(raw).body,
+    rawSize: raw.length,
+  });
+
+  it("모르는 주소는 ignored", async () => {
+    assert.equal(await handleProbeEmail(env, msg("hello@x.com", "hi")), "ignored");
+  });
+
+  it("정상 주소는 stored", async () => {
+    assert.equal(await handleProbeEmail(env, msg("probe-abc123@x.com", '<a href="https://y.com/v">v</a>')), "stored");
+  });
+
+  it("★DB가 터져도 던지지 않는다", async () => {
+    const broken = { DB: { prepare: () => { throw new Error("d1 down"); } } };
+    assert.equal(await handleProbeEmail(broken, msg("probe-abc123@x.com", "hi")), "ignored");
+  });
+});
+
+describe("④ 메일함 경로는 무보호로 열리지 않는다", () => {
+  const emptyDb = { prepare: () => ({ bind: () => ({ all: async () => ({ results: [] }), run: async () => ({}) }) }) };
+  const call = (env, token, method = "GET") =>
+    createApp().request(
+      "/internal/probe-mail?runId=abc123",
+      { method, headers: token ? { authorization: `Bearer ${token}` } : {} },
+      env,
+    );
+
+  it("토큰이 없으면 401", async () => {
+    assert.equal((await call({ DB: emptyDb, INTERNAL_CALLBACK_TOKEN: "t" }, "")).status, 401);
+    assert.equal((await call({ DB: emptyDb, INTERNAL_CALLBACK_TOKEN: "t" }, "wrong")).status, 401);
+  });
+
+  it("★서버에 토큰이 설정 안 됐으면 503 — 무보호로 열리지 않는다", async () => {
+    assert.equal((await call({ DB: emptyDb }, "anything")).status, 503);
+  });
+
+  it("runId가 없으면 400", async () => {
+    const res = await createApp().request(
+      "/internal/probe-mail",
+      { headers: { authorization: "Bearer t" } },
+      { DB: emptyDb, INTERNAL_CALLBACK_TOKEN: "t" },
+    );
+    assert.equal(res.status, 400);
+  });
+
+  it("정상 토큰이면 목록을 준다", async () => {
+    const res = await call({ DB: emptyDb, INTERNAL_CALLBACK_TOKEN: "t" }, "t");
+    assert.equal(res.status, 200);
+    assert.deepEqual((await res.json()).emails, []);
+  });
+
+  it("삭제도 같은 보호를 받는다", async () => {
+    assert.equal((await call({ DB: emptyDb, INTERNAL_CALLBACK_TOKEN: "t" }, "wrong", "DELETE")).status, 401);
+    assert.equal((await call({ DB: emptyDb, INTERNAL_CALLBACK_TOKEN: "t" }, "t", "DELETE")).status, 200);
+  });
+});

--- a/apps/central-plane/test/signup-plan.test.mjs
+++ b/apps/central-plane/test/signup-plan.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * signup-plan.test.mjs — 일회용 계정 만들기 계획 (2026-08-26).
+ *
+ * 고정하는 계약:
+ *   ① **멈춰야 할 곳에서 멈춘다** — 캡차·결제 요구는 우회하지 않는다
+ *   ② 멈춘 이유를 **사용자 말로** 설명한다. 실패가 아니라 한계 보고다
+ *   ③ 우리가 만든 계정임을 **앱 안에서 알아볼 수 있다**
+ *   ④ 앱마다 다른 비밀번호 규칙에 우리 실수로 튕기지 않는다
+ *   ⑤ 확인 링크를 고르되 **확신하지 않는다** — 후보를 순서대로 남긴다
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  planSignup, hasCaptcha, requiresPayment, probeEmailFor, probePassword,
+  probeDisplayName, rankVerificationLinks, blockerMessage,
+} = await import("../dist/signup-plan.js");
+
+const FIELDS = [
+  { selectorHint: "[name=email]", type: "email", label: "이메일" },
+  { selectorHint: "[name=password]", type: "password", label: "비밀번호" },
+  { selectorHint: "[name=name]", type: "text", label: "이름" },
+];
+const base = { runId: "wvc_abc123", mailDomain: "probe.trysimsa.com", fields: FIELDS, submitTexts: ["가입하기"] };
+
+describe("① 멈춰야 할 곳에서 멈춘다", () => {
+  it("★캡차가 보이면 멈춘다 — 우회하지 않는다", () => {
+    for (const markup of ['<div class="g-recaptcha">', "<div data-sitekey cf-turnstile>", "로봇이 아닙니다"]) {
+      assert.equal(hasCaptcha(markup), true, markup);
+      assert.deepEqual(planSignup({ ...base, pageMarkup: markup }), { ok: false, blocker: "captcha" });
+    }
+  });
+
+  it("★결제 정보를 요구하면 멈춘다 — 무료 가입이 아니면 우리 일이 아니다", () => {
+    assert.equal(requiresPayment("카드 번호를 입력하세요"), true);
+    assert.deepEqual(planSignup({ ...base, pageText: "CVC" }), { ok: false, blocker: "payment_required" });
+  });
+
+  it("메일 받을 곳이 없으면 시작도 안 한다 — 중간에 멈춘 계정만 남는다", () => {
+    assert.deepEqual(planSignup({ ...base, mailDomain: undefined }), { ok: false, blocker: "no_mail_domain" });
+  });
+
+  it("가입 화면이 아니면(이메일·비밀번호 칸 없음) 멈춘다", () => {
+    assert.deepEqual(
+      planSignup({ ...base, fields: [{ selectorHint: "[name=q]", type: "text", label: "검색" }] }),
+      { ok: false, blocker: "no_signup_form" },
+    );
+    assert.equal(planSignup({ ...base, submitTexts: [] }).ok, false, "제출 버튼이 없어도 멈춘다");
+  });
+});
+
+describe("② 멈춘 이유를 사용자 말로", () => {
+  it("모든 사유에 KO/EN 문구가 있고, 실패가 아니라 한계로 말한다", () => {
+    for (const b of ["captcha", "payment_required", "no_signup_form", "no_mail_domain", "verification_timeout", "unsafe_action"]) {
+      for (const [loc, re] of [["ko", /확인하지 못했|멈췄어요/], ["en", /could not|stopped/i]]) {
+        const msg = blockerMessage(b, loc);
+        assert.ok(msg.length > 0, `${b}/${loc}`);
+        assert.match(msg, re, `${b}/${loc}`);
+      }
+    }
+  });
+
+  it("★'고장났다'고 말하지 않는다 — 우리가 못 본 것이지 앱의 결함이 아니다", () => {
+    for (const b of ["captcha", "payment_required", "no_signup_form"]) {
+      assert.doesNotMatch(blockerMessage(b, "ko"), /고장|작동 안|오류/);
+    }
+  });
+});
+
+describe("③④ 계정 자체의 성질", () => {
+  it("주소는 검수 실행마다 다르다", () => {
+    assert.equal(probeEmailFor("wvc_1", "probe.x.com"), "probe-wvc_1@probe.x.com");
+    assert.notEqual(probeEmailFor("wvc_1", "d"), probeEmailFor("wvc_2", "d"));
+  });
+
+  it("★비밀번호가 흔한 규칙을 모두 만족한다 — 우리 실수로 튕기지 않게", () => {
+    const pw = probePassword("wvc_abc123");
+    assert.ok(pw.length >= 12, pw);
+    assert.match(pw, /[A-Z]/);
+    assert.match(pw, /[a-z]/);
+    assert.match(pw, /[0-9]/);
+    assert.match(pw, /[^A-Za-z0-9]/);
+  });
+
+  it("runId가 짧거나 기호뿐이어도 규칙을 만족한다", () => {
+    for (const id of ["a", "___", ""]) {
+      const pw = probePassword(id);
+      assert.ok(pw.length >= 12 && /[A-Z]/.test(pw) && /[0-9]/.test(pw) && /[^A-Za-z0-9]/.test(pw), id);
+    }
+  });
+
+  it("★우리가 만든 계정임을 앱 안에서 알아볼 수 있다", () => {
+    assert.match(probeDisplayName("ko"), /Simsa/);
+    assert.match(probeDisplayName("en"), /Simsa/);
+    const p = planSignup(base);
+    assert.ok(p.steps.some((s) => s.action === "fill" && String(s.value).includes("Simsa")));
+  });
+});
+
+describe("계획의 모양", () => {
+  it("이메일·비밀번호·이름을 채우고 제출한 뒤 메일을 기다린다", () => {
+    const p = planSignup(base);
+    assert.equal(p.ok, true);
+    assert.deepEqual(p.steps.map((s) => s.action), ["fill", "fill", "fill", "submit", "await_mail", "open_link"]);
+  });
+
+  it("비밀번호 확인칸에도 같은 값을 넣는다", () => {
+    const p = planSignup({
+      ...base,
+      fields: [...FIELDS, { selectorHint: "[name=password2]", type: "password", label: "비밀번호 확인" }],
+    });
+    const pw = p.steps.filter((s) => s.action === "fill" && s.value === p.password);
+    assert.equal(pw.length, 2);
+  });
+});
+
+describe("⑤ 확인 링크를 고르되 확신하지 않는다", () => {
+  const mails = [
+    { subject: "도움말", links: ["https://app.com/help", "https://app.com/docs"] },
+    { subject: "이메일을 인증해주세요", links: ["https://app.com/verify?token=x", "https://app.com/terms"] },
+  ];
+
+  it("인증 링크가 앞에 온다", () => {
+    assert.equal(rankVerificationLinks(mails)[0], "https://app.com/verify?token=x");
+  });
+
+  it("★확신하지 않고 나머지도 남긴다 — 앱마다 문구가 다르다", () => {
+    const ranked = rankVerificationLinks(mails);
+    assert.ok(ranked.length >= 3, "후보를 버리지 않는다");
+    assert.ok(ranked.includes("https://app.com/help"));
+  });
+
+  it("문서·약관은 뒤로 밀린다", () => {
+    const ranked = rankVerificationLinks(mails);
+    assert.ok(ranked.indexOf("https://app.com/verify?token=x") < ranked.indexOf("https://app.com/terms"));
+  });
+
+  it("중복은 한 번만", () => {
+    const dup = [{ subject: "s", links: ["https://a.com/x", "https://a.com/x"] }];
+    assert.equal(rankVerificationLinks(dup).length, 1);
+  });
+});


### PR DESCRIPTION
## 왜

로그인 뒤 화면을 보지 못하면 검수가 절반에서 멈춥니다. 계정을 얻는 길은 둘인데:

**① 사용자에게 아이디·비밀번호를 받는다 — 쓰지 않습니다.** 유출되면 그 앱뿐 아니라
비밀번호를 재사용한 다른 계정까지 열립니다. 더 나쁜 건 비개발자에게 **"검수 도구에
비밀번호를 주는 습관"을 가르치는 것** — 우리가 안전하게 다뤄도 그 습관이 다음번에
다른 곳에서 그 사람을 다치게 합니다. 소셜 로그인 앱에는 애초에 못 씁니다.

**② 우리가 일회용 계정을 만든다 — 이쪽.** 남의 자격증명을 보관하지 않습니다.

역할 계정(관리자·기업)처럼 자가 가입이 막힌 경우도 같은 구조로 풉니다 — 사용자가
자기 앱에서 우리 주소로 **초대**를 보내면 우리가 받아 가입을 완주합니다.
**초대는 자격증명이 아닙니다**: 사용자가 통제권을 쥐고, 언제든 그 계정을 지울 수 있습니다.

## 이 PR이 만드는 것

| | |
|---|---|
| `probe-mailbox.ts` | 주소 파싱 · 링크 추출 · 저장/조회/삭제 |
| `index.ts`의 `email()` | Email Workers 진입점 — **라우팅 연결 전엔 아무 일도 안 함** |
| `/internal/probe-mail` | 컨테이너가 메일을 꺼내가는 경로 |
| `signup-plan.ts` | 가입 계획 · 멈춤 판단 · 링크 순위 (순수 함수) |
| `0066_probe_mailbox.sql` | 메일함 표 |

## 안전·최소수집

- **본문을 저장하지 않습니다.** 제목과 링크만 — 남의 앱 메일에는 그 앱 사용자의
  정보가 담깁니다.
- **모르는 주소는 조용히 버립니다** — 우리 도메인으로 오는 스팸을 D1에 쌓지 않습니다.
- **수신거부 링크는 넘기지 않습니다** — 누르면 되돌리기 어렵습니다.
- 메일함 경로는 **무보호로 열리지 않습니다**(토큰 미설정 시 503). 확인 링크는
  그 자체가 계정 접근권입니다.
- **캡차·결제 요구에서 멈춥니다.** 우회하지 않습니다.
- **메일 받을 곳이 없으면 시작도 안 합니다** — 중간에 멈춘 계정만 남습니다.
- 멈춘 이유를 사용자 말로 설명하되 **"고장났다"고 말하지 않습니다** — 우리가 못 본
  것이지 앱의 결함이 아닙니다.
- **우리가 만든 계정임을 앱 안에서 알아볼 수 있습니다**(`Simsa 검수 테스트`).

## 검증

- **34건 신규** — 메일함 18(주소 위조 차단·링크 추출 6종·수신거부 제외·DB 장애 내성·
  경로 보호 5) + 가입 계획 16(멈춤 3종·사유 KO/EN 12·비밀번호 규칙·링크 순위).
- central-plane **2164/2164** · typecheck · lint green.

## 아직 켜지지 않습니다

Cloudflare 이메일 라우팅을 이 워커로 연결하고 `PROBE_MAIL_DOMAIN`을 설정해야
동작합니다. **그 전까지는 배포해도 무해합니다**(핸들러가 아무 일도 안 함).
실제 가입 실행을 컨테이너에 배선하는 건 다음 PR입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
