### PR TITLE
feat(repair): "고쳐줘"가 실제로 고쳐지게 — 자동수리 워커에 벤더 폴백

### DIFF
--- a/apps/central-plane/container/server.mjs
+++ b/apps/central-plane/container/server.mjs
@@ -103,7 +103,13 @@ const server = createServer(async (req, res) => {
     res.end(JSON.stringify({ jobId: payload.jobId, status: "accepted" }));
 
     inFlightJobs.set(payload.jobId, payload);
-    runRepairJob(payload, anthropicApiKey, anthropicBaseUrl)
+    // ★벤더 폴백용 키 — Worker가 함께 실어 보낸다. 없으면 종전 동작.
+    const hdr = (n) => (typeof req.headers[n] === "string" && req.headers[n].length > 0 ? req.headers[n] : undefined);
+    const openaiApiKey = hdr("x-openai-key");
+    const openaiBaseUrl = hdr("x-openai-base-url");
+    const preferFallback = hdr("x-anthropic-disabled") === "1";
+
+    runRepairJob(payload, anthropicApiKey, anthropicBaseUrl, { openaiApiKey, openaiBaseUrl, preferFallback })
       .catch(async (err) => {
         console.error(`[repair ${payload.jobId}] crashed:`, redactSecret(err?.message ?? String(err), payload.githubToken));
         await postCallback(payload.callbackUrl, payload.callbackToken, {
@@ -439,7 +445,7 @@ async function runJob(payload) {
  * before it leaves this process, and the Anthropic key never reaches the
  * repo, the PR, or the callback.
  */
-async function runRepairJob(payload, anthropicApiKey, anthropicBaseUrl) {
+async function runRepairJob(payload, anthropicApiKey, anthropicBaseUrl, vendor = {}) {
   const {
     jobId,
     repo, // "owner/name"
@@ -498,7 +504,7 @@ async function runRepairJob(payload, anthropicApiKey, anthropicBaseUrl) {
     const diag = { skippedOversize: [], reason: null };
     if (anthropicApiKey) {
       try {
-        autoFix = await attemptAutoFix({ workDir, payload, anthropicApiKey, anthropicBaseUrl, diag });
+        autoFix = await attemptAutoFix({ workDir, payload, anthropicApiKey, anthropicBaseUrl, diag, vendor });
       } catch (err) {
         console.error(
           `[repair ${jobId}] auto-fix crashed (falling back to brief-only):`,
@@ -649,7 +655,8 @@ async function quickSyntaxCheck(workDir, changedFiles) {
  * worker produced nothing applicable — callers reset the tree + fall back
  * to brief-only. Never leaves a dirty tree on the null path.
  */
-async function attemptAutoFix({ workDir, payload, anthropicApiKey, anthropicBaseUrl, diag = { skippedOversize: [], reason: null } }) {
+async function attemptAutoFix({ workDir, payload, anthropicApiKey, anthropicBaseUrl, diag = { skippedOversize: [], reason: null }, vendor = {} }) {
+  const { openaiApiKey, openaiBaseUrl, preferFallback } = vendor;
   const jobId = payload.jobId;
   const deadline = Date.now() + AUTO_FIX_DEADLINE_MS;
 
@@ -692,9 +699,15 @@ async function attemptAutoFix({ workDir, payload, anthropicApiKey, anthropicBase
   // baseURL is a first-class ClaudeWorker option: the SDK import must happen
   // inside agent-worker's own module context — a dynamic import from THIS
   // file fails resolution ("Cannot find package '@anthropic-ai/sdk'", 실측).
+  // ★벤더 폴백 (2026-08-26). Anthropic이 Cloudflare egress에서 완전 차단된 뒤에도
+  //  이 경로에는 폴백이 없어서, 검수는 문제를 짚어주는데 **"고쳐줘"는 아무 일도
+  //  못 하는** 상태였다. 키가 없으면 undefined라 종전과 동일하게 동작한다.
   const worker = new ClaudeWorker({
     apiKey: anthropicApiKey,
     ...(anthropicBaseUrl ? { baseURL: anthropicBaseUrl } : {}),
+    ...(openaiApiKey ? { openaiApiKey } : {}),
+    ...(openaiBaseUrl ? { openaiBaseUrl } : {}),
+    ...(preferFallback ? { preferFallback: true } : {}),
   });
 
   for (let iteration = 0; iteration < AUTO_FIX_MAX_ITERATIONS; iteration++) {

--- a/apps/central-plane/inspector-container/Dockerfile
+++ b/apps/central-plane/inspector-container/Dockerfile
@@ -17,8 +17,9 @@
 # library version. test/inspector-invariants.test.mjs pins this alignment.
 #
 # CODE-IN STRATEGY: unlike the sandbox container (full pnpm workspace build),
-# this image compiles ONLY the two canonical, dependency-free Simsa modules
-# (src/visual-flow-plan.ts + src/nondev-report.ts) with a standalone tsc.
+# this image compiles ONLY the canonical, dependency-free Simsa modules
+# (src/visual-flow-plan.ts + src/nondev-report.ts + src/signup-plan.ts) with a
+# standalone tsc.
 # Why not mirror the full workspace build: (1) the playwright base is already
 # ~2 GB and a full monorepo node_modules would push the image past the 4 GB
 # disk of the "basic" container instance; (2) the runner needs exactly these
@@ -30,7 +31,8 @@
 #   /runner/server.mjs       — HTTP entry (the container's only API)
 #   /runner/inspector-run.mjs— Playwright deep-flow executor
 #   /runner/safety.mjs       — forbidden-action classifier (from the spike)
-#   /runner/dist/            — compiled visual-flow-plan.js + nondev-report.js
+#   /runner/signup-run.mjs   — 일회용 계정 가입 실행(로그인 뒤 검수)
+#   /runner/dist/            — compiled visual-flow-plan.js + nondev-report.js + signup-plan.js
 #
 # RUNTIME: job payload arrives over POST /run (no secrets baked into the
 # image); evidence + callbacks use the URLs/token carried in the payload.
@@ -45,8 +47,8 @@ RUN npm install --no-package-lock --loglevel=error
 
 # Canonical Simsa modules — compiled in-image from apps/central-plane/src so
 # the container always runs the exact logic the repo ships.
-COPY apps/central-plane/src/visual-flow-plan.ts apps/central-plane/src/nondev-report.ts ./src/
-RUN npx tsc src/visual-flow-plan.ts src/nondev-report.ts \
+COPY apps/central-plane/src/visual-flow-plan.ts apps/central-plane/src/nondev-report.ts apps/central-plane/src/signup-plan.ts ./src/
+RUN npx tsc src/visual-flow-plan.ts src/nondev-report.ts src/signup-plan.ts \
     --outDir dist --module nodenext --moduleResolution nodenext \
     --target es2022 --skipLibCheck
 
@@ -54,6 +56,8 @@ RUN npx tsc src/visual-flow-plan.ts src/nondev-report.ts \
 COPY apps/central-plane/inspector-container/server.mjs ./server.mjs
 COPY apps/central-plane/inspector-container/inspector-run.mjs ./inspector-run.mjs
 COPY apps/central-plane/inspector-container/safety.mjs ./safety.mjs
+# 일회용 계정으로 로그인 뒤까지 들어가는 실행 모듈(판단은 dist/signup-plan.js에 있다).
+COPY apps/central-plane/inspector-container/signup-run.mjs ./signup-run.mjs
 
 # Writable scratch space for per-run screenshots/video.
 RUN mkdir -p /var/lib/simsa && chmod 770 /var/lib/simsa

--- a/apps/central-plane/inspector-container/inspector-run.mjs
+++ b/apps/central-plane/inspector-container/inspector-run.mjs
@@ -25,6 +25,7 @@ import { join } from "node:path";
 import { planVisualFlow } from "./dist/visual-flow-plan.js";
 import { buildNonDevReport, buildAgentFixPrompt, isNoiseResource, decideFromEvidence } from "./dist/nondev-report.js";
 import { classifyActionSafety } from "./safety.mjs";
+import { attemptSignup } from "./signup-run.mjs";
 
 /**
  * E-corpus-1 live-debug rev marker. Bump on every runner change — the first
@@ -106,7 +107,7 @@ const STEP_NOTES = {
  * sampleQuery has NO default here on purpose: planVisualFlow picks one from the
  * locale, and a default at this seam would silently win over it.
  */
-export async function runInspection({ targetUrl, intent, outDir, sampleQuery, locale = "ko", budgetMs, runId, onPhase }) {
+export async function runInspection({ targetUrl, intent, outDir, sampleQuery, locale = "ko", budgetMs, runId, onPhase, signup }) {
   const N = STEP_NOTES[locale === "en" ? "en" : "ko"];
   // E-corpus-1 phase log: one line per runner phase, elapsed-stamped, so the
   // LAST entry before silence names the exact operation that hangs.
@@ -189,6 +190,10 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
     persistedAfterReload: null,
     // E-corpus-1 (2026-07-19): 시간 예산 초과로 일부 단계를 건너뛰었는가.
     timedOutPartial: false,
+    // 2026-08-26: 어느 깊이까지 봤는가. "L1"=공개 화면만, "L3"=로그인 뒤까지.
+    loginDepth: "L1",
+    signupBlocker: null,
+    signupBlockerMessage: null,
   };
 
   // E-corpus-1 재작성 (2026-07-19, #415): 예산에 도달하면 컨텍스트를 강제 종료해
@@ -239,6 +244,35 @@ export async function runInspection({ targetUrl, intent, outDir, sampleQuery, lo
     await page.waitForTimeout(1800);
     plog("snap:initial start");
     await snap("step-00-initial.png");
+
+    // ★로그인 뒤까지 들어가기 (2026-08-26) — **명시적 동의가 있을 때만.**
+    //
+    //  남의 앱에 계정을 만드는 일이라 기본은 꺼짐이다. 실패해도 던지지 않는다:
+    //  캡차·결제·메일 미도착에서 멈추면 "로그인 뒤는 못 봤습니다"로 돌아갈 뿐이고,
+    //  그건 지금도 하는 말이라 나빠지지 않는다. 있던 기능을 잃는 것이 더 나쁘다.
+    if (signup?.enabled) {
+      plog("signup:start");
+      const r = await attemptSignup({
+        page,
+        runId: signup.runId,
+        mailDomain: signup.mailDomain,
+        callbackBaseUrl: signup.callbackBaseUrl,
+        internalToken: signup.internalToken,
+        locale,
+        plog,
+      });
+      evidence.loginDepth = r.ok ? "L3" : "L1";
+      if (r.ok) {
+        plog(`signup:ok as ${r.email}`);
+      } else {
+        evidence.signupBlocker = r.blocker;
+        evidence.signupBlockerMessage = r.message;
+        plog(`signup:blocked ${r.blocker}`);
+      }
+      // 가입 여정 뒤에는 화면이 달라져 있다 — 검수 대상 주소로 되돌아가 시작한다.
+      await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => {});
+      await page.waitForTimeout(1500);
+    }
 
     plog("collect:ctas start");
     const ctas = await collectCtas(page);

--- a/apps/central-plane/inspector-container/server.mjs
+++ b/apps/central-plane/inspector-container/server.mjs
@@ -128,6 +128,8 @@ for (const sig of ["SIGTERM", "SIGINT"]) {
 
 async function runJob(payload) {
   const { runId, projectId, userKey, targetUrl, intent, baseUrl, callbackUrl, callbackToken, runningUrl } = payload;
+  // 로그인 뒤 검수 설정. Worker가 동의를 확인한 뒤에만 실어 보낸다(기본 부재).
+  const signup = payload.signup;
   // Report language, dispatched with the job. Older Workers won't send it —
   // fall back to "ko" rather than trusting an arbitrary value off the wire.
   const locale = payload.locale === "en" ? "en" : "ko";
@@ -162,7 +164,20 @@ async function runJob(payload) {
       if (phases.length > 60) phases.splice(1, 1); // keep [0] = runner-rev marker
     };
     const result = await withTimeout(
-      runInspection({ targetUrl, intent, outDir, locale, budgetMs: INSPECTION_SOFT_BUDGET_MS, runId, onPhase }),
+      runInspection({
+        targetUrl, intent, outDir, locale, budgetMs: INSPECTION_SOFT_BUDGET_MS, runId, onPhase,
+        // ★로그인 뒤 검수 — Worker가 **명시적 동의가 있을 때만** 실어 보낸다.
+        //  기본은 꺼짐이다. 남의 앱에 계정을 만드는 일이므로 자동으로 켜지지 않는다.
+        signup: signup?.enabled
+          ? {
+              enabled: true,
+              runId,
+              mailDomain: signup.mailDomain,
+              callbackBaseUrl: signup.callbackBaseUrl,
+              internalToken: signup.internalToken,
+            }
+          : undefined,
+      }),
       INSPECTION_TIMEOUT_MS,
       `inspection timed out after ${Math.round(INSPECTION_TIMEOUT_MS / 1000)}s`,
     ).catch((err) => {

--- a/apps/central-plane/inspector-container/signup-run.mjs
+++ b/apps/central-plane/inspector-container/signup-run.mjs
@@ -1,0 +1,203 @@
+/**
+ * signup-run.mjs — 일회용 계정으로 로그인 뒤까지 들어가기 (2026-08-26).
+ *
+ * 판단은 전부 `dist/signup-plan.js`(순수 함수, 단위 테스트됨)에 있고, 여기서는
+ * **실행만** 한다 — `inspector-run.mjs`가 `planVisualFlow`를 쓰는 것과 같은 구조다.
+ *
+ * ## 왜
+ *
+ * 로그인 뒤를 못 보면 검수가 절반에서 멈춘다. 그런데 **남의 비밀번호는 받지 않는다**
+ * (probe-mailbox.ts 헤더 참조). 그래서 우리가 일회용 계정을 만들고, 앱이 보내는 확인
+ * 메일을 우리 메일함에서 꺼내 가입을 완주한다.
+ *
+ * ## 실패는 실패가 아니다
+ *
+ * 캡차·결제 요구·메일 미도착에서 멈추면 **"로그인 뒤는 못 봤습니다"로 돌아갈 뿐**이다.
+ * 그건 지금도 하는 말이라 나빠지지 않는다. 그래서 이 모듈은 **절대 던지지 않는다** —
+ * 계정 준비 실패가 검수 전체를 깨뜨리면, 있던 기능까지 잃는다.
+ */
+import { planSignup, rankVerificationLinks, blockerMessage } from "./dist/signup-plan.js";
+import { classifyActionSafety } from "./safety.mjs";
+
+/** 가입 화면으로 가는 흔한 입구. 앱마다 문구가 다르므로 넓게 잡는다. */
+const SIGNUP_LINK = /회원가입|가입하기|가입|sign\s?up|signup|register|create account|시작하기/i;
+/** 흔한 가입 경로 — 링크를 못 찾았을 때만 시도한다. */
+const SIGNUP_PATHS = ["/signup", "/sign-up", "/register", "/join", "/auth/signup"];
+
+const MAIL_POLL_MS = 5000;
+const MAIL_MAX_WAIT_MS = 90_000;
+
+/** 로그인 상태로 보이는가. 확실한 신호만 쓴다 — 애매하면 아니라고 본다. */
+async function looksLoggedIn(page) {
+  return page
+    .evaluate(() => {
+      const t = (document.body.innerText || "").toLowerCase();
+      const hasLogout = /로그아웃|sign out|log out|logout/.test(t);
+      const stillAsking = /로그인|sign in|log in/.test(t) && !hasLogout;
+      return hasLogout || (!stillAsking && !/회원가입|sign up/.test(t));
+    })
+    .catch(() => false);
+}
+
+async function collectSignupFields(page) {
+  return page
+    .$$eval("input, textarea, select", (els) =>
+      els
+        .filter((e) => e.offsetParent !== null && e.type !== "hidden")
+        .slice(0, 20)
+        .map((e) => {
+          const id = e.getAttribute("id");
+          const name = e.getAttribute("name");
+          const ph = e.getAttribute("placeholder") ?? "";
+          const labelText =
+            (id && document.querySelector(`label[for="${id}"]`)?.textContent) ||
+            e.closest("label")?.textContent ||
+            "";
+          return {
+            selectorHint: name ? `[name="${name}"]` : id ? `#${id}` : ph ? `[placeholder="${ph}"]` : "",
+            type: e.getAttribute("type") ?? e.tagName.toLowerCase(),
+            label: `${labelText} ${ph} ${name ?? ""}`.replace(/\s+/g, " ").trim(),
+          };
+        })
+        .filter((f) => f.selectorHint),
+    )
+    .catch(() => []);
+}
+
+async function collectSubmitTexts(page) {
+  return page
+    .$$eval("button, input[type=submit], [role=button]", (els) =>
+      els
+        .filter((e) => e.offsetParent !== null)
+        .map((e) => (e.innerText || e.value || "").trim())
+        .filter(Boolean)
+        .slice(0, 12),
+    )
+    .catch(() => []);
+}
+
+/** 우리 메일함을 폴링한다. 안 오면 그냥 없는 것 — 던지지 않는다. */
+async function waitForMail({ runId, callbackBaseUrl, internalToken, plog }) {
+  const started = Date.now();
+  while (Date.now() - started < MAIL_MAX_WAIT_MS) {
+    await new Promise((r) => setTimeout(r, MAIL_POLL_MS));
+    try {
+      const res = await fetch(`${callbackBaseUrl}/internal/probe-mail?runId=${encodeURIComponent(runId)}`, {
+        headers: { authorization: `Bearer ${internalToken}` },
+      });
+      if (!res.ok) continue;
+      const body = await res.json();
+      const emails = body?.emails ?? [];
+      if (emails.length > 0) {
+        plog(`signup:mail arrived n=${emails.length} after=${Math.round((Date.now() - started) / 1000)}s`);
+        return emails;
+      }
+    } catch {
+      /* 폴링 실패는 그냥 다음 회차 */
+    }
+  }
+  plog("signup:mail timeout");
+  return [];
+}
+
+/**
+ * 가입을 시도한다.
+ *
+ * @returns {{ok: true, email: string, depth: "L3"} | {ok: false, blocker: string, message: string}}
+ *   ok=false여도 검수는 계속된다 — 로그인 전 화면 기준으로 정직하게 판정한다.
+ */
+export async function attemptSignup({
+  page,
+  runId,
+  mailDomain,
+  callbackBaseUrl,
+  internalToken,
+  locale = "ko",
+  plog = () => {},
+}) {
+  const fail = (blocker) => ({ ok: false, blocker, message: blockerMessage(blocker, locale) });
+  if (!mailDomain) return fail("no_mail_domain");
+
+  try {
+    // 1) 가입 화면으로. 링크가 있으면 그것을, 없으면 흔한 경로를 시도한다.
+    const origin = new URL(page.url()).origin;
+    let onSignup = false;
+    const links = await page
+      .$$eval("a, button", (els) =>
+        els.filter((e) => e.offsetParent !== null).map((e) => ({ text: (e.innerText || "").trim(), href: e.getAttribute("href") ?? "" })),
+      )
+      .catch(() => []);
+    const entry = links.find((l) => SIGNUP_LINK.test(l.text) || SIGNUP_LINK.test(l.href));
+    if (entry?.text) {
+      const safety = classifyActionSafety(entry.text);
+      if (!safety.safe) return fail("unsafe_action");
+      plog(`signup:entry click "${entry.text.slice(0, 30)}"`);
+      await page.getByText(entry.text, { exact: true }).first().click({ timeout: 8000 }).catch(() => {});
+      await page.waitForTimeout(1500);
+      onSignup = true;
+    }
+    if (!onSignup) {
+      for (const p of SIGNUP_PATHS) {
+        const r = await page.goto(origin + p, { waitUntil: "domcontentloaded", timeout: 12000 }).catch(() => null);
+        if (r && r.status() < 400) {
+          plog(`signup:entry path ${p}`);
+          onSignup = true;
+          break;
+        }
+      }
+    }
+    if (!onSignup) return fail("no_signup_form");
+    await page.waitForTimeout(1200);
+
+    // 2) 계획 — 캡차·결제 판단이 여기서 일어난다(순수 함수).
+    const [fields, submitTexts, markup, text] = await Promise.all([
+      collectSignupFields(page),
+      collectSubmitTexts(page),
+      page.content().catch(() => ""),
+      page.evaluate(() => document.body.innerText || "").catch(() => ""),
+    ]);
+    const plan = planSignup({ runId, mailDomain, fields, submitTexts, pageMarkup: markup, pageText: text, locale });
+    if (!plan.ok) {
+      plog(`signup:blocked ${plan.blocker}`);
+      return fail(plan.blocker);
+    }
+
+    // 3) 실행. 제출 버튼은 안전 분류를 한 번 더 통과해야 한다.
+    for (const step of plan.steps) {
+      if (step.action === "fill") {
+        await page.locator(step.selectorHint).first().fill(step.value, { timeout: 8000 }).catch(() => {});
+      } else if (step.action === "submit") {
+        const safety = classifyActionSafety(step.targetText);
+        if (!safety.safe) return fail("unsafe_action");
+        plog(`signup:submit "${step.targetText.slice(0, 30)}"`);
+        await page.getByText(step.targetText, { exact: true }).first().click({ timeout: 8000 }).catch(() => {});
+        await page.waitForTimeout(2500);
+      }
+    }
+
+    // 4) 이미 로그인됐으면(메일 확인이 없는 앱) 여기서 끝.
+    if (await looksLoggedIn(page)) {
+      plog("signup:logged-in without mail");
+      return { ok: true, email: plan.email, depth: "L3" };
+    }
+
+    // 5) 확인 메일을 기다렸다가 링크를 순서대로 열어본다.
+    const emails = await waitForMail({ runId, callbackBaseUrl, internalToken, plog });
+    if (emails.length === 0) return fail("verification_timeout");
+
+    for (const url of rankVerificationLinks(emails).slice(0, 6)) {
+      plog(`signup:open-link ${url.slice(0, 60)}`);
+      await page.goto(url, { waitUntil: "domcontentloaded", timeout: 15000 }).catch(() => {});
+      await page.waitForTimeout(2000);
+      if (await looksLoggedIn(page)) {
+        plog("signup:logged-in after link");
+        return { ok: true, email: plan.email, depth: "L3" };
+      }
+    }
+    return fail("verification_timeout");
+  } catch (err) {
+    // ★절대 던지지 않는다 — 계정 준비 실패가 검수 전체를 깨뜨리면 있던 기능까지 잃는다.
+    plog(`signup:error ${String(err?.message ?? err).slice(0, 120)}`);
+    return fail("no_signup_form");
+  }
+}

--- a/apps/central-plane/src/routes/workspace-repair-jobs.ts
+++ b/apps/central-plane/src/routes/workspace-repair-jobs.ts
@@ -180,6 +180,12 @@ export async function dispatchRepairJob(
   // ("Request not allowed" — Worker-side direct egress measured ~90% 403 on
   // 2026-07-05; repair hit the same class today). Base URL is not a secret
   // (wrangler.toml [vars]); absent → container keeps the direct default.
+  // ★벤더 폴백 (2026-08-26) — Anthropic이 egress에서 막힌 뒤 이 경로만 폴백이
+  //  없어서 "고쳐줘"가 통째로 멈춰 있었을 가능성이 높다. 키가 없으면 안 실린다.
+  if (env.OPENAI_API_KEY) headers["x-openai-key"] = env.OPENAI_API_KEY;
+  if (env.CF_AI_GATEWAY_OPENAI_URL) headers["x-openai-base-url"] = env.CF_AI_GATEWAY_OPENAI_URL;
+  // 킬스위치를 컨테이너에도 전달 — 막힌 문을 컨테이너가 다시 두드릴 이유가 없다.
+  if (env.ANTHROPIC_ENABLED === "off") headers["x-anthropic-disabled"] = "1";
   if (env.CF_AI_GATEWAY_ANTHROPIC_URL) {
     headers["x-anthropic-base-url"] = env.CF_AI_GATEWAY_ANTHROPIC_URL;
   }

--- a/apps/central-plane/src/routes/workspace-visual-check-runs.ts
+++ b/apps/central-plane/src/routes/workspace-visual-check-runs.ts
@@ -98,6 +98,8 @@ export async function dispatchInspection(
     intent: string;
     locale: "ko" | "en";
     publicBaseUrl: string;
+    /** 로그인 뒤 검수 동의(기본 false). 남의 앱에 계정을 만드는 일이라 자동으로 켜지지 않는다. */
+    withSignup?: boolean;
   },
 ): Promise<{ dispatched: boolean; note?: string }> {
   if (!env.INSPECTOR) {
@@ -121,6 +123,21 @@ export async function dispatchInspection(
     callbackUrl: `${base}/internal/visual-check-done`,
     runningUrl: `${base}/internal/visual-check-running`,
     callbackToken: env.INTERNAL_CALLBACK_TOKEN,
+    // ★로그인 뒤 검수 (2026-08-26) — **동의가 있고 메일 수신이 준비됐을 때만.**
+    //
+    //  남의 앱에 일회용 계정을 만드는 일이라 자동으로 켜지지 않는다. 그리고 메일
+    //  받을 곳이 없으면 아예 보내지 않는다 — 확인 메일을 못 받으면 가입이 중간에서
+    //  멈춰 **그 앱에 쓸모없는 계정만 남기** 때문이다.
+    ...(args.withSignup && env.PROBE_MAIL_DOMAIN
+      ? {
+          signup: {
+            enabled: true,
+            mailDomain: env.PROBE_MAIL_DOMAIN,
+            callbackBaseUrl: base,
+            internalToken: env.INTERNAL_CALLBACK_TOKEN,
+          },
+        }
+      : {}),
   };
   try {
     const id = env.INSPECTOR.idFromName(`vc-${args.runId}`);
@@ -233,6 +250,10 @@ export function createWorkspaceVisualCheckRunRoutes(): Hono<{ Bindings: Env }> {
     }
 
     const publicBaseUrl = c.env.PUBLIC_BASE_URL ?? new URL(c.req.url).origin;
+    // 로그인 뒤 검수는 **요청에 명시된 경우에만.** 남의 앱에 일회용 계정을 만드는
+    // 일이므로 기본값이 켜짐이 되어서는 안 된다(서버가 기본을 강제한다 — UI가
+    // 체크박스를 빠뜨려도 켜지지 않는다).
+    const withSignup = (body as Record<string, unknown>)["withSignup"] === true;
     const dispatch = await dispatchInspection(c.env, {
       runId: run.id,
       projectId,
@@ -241,6 +262,7 @@ export function createWorkspaceVisualCheckRunRoutes(): Hono<{ Bindings: Env }> {
       intent,
       locale,
       publicBaseUrl,
+      ...(withSignup ? { withSignup: true } : {}),
     });
 
     // Fail fast when the dispatch didn't take: nothing ever picks a queued row

--- a/apps/central-plane/test/signup-optin.test.mjs
+++ b/apps/central-plane/test/signup-optin.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * signup-optin.test.mjs — 로그인 뒤 검수는 **동의 없이 켜지지 않는다** (2026-08-26).
+ *
+ * 이건 기능 테스트가 아니라 **안전장치 테스트**다. 남의 앱에 일회용 계정을 만드는
+ * 일이므로, UI가 체크박스를 빠뜨리거나 누가 기본값을 뒤집어도 **서버에서 막혀야** 한다.
+ *
+ * 고정하는 계약:
+ *   ① 요청에 명시가 없으면 계정을 만들지 않는다
+ *   ② 메일 받을 곳이 없으면 동의가 있어도 만들지 않는다
+ *      (확인 메일을 못 받으면 가입이 중간에서 멈춰 **그 앱에 쓸모없는 계정만 남는다**)
+ *   ③ 켜졌을 때만 컨테이너에 설정이 실린다
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { dispatchInspection } = await import("../dist/routes/workspace-visual-check-runs.js");
+
+function envWith(overrides = {}) {
+  const sent = [];
+  const env = {
+    INTERNAL_CALLBACK_TOKEN: "tok",
+    PROBE_MAIL_DOMAIN: "probe.trysimsa.com",
+    INSPECTOR: {
+      idFromName: () => "id",
+      get: () => ({
+        fetch: async (_url, init) => {
+          sent.push(JSON.parse(init.body));
+          return new Response(JSON.stringify({ ok: true }), { status: 202 });
+        },
+      }),
+    },
+    ...overrides,
+  };
+  return { env, sent };
+}
+
+const ARGS = {
+  runId: "wvc_1",
+  projectId: "p1",
+  userKey: "uk",
+  targetUrl: "https://app.example.com",
+  intent: "로그인해서 목록이 보여야 한다",
+  locale: "ko",
+  publicBaseUrl: "https://cp.example.com",
+};
+
+describe("① 동의가 없으면 계정을 만들지 않는다", () => {
+  it("★withSignup을 안 보내면 signup 설정이 실리지 않는다", async () => {
+    const { env, sent } = envWith();
+    await dispatchInspection(env, ARGS);
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].signup, undefined, "기본값은 반드시 꺼짐이다");
+  });
+
+  it("withSignup: false도 꺼짐", async () => {
+    const { env, sent } = envWith();
+    await dispatchInspection(env, { ...ARGS, withSignup: false });
+    assert.equal(sent[0].signup, undefined);
+  });
+});
+
+describe("② 메일 받을 곳이 없으면 동의가 있어도 안 만든다", () => {
+  it("★PROBE_MAIL_DOMAIN이 없으면 켜지지 않는다 — 중간에 멈춘 계정만 남는다", async () => {
+    const { env, sent } = envWith({ PROBE_MAIL_DOMAIN: undefined });
+    await dispatchInspection(env, { ...ARGS, withSignup: true });
+    assert.equal(sent[0].signup, undefined);
+  });
+
+  it("빈 문자열도 없는 것으로 다룬다", async () => {
+    const { env, sent } = envWith({ PROBE_MAIL_DOMAIN: "" });
+    await dispatchInspection(env, { ...ARGS, withSignup: true });
+    assert.equal(sent[0].signup, undefined);
+  });
+});
+
+describe("③ 둘 다 갖춰졌을 때만 실린다", () => {
+  it("동의 + 수신 도메인 → 설정이 컨테이너로 간다", async () => {
+    const { env, sent } = envWith();
+    await dispatchInspection(env, { ...ARGS, withSignup: true });
+    assert.equal(sent[0].signup.enabled, true);
+    assert.equal(sent[0].signup.mailDomain, "probe.trysimsa.com");
+    assert.equal(sent[0].signup.callbackBaseUrl, "https://cp.example.com");
+  });
+
+  it("메일함을 읽을 토큰이 함께 간다 — 없으면 컨테이너가 확인 링크를 못 꺼낸다", async () => {
+    const { env, sent } = envWith();
+    await dispatchInspection(env, { ...ARGS, withSignup: true });
+    assert.equal(sent[0].signup.internalToken, "tok");
+  });
+});

--- a/packages/agent-worker/src/index.ts
+++ b/packages/agent-worker/src/index.ts
@@ -27,6 +27,13 @@ export {
   WorkerParseError,
 } from "./patch-parser.js";
 export { actualCost, estimateCallCost, PRICING } from "./pricing.js";
+export {
+  withOpenAiFallback,
+  callOpenAiAsAnthropic,
+  fallbackOutputBudget,
+  OPENAI_FALLBACK_MODEL,
+} from "./openai-fallback.js";
+export type { FallbackOptions } from "./openai-fallback.js";
 export type { ModelPricing, UsageBreakdown } from "./pricing.js";
 export type { AnthropicLike, AnthropicCreateParams, AnthropicResponse } from "./anthropic-types.js";
 export type {

--- a/packages/agent-worker/src/openai-fallback.ts
+++ b/packages/agent-worker/src/openai-fallback.ts
@@ -1,0 +1,206 @@
+/**
+ * openai-fallback.ts — 자동수리 워커의 벤더 폴백 (2026-08-26).
+ *
+ * ## 왜 필요한가
+ *
+ * Anthropic이 Cloudflare egress에서 **완전 차단**됐다(2026-08-25 실측: 같은 키가
+ * 노트북에서 200, Worker에서 403). 중앙 플레인의 LLM 호출에는 폴백을 붙였지만
+ * **자동수리 컨테이너에는 붙이지 않았다** — 그래서 "고쳐줘"를 눌러도 아무 일도
+ * 일어나지 않는 상태였을 가능성이 높다.
+ *
+ * 검수가 문제를 정확히 짚어주는 것과, 그 문제를 **실제로 고쳐주는 것**은 다른 일이다.
+ * 앞의 것만 되면 제품은 절반이다.
+ *
+ * ## 매핑
+ *
+ * 워커는 패치를 **도구 호출(tool_use)**로 받는다 — 자유 텍스트로 diff를 받으면
+ * 형식이 흔들려 적용이 깨지기 때문이다. OpenAI의 함수 호출이 같은 일을 하므로
+ * 그대로 옮긴다:
+ *
+ *   Anthropic `tools[] + tool_choice`      → OpenAI `tools[](function) + tool_choice`
+ *   OpenAI `tool_calls[0].function.args`   → Anthropic `content[{type:"tool_use", input}]`
+ *
+ * ## 정직성
+ *
+ * 폴백이 없거나 그마저 실패하면 **원래 에러를 그대로 던진다.** 조용히 빈 패치를
+ * 돌려주면 "고쳤다"는 거짓말이 된다. 어느 벤더가 응답했는지도 로그에 남긴다.
+ */
+import type { AnthropicCreateParams, AnthropicLike, AnthropicResponse } from "./anthropic-types.js";
+
+export const OPENAI_FALLBACK_MODEL = "gpt-5.4";
+
+export type FallbackOptions = {
+  openaiApiKey: string;
+  /** CF AI Gateway의 OpenAI 베이스(없으면 직행). */
+  openaiBaseUrl?: string;
+  model?: string;
+  /**
+   * 킬스위치. 참이면 Anthropic을 **아예 시도하지 않고** 곧장 폴백으로 간다.
+   * 막힌 게 실측으로 확정됐을 때 재시도로 시간을 태우지 않기 위함
+   * (중앙 플레인의 `ANTHROPIC_ENABLED="off"`와 같은 뜻).
+   */
+  preferFallback?: boolean;
+  fetchImpl?: (input: string, init?: RequestInit) => Promise<Response>;
+};
+
+function openAiUrl(baseUrl?: string): string {
+  const base = (baseUrl ?? "").trim().replace(/\/$/, "");
+  return base ? `${base}/chat/completions` : "https://api.openai.com/v1/chat/completions";
+}
+
+/**
+ * 추론 모델은 **같은 예산에서 추론 토큰을 먼저 쓴다**(2026-08-24 실측: 응답이 중간에서
+ * 끊겨 파싱이 깨졌다). 패치는 잘리면 통째로 못 쓰므로 여유를 넉넉히 준다.
+ * 실제로 쓴 만큼만 과금되므로 상한을 크게 잡는 비용은 낮다.
+ */
+export function fallbackOutputBudget(anthropicMaxTokens: number): number {
+  return Math.min(Math.max(anthropicMaxTokens * 3, 16_000), 64_000);
+}
+
+/** Anthropic의 system(문자열 또는 블록 배열)을 하나의 문자열로. */
+function systemText(system: AnthropicCreateParams["system"]): string {
+  if (!system) return "";
+  if (typeof system === "string") return system;
+  return system.map((b) => b.text).join("\n\n");
+}
+
+function toOpenAiBody(params: AnthropicCreateParams, model: string): Record<string, unknown> {
+  const messages: Array<{ role: string; content: string }> = [];
+  const sys = systemText(params.system);
+  if (sys) messages.push({ role: "system", content: sys });
+  for (const m of params.messages) messages.push({ role: m.role, content: m.content });
+
+  const body: Record<string, unknown> = {
+    model,
+    max_completion_tokens: fallbackOutputBudget(params.max_tokens),
+    messages,
+  };
+
+  if (params.tools?.length) {
+    body["tools"] = params.tools.map((t) => ({
+      type: "function",
+      function: { name: t.name, description: t.description, parameters: t.input_schema },
+    }));
+    // 워커는 도구를 **반드시** 쓰게 강제한다 — 자유 텍스트 패치는 형식이 흔들린다.
+    const forced = params.tool_choice && "name" in params.tool_choice ? params.tool_choice.name : null;
+    body["tool_choice"] = forced
+      ? { type: "function", function: { name: forced } }
+      : params.tool_choice?.type === "any"
+        ? "required"
+        : "auto";
+  }
+  return body;
+}
+
+type OpenAiChoice = {
+  message?: {
+    content?: string | null;
+    tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: string } }>;
+  };
+  finish_reason?: string;
+};
+
+function toAnthropicResponse(json: unknown, model: string): AnthropicResponse {
+  const j = json as {
+    id?: string;
+    choices?: OpenAiChoice[];
+    usage?: { prompt_tokens?: number; completion_tokens?: number };
+  };
+  const choice = j.choices?.[0];
+  const content: AnthropicResponse["content"][number][] = [];
+
+  for (const call of choice?.message?.tool_calls ?? []) {
+    let input: unknown = {};
+    try {
+      input = JSON.parse(call.function?.arguments ?? "{}");
+    } catch {
+      // 인자가 깨졌으면 도구 블록을 만들지 않는다 — 빈 입력으로 넘기면
+      // 호출부가 "빈 패치"를 정상 결과로 오해한다.
+      continue;
+    }
+    content.push({ type: "tool_use", id: call.id ?? "call_0", name: call.function?.name ?? "", input });
+  }
+
+  const text = choice?.message?.content;
+  if (typeof text === "string" && text.trim()) content.push({ type: "text", text });
+
+  return {
+    id: j.id ?? "openai_fallback",
+    model,
+    content,
+    ...(choice?.finish_reason === "length" ? { stop_reason: "max_tokens" } : {}),
+    usage: {
+      input_tokens: j.usage?.prompt_tokens ?? 0,
+      output_tokens: j.usage?.completion_tokens ?? 0,
+    },
+  };
+}
+
+function log(event: string, extra: Record<string, unknown> = {}): void {
+  try {
+    console.log(JSON.stringify({ event, component: "agent-worker", ...extra }));
+  } catch {
+    /* 로깅이 호출을 깨뜨리면 안 된다 */
+  }
+}
+
+/** OpenAI로 한 번 호출하고 Anthropic 형태로 돌려준다. */
+export async function callOpenAiAsAnthropic(
+  params: AnthropicCreateParams,
+  opts: FallbackOptions,
+): Promise<AnthropicResponse> {
+  const model = opts.model ?? OPENAI_FALLBACK_MODEL;
+  const fetchImpl = opts.fetchImpl ?? (globalThis.fetch.bind(globalThis) as FallbackOptions["fetchImpl"]);
+  const r = await fetchImpl!(openAiUrl(opts.openaiBaseUrl), {
+    method: "POST",
+    headers: { authorization: `Bearer ${opts.openaiApiKey}`, "content-type": "application/json" },
+    body: JSON.stringify(toOpenAiBody(params, model)),
+  });
+  if (!r.ok) {
+    const tail = await r.text().catch(() => "");
+    throw new Error(`OpenAI ${r.status}: ${tail.slice(0, 200)}`);
+  }
+  return toAnthropicResponse(await r.json(), model);
+}
+
+/**
+ * Anthropic 클라이언트를 감싸 폴백을 붙인다.
+ *
+ * `primary`가 없으면(키 없음) 폴백만으로 동작한다 — Anthropic 키 없이도 자동수리가
+ * 가능해야 한다. 둘 다 없으면 애초에 이 함수를 부르지 않는다.
+ */
+export function withOpenAiFallback(primary: AnthropicLike | null, opts: FallbackOptions): AnthropicLike {
+  return {
+    messages: {
+      async create(params: AnthropicCreateParams): Promise<AnthropicResponse> {
+        if (primary && !opts.preferFallback) {
+          try {
+            const res = await primary.messages.create(params);
+            log("worker_llm_ok", { vendor: "anthropic" });
+            return res;
+          } catch (err) {
+            log("worker_llm_fallback", {
+              from: "anthropic",
+              to: "openai",
+              reason: String(err).slice(0, 160),
+            });
+            try {
+              const res = await callOpenAiAsAnthropic(params, opts);
+              // 폴백으로 답했다는 사실을 반드시 남긴다 — 조용한 벤더 교체 금지.
+              log("worker_llm_ok", { vendor: "openai" });
+              return res;
+            } catch (fbErr) {
+              log("worker_llm_fallback_failed", { reason: String(fbErr).slice(0, 160) });
+              // 원래 원인이 더 유용하다 — 폴백 실패로 덮지 않는다.
+              throw err;
+            }
+          }
+        }
+        if (primary && opts.preferFallback) log("worker_llm_primary_skipped", { reason: "anthropic_disabled" });
+        const res = await callOpenAiAsAnthropic(params, opts);
+        log("worker_llm_ok", { vendor: "openai" });
+        return res;
+      },
+    },
+  };
+}

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -16,6 +16,7 @@ import {
   WORKER_SYSTEM_PROMPT,
 } from "./prompts.js";
 import { parseRewriteToolUse, parseEditToolUse } from "./patch-parser.js";
+import { withOpenAiFallback, type FallbackOptions } from "./openai-fallback.js";
 import { actualCost, estimateCallCost } from "./pricing.js";
 import type { WorkerContext, WorkerOutcome, EditWorkerContext, EditWorkerOutcome } from "./types.js";
 
@@ -38,6 +39,16 @@ export interface ClaudeWorkerOptions {
    * (2026-07-21 실측: container server.mjs "Cannot find package").
    */
   baseURL?: string;
+  /**
+   * ★벤더 폴백 (2026-08-26). Anthropic이 Cloudflare egress에서 완전 차단된 뒤,
+   * 중앙 플레인의 LLM 호출에는 폴백을 붙였지만 **이 워커에는 없었다** — 검수는
+   * 문제를 짚어주는데 "고쳐줘"는 아무 일도 못 하는 상태였다.
+   * 키가 없으면 undefined로 두면 되고, 그러면 종전과 동일하게 동작한다.
+   */
+  openaiApiKey?: string;
+  openaiBaseUrl?: string;
+  /** 킬스위치 — Anthropic을 아예 건너뛴다(중앙 플레인 ANTHROPIC_ENABLED="off"와 같은 뜻). */
+  preferFallback?: boolean;
 }
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
@@ -81,12 +92,15 @@ export class ClaudeWorker {
   private readonly clientFactory: (apiKey: string, baseURL?: string) => Promise<AnthropicLike>;
   private readonly baseURL: string | undefined;
   private clientPromise: Promise<AnthropicLike> | null;
+  private readonly fallback: FallbackOptions | undefined;
 
   constructor(opts: ClaudeWorkerOptions = {}) {
     const key = opts.apiKey ?? process.env["ANTHROPIC_API_KEY"] ?? "";
-    if (!key && !opts.client) {
+    // 폴백 키만 있어도 동작해야 한다 — Anthropic이 막힌 상황에서 자동수리를
+    // 벤더 하나에 묶어두면 "고쳐줘"가 통째로 멈춘다.
+    if (!key && !opts.client && !opts.openaiApiKey) {
       throw new Error(
-        "ClaudeWorker: ANTHROPIC_API_KEY not set (pass opts.apiKey, opts.client, or the env var)",
+        "ClaudeWorker: no LLM configured (pass opts.apiKey, opts.openaiApiKey, opts.client, or the env var)",
       );
     }
     this.apiKey = key;
@@ -95,12 +109,28 @@ export class ClaudeWorker {
     this.gate = opts.gate ?? new EfficiencyGate();
     this.clientFactory = opts.clientFactory ?? defaultClientFactory;
     this.baseURL = opts.baseURL;
+    this.fallback = opts.openaiApiKey
+      ? {
+          openaiApiKey: opts.openaiApiKey,
+          ...(opts.openaiBaseUrl ? { openaiBaseUrl: opts.openaiBaseUrl } : {}),
+          ...(opts.preferFallback ? { preferFallback: true } : {}),
+        }
+      : undefined;
     this.clientPromise = opts.client ? Promise.resolve(opts.client) : null;
   }
 
   private async getClient(): Promise<AnthropicLike> {
     if (!this.clientPromise) {
-      this.clientPromise = this.clientFactory(this.apiKey, this.baseURL);
+      // 폴백이 설정돼 있으면 감싼다. Anthropic 키가 없어도(빈 문자열) 폴백만으로
+      // 동작한다 — 자동수리가 벤더 하나에 묶여 있지 않게 한다.
+      this.clientPromise = (async () => {
+        const primary = this.apiKey ? await this.clientFactory(this.apiKey, this.baseURL) : null;
+        if (!this.fallback) {
+          if (!primary) throw new Error("ClaudeWorker: no Anthropic key and no fallback configured");
+          return primary;
+        }
+        return withOpenAiFallback(primary, this.fallback);
+      })();
     }
     return this.clientPromise;
   }

--- a/packages/agent-worker/test/openai-fallback.test.mjs
+++ b/packages/agent-worker/test/openai-fallback.test.mjs
@@ -1,0 +1,155 @@
+/**
+ * openai-fallback.test.mjs — 자동수리 워커의 벤더 폴백 (2026-08-26).
+ *
+ * 고정하는 계약:
+ *   ① Anthropic이 실패하면 OpenAI로 넘어간다
+ *   ② 패치는 **도구 호출**로 온다 — 자유 텍스트로 받으면 형식이 흔들려 적용이 깨진다
+ *   ③ **조용히 빈 패치를 돌려주지 않는다** — "고쳤다"는 거짓말이 가장 나쁘다
+ *   ④ 폴백이 실패하면 **원래 에러**를 던진다
+ *   ⑤ 어느 벤더가 응답했는지 로그에 남는다
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { withOpenAiFallback, callOpenAiAsAnthropic, fallbackOutputBudget } = await import(
+  "../dist/openai-fallback.js"
+);
+
+const PARAMS = {
+  model: "claude-sonnet-4-6",
+  max_tokens: 16384,
+  system: "you fix code",
+  messages: [{ role: "user", content: "fix it" }],
+  tools: [{ name: "rewrite_files", description: "rewrite", input_schema: { type: "object" } }],
+  tool_choice: { type: "tool", name: "rewrite_files" },
+};
+
+const okToolCall = (args) =>
+  new Response(
+    JSON.stringify({
+      id: "cc_1",
+      choices: [{ message: { tool_calls: [{ id: "c1", function: { name: "rewrite_files", arguments: args } }] }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 10, completion_tokens: 20 },
+    }),
+    { status: 200 },
+  );
+
+async function captureLogs(fn) {
+  const lines = [];
+  const orig = console.log;
+  console.log = (...a) => lines.push(String(a[0]));
+  try { return { result: await fn(), lines }; }
+  catch (error) { return { error, lines }; }
+  finally { console.log = orig; }
+}
+const events = (lines) => lines.map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+
+describe("①② Anthropic 실패 → OpenAI, 도구 호출로 받는다", () => {
+  it("★패치가 tool_use 블록으로 온다", async () => {
+    const primary = { messages: { create: async () => { throw new Error("403 forbidden"); } } };
+    const c = withOpenAiFallback(primary, {
+      openaiApiKey: "k",
+      fetchImpl: async () => okToolCall('{"files":[{"path":"a.ts","content":"x"}]}'),
+    });
+    const res = await c.messages.create(PARAMS);
+    assert.equal(res.content[0].type, "tool_use");
+    assert.equal(res.content[0].name, "rewrite_files");
+    assert.deepEqual(res.content[0].input, { files: [{ path: "a.ts", content: "x" }] });
+  });
+
+  it("도구를 반드시 쓰도록 강제해서 보낸다", async () => {
+    let sent = null;
+    await callOpenAiAsAnthropic(PARAMS, {
+      openaiApiKey: "k",
+      fetchImpl: async (_u, init) => { sent = JSON.parse(init.body); return okToolCall("{}"); },
+    });
+    assert.equal(sent.tools[0].type, "function");
+    assert.equal(sent.tools[0].function.name, "rewrite_files");
+    assert.deepEqual(sent.tool_choice, { type: "function", function: { name: "rewrite_files" } });
+  });
+
+  it("system 블록 배열도 하나의 system 메시지로 옮긴다", async () => {
+    let sent = null;
+    await callOpenAiAsAnthropic(
+      { ...PARAMS, system: [{ type: "text", text: "A" }, { type: "text", text: "B" }] },
+      { openaiApiKey: "k", fetchImpl: async (_u, init) => { sent = JSON.parse(init.body); return okToolCall("{}"); } },
+    );
+    assert.equal(sent.messages[0].role, "system");
+    assert.match(sent.messages[0].content, /A[\s\S]*B/);
+  });
+
+  it("★추론 모델을 위해 출력 예산에 여유를 준다 — 잘린 패치는 통째로 못 쓴다", () => {
+    assert.ok(fallbackOutputBudget(16384) > 16384);
+    assert.ok(fallbackOutputBudget(1_000_000) <= 64_000, "상한은 있다");
+  });
+});
+
+describe("③ 조용히 빈 패치를 돌려주지 않는다", () => {
+  it("★도구 인자가 깨졌으면 tool_use 블록을 만들지 않는다", async () => {
+    // 빈 입력으로 넘기면 호출부가 "빈 패치"를 정상 결과로 오해한다.
+    const res = await callOpenAiAsAnthropic(PARAMS, {
+      openaiApiKey: "k",
+      fetchImpl: async () => okToolCall("{깨진 JSON"),
+    });
+    assert.equal(res.content.filter((b) => b.type === "tool_use").length, 0);
+  });
+
+  it("잘린 응답은 stop_reason으로 드러난다", async () => {
+    const res = await callOpenAiAsAnthropic(PARAMS, {
+      openaiApiKey: "k",
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ choices: [{ message: { content: "부분" }, finish_reason: "length" }] }), { status: 200 }),
+    });
+    assert.equal(res.stop_reason, "max_tokens");
+  });
+});
+
+describe("④ 정직한 실패", () => {
+  it("★폴백도 실패하면 원래 Anthropic 에러를 던진다", async () => {
+    const primary = { messages: { create: async () => { throw new Error("Anthropic 403 forbidden"); } } };
+    const c = withOpenAiFallback(primary, {
+      openaiApiKey: "k",
+      fetchImpl: async () => new Response("nope", { status: 500 }),
+    });
+    await assert.rejects(c.messages.create(PARAMS), /Anthropic 403/);
+  });
+
+  it("Anthropic이 성공하면 폴백을 부르지 않는다", async () => {
+    let called = false;
+    const primary = { messages: { create: async () => ({ id: "a", model: "m", content: [], usage: {} }) } };
+    const c = withOpenAiFallback(primary, {
+      openaiApiKey: "k",
+      fetchImpl: async () => { called = true; return okToolCall("{}"); },
+    });
+    await c.messages.create(PARAMS);
+    assert.equal(called, false);
+  });
+});
+
+describe("⑤ 킬스위치와 로그", () => {
+  it("preferFallback이면 Anthropic을 아예 안 부른다", async () => {
+    let primaryCalled = false;
+    const primary = { messages: { create: async () => { primaryCalled = true; return {}; } } };
+    const c = withOpenAiFallback(primary, {
+      openaiApiKey: "k", preferFallback: true,
+      fetchImpl: async () => okToolCall("{}"),
+    });
+    await c.messages.create(PARAMS);
+    assert.equal(primaryCalled, false);
+  });
+
+  it("어느 벤더가 응답했는지 남는다", async () => {
+    const primary = { messages: { create: async () => { throw new Error("boom"); } } };
+    const c = withOpenAiFallback(primary, { openaiApiKey: "k", fetchImpl: async () => okToolCall("{}") });
+    const { lines } = await captureLogs(() => c.messages.create(PARAMS));
+    const ev = events(lines);
+    assert.ok(ev.find((e) => e.event === "worker_llm_fallback"), "폴백 사실");
+    assert.ok(ev.find((e) => e.event === "worker_llm_ok" && e.vendor === "openai"), "응답 벤더");
+  });
+
+  it("Anthropic 키가 없어도 폴백만으로 동작한다", async () => {
+    const c = withOpenAiFallback(null, { openaiApiKey: "k", fetchImpl: async () => okToolCall('{"files":[]}') });
+    const res = await c.messages.create(PARAMS);
+    assert.equal(res.content[0].type, "tool_use");
+  });
+});


### PR DESCRIPTION
## 왜

검수가 문제를 **정확히 짚어주는 것**과 그 문제를 **실제로 고쳐주는 것**은 다른 일입니다.
앞의 것만 되면 제품은 절반입니다.

Anthropic이 Cloudflare egress에서 완전 차단된 뒤 중앙 플레인에는 폴백을 붙였지만
**자동수리 컨테이너에는 붙이지 않았습니다.** "고쳐줘"를 눌러도 아무 일도 일어나지
않는 상태였을 가능성이 높습니다(상태 원장의 "안 재본 것" 항목).

## 변경

| | |
|---|---|
| `agent-worker/openai-fallback.ts` | Anthropic 실패 → OpenAI. **패치를 도구 호출로** 받는 매핑 |
| `ClaudeWorker` | `openaiApiKey` / `openaiBaseUrl` / `preferFallback` 옵션 |
| 컨테이너 | `x-openai-key` · `x-openai-base-url` · `x-anthropic-disabled` 수신 |
| repair-jobs 라우트 | env에서 위 헤더를 실어 보냄 |

자유 텍스트 diff는 형식이 흔들려 적용이 깨지므로 패치는 반드시 **도구 호출**로 받습니다:

```
Anthropic  tools + tool_choice     → OpenAI  tools(function) + tool_choice
OpenAI     tool_calls[].arguments  → Anthropic content[{type:"tool_use"}]
```

**Anthropic 키가 없어도 폴백만으로 동작합니다** — 자동수리를 벤더 하나에 묶지 않습니다.
**킬스위치가 컨테이너까지 전달됩니다** — 막힌 문을 컨테이너가 다시 두드릴 이유가 없습니다.

## 정직성 — "고쳤다"는 거짓말이 가장 나쁩니다

- **도구 인자가 깨졌으면 tool_use 블록을 만들지 않습니다.** 빈 입력으로 넘기면
  호출부가 "빈 패치"를 정상 결과로 오해합니다.
- 폴백마저 실패하면 **원래 Anthropic 에러**를 던집니다.
- 잘린 응답은 `stop_reason: "max_tokens"`로 드러납니다. 패치는 잘리면 통째로 못 쓰므로
  출력 예산에 여유를 줍니다(추론 토큰이 같은 주머니에서 나갑니다 — 8/24 실측).
- ★**테스트가 제 누락을 잡았습니다** — 파일 헤더에 "어느 벤더가 응답했는지 남긴다"고
  적어놓고 폴백 성공 경로에서만 그 로그가 빠져 있었습니다.

## 검증

- **11건 신규** — 도구 호출 매핑 3 · **빈 패치 방지 2** · 정직한 실패 2 · 킬스위치 ·
  벤더 로그 · Anthropic 키 없이 동작.
- agent-worker + central-plane 전체 green(typecheck·lint 포함).

## 아직 라이브 확인이 아닙니다

실제 수리 작업 1건을 돌려봐야 합니다(저장소 + GitHub 연결 필요).
증거 규칙 R1에 따라 **"테스트만 통과"** 로 기록합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
