### PR TITLE
fix(ux): 개요의 주 버튼을 하나로 — 앞으로 가는 행동만 primary

### DIFF
--- a/apps/dashboard/src/components/IntentConfirmCard.tsx
+++ b/apps/dashboard/src/components/IntentConfirmCard.tsx
@@ -141,6 +141,11 @@ export function IntentConfirmCard({ projectId }: { projectId: string }) {
   const c = t.intentConfirm;
 
   return (
+    // 버튼은 **보조**다 (2026-09-01). 화면당 주 버튼은 하나여야 하고
+    // (uiux-redesign-instructions #5, journey-audit가 P1으로 잰다), 그 하나는
+    // **앞으로 가는 행동** — 지휘 센터의 "지금 할 일" — 이다. 이 카드는 우리가 한
+    // 추론이 맞는지 **확인받는** 자리이고 "나중에"로 건너뛸 수 있다. 대신 카드
+    // 자체를 브랜드 톤으로 띄워 눈에 걸리게 한다.
     <section className="mb-8">
       <div className="card border-brand-200 bg-brand-50/40 p-5">
         {phase === "loading" && <p className="text-sm text-gray-600">{c.loading}</p>}
@@ -180,7 +185,7 @@ export function IntentConfirmCard({ projectId }: { projectId: string }) {
             <button
               onClick={confirm}
               disabled={!oneLine.trim()}
-              className="btn btn-primary btn-sm mt-3 disabled:opacity-50"
+              className="btn btn-secondary btn-sm mt-3 disabled:opacity-50"
             >
               {c.saveMine}
             </button>
@@ -248,7 +253,7 @@ export function IntentConfirmCard({ projectId }: { projectId: string }) {
             )}
 
             <div className="mt-4 flex items-center gap-2">
-              <button onClick={confirm} className="btn btn-primary btn-sm">
+              <button onClick={confirm} className="btn btn-secondary btn-sm">
                 {c.confirm}
               </button>
               <button onClick={() => setPhase("done")} className="text-xs text-gray-500 underline hover:text-gray-700">

--- a/apps/dashboard/src/components/StuckHelper.tsx
+++ b/apps/dashboard/src/components/StuckHelper.tsx
@@ -74,7 +74,8 @@ export function StuckHelper({
         <button
           onClick={submit}
           disabled={!text.trim() || phase === "loading"}
-          className="btn btn-sm btn-primary disabled:opacity-50"
+          // 도움 요청은 보조 행동이다 — 화면의 주 버튼은 "지금 할 일" 하나뿐이다(#5).
+          className="btn btn-sm btn-secondary disabled:opacity-50"
         >
           {phase === "loading" ? t.stuckHelper.loading : t.stuckHelper.submit}
         </button>


### PR DESCRIPTION
## 왜

#514 배포 후 **라이브 journey-audit**를 돌렸습니다: **P0=0**, 그런데 **P1 4건이 전부 같은 것**이었습니다.

```
P1 [ko] 개요 — 지금 할 일이 이 갈래에 맞는가 — primary CTA 3개 — #5 위계 위반 후보
P1 [ko] AF-4 의도 확인 카드 …            — primary CTA 3개
P1 [en] (동일 2건)
```

그리고 이게 **Bae가 지적한 바로 그 증상**입니다 — *"플로우를 아무리 강조해도 부족해 우리 지금 설정된 거 보면."* #514의 서랍은 **텍스트 링크만** 접었고 주 버튼 3개는 그대로였습니다. 즉 앞 PR은 문제의 절반만 고쳤습니다.

## 고친 것

셋 중 **앞으로 가는 것은 지휘 센터 하나**입니다.

| 버튼 | 성격 | 결정 |
|---|---|---|
| 지휘 센터 "지금 할 일" | 앞으로 가는 유일한 행동 | **primary 유지** |
| 의도 확인 "맞아요" | 우리 추론이 맞는지 **확인받는** 자리 — "나중에"로 건너뛸 수 있음 | secondary |
| 막힘 도우미 "제출" | 도움 요청(유틸리티) | secondary |

의도 확인 카드는 **브랜드 톤 배경(`border-brand-200 bg-brand-50/40`)을 유지**합니다 — 버튼 위계를 낮추는 것과 안 보이게 하는 것은 다른 일입니다.

## 검증

- 변경은 `className` 2곳(+근거 주석). 로직·문구 변경 없음.
- dashboard **705/705** · typecheck · build 성공.
- **라이브 확인: 아직** — 배포 후 journey-audit 재주행으로 `cta=1` 확인이 필요합니다(직전 주행 실측 `cta=3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)